### PR TITLE
Always use ordinal scale for binning.

### DIFF
--- a/src/vegalite.js
+++ b/src/vegalite.js
@@ -833,7 +833,7 @@ function axis_def(name, encoding, opt){
     axis.orient = "top";
   }
 
-  if(name=="x" && encoding.isType(name, O)){
+  if (name=="x" && (encoding.isType(name, O) || encoding.bin(name))) {
     axis.properties = {
       labels: {
         angle: {value: 270},


### PR DESCRIPTION
From conversation with @jheer 

>  treat bins as a special data type akin to ordinal but with a special scale instance 

Also fix #67.

I haven’t included option for including/excluding  (should be done together with #76 )

> that can include the empty bins. 

For example:

``` json
{
  "marktype": "square",
  "enc": {
    "x": {"name": "acc","type": "Q","bin": true},
    "y": {"name": "hp","type": "Q","bin": true},
    "color": {"type": "Q","aggr": "count"}
  },
  "cfg": {"dataFormatType": "json","dataUrl": "data/cars.json"}
}
```

![vegalite_ui](https://cloud.githubusercontent.com/assets/111269/5563136/df6ca90e-8e8c-11e4-934b-4bc0dd886a5f.png)
