### PR TITLE
swap arguments order in `schema.util.substract()`

### DIFF
--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -199,7 +199,7 @@ var Encoding = module.exports = (function() {
 
     // remove defaults
     var defaults = schema.instantiate();
-    return schema.util.subtract(defaults, spec);
+    return schema.util.subtract(spec, defaults);
   };
 
   proto.toShorthand = function() {

--- a/src/schema/schemautil.js
+++ b/src/schema/schemautil.js
@@ -23,12 +23,12 @@ util.instantiate = function(schema, required) {
 };
 
 // remove all defaults from an instance
-util.subtract = function(defaults, instance) {
+util.subtract = function(instance, defaults) {
   var changes = {};
   for (var prop in instance) {
     if (!defaults || defaults[prop] !== instance[prop]) {
       if (typeof instance[prop] == 'object') {
-        var c = util.subtract(defaults[prop], instance[prop]);
+        var c = util.subtract(instance[prop], defaults[prop]);
         if (!isEmpty(c))
           changes[prop] = c;
       } else {


### PR DESCRIPTION
basically `subtract(a,b)`  should be `a-b` instead of `b-a`.
