### PR TITLE
use `!!d.data.field` instead of `d.data.field != null`  

### DIFF
--- a/src/compile/filter.js
+++ b/src/compile/filter.js
@@ -35,7 +35,7 @@ module.exports = function(spec, encoding) {
     } else if (operator === 'notNull') {
       // expects a number of fields
       for (var j in operands) {
-        condition += '!!d.data.' + operands[j];
+        condition += '(!!d.data.' + operands[j] + '&& d.data. != "null")';
         if (j < operands.length - 1) {
           condition += ' && ';
         }


### PR DESCRIPTION
so that `notNull` would filter all of `null`, `''` (empty string), and `undefined`
