### PR TITLE
Right aligned numbers for text tables  

### DIFF
--- a/src/compile/marks.js
+++ b/src/compile/marks.js
@@ -352,6 +352,7 @@ function text_props(e, layout, style) {
   // text
   if (e.has(TEXT)) {
     p.text = {field: e.field(TEXT)};
+    p.align = {value: 'right'};
   } else {
     p.text = {value: 'Abc'};
   }
@@ -360,21 +361,6 @@ function text_props(e, layout, style) {
   p.fontWeight = {value: e.font('weight')};
   p.fontStyle = {value: e.font('style')};
   p.baseline = {value: e.text('baseline')};
-
-  // align
-  if (e.has(X)) {
-    if (e.isDimension(X)) {
-      p.align = {value: 'left'};
-      p.dx = {value: e.text('margin')};
-    } else {
-      p.align = {value: 'center'};
-    }
-  } else if (e.has(Y)) {
-    p.align = {value: 'left'};
-    p.dx = {value: e.text('margin')};
-  } else {
-    p.align = {value: e.text('align')};
-  }
 
   return p;
 }


### PR DESCRIPTION
- Right aligned numbers for text tables   #270
- eliminate alignment based on x/y

![shelfviz](https://cloud.githubusercontent.com/assets/111269/6380992/c48599f4-bcf2-11e4-8a7c-66f5f6a78ac2.png)

Still we need to do #247 and also align row/col’s axis to make table nice 
