### PR TITLE
reintroduce isOrdinalScale

### DIFF
--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -189,12 +189,20 @@ var Encoding = module.exports = (function() {
     return (fieldDef.type & type) > 0;
   };
 
+  Encoding.isOrdinalScale = function(encoding, encType) {
+    return vlfield.isOrdinalScale(encoding.enc(encType), true);
+  };
+
   Encoding.isDimension = function(encoding, encType) {
     return vlfield.isDimension(encoding.enc(encType), true);
   };
 
   Encoding.isMeasure = function(encoding, encType) {
     return vlfield.isMeasure(encoding.enc(encType), true);
+  };
+
+  proto.isOrdinalScale = function(encType) {
+    return this.has(encType) && Encoding.isOrdinalScale(this, encType);
   };
 
   proto.isDimension = function(encType) {

--- a/src/compile/layout.js
+++ b/src/compile/layout.js
@@ -36,7 +36,7 @@ function box(encoding, stats) {
 
   // set cellWidth
   if (hasX) {
-    if (encoding.isDimension(X)) {
+    if (encoding.isOrdinalScale(X)) {
       // for ordinal, hasCol or not doesn't matter -- we scale based on cardinality
       cellWidth = (xCardinality + encoding.band(X).padding) * encoding.bandSize(X, useSmallBand);
     } else {
@@ -52,7 +52,7 @@ function box(encoding, stats) {
 
   // set cellHeight
   if (hasY) {
-    if (encoding.isDimension(Y)) {
+    if (encoding.isOrdinalScale(Y)) {
       // for ordinal, hasCol or not doesn't matter -- we scale based on cardinality
       cellHeight = (yCardinality + encoding.band(Y).padding) * encoding.bandSize(Y, useSmallBand);
     } else {

--- a/src/compile/marks.js
+++ b/src/compile/marks.js
@@ -111,26 +111,26 @@ function bar_props(e, layout) {
   }
 
   // width
-  if (!e.isMeasure(X)) { // no X or X is ordinal
+  if (!e.has(X) || e.isOrdinalScale(X)) { // no X or X is ordinal
     if (e.has(SIZE)) {
       p.width = {scale: SIZE, field: e.field(SIZE)};
     } else {
       // p.width = {scale: X, band: true, offset: -1};
       p.width = {value: e.bandSize(X, layout.x.useSmallBand), offset: -1};
     }
-  } else { // X is Quant
+  } else { // X is Quant or Time Scale
     p.width = {value: e.bandSize(X, layout.x.useSmallBand), offset: -1};
   }
 
   // height
-  if (!e.isMeasure(Y)) { // no Y or Y is ordinal
+  if (!e.has(Y) || e.isOrdinalScale(Y)) { // no Y or Y is ordinal
     if (e.has(SIZE)) {
       p.height = {scale: SIZE, field: e.field(SIZE)};
     } else {
       // p.height = {scale: Y, band: true, offset: -1};
       p.height = {value: e.bandSize(Y, layout.y.useSmallBand), offset: -1};
     }
-  } else { // Y is Quant
+  } else { // Y is Quant or Time Scale
     p.height = {value: e.bandSize(Y, layout.y.useSmallBand), offset: -1};
   }
 

--- a/src/field.js
+++ b/src/field.js
@@ -102,10 +102,20 @@ function getIsType(useTypeCode) {
   return useTypeCode ? vlfield.isType : vlfield.isType.byName;
 }
 
-function isDimension(field, useTypeCode /*optional*/) {
+/*
+ * Most fields that use ordinal scale are dimensions.
+ * However, YEAR(T), YEARMONTH(T) use time scale, not ordinal but are dimensions too.
+ */
+vlfield.isOrdinalScale = function(field, useTypeCode /*optional*/) {
   var isType = getIsType(useTypeCode);
   return  isType(field, O) || field.bin ||
     ( isType(field, T) && field.fn && time.isOrdinalFn(field.fn) );
+};
+
+function isDimension(field, useTypeCode /*optional*/) {
+  var isType = getIsType(useTypeCode);
+  return  isType(field, O) || field.bin ||
+    ( isType(field, T) && field.fn );
 }
 
 /**


### PR DESCRIPTION
Fixes #288

Most fields that use ordinal scale are dimensions.
However, `YEAR(T)`, `YEARMONTH(T)` use time scale, not ordinal but are dimensions too.

I also replace `isDimension` with `isOrdinalScale` where I see appropriate ... hope i didn't miss anything.
Feel free to find all `isDimension` and suggest other switch
