### PR TITLE
First step to migrate to Vega 2

### DIFF
--- a/editor/bower.json
+++ b/editor/bower.json
@@ -15,6 +15,6 @@
     "tests"
   ],
   "dependencies": {
-    "vega": "^1.5.4"
+    "vega": "^2.2.6"
   }
 }

--- a/gallery/bower.json
+++ b/gallery/bower.json
@@ -15,7 +15,7 @@
     "tests"
   ],
   "dependencies": {
-    "vega": "^1.0.0",
+    "vega": "^2.2.6",
     "angular": "^1.4.3"
   }
 }

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -18,7 +18,7 @@ module.exports = (function() {
     this._enc = specExtended.encoding;
     this._config = specExtended.config;
     this._filter = specExtended.filter;
-    // this._vega2 = true;
+    this._vega2 = true;
   }
 
   var proto = Encoding.prototype;

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -18,7 +18,6 @@ module.exports = (function() {
     this._enc = specExtended.encoding;
     this._config = specExtended.config;
     this._filter = specExtended.filter;
-    this._vega2 = true;
   }
 
   var proto = Encoding.prototype;
@@ -124,7 +123,6 @@ module.exports = (function() {
   // get "field" reference for vega
   proto.fieldRef = function(et, opt) {
     opt = opt || {};
-    opt.data = !this._vega2 && (opt.data !== false);
     return vlfield.fieldRef(this._enc[et], opt);
   };
 

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -192,8 +192,8 @@ axis.labels.format = function (def, name, encoding, stats) {
   } else if (encoding.isTypes(name, [N, O]) && encoding.axis(name).maxLabelLength) {
     setter(def,
       ['properties','labels','text','template'],
-      '{{' + (encoding._vega2 ?  'datum.data': 'data') +
-      ' | truncate:' + encoding.axis(name).maxLabelLength + '}}'
+      '{{ datum.data | truncate:' +
+      encoding.axis(name).maxLabelLength + '}}'
     );
   }
 

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -192,8 +192,9 @@ axis.labels.format = function (def, name, encoding, stats) {
   } else if (encoding.isTypes(name, [N, O]) && encoding.axis(name).maxLabelLength) {
     setter(def,
       ['properties','labels','text','template'],
-      '{{data | truncate:' + encoding.axis(name).maxLabelLength + '}}'
-      );
+      '{{' + (encoding._vega2 ?  'datum.data': 'data') +
+      ' | truncate:' + encoding.axis(name).maxLabelLength + '}}'
+    );
   }
 
   return def;

--- a/src/compiler/data.js
+++ b/src/compiler/data.js
@@ -111,7 +111,7 @@ data.raw.transform.bin = function(encoding) {
     if (encoding.bin(encType)) {
       transform.push({
         type: 'bin',
-        field: encoding.fieldRef(encType, {nofn: true}),
+        field: field.name,
         output: encoding.fieldRef(encType),
         maxbins: encoding.bin(encType).maxbins
       });
@@ -170,7 +170,7 @@ data.aggregate = function(encoding) {
       }else {
         meas[field.aggregate + '|' + field.name] = {
           op: field.aggregate,
-          field: encoding.fieldRef(encType, {nofn: true})
+          field: field.name
         };
       }
     } else {

--- a/src/compiler/data.js
+++ b/src/compiler/data.js
@@ -126,7 +126,7 @@ data.raw.transform.filter = function(encoding) {
     var operator = filter.operator;
     var operands = filter.operands;
 
-    var d = 'd.' + (encoding._vega2 ? '' : 'data.');
+    var d = encoding._vega2 ? 'datum.' : 'd.data.';
 
     if (BINARY[operator]) {
       // expects a field and a value

--- a/src/compiler/data.js
+++ b/src/compiler/data.js
@@ -94,7 +94,7 @@ var BINARY = {
 data.raw.transform.time = function(encoding) {
   return encoding.reduce(function(transform, field, encType) {
     if (field.type === T && field.timeUnit) {
-      var fieldRef = encoding.fieldRef(encType, {nofn: true, d: !encoding._vega2, datum: encoding._vega2});
+      var fieldRef = encoding.fieldRef(encType, {nofn: true, datum: true});
 
       transform.push({
         type: 'formula',
@@ -126,7 +126,7 @@ data.raw.transform.filter = function(encoding) {
     var operator = filter.operator;
     var operands = filter.operands;
 
-    var d = encoding._vega2 ? 'datum.' : 'd.data.';
+    var d = 'datum.';
 
     if (BINARY[operator]) {
       // expects a field and a value
@@ -201,7 +201,7 @@ data.filterNonPositive = function(dataTable, encoding) {
     if (encoding.scale(encType).type === 'log') {
       dataTable.transform.push({
         type: 'filter',
-        test: encoding.fieldRef(encType, encoding._vega2 ? {datum: 1} : {d: 1}) + ' > 0'
+        test: encoding.fieldRef(encType, {datum: 1}) + ' > 0'
       });
     }
   });

--- a/src/compiler/data.js
+++ b/src/compiler/data.js
@@ -94,12 +94,12 @@ var BINARY = {
 data.raw.transform.time = function(encoding) {
   return encoding.reduce(function(transform, field, encType) {
     if (field.type === T && field.timeUnit) {
+      var fieldRef = encoding.fieldRef(encType, {nofn: true, d: !encoding._vega2, datum: encoding._vega2});
+
       transform.push({
         type: 'formula',
         field: encoding.fieldRef(encType),
-        expr: time.formula(field.timeUnit,
-                           encoding.fieldRef(encType, {nofn: true, d: true})
-                          )
+        expr: time.formula(field.timeUnit, fieldRef)
       });
     }
     return transform;
@@ -201,7 +201,7 @@ data.filterNonPositive = function(dataTable, encoding) {
     if (encoding.scale(encType).type === 'log') {
       dataTable.transform.push({
         type: 'filter',
-        test: encoding.fieldRef(encType, {d: 1}) + ' > 0'
+        test: encoding.fieldRef(encType, encoding._vega2 ? {datum: 1} : {d: 1}) + ' > 0'
       });
     }
   });

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -79,7 +79,6 @@ scale.domain = function (name, encoding, stats, opt) {
     return {
       data: STACKED,
       field: encoding.fieldRef(name, {
-        data: !encoding._vega2,
         prefn: (opt.facet ? 'max_' : '') + 'sum_'
       })
     };

--- a/src/compiler/sort.js
+++ b/src/compiler/sort.js
@@ -18,13 +18,13 @@ function sort(data, encoding, stats, opt) {
       var fields = sortBy.map(function(d) {
         return {
           op: d.aggregate,
-          field: vlfield.fieldRef(d, {nofn: true, data: !encoding._vega2})
+          field: vlfield.fieldRef(d, {nofn: true})
         };
       });
 
       var byClause = sortBy.map(function(d) {
         var reverse = (d.reverse ? '-' : '');
-        return reverse + vlfield.fieldRef(d, {data: !encoding._vega2});
+        return reverse + vlfield.fieldRef(d);
       });
 
       var dataName = sort.getDataName(encType);

--- a/src/compiler/time.js
+++ b/src/compiler/time.js
@@ -5,7 +5,7 @@ var util = require('../util'),
 
 var time = module.exports = {};
 
-var LONG_DATE = new Date(2014, 8, 17);
+var LONG_DATE = new Date(Date.UTC(2014, 8, 17));
 
 time.cardinality = function(field, stats, filterNull, type) {
   var timeUnit = field.timeUnit;

--- a/src/field.js
+++ b/src/field.js
@@ -16,9 +16,7 @@ var vlfield = module.exports = {};
  * @param field
  * @param opt
  *   opt.nofn -- exclude bin, aggregate, timeUnit
- *   opt.data - include 'data.'
  *   opt.datum - include 'datum.'
- *   opt.d - include 'd.'
  *   opt.fn - replace fn with custom function prefix
  *   opt.prefn - prepend fn with custom function prefix
 
@@ -28,8 +26,6 @@ vlfield.fieldRef = function(field, opt) {
   opt = opt || {};
 
   var f = (opt.datum ? 'datum.' : '') +
-          (opt.d ? 'd.' : '') +
-          (opt.data ? 'data.' : '') +
           (opt.prefn || ''),
     nofn = opt.nofn || opt.fn,
     name = field.name;

--- a/src/field.js
+++ b/src/field.js
@@ -17,6 +17,7 @@ var vlfield = module.exports = {};
  * @param opt
  *   opt.nofn -- exclude bin, aggregate, timeUnit
  *   opt.data - include 'data.'
+ *   opt.datum - include 'datum.'
  *   opt.d - include 'd.'
  *   opt.fn - replace fn with custom function prefix
  *   opt.prefn - prepend fn with custom function prefix
@@ -26,7 +27,8 @@ var vlfield = module.exports = {};
 vlfield.fieldRef = function(field, opt) {
   opt = opt || {};
 
-  var f = (opt.d ? 'd.' : '') +
+  var f = (opt.datum ? 'datum.' : '') +
+          (opt.d ? 'd.' : '') +
           (opt.data ? 'data.' : '') +
           (opt.prefn || ''),
     nofn = opt.nofn || opt.fn,

--- a/test/compiler/data.spec.js
+++ b/test/compiler/data.spec.js
@@ -36,7 +36,7 @@ describe('data', function () {
       var rawTransform = _data[0].transform;
       expect(rawTransform[rawTransform.length - 1]).to.eql({
         type: 'filter',
-        test: 'd.data.b > 0'
+        test: 'datum.b > 0'
       });
     });
   });
@@ -122,8 +122,8 @@ describe('data.raw', function() {
         var transform = data.raw.transform.bin(encoding);
         expect(transform[0]).to.eql({
           type: 'bin',
-          field: 'data.Acceleration',
-          output: 'data.bin_Acceleration',
+          field: 'Acceleration',
+          output: 'bin_Acceleration',
           maxbins: 15
         });
       });
@@ -135,8 +135,8 @@ describe('data.raw', function() {
 
         expect(transform[0]).to.eql({
           type: 'filter',
-          test: '(d.data.a!==null) && (d.data.Acceleration!==null)' +
-          ' && (d.data.a > b) && (d.data.c == d)'
+          test: '(datum.a!==null) && (datum.Acceleration!==null)' +
+          ' && (datum.a > b) && (datum.c == d)'
         });
       });
 
@@ -159,8 +159,8 @@ describe('data.raw', function() {
         var transform = data.raw.transform.time(encoding);
         expect(transform[0]).to.eql({
           type: 'formula',
-          field: 'data.year_a',
-          expr: 'utcyear(d.data.a)'
+          field: 'year_a',
+          expr: 'utcyear(datum.a)'
         });
       });
     });
@@ -199,10 +199,10 @@ describe('data.aggregated', function () {
       "source": "raw",
       "transform": [{
         "type": "aggregate",
-        "groupby": ["data.origin"],
+        "groupby": ["origin"],
         "fields": [{
           "op": "sum",
-          "field": "data.Acceleration"
+          "field": "Acceleration"
         },{
           "op": "count",
           "field": "*"

--- a/test/compiler/marks.spec.js
+++ b/test/compiler/marks.spec.js
@@ -80,7 +80,7 @@ describe('compile.marks', function() {
         expect(def.y).to.eql({value: e.bandSize(Y, mockLayout.y.useSmallBand) / 2});
       });
       it('should scale on x', function() {
-        expect(def.x).to.eql({scale: X, field: "data.year"});
+        expect(def.x).to.eql({scale: X, field: "year"});
       });
     });
 
@@ -92,7 +92,7 @@ describe('compile.marks', function() {
         expect(def.x).to.eql({value: e.bandSize(X, mockLayout.x.useSmallBand) / 2});
       });
       it('should scale on y', function() {
-        expect(def.y).to.eql({scale: Y, field: "data.year"});
+        expect(def.y).to.eql({scale: Y, field: "year"});
       });
     });
 
@@ -101,10 +101,10 @@ describe('compile.marks', function() {
           e = Encoding.fromSpec(f),
           def = marks.point.prop(e, mockLayout, {});
       it('should scale on x', function() {
-        expect(def.x).to.eql({scale: X, field: "data.year"});
+        expect(def.x).to.eql({scale: X, field: "year"});
       });
       it('should scale on y', function(){
-        expect(def.y).to.eql({scale: Y, field: "data.yield"});
+        expect(def.y).to.eql({scale: Y, field: "yield"});
       });
     });
 
@@ -114,7 +114,7 @@ describe('compile.marks', function() {
             e = Encoding.fromSpec(f),
             def = marks.point.prop(e, mockLayout, {});
         it('should have scale for size', function () {
-          expect(def.size).to.eql({scale: SIZE, field: "data.count"});
+          expect(def.size).to.eql({scale: SIZE, field: "count"});
         });
       });
 
@@ -123,7 +123,7 @@ describe('compile.marks', function() {
             e = Encoding.fromSpec(f),
             def = marks.point.prop(e, mockLayout, {});
         it('should have scale for color', function () {
-          expect(def.stroke).to.eql({scale: COLOR, field: "data.yield"});
+          expect(def.stroke).to.eql({scale: COLOR, field: "yield"});
         });
       });
 
@@ -132,7 +132,7 @@ describe('compile.marks', function() {
             e = Encoding.fromSpec(f),
             def = marks.point.prop(e, mockLayout, {});
         it('should have scale for shape', function () {
-          expect(def.shape).to.eql({scale: SHAPE, field: "data.bin_yield"});
+          expect(def.shape).to.eql({scale: SHAPE, field: "bin_yield"});
         });
       });
     });
@@ -144,10 +144,10 @@ describe('compile.marks', function() {
           e = Encoding.fromSpec(f),
           def = marks.line.prop(e, mockLayout, {});
       it('should have scale for x', function() {
-        expect(def.x).to.eql({scale: X, field: "data.year"});
+        expect(def.x).to.eql({scale: X, field: "year"});
       });
       it('should have scale for y', function(){
-        expect(def.y).to.eql({scale: Y, field: "data.yield"});
+        expect(def.y).to.eql({scale: Y, field: "yield"});
       });
     });
 
@@ -157,7 +157,7 @@ describe('compile.marks', function() {
             e = Encoding.fromSpec(f),
             def = marks.line.prop(e, mockLayout, {});
         it('should have scale for color', function () {
-          expect(def.stroke).to.eql({scale: COLOR, field: "data.Acceleration"});
+          expect(def.stroke).to.eql({scale: COLOR, field: "Acceleration"});
         });
       });
     });
@@ -169,10 +169,10 @@ describe('compile.marks', function() {
           e = Encoding.fromSpec(f),
           def = marks.area.prop(e, mockLayout, {});
       it('should have scale for x', function() {
-        expect(def.x).to.eql({scale: X, field: "data.Displacement"});
+        expect(def.x).to.eql({scale: X, field: "Displacement"});
       });
       it('should have scale for y', function(){
-        expect(def.y).to.eql({scale: Y, field: "data.Acceleration"});
+        expect(def.y).to.eql({scale: Y, field: "Acceleration"});
       });
     });
 
@@ -182,7 +182,7 @@ describe('compile.marks', function() {
             e = Encoding.fromSpec(f),
             def = marks.area.prop(e, mockLayout, {});
         it('should have scale for color', function () {
-          expect(def.fill).to.eql({scale: COLOR, field: "data.Miles_per_Gallon"});
+          expect(def.fill).to.eql({scale: COLOR, field: "Miles_per_Gallon"});
         });
       });
     });

--- a/test/compiler/scale.spec.js
+++ b/test/compiler/scale.spec.js
@@ -41,7 +41,7 @@ describe('vl.compile.scale', function() {
 
       expect(domain).to.eql({
         data: 'stacked',
-        field: 'data.max_sum_origin'
+        field: 'max_sum_origin'
       });
     });
 
@@ -60,7 +60,7 @@ describe('vl.compile.scale', function() {
 
       expect(domain).to.eql({
         data: 'stacked',
-        field: 'data.max_sum_sum_origin'
+        field: 'max_sum_sum_origin'
       });
     });
 

--- a/test/compiler/sort.spec.js
+++ b/test/compiler/sort.spec.js
@@ -29,28 +29,28 @@ describe('Sort', function() {
     expect(data[2].transform).to.deep.equal([
       {
         type: 'aggregate',
-        groupby: [ 'data.foo' ],
+        groupby: [ 'foo' ],
         fields: [{
-          field: 'data.bar',
+          field: 'bar',
           op: 'avg'
         }]
       },
-      { type: 'sort', by: [ 'data.avg_bar' ] }
+      { type: 'sort', by: [ 'avg_bar' ] }
     ]);
 
     expect(data[3].transform).to.deep.equal([
       {
         type: 'aggregate',
-        groupby: [ 'data.baz' ],
+        groupby: [ 'baz' ],
         fields: [{
-          field: 'data.bar',
+          field: 'bar',
           op: 'sum'
         }, {
-          field: 'data.foo',
+          field: 'foo',
           op: 'max'
         }]
       },
-      { type: 'sort', by: [ 'data.sum_bar', '-data.max_foo' ] }
+      { type: 'sort', by: [ 'sum_bar', '-max_foo' ] }
     ]);
   });
 });

--- a/test/compiler/stack.spec.js
+++ b/test/compiler/stack.spec.js
@@ -39,14 +39,14 @@ describe('vl.compile.stack()', function () {
         return t.type === 'aggregate';
       })[0];
       expect(tableAggrTransform.groupby.length).to.equal(2);
-      expect(tableAggrTransform.groupby.indexOf('data.bin_Cost__Total_$')).to.gt(-1);
+      expect(tableAggrTransform.groupby.indexOf('bin_Cost__Total_$')).to.gt(-1);
 
       var stackedData = vgSpec.data.filter(function(data) {
         return data.name === 'stacked';
       });
       expect(stackedData.length).to.equal(1);
       var stackedAggrTransform = stackedData[0].transform[0];
-      expect(stackedAggrTransform.groupby[0]).to.equal('data.bin_Cost__Total_$');
+      expect(stackedAggrTransform.groupby[0]).to.equal('bin_Cost__Total_$');
     });
   });
 
@@ -64,7 +64,7 @@ describe('vl.compile.stack()', function () {
         return t.type === 'aggregate';
       })[0];
       expect(tableAggrTransform.groupby.length).to.equal(2);
-      expect(tableAggrTransform.groupby.indexOf('data.bin_Cost__Total_$')).to.gt(-1);
+      expect(tableAggrTransform.groupby.indexOf('bin_Cost__Total_$')).to.gt(-1);
 
       var stackedData = vgSpec.data.filter(function(data) {
         return data.name === 'stacked';
@@ -72,7 +72,7 @@ describe('vl.compile.stack()', function () {
 
       expect(stackedData.length).to.equal(1);
       var stackedAggrTransform = stackedData[0].transform[0];
-      expect(stackedAggrTransform.groupby[0]).to.equal('data.bin_Cost__Total_$');
+      expect(stackedAggrTransform.groupby[0]).to.equal('bin_Cost__Total_$');
     });
   });
 


### PR DESCRIPTION
Let’s create a set of small PRs to merge to 0.8 so we can easily review changes.  
(And merge `0.8` to `master` when we are done with migration)

- update vega dependency in editor and gallery
- removed `_vega2` flag ~~turn on `_vega2` flag (let’s keep it for now, but we should eventually remove it)~~  
- replace `d.data` with `datum` in filter
- add `datum.` option to fieldRef and use it in time transform and filter non-positive value when log are presented when `encoding._vega2` is `true`
- eliminate `data.` from test.  
- eliminate outdated fieldRef options
- only use field.name where applicable
