### PR TITLE
More small modifications for vega2 migration

### DIFF
--- a/src/compiler/compiler.js
+++ b/src/compiler/compiler.js
@@ -58,7 +58,7 @@ compiler.compileEncoding = function (encoding, stats) {
       // global scales contains only time unit scales
       scales: compiler.time.scales(encoding),
       marks: [{
-        _name: 'cell',
+        name: 'cell',
         type: 'group',
         properties: {
           enter: {

--- a/src/compiler/facet.js
+++ b/src/compiler/facet.js
@@ -12,7 +12,7 @@ module.exports = faceting;
 function groupdef(name, opt) {
   opt = opt || {};
   return {
-    _name: name || undefined,
+    name: name || undefined,
     type: 'group',
     from: opt.from,
     properties: {

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -99,7 +99,8 @@ scale.domain = function (name, encoding, stats, opt) {
       (encoding.isType(name, T) && (!timeUnit || !time.isOrdinalFn(timeUnit)))
     )
   ) {
-    return {data: RAW, field: encoding.fieldRef(name, {nofn: !timeUnit})};
+
+    return {data: RAW, field: encoding.fieldRef(name)};
   }
 
   var data = encoding.sort(name, stats).length > 0 ?

--- a/src/compiler/subfacet.js
+++ b/src/compiler/subfacet.js
@@ -7,7 +7,7 @@ module.exports = subfaceting;
 function subfaceting(group, mdef, details, stack, encoding) {
   var m = group.marks;
   var g = {
-    _name: 'subfacet',
+    name: 'subfacet',
     type: 'group',
     from: mdef.from,
     properties: {


### PR DESCRIPTION
- use the new `name` mark property in groups
- fix incorrect fieldRef call

Please merge #602 first.  See branch specific diff [here](https://github.com/vega/vega-lite/compare/kw/filter-null...kw/vg2-more)