### PR TITLE
Extract `data.raw.transform.nullFilter` from `data.raw.transform.filter`

### DIFF
--- a/editor/bower.json
+++ b/editor/bower.json
@@ -15,6 +15,6 @@
     "tests"
   ],
   "dependencies": {
-    "vega": "^1.5.4"
+    "vega": "^2.2.6"
   }
 }

--- a/gallery/bower.json
+++ b/gallery/bower.json
@@ -15,7 +15,7 @@
     "tests"
   ],
   "dependencies": {
-    "vega": "^1.0.0",
+    "vega": "^2.2.6",
     "angular": "^1.4.3"
   }
 }

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -100,25 +100,7 @@ module.exports = (function() {
   };
 
   proto.filter = function() {
-    var filterNull = [],
-      fields = this.fields(),
-      self = this;
-
-    util.forEach(fields, function(fieldList, fieldName) {
-      if (fieldName === '*') return; //count
-
-      if ((self.config('filterNull').Q && fieldList.containsType[Q]) ||
-          (self.config('filterNull').T && fieldList.containsType[T]) ||
-          (self.config('filterNull').O && fieldList.containsType[O]) ||
-          (self.config('filterNull').N && fieldList.containsType[N])) {
-        filterNull.push({
-          operands: [fieldName],
-          operator: 'notNull'
-        });
-      }
-    });
-
-    return filterNull.concat(this._filter);
+    return this._filter;
   };
 
   // get "field" reference for vega

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -18,7 +18,6 @@ module.exports = (function() {
     this._enc = specExtended.encoding;
     this._config = specExtended.config;
     this._filter = specExtended.filter;
-    // this._vega2 = true;
   }
 
   var proto = Encoding.prototype;
@@ -106,7 +105,6 @@ module.exports = (function() {
   // get "field" reference for vega
   proto.fieldRef = function(et, opt) {
     opt = opt || {};
-    opt.data = !this._vega2 && (opt.data !== false);
     return vlfield.fieldRef(this._enc[et], opt);
   };
 

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -101,9 +101,9 @@ axis.grid = function(def, name, encoding, layout) {
           value: def.offset
         },
         x2: {
+          field: {group: 'mark.group.width'},
           offset: def.offset + (layout.cellWidth * 0.05),
           // default value(s) -- vega doesn't do recursive merge
-          group: 'mark.group.width',
           mult: 1
         },
         stroke: { value: encoding.config('cellGridColor') },
@@ -192,8 +192,9 @@ axis.labels.format = function (def, name, encoding, stats) {
   } else if (encoding.isTypes(name, [N, O]) && encoding.axis(name).maxLabelLength) {
     setter(def,
       ['properties','labels','text','template'],
-      '{{data | truncate:' + encoding.axis(name).maxLabelLength + '}}'
-      );
+      '{{ datum.data | truncate:' +
+      encoding.axis(name).maxLabelLength + '}}'
+    );
   }
 
   return def;

--- a/src/compiler/compiler.js
+++ b/src/compiler/compiler.js
@@ -62,8 +62,12 @@ compiler.compileEncoding = function (encoding, stats) {
         type: 'group',
         properties: {
           enter: {
-            width: layout.cellWidth ? {value: layout.cellWidth} : {group: 'width'},
-            height: layout.cellHeight ? {value: layout.cellHeight} : {group: 'height'}
+            width: layout.cellWidth ?
+                     {value: layout.cellWidth} :
+                     {field: {group: 'width'}},
+            height: layout.cellHeight ?
+                    {value: layout.cellHeight} :
+                    {field: {group: 'height'}}
           }
         }
       }]

--- a/src/compiler/data.js
+++ b/src/compiler/data.js
@@ -96,12 +96,12 @@ var BINARY = {
 data.raw.transform.time = function(encoding) {
   return encoding.reduce(function(transform, field, encType) {
     if (field.type === T && field.timeUnit) {
+      var fieldRef = encoding.fieldRef(encType, {nofn: true, datum: true});
+
       transform.push({
         type: 'formula',
         field: encoding.fieldRef(encType),
-        expr: time.formula(field.timeUnit,
-                           encoding.fieldRef(encType, {nofn: true, d: true})
-                          )
+        expr: time.formula(field.timeUnit, fieldRef)
       });
     }
     return transform;
@@ -113,7 +113,7 @@ data.raw.transform.bin = function(encoding) {
     if (encoding.bin(encType)) {
       transform.push({
         type: 'bin',
-        field: encoding.fieldRef(encType, {nofn: true}),
+        field: field.name,
         output: encoding.fieldRef(encType),
         maxbins: encoding.bin(encType).maxbins
       });
@@ -155,7 +155,7 @@ data.raw.transform.filter = function(encoding) {
     var operator = filter.operator;
     var operands = filter.operands;
 
-    var d = 'd.' + (encoding._vega2 ? '' : 'data.');
+    var d = 'datum.';
 
     if (BINARY[operator]) {
       // expects a field and a value
@@ -191,7 +191,7 @@ data.aggregate = function(encoding) {
       }else {
         meas[field.aggregate + '|' + field.name] = {
           op: field.aggregate,
-          field: encoding.fieldRef(encType, {nofn: true})
+          field: field.name
         };
       }
     } else {
@@ -222,7 +222,7 @@ data.filterNonPositive = function(dataTable, encoding) {
     if (encoding.scale(encType).type === 'log') {
       dataTable.transform.push({
         type: 'filter',
-        test: encoding.fieldRef(encType, {d: 1}) + ' > 0'
+        test: encoding.fieldRef(encType, {datum: 1}) + ' > 0'
       });
     }
   });

--- a/src/compiler/data.js
+++ b/src/compiler/data.js
@@ -123,12 +123,12 @@ data.raw.transform.bin = function(encoding) {
 };
 
 /**
- * @return {Object} filter transform for filtering null value based on filterNul config
+ * @return {Object} An array that might contain a filter transform for filtering null value based on filterNul config
  */
 data.raw.transform.nullFilter = function(encoding) {
   var filteredFields = util.reduce(encoding.fields(),
     function(filteredFields, fieldList, fieldName) {
-      if (fieldName === '*') return; //count
+      if (fieldName === '*') return filteredFields; //count
 
       // TODO(#597) revise how filterNull is structured.
       if ((encoding.config('filterNull').Q && fieldList.containsType[Q]) ||
@@ -138,14 +138,15 @@ data.raw.transform.nullFilter = function(encoding) {
         filteredFields.push(fieldName);
       }
       return filteredFields;
-    });
+    }, []);
 
-  return {
-    type: 'filter',
-    test: filteredFields.map(function(fieldName) {
-      return fieldName + '!==null';
-    }).join(' && ')
-  };
+  return filteredFields.length > 0 ?
+    [{
+      type: 'filter',
+      test: filteredFields.map(function(fieldName) {
+        return fieldName + '!==null';
+      }).join(' && ')
+    }] : [];
 };
 
 data.raw.transform.filter = function(encoding) {

--- a/src/compiler/data.js
+++ b/src/compiler/data.js
@@ -75,8 +75,10 @@ data.raw.formatParse = function(encoding) {
  * transforms for time unit, binning and filtering.
  */
 data.raw.transform = function(encoding) {
+  // null filter comes first so transforms are not performed on null values
   // time and bin should come before filter so we can filter by time and bin
-  return data.raw.transform.time(encoding).concat(
+  return data.raw.transform.nullFilter(encoding).concat(
+    data.raw.transform.time(encoding),
     data.raw.transform.bin(encoding),
     data.raw.transform.filter(encoding)
   );
@@ -120,6 +122,32 @@ data.raw.transform.bin = function(encoding) {
   }, []);
 };
 
+/**
+ * @return {Object} filter transform for filtering null value based on filterNul config
+ */
+data.raw.transform.nullFilter = function(encoding) {
+  var filteredFields = util.reduce(encoding.fields(),
+    function(filteredFields, fieldList, fieldName) {
+      if (fieldName === '*') return; //count
+
+      // TODO(#597) revise how filterNull is structured.
+      if ((encoding.config('filterNull').Q && fieldList.containsType[Q]) ||
+          (encoding.config('filterNull').T && fieldList.containsType[T]) ||
+          (encoding.config('filterNull').O && fieldList.containsType[O]) ||
+          (encoding.config('filterNull').N && fieldList.containsType[N])) {
+        filteredFields.push(fieldName);
+      }
+      return filteredFields;
+    });
+
+  return {
+    type: 'filter',
+    test: filteredFields.map(function(fieldName) {
+      return fieldName + '!==null';
+    }).join(' && ')
+  };
+};
+
 data.raw.transform.filter = function(encoding) {
   var filters = encoding.filter().reduce(function(f, filter) {
     var condition = '';
@@ -137,14 +165,6 @@ data.raw.transform.filter = function(encoding) {
       var op1 = operands[0];
       var op2 = operands[1];
       condition = d + op1 + ' ' + operator + ' ' + op2;
-    } else if (operator === 'notNull') {
-      // expects a number of fields
-      for (var j=0; j<operands.length; j++) {
-        condition += d + operands[j] + '!==null';
-        if (j < operands.length - 1) {
-          condition += ' && ';
-        }
-      }
     } else {
       util.warn('Unsupported operator: ', operator);
       return f;

--- a/src/compiler/facet.js
+++ b/src/compiler/facet.js
@@ -19,8 +19,8 @@ function groupdef(name, opt) {
       enter: {
         x: opt.x || undefined,
         y: opt.y || undefined,
-        width: opt.width || {group: 'width'},
-        height: opt.height || {group: 'height'}
+        width: opt.width || {field: {group: 'width'}},
+        height: opt.height || {field: {group: 'height'}}
       }
     },
     scales: opt.scales || undefined,

--- a/src/compiler/layout.js
+++ b/src/compiler/layout.js
@@ -99,6 +99,7 @@ function getMaxNumberLength(encoding, et, fieldStats) {
   return d3_format.format(format)(fieldStats.max).length;
 }
 
+// TODO(#600) revise this
 function getMaxLength(encoding, stats, et) {
   var field = encoding.field(et),
     fieldStats = stats[field.name];

--- a/src/compiler/marks.js
+++ b/src/compiler/marks.js
@@ -130,12 +130,15 @@ function bar_props(e, layout, style) {
   // y's & height
   if (e.isMeasure(Y)) {
     p.y = {scale: Y, field: e.fieldRef(Y)};
-    p.y2 = {group: 'height'};
+    p.y2 = {field: {group: 'height'}};
   } else {
     if (e.has(Y)) { // is ordinal
       p.yc = {scale: Y, field: e.fieldRef(Y)};
     } else {
-      p.y2 = {group: 'height', offset: -e.config('singleBarOffset')};
+      p.y2 = {
+        field: {group: 'height'},
+        offset: -e.config('singleBarOffset')
+      };
     }
 
     if (e.has(SIZE)) {
@@ -231,7 +234,7 @@ function line_props(e,layout, style) {
   if (e.has(Y)) {
     p.y = {scale: Y, field: e.fieldRef(Y)};
   } else if (!e.has(Y)) {
-    p.y = {group: 'height'};
+    p.y = {field: {group: 'height'}};
   }
 
   // stroke
@@ -273,7 +276,7 @@ function area_props(e, layout, style) {
   } else if (e.has(Y)) {
     p.y = {scale: Y, field: e.fieldRef(Y)};
   } else {
-    p.y = {group: 'height'};
+    p.y = {field: {group: 'height'}};
   }
 
   // fill

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -79,7 +79,6 @@ scale.domain = function (name, encoding, stats, opt) {
     return {
       data: STACKED,
       field: encoding.fieldRef(name, {
-        data: !encoding._vega2,
         prefn: (opt.facet ? 'max_' : '') + 'sum_'
       })
     };

--- a/src/compiler/sort.js
+++ b/src/compiler/sort.js
@@ -18,13 +18,13 @@ function sort(data, encoding, stats, opt) {
       var fields = sortBy.map(function(d) {
         return {
           op: d.aggregate,
-          field: vlfield.fieldRef(d, {nofn: true, data: !encoding._vega2})
+          field: vlfield.fieldRef(d, {nofn: true})
         };
       });
 
       var byClause = sortBy.map(function(d) {
         var reverse = (d.reverse ? '-' : '');
-        return reverse + vlfield.fieldRef(d, {data: !encoding._vega2});
+        return reverse + vlfield.fieldRef(d);
       });
 
       var dataName = sort.getDataName(encType);

--- a/src/compiler/subfacet.js
+++ b/src/compiler/subfacet.js
@@ -12,8 +12,8 @@ function subfaceting(group, mdef, details, stack, encoding) {
     from: mdef.from,
     properties: {
       enter: {
-        width: {group: 'width'},
-        height: {group: 'height'}
+        width: {field: {group: 'width'}},
+        height: {field: {group: 'height'}}
       }
     },
     marks: m

--- a/src/compiler/time.js
+++ b/src/compiler/time.js
@@ -5,7 +5,10 @@ var util = require('../util'),
 
 var time = module.exports = {};
 
-var LONG_DATE = new Date(2014, 8, 17);
+// 'Wednesday September 17 04:00:00 2014'
+// Wednesday is the longest date
+// September is the longest month (8 in javascript as it is zero-indexed).
+var LONG_DATE = new Date(Date.UTC(2014, 8, 17));
 
 time.cardinality = function(field, stats, filterNull, type) {
   var timeUnit = field.timeUnit;
@@ -53,6 +56,7 @@ time.maxLength = function(timeUnit, encoding) {
     case 'year':
       return 4; //'1998'
   }
+  // TODO(#600) revise this
   // no time unit
   var timeFormat = encoding.config('timeFormat');
   return d3_time_format.utcFormat(timeFormat)(LONG_DATE).length;

--- a/src/field.js
+++ b/src/field.js
@@ -16,8 +16,7 @@ var vlfield = module.exports = {};
  * @param field
  * @param opt
  *   opt.nofn -- exclude bin, aggregate, timeUnit
- *   opt.data - include 'data.'
- *   opt.d - include 'd.'
+ *   opt.datum - include 'datum.'
  *   opt.fn - replace fn with custom function prefix
  *   opt.prefn - prepend fn with custom function prefix
 
@@ -26,8 +25,7 @@ var vlfield = module.exports = {};
 vlfield.fieldRef = function(field, opt) {
   opt = opt || {};
 
-  var f = (opt.d ? 'd.' : '') +
-          (opt.data ? 'data.' : '') +
+  var f = (opt.datum ? 'datum.' : '') +
           (opt.prefn || ''),
     nofn = opt.nofn || opt.fn,
     name = field.name;

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -610,6 +610,7 @@ var config = {
     },
 
     // filter null
+    // TODO(#597) revise this config
     filterNull: {
       type: 'object',
       properties: {

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -613,6 +613,7 @@ var config = {
     filterNull: {
       type: 'object',
       properties: {
+        N: {type:'boolean', default: false},
         O: {type:'boolean', default: false},
         Q: {type:'boolean', default: true},
         T: {type:'boolean', default: true}

--- a/test/Encoding.spec.js
+++ b/test/Encoding.spec.js
@@ -14,29 +14,3 @@ describe('Encoding.fromShorthand()', function () {
   });
 });
 
-describe('encoding.filter()', function () {
-  var spec = {
-      marktype: 'point',
-      encoding: {
-        y: {name: 'Q', type:'Q'},
-        x: {name: 'T', type:'T'},
-        color: {name: 'O', type:'O'}
-      }
-    };
-  it('should add filterNull for Q and T by default', function () {
-    var encoding = Encoding.fromSpec(spec),
-      filter = encoding.filter();
-    expect(filter.length).to.equal(2);
-    expect(filter.indexOf({name: 'O', type:'O'})).to.equal(-1);
-  });
-
-  it('should add filterNull for O when specified', function () {
-    var encoding = Encoding.fromSpec(spec, {
-      config: {
-        filterNull: {O: true}
-      }
-    });
-    var filter = encoding.filter();
-    expect(filter.length).to.equal(3);
-  });
-});

--- a/test/compiler/data.spec.js
+++ b/test/compiler/data.spec.js
@@ -129,15 +129,47 @@ describe('data.raw', function() {
       });
     });
 
-    describe('filter', function () {
-      it('should return filter transform that include filter null', function () {
-        var transform = data.raw.transform.filter(encoding);
+    describe('nullFilter', function() {
+      var spec = {
+          marktype: 'point',
+          encoding: {
+            y: {name: 'Q', type:'Q'},
+            x: {name: 'T', type:'T'},
+            color: {name: 'O', type:'O'}
+          }
+        };
 
-        expect(transform[0]).to.eql({
-          type: 'filter',
-          test: '(d.data.a!==null) && (d.data.Acceleration!==null)' +
-          ' && (d.data.a > b) && (d.data.c == d)'
+      it('should add filterNull for Q and T by default', function () {
+        var encoding = Encoding.fromSpec(spec);
+        expect(data.raw.transform.nullFilter(encoding))
+          .to.eql([{
+            type: 'filter',
+            test: 'T!==null && Q!==null'
+          }]);
+      });
+
+      it('should add filterNull for O when specified', function () {
+        var encoding = Encoding.fromSpec(spec, {
+          config: {
+            filterNull: {O: true}
+          }
         });
+        expect(data.raw.transform.nullFilter(encoding))
+          .to.eql([{
+            type: 'filter',
+            test:'T!==null && Q!==null && O!==null'
+          }]);
+      });
+      // });
+    });
+
+    describe('filter', function () {
+      it('should return array that contains a filter transform', function () {
+        expect(data.raw.transform.filter(encoding))
+          .to.eql([{
+            type: 'filter',
+            test: '(d.data.a > b) && (d.data.c == d)'
+          }]);
       });
 
       it('should exclude unsupported operator', function () {
@@ -165,11 +197,12 @@ describe('data.raw', function() {
       });
     });
 
-    it('should time and bin before filter', function () {
+    it('should have null filter, timeUnit, bin then filter', function () {
       var transform = data.raw.transform(encoding);
-      expect(transform[0].type).to.eql('formula');
-      expect(transform[1].type).to.eql('bin');
-      expect(transform[2].type).to.eql('filter');
+      expect(transform[0].type).to.eql('filter');
+      expect(transform[1].type).to.eql('formula');
+      expect(transform[2].type).to.eql('bin');
+      expect(transform[3].type).to.eql('filter');
     });
 
   });

--- a/test/compiler/data.spec.js
+++ b/test/compiler/data.spec.js
@@ -36,7 +36,7 @@ describe('data', function () {
       var rawTransform = _data[0].transform;
       expect(rawTransform[rawTransform.length - 1]).to.eql({
         type: 'filter',
-        test: 'd.data.b > 0'
+        test: 'datum.b > 0'
       });
     });
   });
@@ -122,8 +122,8 @@ describe('data.raw', function() {
         var transform = data.raw.transform.bin(encoding);
         expect(transform[0]).to.eql({
           type: 'bin',
-          field: 'data.Acceleration',
-          output: 'data.bin_Acceleration',
+          field: 'Acceleration',
+          output: 'bin_Acceleration',
           maxbins: 15
         });
       });
@@ -191,8 +191,8 @@ describe('data.raw', function() {
         var transform = data.raw.transform.time(encoding);
         expect(transform[0]).to.eql({
           type: 'formula',
-          field: 'data.year_a',
-          expr: 'utcyear(d.data.a)'
+          field: 'year_a',
+          expr: 'utcyear(datum.a)'
         });
       });
     });
@@ -232,10 +232,10 @@ describe('data.aggregated', function () {
       "source": "raw",
       "transform": [{
         "type": "aggregate",
-        "groupby": ["data.origin"],
+        "groupby": ["origin"],
         "fields": [{
           "op": "sum",
-          "field": "data.Acceleration"
+          "field": "Acceleration"
         },{
           "op": "count",
           "field": "*"

--- a/test/compiler/marks.spec.js
+++ b/test/compiler/marks.spec.js
@@ -18,7 +18,7 @@ describe('compile.marks', function() {
           e = Encoding.fromSpec(f),
           def = marks.bar.prop(e, mockLayout, {});
       it('should end on axis', function() {
-        expect(def.y2).to.eql({group: 'height'});
+        expect(def.y2).to.eql({field: {group: 'height'}});
       });
       it('should has no height', function(){
         expect(def.height).to.be.undefined;
@@ -42,7 +42,7 @@ describe('compile.marks', function() {
           e = Encoding.fromSpec(f),
           def = marks.bar.prop(e, mockLayout, {});
       it('should end on axis', function() {
-        expect(def.y2).to.eql({group: 'height'});
+        expect(def.y2).to.eql({field: {group: 'height'}});
       });
       it('should have no height', function(){
         expect(def.height).to.be.undefined;
@@ -64,7 +64,7 @@ describe('compile.marks', function() {
       });
       it('should have y-offset', function(){
         expect(def.y2).to.eql({
-          group: 'height',
+          field: {group: 'height'},
           offset: -5 // -config.singleBarOffset
         });
       });
@@ -80,7 +80,7 @@ describe('compile.marks', function() {
         expect(def.y).to.eql({value: e.bandSize(Y, mockLayout.y.useSmallBand) / 2});
       });
       it('should scale on x', function() {
-        expect(def.x).to.eql({scale: X, field: "data.year"});
+        expect(def.x).to.eql({scale: X, field: "year"});
       });
     });
 
@@ -92,7 +92,7 @@ describe('compile.marks', function() {
         expect(def.x).to.eql({value: e.bandSize(X, mockLayout.x.useSmallBand) / 2});
       });
       it('should scale on y', function() {
-        expect(def.y).to.eql({scale: Y, field: "data.year"});
+        expect(def.y).to.eql({scale: Y, field: "year"});
       });
     });
 
@@ -101,10 +101,10 @@ describe('compile.marks', function() {
           e = Encoding.fromSpec(f),
           def = marks.point.prop(e, mockLayout, {});
       it('should scale on x', function() {
-        expect(def.x).to.eql({scale: X, field: "data.year"});
+        expect(def.x).to.eql({scale: X, field: "year"});
       });
       it('should scale on y', function(){
-        expect(def.y).to.eql({scale: Y, field: "data.yield"});
+        expect(def.y).to.eql({scale: Y, field: "yield"});
       });
     });
 
@@ -114,7 +114,7 @@ describe('compile.marks', function() {
             e = Encoding.fromSpec(f),
             def = marks.point.prop(e, mockLayout, {});
         it('should have scale for size', function () {
-          expect(def.size).to.eql({scale: SIZE, field: "data.count"});
+          expect(def.size).to.eql({scale: SIZE, field: "count"});
         });
       });
 
@@ -123,7 +123,7 @@ describe('compile.marks', function() {
             e = Encoding.fromSpec(f),
             def = marks.point.prop(e, mockLayout, {});
         it('should have scale for color', function () {
-          expect(def.stroke).to.eql({scale: COLOR, field: "data.yield"});
+          expect(def.stroke).to.eql({scale: COLOR, field: "yield"});
         });
       });
 
@@ -132,7 +132,7 @@ describe('compile.marks', function() {
             e = Encoding.fromSpec(f),
             def = marks.point.prop(e, mockLayout, {});
         it('should have scale for shape', function () {
-          expect(def.shape).to.eql({scale: SHAPE, field: "data.bin_yield"});
+          expect(def.shape).to.eql({scale: SHAPE, field: "bin_yield"});
         });
       });
     });
@@ -144,10 +144,10 @@ describe('compile.marks', function() {
           e = Encoding.fromSpec(f),
           def = marks.line.prop(e, mockLayout, {});
       it('should have scale for x', function() {
-        expect(def.x).to.eql({scale: X, field: "data.year"});
+        expect(def.x).to.eql({scale: X, field: "year"});
       });
       it('should have scale for y', function(){
-        expect(def.y).to.eql({scale: Y, field: "data.yield"});
+        expect(def.y).to.eql({scale: Y, field: "yield"});
       });
     });
 
@@ -157,7 +157,7 @@ describe('compile.marks', function() {
             e = Encoding.fromSpec(f),
             def = marks.line.prop(e, mockLayout, {});
         it('should have scale for color', function () {
-          expect(def.stroke).to.eql({scale: COLOR, field: "data.Acceleration"});
+          expect(def.stroke).to.eql({scale: COLOR, field: "Acceleration"});
         });
       });
     });
@@ -169,10 +169,10 @@ describe('compile.marks', function() {
           e = Encoding.fromSpec(f),
           def = marks.area.prop(e, mockLayout, {});
       it('should have scale for x', function() {
-        expect(def.x).to.eql({scale: X, field: "data.Displacement"});
+        expect(def.x).to.eql({scale: X, field: "Displacement"});
       });
       it('should have scale for y', function(){
-        expect(def.y).to.eql({scale: Y, field: "data.Acceleration"});
+        expect(def.y).to.eql({scale: Y, field: "Acceleration"});
       });
     });
 
@@ -182,7 +182,7 @@ describe('compile.marks', function() {
             e = Encoding.fromSpec(f),
             def = marks.area.prop(e, mockLayout, {});
         it('should have scale for color', function () {
-          expect(def.fill).to.eql({scale: COLOR, field: "data.Miles_per_Gallon"});
+          expect(def.fill).to.eql({scale: COLOR, field: "Miles_per_Gallon"});
         });
       });
     });

--- a/test/compiler/scale.spec.js
+++ b/test/compiler/scale.spec.js
@@ -41,7 +41,7 @@ describe('vl.compile.scale', function() {
 
       expect(domain).to.eql({
         data: 'stacked',
-        field: 'data.max_sum_origin'
+        field: 'max_sum_origin'
       });
     });
 
@@ -60,7 +60,7 @@ describe('vl.compile.scale', function() {
 
       expect(domain).to.eql({
         data: 'stacked',
-        field: 'data.max_sum_sum_origin'
+        field: 'max_sum_sum_origin'
       });
     });
 

--- a/test/compiler/sort.spec.js
+++ b/test/compiler/sort.spec.js
@@ -29,28 +29,28 @@ describe('Sort', function() {
     expect(data[2].transform).to.deep.equal([
       {
         type: 'aggregate',
-        groupby: [ 'data.foo' ],
+        groupby: [ 'foo' ],
         fields: [{
-          field: 'data.bar',
+          field: 'bar',
           op: 'avg'
         }]
       },
-      { type: 'sort', by: [ 'data.avg_bar' ] }
+      { type: 'sort', by: [ 'avg_bar' ] }
     ]);
 
     expect(data[3].transform).to.deep.equal([
       {
         type: 'aggregate',
-        groupby: [ 'data.baz' ],
+        groupby: [ 'baz' ],
         fields: [{
-          field: 'data.bar',
+          field: 'bar',
           op: 'sum'
         }, {
-          field: 'data.foo',
+          field: 'foo',
           op: 'max'
         }]
       },
-      { type: 'sort', by: [ 'data.sum_bar', '-data.max_foo' ] }
+      { type: 'sort', by: [ 'sum_bar', '-max_foo' ] }
     ]);
   });
 });

--- a/test/compiler/stack.spec.js
+++ b/test/compiler/stack.spec.js
@@ -39,14 +39,14 @@ describe('vl.compile.stack()', function () {
         return t.type === 'aggregate';
       })[0];
       expect(tableAggrTransform.groupby.length).to.equal(2);
-      expect(tableAggrTransform.groupby.indexOf('data.bin_Cost__Total_$')).to.gt(-1);
+      expect(tableAggrTransform.groupby.indexOf('bin_Cost__Total_$')).to.gt(-1);
 
       var stackedData = vgSpec.data.filter(function(data) {
         return data.name === 'stacked';
       });
       expect(stackedData.length).to.equal(1);
       var stackedAggrTransform = stackedData[0].transform[0];
-      expect(stackedAggrTransform.groupby[0]).to.equal('data.bin_Cost__Total_$');
+      expect(stackedAggrTransform.groupby[0]).to.equal('bin_Cost__Total_$');
     });
   });
 
@@ -64,7 +64,7 @@ describe('vl.compile.stack()', function () {
         return t.type === 'aggregate';
       })[0];
       expect(tableAggrTransform.groupby.length).to.equal(2);
-      expect(tableAggrTransform.groupby.indexOf('data.bin_Cost__Total_$')).to.gt(-1);
+      expect(tableAggrTransform.groupby.indexOf('bin_Cost__Total_$')).to.gt(-1);
 
       var stackedData = vgSpec.data.filter(function(data) {
         return data.name === 'stacked';
@@ -72,7 +72,7 @@ describe('vl.compile.stack()', function () {
 
       expect(stackedData.length).to.equal(1);
       var stackedAggrTransform = stackedData[0].transform[0];
-      expect(stackedAggrTransform.groupby[0]).to.equal('data.bin_Cost__Total_$');
+      expect(stackedAggrTransform.groupby[0]).to.equal('bin_Cost__Total_$');
     });
   });
 


### PR DESCRIPTION
Extract `data.raw.transform.nullFilter` from `data.raw.transform.filter` so that we can perform `nullFilter` before binning and timeUnit calculation but perform general filter afterward.

We can further optimize by only apply filter based on bin/time unit afterward so that we perform less transforms, but I do not think it is that important — at least for now.  

**Please merge #591 first!**