### PR TITLE
Move filter to data.filter and use Vega expression

### DIFF
--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -100,25 +100,7 @@ module.exports = (function() {
   };
 
   proto.filter = function() {
-    var filterNull = [],
-      fields = this.fields(),
-      self = this;
-
-    util.forEach(fields, function(fieldList, fieldName) {
-      if (fieldName === '*') return; //count
-
-      if ((self.config('filterNull').Q && fieldList.containsType[Q]) ||
-          (self.config('filterNull').T && fieldList.containsType[T]) ||
-          (self.config('filterNull').O && fieldList.containsType[O]) ||
-          (self.config('filterNull').N && fieldList.containsType[N])) {
-        filterNull.push({
-          operands: [fieldName],
-          operator: 'notNull'
-        });
-      }
-    });
-
-    return filterNull.concat(this._filter);
+    return this._filter;
   };
 
   // get "field" reference for vega

--- a/src/compiler/data.js
+++ b/src/compiler/data.js
@@ -141,13 +141,11 @@ data.raw.transform.nullFilter = function(encoding) {
 };
 
 data.raw.transform.filter = function(encoding) {
-  var filters = encoding.data().filter;
-  if (filters.length === 0) return [];
-
-  return [{
+  var filter = encoding.data().filter;
+  return filter ? [{
       type: 'filter',
-      test: '(' + filters.join(') && (') + ')'
-  }];
+      test: filter
+  }] : [];
 };
 
 data.aggregate = function(encoding) {

--- a/src/compiler/data.js
+++ b/src/compiler/data.js
@@ -123,12 +123,12 @@ data.raw.transform.bin = function(encoding) {
 };
 
 /**
- * @return {Object} filter transform for filtering null value based on filterNul config
+ * @return {Object} An array that might contain a filter transform for filtering null value based on filterNul config
  */
 data.raw.transform.nullFilter = function(encoding) {
   var filteredFields = util.reduce(encoding.fields(),
     function(filteredFields, fieldList, fieldName) {
-      if (fieldName === '*') return; //count
+      if (fieldName === '*') return filteredFields; //count
 
       // TODO(#597) revise how filterNull is structured.
       if ((encoding.config('filterNull').Q && fieldList.containsType[Q]) ||
@@ -138,14 +138,15 @@ data.raw.transform.nullFilter = function(encoding) {
         filteredFields.push(fieldName);
       }
       return filteredFields;
-    });
+    }, []);
 
-  return {
-    type: 'filter',
-    test: filteredFields.map(function(fieldName) {
-      return fieldName + '!==null';
-    }).join(' && ')
-  };
+  return filteredFields.length > 0 ?
+    [{
+      type: 'filter',
+      test: filteredFields.map(function(fieldName) {
+        return fieldName + '!==null';
+      }).join(' && ')
+    }] : [];
 };
 
 data.raw.transform.filter = function(encoding) {

--- a/src/compiler/data.js
+++ b/src/compiler/data.js
@@ -84,15 +84,6 @@ data.raw.transform = function(encoding) {
   );
 };
 
-var BINARY = {
-  '>':  true,
-  '>=': true,
-  '=':  true,
-  '!=': true,
-  '<':  true,
-  '<=': true
-};
-
 data.raw.transform.time = function(encoding) {
   return encoding.reduce(function(transform, field, encType) {
     if (field.type === T && field.timeUnit) {
@@ -150,34 +141,12 @@ data.raw.transform.nullFilter = function(encoding) {
 };
 
 data.raw.transform.filter = function(encoding) {
-  var filters = encoding.filter().reduce(function(f, filter) {
-    var condition = '';
-    var operator = filter.operator;
-    var operands = filter.operands;
-
-    var d = 'd.' + (encoding._vega2 ? '' : 'data.');
-
-    if (BINARY[operator]) {
-      // expects a field and a value
-      if (operator === '=') {
-        operator = '==';
-      }
-
-      var op1 = operands[0];
-      var op2 = operands[1];
-      condition = d + op1 + ' ' + operator + ' ' + op2;
-    } else {
-      util.warn('Unsupported operator: ', operator);
-      return f;
-    }
-    f.push('(' + condition + ')');
-    return f;
-  }, []);
+  var filters = encoding.data().filter;
   if (filters.length === 0) return [];
 
   return [{
       type: 'filter',
-      test: filters.join(' && ')
+      test: '(' + filters.join(') && (') + ')'
   }];
 };
 

--- a/src/compiler/data.js
+++ b/src/compiler/data.js
@@ -75,8 +75,10 @@ data.raw.formatParse = function(encoding) {
  * transforms for time unit, binning and filtering.
  */
 data.raw.transform = function(encoding) {
+  // null filter comes first so transforms are not performed on null values
   // time and bin should come before filter so we can filter by time and bin
-  return data.raw.transform.time(encoding).concat(
+  return data.raw.transform.nullFilter(encoding).concat(
+    data.raw.transform.time(encoding),
     data.raw.transform.bin(encoding),
     data.raw.transform.filter(encoding)
   );
@@ -120,6 +122,32 @@ data.raw.transform.bin = function(encoding) {
   }, []);
 };
 
+/**
+ * @return {Object} filter transform for filtering null value based on filterNul config
+ */
+data.raw.transform.nullFilter = function(encoding) {
+  var filteredFields = util.reduce(encoding.fields(),
+    function(filteredFields, fieldList, fieldName) {
+      if (fieldName === '*') return; //count
+
+      // TODO(#597) revise how filterNull is structured.
+      if ((encoding.config('filterNull').Q && fieldList.containsType[Q]) ||
+          (encoding.config('filterNull').T && fieldList.containsType[T]) ||
+          (encoding.config('filterNull').O && fieldList.containsType[O]) ||
+          (encoding.config('filterNull').N && fieldList.containsType[N])) {
+        filteredFields.push(fieldName);
+      }
+      return filteredFields;
+    });
+
+  return {
+    type: 'filter',
+    test: filteredFields.map(function(fieldName) {
+      return fieldName + '!==null';
+    }).join(' && ')
+  };
+};
+
 data.raw.transform.filter = function(encoding) {
   var filters = encoding.filter().reduce(function(f, filter) {
     var condition = '';
@@ -137,14 +165,6 @@ data.raw.transform.filter = function(encoding) {
       var op1 = operands[0];
       var op2 = operands[1];
       condition = d + op1 + ' ' + operator + ' ' + op2;
-    } else if (operator === 'notNull') {
-      // expects a number of fields
-      for (var j=0; j<operands.length; j++) {
-        condition += d + operands[j] + '!==null';
-        if (j < operands.length - 1) {
-          condition += ' && ';
-        }
-      }
     } else {
       util.warn('Unsupported operator: ', operator);
       return f;

--- a/src/compiler/layout.js
+++ b/src/compiler/layout.js
@@ -99,6 +99,7 @@ function getMaxNumberLength(encoding, et, fieldStats) {
   return d3_format.format(format)(fieldStats.max).length;
 }
 
+// TODO(#600) revise this
 function getMaxLength(encoding, stats, et) {
   var field = encoding.field(et),
     fieldStats = stats[field.name];

--- a/src/compiler/time.js
+++ b/src/compiler/time.js
@@ -5,7 +5,10 @@ var util = require('../util'),
 
 var time = module.exports = {};
 
-var LONG_DATE = new Date(2014, 8, 17);
+// 'Wednesday September 17 04:00:00 2014'
+// Wednesday is the longest date
+// September is the longest month (8 in javascript as it is zero-indexed).
+var LONG_DATE = new Date(Date.UTC(2014, 8, 17));
 
 time.cardinality = function(field, stats, filterNull, type) {
   var timeUnit = field.timeUnit;
@@ -53,6 +56,7 @@ time.maxLength = function(timeUnit, encoding) {
     case 'year':
       return 4; //'1998'
   }
+  // TODO(#600) revise this
   // no time unit
   var timeFormat = encoding.config('timeFormat');
   return d3_time_format.utcFormat(timeFormat)(LONG_DATE).length;

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -558,11 +558,8 @@ var data = {
     },
     // filter
     filter: {
-      type: 'array',
-      default: [],
-      items: {
-        type: 'string'
-      }
+      type: 'string',
+      default: undefined
     }
   }
 };

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -610,6 +610,7 @@ var config = {
     },
 
     // filter null
+    // TODO(#597) revise this config
     filterNull: {
       type: 'object',
       properties: {

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -613,6 +613,7 @@ var config = {
     filterNull: {
       type: 'object',
       properties: {
+        N: {type:'boolean', default: false},
         O: {type:'boolean', default: false},
         Q: {type:'boolean', default: true},
         T: {type:'boolean', default: true}

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -534,25 +534,6 @@ var text = merge(clone(onlyQuantitativeField), textMixin, sortMixin);
 
 // TODO add label
 
-var filter = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      operands: {
-        type: 'array',
-        items: {
-          type: ['string', 'boolean', 'integer', 'number']
-        }
-      },
-      operator: {
-        type: 'string',
-        enum: ['>', '>=', '=', '!=', '<', '<=', 'notNull']
-      }
-    }
-  }
-};
-
 var data = {
   type: 'object',
   properties: {
@@ -573,6 +554,14 @@ var data = {
       items: {
         type: 'object',
         additionalProperties: true
+      }
+    },
+    // filter
+    filter: {
+      type: 'array',
+      default: [],
+      items: {
+        type: 'string'
       }
     }
   }
@@ -783,7 +772,6 @@ schema.schema = {
         detail: detail
       }
     },
-    filter: filter,
     config: config
   }
 };

--- a/test/Encoding.spec.js
+++ b/test/Encoding.spec.js
@@ -14,29 +14,3 @@ describe('Encoding.fromShorthand()', function () {
   });
 });
 
-describe('encoding.filter()', function () {
-  var spec = {
-      marktype: 'point',
-      encoding: {
-        y: {name: 'Q', type:'Q'},
-        x: {name: 'T', type:'T'},
-        color: {name: 'O', type:'O'}
-      }
-    };
-  it('should add filterNull for Q and T by default', function () {
-    var encoding = Encoding.fromSpec(spec),
-      filter = encoding.filter();
-    expect(filter.length).to.equal(2);
-    expect(filter.indexOf({name: 'O', type:'O'})).to.equal(-1);
-  });
-
-  it('should add filterNull for O when specified', function () {
-    var encoding = Encoding.fromSpec(spec, {
-      config: {
-        filterNull: {O: true}
-      }
-    });
-    var filter = encoding.filter();
-    expect(filter.length).to.equal(3);
-  });
-});

--- a/test/compiler/data.spec.js
+++ b/test/compiler/data.spec.js
@@ -101,7 +101,7 @@ describe('data.raw', function() {
   describe('transform', function () {
     var encoding = Encoding.fromSpec({
       data: {
-        filter: ['datum.a > datum.b', 'datum.c === datum.d']
+        filter: 'datum.a > datum.b && datum.c === datum.d'
       },
       encoding: {
         x: {name: 'a', type:'T', timeUnit: 'year'},
@@ -164,21 +164,8 @@ describe('data.raw', function() {
         expect(data.raw.transform.filter(encoding))
           .to.eql([{
             type: 'filter',
-            test: '(datum.a > datum.b) && (datum.c === datum.d)'
+            test: 'datum.a > datum.b && datum.c === datum.d'
           }]);
-      });
-
-      it('should exclude unsupported operator', function () {
-        var badEncoding = Encoding.fromSpec({
-          filter: [{
-            operator: '*',
-            operands: ['a', 'b']
-          }]
-        });
-
-        var transform = data.raw.transform.filter(badEncoding);
-
-        expect(transform.length).to.equal(0);
       });
     });
 

--- a/test/compiler/data.spec.js
+++ b/test/compiler/data.spec.js
@@ -100,6 +100,9 @@ describe('data.raw', function() {
 
   describe('transform', function () {
     var encoding = Encoding.fromSpec({
+      data: {
+        filter: ['datum.a > datum.b', 'datum.c === datum.d']
+      },
       encoding: {
         x: {name: 'a', type:'T', timeUnit: 'year'},
         y: {
@@ -107,14 +110,7 @@ describe('data.raw', function() {
           'name': 'Acceleration',
           'type': 'Q'
         }
-      },
-      filter: [{
-        operator: '>',
-        operands: ['a', 'b']
-      },{
-        operator: '=',
-        operands: ['c', 'd']
-      }]
+      }
     });
 
     describe('bin', function() {
@@ -168,7 +164,7 @@ describe('data.raw', function() {
         expect(data.raw.transform.filter(encoding))
           .to.eql([{
             type: 'filter',
-            test: '(d.data.a > b) && (d.data.c == d)'
+            test: '(datum.a > datum.b) && (datum.c === datum.d)'
           }]);
       });
 

--- a/test/compiler/data.spec.js
+++ b/test/compiler/data.spec.js
@@ -129,15 +129,47 @@ describe('data.raw', function() {
       });
     });
 
-    describe('filter', function () {
-      it('should return filter transform that include filter null', function () {
-        var transform = data.raw.transform.filter(encoding);
+    describe('nullFilter', function() {
+      var spec = {
+          marktype: 'point',
+          encoding: {
+            y: {name: 'Q', type:'Q'},
+            x: {name: 'T', type:'T'},
+            color: {name: 'O', type:'O'}
+          }
+        };
 
-        expect(transform[0]).to.eql({
-          type: 'filter',
-          test: '(d.data.a!==null) && (d.data.Acceleration!==null)' +
-          ' && (d.data.a > b) && (d.data.c == d)'
+      it('should add filterNull for Q and T by default', function () {
+        var encoding = Encoding.fromSpec(spec);
+        expect(data.raw.transform.nullFilter(encoding))
+          .to.eql([{
+            type: 'filter',
+            test: 'T!==null && Q!==null'
+          }]);
+      });
+
+      it('should add filterNull for O when specified', function () {
+        var encoding = Encoding.fromSpec(spec, {
+          config: {
+            filterNull: {O: true}
+          }
         });
+        expect(data.raw.transform.nullFilter(encoding))
+          .to.eql([{
+            type: 'filter',
+            test:'T!==null && Q!==null && O!==null'
+          }]);
+      });
+      // });
+    });
+
+    describe('filter', function () {
+      it('should return array that contains a filter transform', function () {
+        expect(data.raw.transform.filter(encoding))
+          .to.eql([{
+            type: 'filter',
+            test: '(d.data.a > b) && (d.data.c == d)'
+          }]);
       });
 
       it('should exclude unsupported operator', function () {
@@ -165,11 +197,12 @@ describe('data.raw', function() {
       });
     });
 
-    it('should time and bin before filter', function () {
+    it('should have null filter, timeUnit, bin then filter', function () {
       var transform = data.raw.transform(encoding);
-      expect(transform[0].type).to.eql('formula');
-      expect(transform[1].type).to.eql('bin');
-      expect(transform[2].type).to.eql('filter');
+      expect(transform[0].type).to.eql('filter');
+      expect(transform[1].type).to.eql('formula');
+      expect(transform[2].type).to.eql('bin');
+      expect(transform[3].type).to.eql('filter');
     });
 
   });


### PR DESCRIPTION
Fixes #588  Move filter to data.filter and use Vega expression.

Now filter simply accepts a string, which should be a Vega expression.  

Please merge #599 first !  (See [Branch Specific Diff](https://github.com/uwdata/vega-lite/compare/kw/filter-null...kw/588-data.filter))


## TODO after merge
- [ ] update docs