### PR TITLE
Move filter to data.filter and use Vega expression.

### DIFF
--- a/src/compiler/data.js
+++ b/src/compiler/data.js
@@ -141,13 +141,11 @@ data.raw.transform.nullFilter = function(encoding) {
 };
 
 data.raw.transform.filter = function(encoding) {
-  var filters = encoding.data().filter;
-  if (filters.length === 0) return [];
-
-  return [{
+  var filter = encoding.data().filter;
+  return filter ? [{
       type: 'filter',
-      test: '(' + filters.join(') && (') + ')'
-  }];
+      test: filter
+  }] : [];
 };
 
 data.aggregate = function(encoding) {

--- a/src/compiler/data.js
+++ b/src/compiler/data.js
@@ -84,15 +84,6 @@ data.raw.transform = function(encoding) {
   );
 };
 
-var BINARY = {
-  '>':  true,
-  '>=': true,
-  '=':  true,
-  '!=': true,
-  '<':  true,
-  '<=': true
-};
-
 data.raw.transform.time = function(encoding) {
   return encoding.reduce(function(transform, field, encType) {
     if (field.type === T && field.timeUnit) {
@@ -150,34 +141,12 @@ data.raw.transform.nullFilter = function(encoding) {
 };
 
 data.raw.transform.filter = function(encoding) {
-  var filters = encoding.filter().reduce(function(f, filter) {
-    var condition = '';
-    var operator = filter.operator;
-    var operands = filter.operands;
-
-    var d = 'd.' + (encoding._vega2 ? '' : 'data.');
-
-    if (BINARY[operator]) {
-      // expects a field and a value
-      if (operator === '=') {
-        operator = '==';
-      }
-
-      var op1 = operands[0];
-      var op2 = operands[1];
-      condition = d + op1 + ' ' + operator + ' ' + op2;
-    } else {
-      util.warn('Unsupported operator: ', operator);
-      return f;
-    }
-    f.push('(' + condition + ')');
-    return f;
-  }, []);
+  var filters = encoding.data().filter;
   if (filters.length === 0) return [];
 
   return [{
       type: 'filter',
-      test: filters.join(' && ')
+      test: '(' + filters.join(') && (') + ')'
   }];
 };
 

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -558,11 +558,8 @@ var data = {
     },
     // filter
     filter: {
-      type: 'array',
-      default: [],
-      items: {
-        type: 'string'
-      }
+      type: 'string',
+      default: undefined
     }
   }
 };

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -534,25 +534,6 @@ var text = merge(clone(onlyQuantitativeField), textMixin, sortMixin);
 
 // TODO add label
 
-var filter = {
-  type: 'array',
-  items: {
-    type: 'object',
-    properties: {
-      operands: {
-        type: 'array',
-        items: {
-          type: ['string', 'boolean', 'integer', 'number']
-        }
-      },
-      operator: {
-        type: 'string',
-        enum: ['>', '>=', '=', '!=', '<', '<=', 'notNull']
-      }
-    }
-  }
-};
-
 var data = {
   type: 'object',
   properties: {
@@ -573,6 +554,14 @@ var data = {
       items: {
         type: 'object',
         additionalProperties: true
+      }
+    },
+    // filter
+    filter: {
+      type: 'array',
+      default: [],
+      items: {
+        type: 'string'
       }
     }
   }
@@ -783,7 +772,6 @@ schema.schema = {
         detail: detail
       }
     },
-    filter: filter,
     config: config
   }
 };

--- a/test/compiler/data.spec.js
+++ b/test/compiler/data.spec.js
@@ -101,7 +101,7 @@ describe('data.raw', function() {
   describe('transform', function () {
     var encoding = Encoding.fromSpec({
       data: {
-        filter: ['datum.a > datum.b', 'datum.c === datum.d']
+        filter: 'datum.a > datum.b && datum.c === datum.d'
       },
       encoding: {
         x: {name: 'a', type:'T', timeUnit: 'year'},
@@ -164,21 +164,8 @@ describe('data.raw', function() {
         expect(data.raw.transform.filter(encoding))
           .to.eql([{
             type: 'filter',
-            test: '(datum.a > datum.b) && (datum.c === datum.d)'
+            test: 'datum.a > datum.b && datum.c === datum.d'
           }]);
-      });
-
-      it('should exclude unsupported operator', function () {
-        var badEncoding = Encoding.fromSpec({
-          filter: [{
-            operator: '*',
-            operands: ['a', 'b']
-          }]
-        });
-
-        var transform = data.raw.transform.filter(badEncoding);
-
-        expect(transform.length).to.equal(0);
       });
     });
 

--- a/test/compiler/data.spec.js
+++ b/test/compiler/data.spec.js
@@ -100,6 +100,9 @@ describe('data.raw', function() {
 
   describe('transform', function () {
     var encoding = Encoding.fromSpec({
+      data: {
+        filter: ['datum.a > datum.b', 'datum.c === datum.d']
+      },
       encoding: {
         x: {name: 'a', type:'T', timeUnit: 'year'},
         y: {
@@ -107,14 +110,7 @@ describe('data.raw', function() {
           'name': 'Acceleration',
           'type': 'Q'
         }
-      },
-      filter: [{
-        operator: '>',
-        operands: ['a', 'b']
-      },{
-        operator: '=',
-        operands: ['c', 'd']
-      }]
+      }
     });
 
     describe('bin', function() {
@@ -168,7 +164,7 @@ describe('data.raw', function() {
         expect(data.raw.transform.filter(encoding))
           .to.eql([{
             type: 'filter',
-            test: '(d.data.a > b) && (d.data.c == d)'
+            test: '(datum.a > datum.b) && (datum.c === datum.d)'
           }]);
       });
 


### PR DESCRIPTION
Fixes #588  Move filter to data.filter and use Vega expression.

Now filter simply accepts a string, which should be a Vega expression.  

Please merge #596 first !  (See [Branch Specific Diff](https://github.com/uwdata/vega-lite/compare/kw/vg2-more...kw/588-data.filter))


## TODO after merge
- [ ] update docs (`filter` => `data.filter`)