### PR TITLE
Remove outdated legends error log, set default legends orient

### DIFF
--- a/src/compiler/legend.js
+++ b/src/compiler/legend.js
@@ -14,22 +14,19 @@ legend.defs = function(encoding, style) {
 
   if (encoding.has(COLOR) && encoding.field(COLOR).legend) {
     defs.push(legend.def(COLOR, encoding, {
-      fill: COLOR,
-      orient: 'right'
+      fill: COLOR
     }, style));
   }
 
   if (encoding.has(SIZE) && encoding.field(SIZE).legend) {
     defs.push(legend.def(SIZE, encoding, {
-      size: SIZE,
-      orient: defs.length === 1 ? 'left' : 'right'
+      size: SIZE
     }, style));
   }
 
   if (encoding.has(SHAPE) && encoding.field(SHAPE).legend) {
     defs.push(legend.def(SHAPE, encoding, {
-      shape: SHAPE,
-      orient: defs.length === 1 ? 'left' : 'right'
+      shape: SHAPE
     }, style));
   }
   return defs;
@@ -39,6 +36,8 @@ legend.def = function(name, encoding, def, style) {
   var timeUnit = encoding.field(name).timeUnit;
 
   def.title = legend.title(name, encoding);
+  def.orient = encoding.field(name).legend.orient;
+
   def = legend.style(name, encoding, def, style);
 
   if (encoding.isType(name, T) &&

--- a/src/compiler/legend.js
+++ b/src/compiler/legend.js
@@ -27,9 +27,6 @@ legend.defs = function(encoding, style) {
   }
 
   if (encoding.has(SHAPE) && encoding.field(SHAPE).legend) {
-    if (defs.length === 2) {
-      console.error('Vega-lite currently only supports two legends');
-    }
     defs.push(legend.def(SHAPE, encoding, {
       shape: SHAPE,
       orient: defs.length === 1 ? 'left' : 'right'

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -281,6 +281,11 @@ var legendMixin = {
           type: 'string',
           default: undefined,
           description: 'A title for the legend. (Shows field name and its function by default.)'
+        },
+        orient: {
+          type: 'string',
+          default: 'right',
+          description: 'The orientation of the legend. One of "left" or "right". This determines how the legend is positioned within the scene. The default is "right".'
         }
       }
     }


### PR DESCRIPTION
Fixes #131  

- set legend's orient to right by default (similar to Vega)
- remove outdated comment regarding multiple legends. (This is automatically fixed when we migrate to vega 2) 