### PR TITLE
Migrate Stack to Vega 2

### DIFF
--- a/gallery/gallery.js
+++ b/gallery/gallery.js
@@ -64,6 +64,17 @@ var EXAMPLES = [
       'data': {'url': 'data/cars.json'}
     }
   },{
+    title: 'Stacked Bar Chart',
+    spec: {
+      'marktype': 'bar',
+      'encoding': {
+        'x': {'name': 'variety','type': 'N'},
+        'y': {'name': 'yield','type': 'Q','aggregate': 'sum'},
+        'color': {'name': 'site', 'type': 'N'}
+      },
+      'data': {'url': 'data/barley.json'}
+    }
+  },{
     title: 'Barleys',
     spec: {
       data: {url: 'data/barley.json'},

--- a/gallery/gallery.js
+++ b/gallery/gallery.js
@@ -37,7 +37,7 @@ var EXAMPLES = [
       marktype: 'line',
       encoding: {
         x: {'name': 'Year','type': 'T','timeUnit': 'year'},
-        y: {'name': 'Horsepower','type': 'Q','aggregate': 'avg'}
+        y: {'name': 'Horsepower','type': 'Q','aggregate': 'mean'}
       },
       data: {'url': 'data/cars.json'}
     }
@@ -133,8 +133,8 @@ var EXAMPLES = [
       'marktype': 'text',
       'encoding': {
         'row': {'name': 'Origin','type': 'O'},
-        'col': {'axis': {'maxLabelLength': 25},'name': 'Cylinders','type': 'O'},
-        'color': {'name': 'Horsepower','type': 'Q','aggregate': 'avg'},
+        'col': {'name': 'Cylinders','type': 'O'},
+        'color': {'name': 'Horsepower','type': 'Q','aggregate': 'mean'},
         'text': {'name': '*','type': 'Q','aggregate': 'count'}
       },
       'data': {'url': 'data/cars.json'}
@@ -146,11 +146,7 @@ var EXAMPLES = [
       'encoding': {
         'x': {'name': 'Year','type': 'T','timeUnit': 'year'},
         'y': {'name': 'Weight_in_lbs','type': 'Q','aggregate': 'sum'},
-        'color': {
-          'scale': {'quantitativeRange': ['#AFC6A3','#09622A']},
-          'name': 'Cylinders',
-          'type': 'O'
-        }
+        'color': {'name': 'Cylinders', 'type': 'O'}
       },
       'data': {'url': 'data/cars.json'}
     }

--- a/src/compiler/compiler.js
+++ b/src/compiler/compiler.js
@@ -87,7 +87,7 @@ compiler.compileEncoding = function (encoding, stats) {
   var details = encoding.details(),
     stack = encoding.isAggregate() && details.length > 0 && compiler.stack(spec.data, encoding, mdef); // modify spec.data, mdef.{from,properties}
 
-  if (details.length > 0 && (stack || lineType)) {
+  if (details.length > 0 && lineType) {
     //subfacet to group stack / line together in one group
     compiler.subfacet(group, mdef, details, stack, encoding);
   }

--- a/src/compiler/stack.js
+++ b/src/compiler/stack.js
@@ -53,17 +53,32 @@ function stacking(data, encoding, mdef) {
 
   data.push(stacked);
 
+  var valName = encoding.fieldName(val);
+  var startField = valName + '_start';
+  var endField = valName + '_end';
+
   // add stack transform to mark
   mdef.from.transform = [{
     type: 'stack',
-    point: encoding.fieldRef(dim),
-    height: encoding.fieldRef(val),
-    output: {y1: val, y0: val + '2'}
+    groupby: encoding.fieldRef(dim),
+    field: encoding.fieldRef(val),
+    // TODO consider adding sortby
+    // FIXME: figure out why renamed output does not work
+    output: {layout_start: startField, layout_end: endField}
   }];
 
   // TODO: This is super hack-ish -- consolidate into modular mark properties?
-  mdef.properties.update[val] = mdef.properties.enter[val] = {scale: val, field: val};
-  mdef.properties.update[val + '2'] = mdef.properties.enter[val + '2'] = {scale: val, field: val + '2'};
+  mdef.properties.update[val] = mdef.properties.enter[val] = {
+    scale: val,
+    // field: startField
+    field: 'layout_start'
+  };
+  mdef.properties.update[val + '2'] = mdef.properties.enter[val + '2'] = {
+    scale: val,
+    // TODO: use renamed output
+    // field: endField
+    field: 'layout_end'
+  };
 
   return val; //return stack encoding
 }

--- a/src/compiler/stack.js
+++ b/src/compiler/stack.js
@@ -66,7 +66,7 @@ function stacking(data, encoding, mdef) {
     output: {start: startField, end: endField}
   }];
 
-  // TODO: This is super hack-ish -- consolidate into modular mark properties?
+  // TODO(#276): This is super hack-ish -- consolidate into modular mark properties?
   mdef.properties.update[val] = mdef.properties.enter[val] = {
     scale: val,
     field: startField

--- a/src/compiler/stack.js
+++ b/src/compiler/stack.js
@@ -62,7 +62,7 @@ function stacking(data, encoding, mdef) {
     type: 'stack',
     groupby: encoding.fieldRef(dim),
     field: encoding.fieldRef(val),
-    // TODO consider adding sortby
+    // TODO(#39) add sort by
     output: {start: startField, end: endField}
   }];
 

--- a/src/compiler/stack.js
+++ b/src/compiler/stack.js
@@ -63,21 +63,17 @@ function stacking(data, encoding, mdef) {
     groupby: encoding.fieldRef(dim),
     field: encoding.fieldRef(val),
     // TODO consider adding sortby
-    // FIXME: figure out why renamed output does not work
-    output: {layout_start: startField, layout_end: endField}
+    output: {start: startField, end: endField}
   }];
 
   // TODO: This is super hack-ish -- consolidate into modular mark properties?
   mdef.properties.update[val] = mdef.properties.enter[val] = {
     scale: val,
-    // field: startField
-    field: 'layout_start'
+    field: startField
   };
   mdef.properties.update[val + '2'] = mdef.properties.enter[val + '2'] = {
     scale: val,
-    // TODO: use renamed output
-    // field: endField
-    field: 'layout_end'
+    field: endField
   };
 
   return val; //return stack encoding

--- a/src/compiler/subfacet.js
+++ b/src/compiler/subfacet.js
@@ -24,7 +24,7 @@ function subfaceting(group, mdef, details, stack, encoding) {
 
   //TODO test LOD -- we should support stack / line without color (LOD) field
   var trans = (g.from.transform || (g.from.transform = []));
-  trans.unshift({type: 'facet', groupby: details});
+  trans.push({type: 'facet', groupby: details});
 
   if (stack && encoding.has(COLOR)) {
     trans.unshift({type: 'sort', by: encoding.fieldRef(COLOR)});

--- a/src/compiler/subfacet.js
+++ b/src/compiler/subfacet.js
@@ -26,6 +26,7 @@ function subfaceting(group, mdef, details, stack, encoding) {
   var trans = (g.from.transform || (g.from.transform = []));
   trans.push({type: 'facet', groupby: details});
 
+  // TODO: understand why we need this sort transform and write comment
   if (stack && encoding.has(COLOR)) {
     trans.unshift({type: 'sort', by: encoding.fieldRef(COLOR)});
   }


### PR DESCRIPTION
Fixes #412  and part of #459

- Use vega2 stack's parameter and rename it to `<field_name>_start|end`, remove the need to add facet transform before stacking
- Add a stacked bar chart example 
- Make facet comes after stack for stacked area chart  (This makes stacked area chart looks almost right but still looks weird due to #307 – see [example screenshot] (https://www.evernote.com/l/AAi8LLKSH3lDgZYIOTW39BQDzY4As6Vy2hk))

Please merge #617 first !  (See [Branch Specific Diff](https://github.com/uwdata/vega-lite/compare/kw/scale-refactor...kw/vg2-stack))