### PR TITLE
Update Aggregate Function List to be similar to Vega 2

### DIFF
--- a/editor/editor.js
+++ b/editor/editor.js
@@ -204,9 +204,9 @@ vled.init = function() {
     document.getElementById('vlspec').value = JSON.stringify({
       marktype: 'point',
       encoding: {
-        x: {type: 'Q',name: 'yield',aggr: 'avg'},
+        x: {type: 'Q',name: 'yield',aggr: 'mean'},
         y: {
-          sort: [{name: 'yield', aggr: 'avg', reverse: false}],
+          sort: [{name: 'yield', aggr: 'mean', reverse: false}],
           type: 'N',
           name: 'variety'
         },

--- a/gallery/gallery.js
+++ b/gallery/gallery.js
@@ -37,7 +37,7 @@ var EXAMPLES = [
       marktype: 'line',
       encoding: {
         x: {'name': 'Year','type': 'T','timeUnit': 'year'},
-        y: {'name': 'Horsepower','type': 'Q','aggregate': 'avg'}
+        y: {'name': 'Horsepower','type': 'Q','aggregate': 'mean'}
       },
       data: {'url': 'data/cars.json'}
     }
@@ -134,7 +134,7 @@ var EXAMPLES = [
       'encoding': {
         'row': {'name': 'Origin','type': 'O'},
         'col': {'axis': {'maxLabelLength': 25},'name': 'Cylinders','type': 'O'},
-        'color': {'name': 'Horsepower','type': 'Q','aggregate': 'avg'},
+        'color': {'name': 'Horsepower','type': 'Q','aggregate': 'mean'},
         'text': {'name': '*','type': 'Q','aggregate': 'count'}
       },
       'data': {'url': 'data/cars.json'}

--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -125,8 +125,7 @@ module.exports = (function() {
     }
     var fn = this._enc[et].aggregate || this._enc[et].timeUnit || (this._enc[et].bin && 'bin');
     if (fn) {
-      var uppercase = fn === 'avg' ? 'MEAN' :fn.toUpperCase();
-      return uppercase + '(' + this._enc[et].name + ')';
+      return fn.toUpperCase() + '(' + this._enc[et].name + ')';
     } else {
       return this._enc[et].name;
     }

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -24,7 +24,7 @@ schema.aggregate = {
     Q: VALID_OPS,
     O: ['median','min','max'],
     N: [],
-    T: ['avg', 'median', 'min', 'max'],
+    T: ['mean', 'median', 'min', 'max'],
     '': ['count']
   },
   supportedTypes: toMap([Q, N, O, T, ''])

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -8,6 +8,8 @@ var schema = module.exports = {},
   toMap = util.toMap,
   colorbrewer = require('colorbrewer');
 
+var VALID_OPS = require('vega/src/transforms/Aggregate').VALID_OPS;
+
 schema.util = require('./schemautil');
 
 schema.marktype = {
@@ -17,9 +19,9 @@ schema.marktype = {
 
 schema.aggregate = {
   type: 'string',
-  enum: ['avg', 'sum', 'median', 'min', 'max', 'count'],
+  enum: VALID_OPS,
   supportedEnums: {
-    Q: ['avg', 'median', 'sum', 'min', 'max', 'count'],
+    Q: VALID_OPS,
     O: ['median','min','max'],
     N: [],
     T: ['avg', 'median', 'min', 'max'],
@@ -236,7 +238,7 @@ var sortMixin = {
         },
         op: {
           type: 'string',
-          enum: ['avg', 'sum', 'min', 'max', 'count'],
+          enum: VALID_OPS,
           description: 'The field name to aggregate over.'
         }
       }

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -8,7 +8,15 @@ var schema = module.exports = {},
   toMap = util.toMap,
   colorbrewer = require('colorbrewer');
 
-var VALID_OPS = require('vega/src/transforms/Aggregate').VALID_OPS;
+
+var VALID_OPS = [
+  'values', 'count', 'valid', 'missing', 'distinct',
+  'sum', 'mean', 'average', 'variance', 'variancep', 'stdev',
+  'stdevp', 'median', 'q1', 'q3', 'modeskew', 'min', 'max',
+  'argmin', 'argmax'
+];
+// TODO(#620): refer to VALID_OPS in Vega schema instead
+// var VALID_OPS = require('vega/src/transforms/Aggregate').VALID_OPS;
 
 schema.util = require('./schemautil');
 

--- a/test/Encoding.spec.js
+++ b/test/Encoding.spec.js
@@ -6,7 +6,7 @@ var Encoding = require('../src/Encoding');
 
 describe('Encoding.fromShorthand()', function () {
   it('should parse shorthand correctly', function () {
-    var shorthand = 'mark=point|x=Effect__Amount_of_damage,O|y=avg_Cost__Total_$,Q';
+    var shorthand = 'mark=point|x=Effect__Amount_of_damage,O|y=mean_Cost__Total_$,Q';
     var encoding = Encoding.fromShorthand(shorthand);
     expect(encoding.has('y')).ok;
     expect(encoding.has('x')).ok;

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -8,7 +8,7 @@ f.bars.log_ver = {
   "marktype": "bar",
   "encoding": {
     "x": {"bin": {"maxbins": 15},"type": "Q","name": "IMDB_Rating"},
-    "y": {"scale": {"type": "log"},"type": "Q","name": "US_Gross","aggregate": "avg"}
+    "y": {"scale": {"type": "log"},"type": "Q","name": "US_Gross","aggregate": "mean"}
   },
   "data": {"url": "data/movies.json"}
 };
@@ -17,7 +17,7 @@ f.bars.log_hor = {
   "marktype": "bar",
   "encoding": {
     "y": {"bin": {"maxbins": 15},"type": "Q","name": "IMDB_Rating"},
-    "x": {"scale": {"type": "log"},"type": "Q","name": "US_Gross","aggregate": "avg"}
+    "x": {"scale": {"type": "log"},"type": "Q","name": "US_Gross","aggregate": "mean"}
   },
   "data": {"url": "data/movies.json"}
 };
@@ -42,7 +42,7 @@ f.stack = {};
 f.stack.binY = {
   "marktype": "bar",
   "encoding": {
-    "x": {"type": "Q","name": "Cost__Other","aggregate": "avg"},
+    "x": {"type": "Q","name": "Cost__Other","aggregate": "mean"},
     "y": {"bin": true,"type": "Q","name": "Cost__Total_$"},
     "color": {"type": "O","name": "Effect__Amount_of_damage"}
   }
@@ -50,7 +50,7 @@ f.stack.binY = {
 f.stack.binX = {
   "marktype": "bar",
   "encoding": {
-    "y": {"type": "Q","name": "Cost__Other","aggregate": "avg"},
+    "y": {"type": "Q","name": "Cost__Other","aggregate": "mean"},
     "x": {"bin": true,"type": "Q","name": "Cost__Total_$"},
     "color": {"type": "O","name": "Effect__Amount_of_damage"}
   }


### PR DESCRIPTION
Fixes #448, Fixes #611, Related #620 

- `avg` => `mean`
- add all supported aggregation in Vega 2

Please merge #615 first !  (See [Branch Specific Diff](https://github.com/uwdata/vega-lite/compare/kw/vg2-stack...kw/448-aggregate-fn))

~~TODO~~
- [ ] ~~Since this is only used in schema, should we install vega as dependency or devDependency?~~
- [ ] ~~When I add the require('vega/src/...') I got the following error~~

```
Error: Cannot find module 'through'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/kanitw/Documents/_code/_idl/_visrec/vega-lite/node_modules/vega/scripts/strip-schema.js:8:15)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
```


