### PR TITLE
Simplify stack code

### DIFF
--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -260,10 +260,37 @@ module.exports = (function() {
       spec.encoding.color;
   };
 
-  proto.isStack = function() {
-    // FIXME update this once we have control for stack ...
-    return (this.is('bar') || this.is('area')) && this.has('color');
+  /**
+   * Check if the encoding should be stacked and return the stack dimenstion and value fields.
+   * @return {Object} An object containing two properties:
+   * - dimension - the dimension field
+   * - value - the value field
+   */
+  proto.stack = function() {
+    if ((this.is('bar') || this.is('area')) &&
+        (this.has('color') || this.has('detail')) &&
+        // TODO(#) update this once we have control for stack ...
+        this.isAggregate()) {
+
+      var isXMeasure = this.isMeasure(X);
+      var isYMeasure = this.isMeasure(Y);
+
+      if (isXMeasure && !isYMeasure) {
+        return {
+          dimension: Y,
+          value: X
+        };
+      } else if (isYMeasure && !isXMeasure) {
+        return {
+          dimension: X,
+          value: Y
+        };
+      }
+    }
+    return null; // no stack encoding
   };
+
+
 
   proto.details = function() {
     var encoding = this;

--- a/src/compiler/compiler.js
+++ b/src/compiler/compiler.js
@@ -99,7 +99,9 @@ compiler.compileEncoding = function (encoding, stats) {
   // auto-sort line/area values
   if (lineType && encoding.config('autoSortLine')) {
     var f = (encoding.isMeasure(X) && encoding.isDimension(Y)) ? Y : X;
-    if (!mdef.from) mdef.from = {};
+    if (!mdef.from) {
+      mdef.from = {};
+    }
     // TODO: why - ?
     mdef.from.transform = [{type: 'sort', by: '-' + encoding.fieldRef(f)}];
   }
@@ -115,10 +117,13 @@ compiler.compileEncoding = function (encoding, stats) {
     spec.legends = legend.defs(encoding, style);
   } else {
     group.scales = scale.defs(singleScaleNames, encoding, layout, stats);
-
     group.axes = [];
-    if (encoding.has(X)) group.axes.push(axis.def(X, encoding, layout, stats));
-    if (encoding.has(Y)) group.axes.push(axis.def(Y, encoding, layout, stats));
+    if (encoding.has(X)) {
+      group.axes.push(axis.def(X, encoding, layout, stats));
+    }
+    if (encoding.has(Y)) {
+      group.axes.push(axis.def(Y, encoding, layout, stats));
+    }
 
     group.legends = legend.defs(encoding, style);
   }

--- a/src/compiler/compiler.js
+++ b/src/compiler/compiler.js
@@ -80,16 +80,20 @@ compiler.compileEncoding = function (encoding, stats) {
     mdefs = group.marks = marks.def(encoding, layout, style, stats),
     mdef = mdefs[mdefs.length - 1];  // TODO: remove this dirty hack by refactoring the whole flow
 
+  var stack = encoding.stack();
+  if (stack) {
+    // modify mdef.{from,properties}
+    compiler.stack(encoding, mdef, stack);
+  }
+
   var lineType = marks[encoding.marktype()].line;
 
   // handle subfacets
-
-  var details = encoding.details(),
-    stack = encoding.isAggregate() && details.length > 0 && compiler.stack(spec.data, encoding, mdef); // modify spec.data, mdef.{from,properties}
+  var details = encoding.details();
 
   if (details.length > 0 && lineType) {
     //subfacet to group stack / line together in one group
-    compiler.subfacet(group, mdef, details, stack, encoding);
+    compiler.subfacet(group, mdef, details, encoding);
   }
 
   // auto-sort line/area values
@@ -107,10 +111,10 @@ compiler.compileEncoding = function (encoding, stats) {
 
   // Small Multiples
   if (encoding.has(ROW) || encoding.has(COL)) {
-    spec = compiler.facet(group, encoding, layout, spec, singleScaleNames, stack, stats);
+    spec = compiler.facet(group, encoding, layout, spec, singleScaleNames, stats);
     spec.legends = legend.defs(encoding, style);
   } else {
-    group.scales = scale.defs(singleScaleNames, encoding, layout, stats, {stack: stack});
+    group.scales = scale.defs(singleScaleNames, encoding, layout, stats);
 
     group.axes = [];
     if (encoding.has(X)) group.axes.push(axis.def(X, encoding, layout, stats));

--- a/src/compiler/data.js
+++ b/src/compiler/data.js
@@ -216,6 +216,7 @@ data.aggregate = function(encoding) {
 data.stack = function(encoding, stack) {
   var dim = stack.dimension;
   var val = stack.value;
+  var facets = encoding.facets();
 
   var stacked = {
     name: STACKED,
@@ -226,8 +227,6 @@ data.stack = function(encoding, stack) {
       summarize: [{ops: ['sum'], field: encoding.fieldRef(val)}]
     }]
   };
-
-  var facets = encoding.facets();
 
   if (facets && facets.length > 0) {
     stacked.transform.push({ //calculate max for each facet
@@ -240,6 +239,7 @@ data.stack = function(encoding, stack) {
       }]
     });
   }
+  return stacked;
 };
 
 data.filterNonPositive = function(dataTable, encoding) {

--- a/src/compiler/data.js
+++ b/src/compiler/data.js
@@ -22,12 +22,20 @@ function data(encoding, stats) {
   var def = [data.raw(encoding, stats)];
 
   var aggregate = data.aggregate(encoding);
-  if (aggregate) def.push(data.aggregate(encoding));
+  if (aggregate) {
+    def.push(data.aggregate(encoding));
+  }
 
   // TODO add "having" filter here
 
   // append non-positive filter at the end for the data table
   data.filterNonPositive(def[def.length - 1], encoding);
+
+  // Stack
+  var stack = encoding.stack();
+  if (stack) {
+    def.push(data.stack(encoding, stack));
+  }
 
   return def;
 }
@@ -200,6 +208,38 @@ data.aggregate = function(encoding) {
   }
 
   return null;
+};
+
+/**
+ * Add stacked data source, for feeding the shared scale.
+ */
+data.stack = function(encoding, stack) {
+  var dim = stack.dimension;
+  var val = stack.value;
+
+  var stacked = {
+    name: STACKED,
+    source: encoding.dataTable(),
+    transform: [{
+      type: 'aggregate',
+      groupby: [encoding.fieldRef(dim)].concat(facets), // dim and other facets
+      summarize: [{ops: ['sum'], field: encoding.fieldRef(val)}]
+    }]
+  };
+
+  var facets = encoding.facets();
+
+  if (facets && facets.length > 0) {
+    stacked.transform.push({ //calculate max for each facet
+      type: 'aggregate',
+      groupby: facets,
+      summarize: [{
+        ops: ['max'],
+        // we want max of sum from above transform
+        field: encoding.fieldRef(val, {prefn: 'sum_'})
+      }]
+    });
+  }
 };
 
 data.filterNonPositive = function(dataTable, encoding) {

--- a/src/compiler/facet.js
+++ b/src/compiler/facet.js
@@ -121,7 +121,7 @@ function faceting(group, encoding, layout, spec, singleScaleNames, stats) {
     encoding,
     layout,
     stats,
-    {facet: true}
+    true
   )); // row/col scales + cell scales
 
   if (cellAxes.length > 0) {

--- a/src/compiler/facet.js
+++ b/src/compiler/facet.js
@@ -29,7 +29,7 @@ function groupdef(name, opt) {
   };
 }
 
-function faceting(group, encoding, layout, spec, singleScaleNames, stack, stats) {
+function faceting(group, encoding, layout, spec, singleScaleNames, stats) {
   var enter = group.properties.enter;
   var facetKeys = [], cellAxes = [], from, axesGrp;
 
@@ -121,7 +121,7 @@ function faceting(group, encoding, layout, spec, singleScaleNames, stack, stats)
     encoding,
     layout,
     stats,
-    {stack: stack, facet: true}
+    {facet: true}
   )); // row/col scales + cell scales
 
   if (cellAxes.length > 0) {

--- a/src/compiler/marks.js
+++ b/src/compiler/marks.js
@@ -39,7 +39,6 @@ marks.def = function(encoding, layout, style, stats) {
 
 marks.bar = {
   type: 'rect',
-  stack: true,
   prop: bar_props,
   supportedEncoding: {row: 1, col: 1, x: 1, y: 1, size: 1, color: 1}
 };
@@ -54,7 +53,6 @@ marks.line = {
 
 marks.area = {
   type: 'area',
-  stack: true,
   line: true,
   requiredEncoding: ['x', 'y'],
   prop: area_props,

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -15,17 +15,15 @@ scale.names = function(props) {
   }, {}));
 };
 
-scale.defs = function(names, encoding, layout, stats, opt) {
-  opt = opt || {};
-
+scale.defs = function(names, encoding, layout, stats, facet) {
   return names.reduce(function(a, name) {
     var scaleDef = {
       name: name,
       type: scale.type(name, encoding)
     };
 
-    scaleDef.domain = scale.domain(scaleDef, encoding, stats, opt);
-    scaleDef = scale.range(scaleDef, encoding, layout, stats, opt);
+    scaleDef.domain = scale.domain(scaleDef, encoding, stats, facet);
+    scaleDef = scale.range(scaleDef, encoding, layout, stats);
 
     return (a.push(scaleDef), a);
   }, []);
@@ -48,9 +46,7 @@ scale.type = function(name, encoding) {
   }
 };
 
-scale.domain = function (scaleDef, encoding, stats, opt) {
-  opt = opt || {};
-
+scale.domain = function (scaleDef, encoding, stats, facet) {
   var name = scaleDef.name;
 
   var encDef = encoding.encDef(name);
@@ -80,7 +76,7 @@ scale.domain = function (scaleDef, encoding, stats, opt) {
       data: STACKED,
       field: encoding.fieldRef(name, {
         // If faceted, scale is determined by the max of sum in each facet.
-        prefn: (opt.facet ? 'max_' : '') + 'sum_'
+        prefn: (facet ? 'max_' : '') + 'sum_'
       })
     };
   }

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -74,7 +74,8 @@ scale.domain = function (scaleDef, encoding, stats, opt) {
   }
 
   // For stack, use STACKED data.
-  if (name == opt.stack) {
+  var stack = encoding.stack();
+  if (stack && name === stack.value) {
     return {
       data: STACKED,
       field: encoding.fieldRef(name, {

--- a/src/compiler/stack.js
+++ b/src/compiler/stack.js
@@ -8,7 +8,7 @@ function stacking(encoding, mdef, stack) {
   var dim = stack.dimension;
   var val = stack.value;
 
-  var valName = encoding.encDef(val).name;
+  var valName = encoding.fieldRef(val);
   var startField = valName + '_start';
   var endField = valName + '_end';
 

--- a/src/compiler/stack.js
+++ b/src/compiler/stack.js
@@ -2,58 +2,11 @@
 
 require('../globals');
 
-var  marks = require('./marks');
-
 module.exports = stacking;
 
-function stacking(data, encoding, mdef) {
-  // check if the encoding supports stack
-  if (!marks[encoding.marktype()].stack) return false;
-
-  // TODO: add || encoding.has(LOD) here once LOD is implemented
-  if (!encoding.has(COLOR)) return false;
-
-  var dim = null, val = null, idx = null,
-    isXMeasure = encoding.isMeasure(X),
-    isYMeasure = encoding.isMeasure(Y),
-    facets = encoding.facets();
-
-  if (isXMeasure && !isYMeasure) {
-    dim = Y;
-    val = X;
-    idx = 0;
-  } else if (isYMeasure && !isXMeasure) {
-    dim = X;
-    val = Y;
-    idx = 1;
-  } else {
-    return null; // no stack encoding
-  }
-
-  // add transform to compute sums for scale
-  var stacked = {
-    name: STACKED,
-    source: encoding.dataTable(),
-    transform: [{
-      type: 'aggregate',
-      groupby: [encoding.fieldRef(dim)].concat(facets), // dim and other facets
-      summarize: [{ops: ['sum'], field: encoding.fieldRef(val)}]
-    }]
-  };
-
-  if (facets && facets.length > 0) {
-    stacked.transform.push({ //calculate max for each facet
-      type: 'aggregate',
-      groupby: facets,
-      summarize: [{
-        ops: ['max'],
-        // we want max of sum from above transform
-        field: encoding.fieldRef(val, {prefn: 'sum_'})
-      }]
-    });
-  }
-
-  data.push(stacked);
+function stacking(encoding, mdef, stack) {
+  var dim = stack.dimension;
+  var val = stack.value;
 
   var valName = encoding.encDef(val).name;
   var startField = valName + '_start';

--- a/src/compiler/subfacet.js
+++ b/src/compiler/subfacet.js
@@ -4,7 +4,7 @@ require('../globals');
 
 module.exports = subfaceting;
 
-function subfaceting(group, mdef, details, stack, encoding) {
+function subfaceting(group, mdef, details, encoding) {
   var m = group.marks;
   var g = {
     name: 'subfacet',
@@ -27,6 +27,7 @@ function subfaceting(group, mdef, details, stack, encoding) {
   trans.push({type: 'facet', groupby: details});
 
   // TODO: understand why we need this sort transform and write comment
+  var stack = encoding.stack();
   if (stack && encoding.has(COLOR)) {
     trans.unshift({type: 'sort', by: encoding.fieldRef(COLOR)});
   }

--- a/test/compiler/scale.spec.js
+++ b/test/compiler/scale.spec.js
@@ -27,34 +27,35 @@ describe('vl.compile.scale', function() {
     describe('for stack', function() {
       it('should return correct stack', function() {
         var domain = vlscale.domain(linearScaleDef, Encoding.fromSpec({
+          marktype: 'bar',
           encoding: {
             y: {
+              aggregate: 'sum',
               name: 'origin'
-            }
+            },
+            x: {name: 'x', type: 'O'},
+            color: {name: 'color', type: 'O'}
           }
-        }), {}, {
-          stack: 'y',
-          facet: true
-        });
+        }), {}, true);
 
         expect(domain).to.eql({
           data: 'stacked',
-          field: 'max_sum_origin'
+          field: 'max_sum_sum_origin'
         });
       });
 
       it('should return correct aggregated stack', function() {
         var domain = vlscale.domain(linearScaleDef, Encoding.fromSpec({
+          marktype: 'bar',
           encoding: {
             y: {
               aggregate: 'sum',
               name: 'origin'
-            }
+            },
+            x: {name: 'x', type: 'O'},
+            color: {name: 'color', type: 'O'}
           }
-        }), {}, {
-          stack: 'y',
-          facet: true
-        });
+        }), {}, true);
 
         expect(domain).to.eql({
           data: 'stacked',


### PR DESCRIPTION
#276

- move stack’s stacked data transform to `data.stack`
- add `encoding.stack` so we do not have to pass `stack` around

- TODO in future PRs 
  - consider caching stack as encoding’s property to avoid redundant computation
  - remove `stack.js` and move the same logic to `marks.js` to reduce side effect
  - consider if there is a way to avoid creating stacked data, which perform redundant calculation with scales in each facet.  (maybe signal could work)