### PR TITLE
Fix remaining basic migration issues

### DIFF
--- a/src/compiler/facet.js
+++ b/src/compiler/facet.js
@@ -67,7 +67,7 @@ function faceting(group, encoding, layout, spec, singleScaleNames, stats) {
 
     axesGrp = groupdef('x-axes', {
         axes: encoding.has(X) ? [axis.def(X, encoding, layout, stats)] : undefined,
-        x: hasCol ? {scale: COL, field: 'keys.0'} : {value: 0},
+        x: hasCol ? {scale: COL, field: encoding.fieldRef(COL)} : {value: 0},
         width: hasCol && {'value': layout.cellWidth}, //HACK?
         from: from
       });
@@ -99,7 +99,7 @@ function faceting(group, encoding, layout, spec, singleScaleNames, stats) {
 
     axesGrp = groupdef('y-axes', {
       axes: encoding.has(Y) ? [axis.def(Y, encoding, layout, stats)] : undefined,
-      y: hasRow && {scale: ROW, field: 'keys.0'},
+      y: hasRow && {scale: ROW, field: encoding.fieldRef(ROW)},
       x: hasRow && {value: 0},
       height: hasRow && {'value': layout.cellHeight}, //HACK?
       from: from

--- a/src/compiler/marks.js
+++ b/src/compiler/marks.js
@@ -424,7 +424,7 @@ function text_props(e, layout, style, stats) {
       var fieldStats = stats[e.encDef(TEXT).name],
         numberFormat = encDef.format || e.numberFormat(fieldStats);
 
-      p.text = {template: '{{' + e.fieldRef(TEXT) + ' | number:\'' +
+      p.text = {template: '{{' + e.fieldRef(TEXT, {datum: true}) + ' | number:\'' +
         numberFormat +'\'}}'};
       p.align = {value: encDef.align};
     } else {


### PR DESCRIPTION
Fixes #459 (replacing #638)

- eliminate `keys.0` reference
- add `datum.` in template reference

After merging this to `0.8`, we should test this with voyager a bit and consider releasing `0.8.1`.  