### PR TITLE
Fixing validation errors 

### DIFF
--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -82,6 +82,7 @@ axis.grid = function(def, encoding, name, layout) {
       def.properties.grid = {
         x: {
           offset: layout.cellWidth * (1+ cellPadding/2.0),
+          band: true,
           // default value(s) -- vega doesn't do recursive merge
           scale: 'col'
         },
@@ -96,6 +97,7 @@ axis.grid = function(def, encoding, name, layout) {
       def.properties.grid = {
         y: {
           offset: -layout.cellHeight * (cellPadding/2),
+          band: true,
           // default value(s) -- vega doesn't do recursive merge
           scale: 'row'
         },

--- a/src/compiler/facet.js
+++ b/src/compiler/facet.js
@@ -11,22 +11,31 @@ module.exports = faceting;
 
 function groupdef(name, opt) {
   opt = opt || {};
-  return {
+  var group = {
     name: name || undefined,
     type: 'group',
-    from: opt.from,
     properties: {
       enter: {
-        x: opt.x || undefined,
-        y: opt.y || undefined,
         width: opt.width || {field: {group: 'width'}},
         height: opt.height || {field: {group: 'height'}}
       }
-    },
-    scales: opt.scales || undefined,
-    axes: opt.axes || undefined,
-    marks: opt.marks || []
+    }
   };
+
+  if (opt.from) {
+    group.from = opt.from;
+  }
+  if (opt.x) {
+    group.properties.enter.x = opt.x;
+  }
+  if (opt.y) {
+    group.properties.enter.y = opt.y;
+  }
+  if (opt.axes) {
+    group.axes = opt.axes;
+  }
+
+  return group;
 }
 
 function faceting(group, encoding, layout, spec, singleScaleNames, stats) {

--- a/src/compiler/stack.js
+++ b/src/compiler/stack.js
@@ -15,9 +15,9 @@ function stacking(encoding, mdef, stack) {
   // add stack transform to mark
   mdef.from.transform = [{
     type: 'stack',
-    groupby: encoding.fieldRef(groupby),
+    groupby: [encoding.fieldRef(groupby)],
     field: encoding.fieldRef(field),
-    sortby: '-' + encoding.fieldRef(stack.stack),
+    sortby: ['-' + encoding.fieldRef(stack.stack)],
     output: {start: startField, end: endField}
   }];
 

--- a/test/examples.js
+++ b/test/examples.js
@@ -20,8 +20,6 @@ e = e.concat(addTitles(__.values(f.bars), 'bars'));
 e = e.concat(addTitles(__.values(f.points), 'points'));
 e = e.concat(addTitles(__.values(f.lines), 'lines'));
 e = e.concat(addTitles(__.values(f.area), 'area'));
-
-// TODO(#640): fix validation errors
-// e = e.concat(galleryExamples);
+e = e.concat(galleryExamples);
 
 module.exports = e;


### PR DESCRIPTION
Fixes #640

- add `band:true` to `properties.grid` (I originally omitted this as `band:true` was grid's default)
- do not produce `undefined` in the spec.
- Make stack transform's `groupby,sortby` an array

All examples now pass vega's schema validator!