### PR TITLE
Fix incorrect field reference when scale.useRawDomain is activated

### DIFF
--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -109,14 +109,22 @@ scale._useRawDomain = function (encoding, name) {
   var useRawDomainEnabled = scaleUseRawDomain !== undefined ?
       scaleUseRawDomain : encoding.config('useRawDomain');
 
-  var notCountOrSum = !encDef.aggregate || (encDef.aggregate !=='count' && encDef.aggregate !== 'sum');
+  var notCountOrSum = !encDef.aggregate ||
+    (encDef.aggregate !=='count' && encDef.aggregate !== 'sum');
 
   return  useRawDomainEnabled &&
     notCountOrSum && (
       // Q always uses non-ordinal scale except when it's binned and thus uses ordinal scale.
-            (encoding.isType(name, Q) && !encDef.bin) ||
+      (
+        encoding.isType(name, Q) &&
+        !encDef.bin // TODO(#614): this must be changed once bin is reimplemented
+      ) ||
+      // TODO: revise this
       // T uses non-ordinal scale when there's no unit or when the unit is not ordinal.
-            (encoding.isType(name, T) && (!encDef.timeUnit || !time.isOrdinalFn(encDef.timeUnit)))
+      (
+        encoding.isType(name, T) &&
+        (!encDef.timeUnit || !time.isOrdinalFn(encDef.timeUnit))
+      )
     );
 };
 

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -82,8 +82,13 @@ scale.domain = function (scaleDef, encoding, stats, facet) {
   }
 
   var domain = scale._useRawDomain(encoding, name) ?
-                { data: RAW, field: encDef.name } :
-                { data: encoding.dataTable(), field: encoding.fieldRef(name) };
+    {
+      data: RAW,
+      field: encoding.fieldRef(name, {noAggregate:true})
+    } : {
+      data: encoding.dataTable(),
+      field: encoding.fieldRef(name)
+    };
 
   // For ordinal scale, add domain's property if provided.
   var sort = scaleDef.type === 'ordinal' && encoding.sort(name);
@@ -107,12 +112,12 @@ scale._useRawDomain = function (encoding, name) {
   var notCountOrSum = !encDef.aggregate || (encDef.aggregate !=='count' && encDef.aggregate !== 'sum');
 
   return  useRawDomainEnabled &&
-          notCountOrSum && (
-            // Q always uses non-ordinal scale except when it's binned and thus uses ordinal scale.
+    notCountOrSum && (
+      // Q always uses non-ordinal scale except when it's binned and thus uses ordinal scale.
             (encoding.isType(name, Q) && !encDef.bin) ||
-            // T uses non-ordinal scale when there's no unit or when the unit is not ordinal.
+      // T uses non-ordinal scale when there's no unit or when the unit is not ordinal.
             (encoding.isType(name, T) && (!encDef.timeUnit || !time.isOrdinalFn(encDef.timeUnit)))
-          );
+    );
 };
 
 

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -97,7 +97,13 @@ scale.domain = function (scaleDef, encoding, stats, facet) {
   return domain;
 };
 
-/** Determine if useRawDomain should be activated for this scale. */
+/**
+ * Determine if useRawDomain should be activated for this scale.
+ * @return {Boolean} Returns true if all of the following conditons applies:
+ * 1. `useRawDomain` is enabled either through scale or config
+ * 2. Aggregation function is not `count` or `sum`
+ * 3. The scale is quantitative or time scale.
+ */
 scale._useRawDomain = function (encoding, name) {
   var encDef = encoding.encDef(name);
 
@@ -114,7 +120,7 @@ scale._useRawDomain = function (encoding, name) {
 
   return  useRawDomainEnabled &&
     notCountOrSum && (
-      // Q always uses non-ordinal scale except when it's binned and thus uses ordinal scale.
+      // Q always uses quantitative scale except when it's binned and thus uses ordinal scale.
       (
         encoding.isType(name, Q) &&
         !encDef.bin // TODO(#614): this must be changed once bin is reimplemented

--- a/src/encdef.js
+++ b/src/encdef.js
@@ -35,7 +35,7 @@ vlfield.fieldRef = function(field, opt) {
     return f + opt.fn + '_' + name;
   } else if (!opt.nofn && field.bin) {
     return f + 'bin_' + name;
-  } else if (!opt.nofn && field.aggregate) {
+  } else if (!opt.nofn && !opt.noAggregate && field.aggregate) {
     return f + field.aggregate + '_' + name;
   } else if (!opt.nofn && field.timeUnit) {
     return f + field.timeUnit + '_' + name;

--- a/src/encdef.js
+++ b/src/encdef.js
@@ -16,6 +16,7 @@ var vlfield = module.exports = {};
  * @param field
  * @param opt
  *   opt.nofn -- exclude bin, aggregate, timeUnit
+ *   opt.noAggregate -- exclude aggregation function
  *   opt.datum - include 'datum.'
  *   opt.fn - replace fn with custom function prefix
  *   opt.prefn - prepend fn with custom function prefix
@@ -25,22 +26,20 @@ var vlfield = module.exports = {};
 vlfield.fieldRef = function(field, opt) {
   opt = opt || {};
 
-  var f = (opt.datum ? 'datum.' : '') +
-          (opt.prefn || ''),
-    nofn = opt.nofn || opt.fn,
+  var f = (opt.datum ? 'datum.' : '') + (opt.prefn || ''),
     name = field.name;
 
   if (vlfield.isCount(field)) {
     return f + 'count';
-  } else if (!nofn && field.bin) {
-    return f + 'bin_' + name;
-  } else if (!nofn && field.aggregate) {
-    return f + field.aggregate + '_' + name;
-  } else if (!nofn && field.timeUnit) {
-    return f + field.timeUnit + '_' + name;
   } else if (opt.fn) {
     return f + opt.fn + '_' + name;
-  } else {
+  } else if (!opt.nofn && field.bin) {
+    return f + 'bin_' + name;
+  } else if (!opt.nofn && field.aggregate) {
+    return f + field.aggregate + '_' + name;
+  } else if (!opt.nofn && field.timeUnit) {
+    return f + field.timeUnit + '_' + name;
+  }  else {
     return f + name;
   }
 };


### PR DESCRIPTION
- extract `scale._useRawDomain()` to simplify the code and refer to field correctly when `useRawDomain` is activated.
- add `noAggregate` option for `vl.field.fieldRef` and simplify the method

This fixes the broken `MEAN` bug in voyager https://github.com/vega/voyager/issues/207.