### PR TITLE
Migrate `Encoding.toggleSort` to `vega-lite-ui` and fix domain when sort by aggregation of a sort field.

### DIFF
--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -354,38 +354,5 @@ module.exports = (function() {
     return spec;
   };
 
-  // FIXME: REMOVE everything below here
-
-  Encoding.toggleSort = function(spec) {
-    spec.config = spec.config || {};
-    spec.config.toggleSort = spec.config.toggleSort === Q ? N : Q;
-    return spec;
-  };
-
-
-  Encoding.toggleSort.direction = function(spec) {
-    if (!Encoding.toggleSort.support(spec)) { return; }
-    var enc = spec.encoding;
-    return enc.x.type === N ? 'x' : 'y';
-  };
-
-  Encoding.toggleSort.mode = function(spec) {
-    return spec.config.toggleSort;
-  };
-
-  Encoding.toggleSort.support = function(spec, stats) {
-    var enc = spec.encoding,
-      isTypes = vlEncDef.isTypes;
-
-    if (vlenc.has(enc, ROW) || vlenc.has(enc, COL) ||
-      !vlenc.has(enc, X) || !vlenc.has(enc, Y) ||
-      !Encoding.alwaysNoOcclusion(spec, stats)) {
-      return false;
-    }
-
-    return ( isTypes(enc.x, [N,O]) && vlEncDef.isMeasure(enc.y)) ? 'x' :
-      ( isTypes(enc.y, [N,O]) && vlEncDef.isMeasure(enc.x)) ? 'y' : false;
-  };
-
   return Encoding;
 })();

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -25,7 +25,7 @@ scale.defs = function(names, encoding, layout, stats, facet) {
 
     // add `reverse` if applicable
     var reverse = scale.reverse(encoding, name);
-    if (reverse !== undefined) {
+    if (reverse) {
       scaleDef.reverse = reverse;
     }
 

--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -84,22 +84,28 @@ scale.domain = function (encoding, name, type, stats, facet) {
     };
   }
 
-  var domain = scale._useRawDomain(encoding, name) ?
-    {
+  var useRawDomain = scale._useRawDomain(encoding, name);
+  var sort = scale.sort(encoding, name, type);
+
+  if (useRawDomain) {
+    return {
       data: RAW,
       field: encoding.fieldRef(name, {noAggregate:true})
-    } : {
+    };
+  } else if (sort) { // have sort
+    return {
+      // If sort by aggregation of a specified sort field, we need to use RAW table,
+      // so we can aggregate values for the scale independently from the main aggregation.
+      data: sort.op ? RAW : encoding.dataTable(),
+      field: encoding.fieldRef(name),
+      sort: sort
+    };
+  } else {
+    return {
       data: encoding.dataTable(),
       field: encoding.fieldRef(name)
     };
-
-  // Add `sort` if applicable
-  var sort = scale.sort(encoding, name, type);
-  if (sort) {
-    domain.sort = sort;
   }
-
-  return domain;
 };
 
 scale.sort = function(encoding, name, type) {

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -665,10 +665,6 @@ var config = {
         T: {type:'boolean', default: true}
       }
     },
-    toggleSort: {
-      type: 'string',
-      default: O
-    },
     autoSortLine: {
       type: 'boolean',
       default: true


### PR DESCRIPTION
- remove Encoding.toggleSort and migrate to vega-lite-ui
- only output vega `scale.reverse` when it is `true`
- Make sure that If sort by aggregation of a specified sort field,  use RAW table so we can aggregate value for the scale independently from the main aggregation. 

Please merge #670, #671, #672 first!