### PR TITLE
Make Grid works correctly + add cellGridOffset

### DIFF
--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -81,6 +81,7 @@ axis.grid = function(def, encoding, name, layout) {
       // set grid property -- put the lines on the right the cell
       var yOffset = encoding.config('cellGridOffset');
 
+      // TODO(#677): this should depend on orient
       def.properties.grid = {
         x: {
           offset: layout.cellWidth * (1+ cellPadding/2.0),
@@ -101,6 +102,7 @@ axis.grid = function(def, encoding, name, layout) {
     } else if (isRow) {
       var xOffset = encoding.config('cellGridOffset');
 
+      // TODO(#677): this should depend on orient
       // set grid property -- put the lines on the top
       def.properties.grid = {
         y: {

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -82,9 +82,9 @@ axis.grid = function(def, encoding, name, layout) {
       def.properties.grid = {
         x: {
           offset: layout.cellWidth * (1+ cellPadding/2.0),
-          band: true,
           // default value(s) -- vega doesn't do recursive merge
-          scale: 'col'
+          scale: 'col',
+          field: 'data'
         },
         y: {
           value: -layout.cellHeight * (cellPadding/2),
@@ -97,9 +97,9 @@ axis.grid = function(def, encoding, name, layout) {
       def.properties.grid = {
         y: {
           offset: -layout.cellHeight * (cellPadding/2),
-          band: true,
           // default value(s) -- vega doesn't do recursive merge
-          scale: 'row'
+          scale: 'row',
+          field: 'data'
         },
         x: {
           value: def.offset

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -96,7 +96,7 @@ axis.grid = function(def, encoding, name, layout) {
           offset: yOffset
         },
         stroke: { value: encoding.config('cellGridColor') },
-        opacity: { value: encoding.config('cellGridOpacity') }
+        strokeOpacity: { value: encoding.config('cellGridOpacity') }
       };
     } else if (isRow) {
       var xOffset = encoding.config('cellGridOffset');

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -79,6 +79,8 @@ axis.grid = function(def, encoding, name, layout) {
 
     if (isCol) {
       // set grid property -- put the lines on the right the cell
+      var yOffset = encoding.config('cellGridOffset');
+
       def.properties.grid = {
         x: {
           offset: layout.cellWidth * (1+ cellPadding/2.0),
@@ -87,12 +89,18 @@ axis.grid = function(def, encoding, name, layout) {
           field: 'data'
         },
         y: {
-          value: -layout.cellHeight * (cellPadding/2),
+          value: -yOffset,
+        },
+        y2: {
+          field: {group: 'height', level: 2},
+          offset: yOffset
         },
         stroke: { value: encoding.config('cellGridColor') },
         opacity: { value: encoding.config('cellGridOpacity') }
       };
     } else if (isRow) {
+      var xOffset = encoding.config('cellGridOffset');
+
       // set grid property -- put the lines on the top
       def.properties.grid = {
         y: {
@@ -102,21 +110,21 @@ axis.grid = function(def, encoding, name, layout) {
           field: 'data'
         },
         x: {
-          value: def.offset
+          value: def.offset - xOffset
         },
         x2: {
           field: {group: 'mark.group.width'},
-          offset: def.offset + (layout.cellWidth * 0.05),
+          offset: def.offset + xOffset,
           // default value(s) -- vega doesn't do recursive merge
           mult: 1
         },
         stroke: { value: encoding.config('cellGridColor') },
-        opacity: { value: encoding.config('cellGridOpacity') }
+        strokeOpacity: { value: encoding.config('cellGridOpacity') }
       };
     } else {
       def.properties.grid = {
         stroke: { value: encoding.config('gridColor') },
-        opacity: { value: encoding.config('gridOpacity') }
+        strokeOpacity: { value: encoding.config('gridOpacity') }
       };
     }
   }

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -719,6 +719,10 @@ var config = {
       maximum: 1,
       default: 0.15
     },
+    cellGridOffset: {
+      type: 'number',
+      default: 6 // equal to tickSize
+    },
     cellBackgroundColor: {
       type: 'string',
       role: 'color',

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -651,7 +651,7 @@ var config = {
       type: 'number',
       minimum: 0,
       maximum: 1,
-      default: 0.5
+      default: 0.08
     },
 
     // filter null
@@ -717,7 +717,7 @@ var config = {
       type: 'number',
       minimum: 0,
       maximum: 1,
-      default: 0.15
+      default: 0.25
     },
     cellGridOffset: {
       type: 'number',


### PR DESCRIPTION
- correctly makes grid working by referring to `field: 'data'` -- fixes #660
- Add `cellGridOffset` and make it equals to Vega’s default `tickSize` by default
- use `strokeOpacity` instead of `opacity` (Address a follow up concern in #661)


