### PR TITLE
Make `grid` value automatically determined

### DIFF
--- a/docs/Encoding-Mapping.md
+++ b/docs/Encoding-Mapping.md
@@ -102,8 +102,8 @@ Scales of quantitative fields are linear scales by default, but users can specif
 
 ## axis
 
-Vega-lite's `axis` object supports the following [Vega axis properties](https://github.com/vega/vega/wiki/Axes#axis-properties)<sup>1</sup>:
-`format`, `grid`, `layer`, `orient`, `ticks`, `title`<sup>2</sup>, and `titleOffset`<sup>3</sup>.
+Vega-lite's `axis` object supports the following [Vega axis properties](https://github.com/vega/vega/wiki/Axes#axis-properties):
+`format`, `grid`<sup>1</sup>, `layer`, `orient`, `ticks`, `title` <sup>2</sup>, and `titleOffset`<sup>3,4</sup>.
 See [Vega documentation](https://github.com/vega/vega/wiki/Axes#axis-properties) for more information.
 
 Moreover, Vega-lite supports the following additional axis properties.
@@ -115,9 +115,11 @@ Moreover, Vega-lite supports the following additional axis properties.
 | titleMaxLength  | Integer       | Max length for axis title when the title is automatically generated from the field\'s description.  If the   |
 | titleOffset     | Integer       | Offset between the axis title and the axis.  |
 
+<sup>1</sup>
+If `grid` is unspecified, the default value is `true` for ROW and COL. For X
+and Y, the default value is `true` for quantitative fields and `false`
+otherwise.
 
-<sup>1</sup> __In Roadmap__:
-Other applicable Vega axis properties will be added. [#181](../../issues/181)
 
 <sup>2</sup>
 If unspecified, axis's `title` is generated from the field's name and transformation function applied e.g, "field_name", "SUM(field_name)", "BIN(field_name)", "YEAR(field_name)".
@@ -125,6 +127,10 @@ If unspecified, axis's `title` is generated from the field's name and transforma
 <sup>3</sup>
 If unspecified, `titleOffset` is automatically determined.
 __TODO: add detail about default behavior__
+
+<sup>4</sup> __In Roadmap__:
+Other applicable Vega axis properties will be added. [#181](../../issues/181)
+
 
 ## legends
 

--- a/docs/Encoding-Mapping.md
+++ b/docs/Encoding-Mapping.md
@@ -120,12 +120,11 @@ If `grid` is unspecified, the default value is `true` for ROW and COL. For X
 and Y, the default value is `true` for quantitative fields and `false`
 otherwise.
 
-
 <sup>2</sup>
-If unspecified, axis's `title` is generated from the field's name and transformation function applied e.g, "field_name", "SUM(field_name)", "BIN(field_name)", "YEAR(field_name)".
+If `title` is unspecified, the default value is produced from the field's name and transformation function applied e.g, "field_name", "SUM(field_name)", "BIN(field_name)", "YEAR(field_name)".
 
 <sup>3</sup>
-If unspecified, `titleOffset` is automatically determined.
+If `titleOffset` is unspecified, the default value is automatically determined.
 __TODO: add detail about default behavior__
 
 <sup>4</sup> __In Roadmap__:

--- a/docs/Encoding-Mapping.md
+++ b/docs/Encoding-Mapping.md
@@ -117,7 +117,7 @@ Moreover, Vega-lite supports the following additional axis properties.
 
 <sup>1</sup>
 If `grid` is unspecified, the default value is `true` for ROW and COL. For X
-and Y, the default value is `true` for quantitative fields and `false`
+and Y, the default value is `true` for quantitative and time fields and `false`
 otherwise.
 
 <sup>2</sup>

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -79,7 +79,15 @@ axis.grid = function(def, encoding, name, layout) {
     isCol = name == COL,
     isRow = name == ROW;
 
-  if (encoding.axis(name).grid) {
+  var _grid = encoding.axis(name).grid;
+
+  // If `grid` is unspecified, the default value is `true` for ROW and COL. For X
+  // and Y, the default value is `true` for quantitative fields and `false` otherwise.
+  var grid = _grid === undefined ?
+    (name === ROW || name === COL || encoding.isType(name, Q)) :
+    _grid;
+
+  if (grid) {
     def.grid = true;
 
     if (isCol) {

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -82,9 +82,9 @@ axis.grid = function(def, encoding, name, layout) {
   var _grid = encoding.axis(name).grid;
 
   // If `grid` is unspecified, the default value is `true` for ROW and COL. For X
-  // and Y, the default value is `true` for quantitative fields and `false` otherwise.
+  // and Y, the default value is `true` for quantitative and time fields and `false` otherwise.
   var grid = _grid === undefined ?
-    (name === ROW || name === COL || encoding.isType(name, Q)) :
+    (name === ROW || name === COL || encoding.isTypes(name, [Q, T])) :
     _grid;
 
   if (grid) {

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -166,8 +166,8 @@ var axisMixin = {
         },
         grid: {
           type: 'boolean',
-          default: true,
-          description: 'A flag indicate if gridlines should be created in addition to ticks.'
+          default: undefined,
+          description: 'A flag indicate if gridlines should be created in addition to ticks. If `grid` is unspecified, the default value is `true` for ROW and COL. For X and Y, the default value is `true` for quantitative fields and `false` otherwise.'
         },
         layer: {
           type: 'string',

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -167,7 +167,7 @@ var axisMixin = {
         grid: {
           type: 'boolean',
           default: undefined,
-          description: 'A flag indicate if gridlines should be created in addition to ticks. If `grid` is unspecified, the default value is `true` for ROW and COL. For X and Y, the default value is `true` for quantitative fields and `false` otherwise.'
+          description: 'A flag indicate if gridlines should be created in addition to ticks. If `grid` is unspecified, the default value is `true` for ROW and COL. For X and Y, the default value is `true` for quantitative and time fields and `false` otherwise.'
         },
         layer: {
           type: 'string',


### PR DESCRIPTION
Fixes #378

If `grid` is unspecified, the default value is `true` for ROW and COL. For X
and Y, the default value is `true` for quantitative fields and `false`
otherwise.