### PR TITLE
Change default values for sort and stack

### DIFF
--- a/gallery/examples.js
+++ b/gallery/examples.js
@@ -165,12 +165,23 @@ var EXAMPLES = [
       'data': {'url': 'data/cars.json'}
     }
   },{
-    title: 'Stacked Bar Chart',
+    title: 'Horizontal Stacked Bar Chart',
     spec: {
       'marktype': 'bar',
       'encoding': {
         'x': {'name': 'yield','type': 'Q','aggregate': 'sum'},
         'y': {'name': 'variety','type': 'N'},
+        'color': {'name': 'site', 'type': 'N'}
+      },
+      'data': {'url': 'data/barley.json'}
+    }
+  },{
+    title: 'Vertical Stacked Bar Chart',
+    spec: {
+      'marktype': 'bar',
+      'encoding': {
+        'y': {'name': 'yield','type': 'Q','aggregate': 'sum'},
+        'x': {'name': 'variety','type': 'N'},
         'color': {'name': 'site', 'type': 'N'}
       },
       'data': {'url': 'data/barley.json'}

--- a/src/compiler/stack.js
+++ b/src/compiler/stack.js
@@ -17,7 +17,7 @@ function stacking(encoding, mdef, stack) {
     type: 'stack',
     groupby: [encoding.fieldRef(groupby)],
     field: encoding.fieldRef(field),
-    sortby: [(stack.properties.reverse ? '' : '-') + encoding.fieldRef(stack.stack)],
+    sortby: [(stack.properties.reverse ? '-' : '') + encoding.fieldRef(stack.stack)],
     output: {start: startField, end: endField}
   };
 

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -226,12 +226,12 @@ var sortMixin = {
   type: 'object',
   properties: {
     sort: {
-      default: undefined,
+      default: 'ascending',
       supportedTypes: toMap([N, O]),
       oneOf: [
         {
           type: 'string',
-          enum: ['ascending', 'descending']
+          enum: ['ascending', 'descending', 'unsorted']
         },
         { // sort by aggregation of another field
           type: 'object',

--- a/test/compiler/scale.spec.js
+++ b/test/compiler/scale.spec.js
@@ -193,7 +193,8 @@ describe('vl.compile.scale', function() {
         expect(vlscale.domain(encoding, 'y', 'ordinal'))
           .to.eql({
             data: RAW,
-            field: 'origin'
+            field: 'origin',
+            sort: true
           });
       });
     });


### PR DESCRIPTION
- Make encoding definition `sort=‘ascending’` by default  — closes #663.
- No longer add `’-‘` to `sortby` in the output `stack` transform by default 