### PR TITLE
Fix facet misalignment due to the missing outerPadding

### DIFF
--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -26,7 +26,7 @@ scale.defs = function(names, encoding, layout, stats, facet) {
     var properties = ['range', 'reverse', 'round',
         'clamp', 'nice', // quantitative / time
         'exponent', 'zero', // quantitative
-        'bandWidth', 'padding', 'points' // ordinal
+        'bandWidth', 'outerPadding', 'padding', 'points' // ordinal
       ];
 
     properties.forEach(function(property) {
@@ -219,6 +219,18 @@ scale.nice = function(encoding, name, type) {
     case ROW: /* fall through */
     case COL:
       return true;
+  }
+  return undefined;
+};
+
+scale.outerPadding = function(encoding, name, type) {
+  if (type === 'ordinal') {
+    if (encoding.encDef(name).scale.outerPadding !== undefined) {
+      return encoding.encDef(name).scale.outerPadding; // explicit value
+    }
+    if (name === ROW || name === COL) {
+      return 0;
+    }
   }
   return undefined;
 };

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -116,6 +116,11 @@ var ordinalScaleMixin = {
       default: undefined
     },
     /* Ordinal Scale Properties */
+    outerPadding: {
+      type: 'number',
+      default: undefined
+      // TODO: add description once it is documented in Vega
+    },
     padding: {
       type: 'number',
       default: undefined,


### PR DESCRIPTION
(I didn’t include `outerPadding` when I refactor axis because it’s not in the Vega document so I thought it doesn’t affect anything, but I was wrong.)