### PR TITLE
Eliminate stats from numberFormat #648

### DIFF
--- a/src/Encoding.js
+++ b/src/Encoding.js
@@ -171,10 +171,9 @@ module.exports = (function() {
     return this._enc[et].value;
   };
 
-  proto.numberFormat = function(fieldStats) {
-    var formatConfig = fieldStats.max > this.config('maxSmallNumber') ?
-      'largeNumberFormat': 'smallNumberFormat';
-    return this.config(formatConfig);
+  proto.numberFormat = function(/*name*/) {
+    // TODO(#497): have different number format based on numberType (discrete/continuous)
+    return this.config('numberFormat');
   };
 
   proto.sort = function(et, stats) {

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -30,7 +30,7 @@ axis.def = function(name, encoding, layout, stats, opt) {
 
   // Add axis label custom scale (for bin / time)
   def = axis.labels.scale(def, encoding, name);
-  def = axis.labels.format(def, encoding, name, stats);
+  def = axis.labels.format(def, encoding, name);
   def = axis.labels.angle(def, encoding, name);
 
   // for x-axis, set ticks for Q or rotate scale for ordinal scale
@@ -204,13 +204,11 @@ axis.labels.scale = function(def, encoding, name) {
 /**
  * Determine number format or truncate if maxLabel length is presented.
  */
-axis.labels.format = function (def, encoding, name, stats) {
-  var fieldStats = stats[encoding.encDef(name).name];
-
+axis.labels.format = function (def, encoding, name) {
   if (encoding.axis(name).format) {
     def.format = encoding.axis(name).format;
-  } else if (encoding.isType(name, Q) || fieldStats.type === 'number') {
-    def.format = encoding.numberFormat(fieldStats);
+  } else if (encoding.isType(name, Q)) {
+    def.format = encoding.numberFormat(name);
   } else if (encoding.isType(name, T)) {
     var timeUnit = encoding.encDef(name).timeUnit;
     if (!timeUnit) {

--- a/src/compiler/compiler.js
+++ b/src/compiler/compiler.js
@@ -80,7 +80,7 @@ compiler.compileEncoding = function (encoding, stats) {
 
   // marks
   var style = compiler.style(encoding, stats),
-    mdefs = group.marks = marks.def(encoding, layout, style, stats),
+    mdefs = group.marks = marks.def(encoding, layout, style),
     mdef = mdefs[mdefs.length - 1];  // TODO: remove this dirty hack by refactoring the whole flow
 
   var stack = encoding.stack();

--- a/src/compiler/layout.js
+++ b/src/compiler/layout.js
@@ -91,11 +91,8 @@ function box(encoding, stats) {
   };
 }
 
-
-// FIXME fieldStats.max isn't always the longest
 function getMaxNumberLength(encoding, et, fieldStats) {
-  var format = encoding.numberFormat(et, fieldStats);
-
+  var format = encoding.numberFormat(et);
   return d3_format.format(format)(fieldStats.max).length;
 }
 

--- a/src/compiler/marks.js
+++ b/src/compiler/marks.js
@@ -4,7 +4,7 @@ require('../globals');
 
 var marks = module.exports = {};
 
-marks.def = function(encoding, layout, style, stats) {
+marks.def = function(encoding, layout, style) {
 
   var defs = [],
     mark = marks[encoding.marktype()],
@@ -27,7 +27,7 @@ marks.def = function(encoding, layout, style, stats) {
   }
 
   // add the mark def for the main thing
-  var p = mark.prop(encoding, layout, style, stats);
+  var p = mark.prop(encoding, layout, style);
   defs.push({
     type: mark.type,
     from: {data: from},
@@ -391,7 +391,7 @@ function filled_point_props(shape) {
   };
 }
 
-function text_props(e, layout, style, stats) {
+function text_props(e, layout, style) {
   var p = {},
     encDef = e.encDef(TEXT);
 
@@ -430,8 +430,7 @@ function text_props(e, layout, style, stats) {
   // text
   if (e.has(TEXT)) {
     if (e.isType(TEXT, Q)) {
-      var fieldStats = stats[e.encDef(TEXT).name],
-        numberFormat = encDef.format || e.numberFormat(fieldStats);
+      var numberFormat = encDef.format || e.numberFormat(TEXT);
 
       p.text = {template: '{{' + e.fieldRef(TEXT, {datum: true}) + ' | number:\'' +
         numberFormat +'\'}}'};

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -825,21 +825,9 @@ var config = {
       type: 'integer',
       default: 6
     },
-    maxSmallNumber: {
-      type: 'number',
-      default: 10000,
-      description: 'maximum number that a field will be considered smallNumber.'+
-                   'Used for axis labelling.'
-    },
-    smallNumberFormat: {
+    numberFormat: {
       type: 'string',
-      default: '',
-      description: 'D3 Number format for axis labels and text tables '+
-                   'for number <= maxSmallNumber. Used for axis labelling.'
-    },
-    largeNumberFormat: {
-      type: 'string',
-      default: '.3s',
+      default: 's',
       description: 'D3 Number format for axis labels and text tables ' +
                    'for number > maxSmallNumber.'
     },


### PR DESCRIPTION
- Eliminate stats from numberFormat #648
- remove `largeNumberFormat`, `smallNumberFormat` and `maxSmallNumber` from config.  