### PR TITLE
Refactor axis to minimize side effects

### DIFF
--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -20,9 +20,9 @@ axis.def = function(name, encoding, layout, stats) {
 
   // Add optional properties
   [
-    // has special rules (so it has axis[property] methods)
+    // properties with special rules (so it has axis[property] methods) -- call rule functions
     'format', 'grid', 'orient', 'tickSize', 'ticks', 'title', 'titleOffset',
-    // only produce default values in the schema, or explicit value if specified
+    // Otherwise, only produce default values in the schema, or explicit value if specified
     'layer', 'tickPadding', 'tickSize', 'tickSizeMajor', 'tickSizeMinor', 'tickSizeEnd',
     'values', 'subdivide'
   ].forEach(function(property) {
@@ -36,7 +36,6 @@ axis.def = function(name, encoding, layout, stats) {
 
   // FIXME move offset to above
   if(isRow) def.offset = axis.titleOffset(encoding, Y, layout) + 20;
-
 
   // Add properties under axis.properties
   var properties = encoding.encDef(name).axis.properties || {};
@@ -97,7 +96,7 @@ axis.orient = function(encoding, name, layout, stats) {
   } else if (name === COL) {
     return 'top';
   } else if (name === X && encoding.has(Y) && encoding.isOrdinalScale(Y) && encoding.cardinality(Y, stats) > 30) {
-    // FIXME remove this case
+    // FIXME remove this case and migrate this logic to vega-lite-ui
     // x-axis for long y - put on top
     return 'top';
   }
@@ -163,6 +162,8 @@ axis.titleOffset = function (encoding, name, layout) {
   }
   return getter(layout, [name, 'axisTitleOffset']);
 };
+
+// PROPERTIES
 
 axis.properties = {};
 

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -180,7 +180,6 @@ axis.properties.axis = function(encoding, name, spec) {
   return spec || undefined;
 };
 
-
 axis.properties.grid = function(encoding, name, spec, layout, def) {
   var cellPadding = layout.cellPadding;
 
@@ -241,18 +240,6 @@ axis.properties.grid = function(encoding, name, spec, layout, def) {
   return spec || undefined;
 };
 
-axis.properties.title = function(encoding, name, spec, layout) {
-  if (name === ROW) {
-    return util.extend({
-      angle: {value: 0},
-      align: {value: 'right'},
-      baseline: {value: 'middle'},
-      dy: {value: (-layout.height / 2) - 20}
-    }, spec || {});
-  }
-  return spec || undefined;
-};
-
 axis.properties.labels = function(encoding, name, spec, layout, def) {
   var timeUnit = encoding.encDef(name).timeUnit;
   if (encoding.isType(name, T) && timeUnit && (time.hasScale(timeUnit))) {
@@ -280,6 +267,18 @@ axis.properties.labels = function(encoding, name, spec, layout, def) {
       }, spec || {});
     }
   }
-
   return spec || undefined;
 };
+
+axis.properties.title = function(encoding, name, spec, layout) {
+  if (name === ROW) {
+    return util.extend({
+      angle: {value: 0},
+      align: {value: 'right'},
+      baseline: {value: 'middle'},
+      dy: {value: (-layout.height / 2) - 20}
+    }, spec || {});
+  }
+  return spec || undefined;
+};
+

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -35,14 +35,9 @@ axis.def = function(name, encoding, layout, stats) {
 
   // Add properties under axis.properties
   var properties = encoding.encDef(name).axis.properties || {};
-  var opt = {
-    grid: def.grid,
-    offset: def.offset || 0,
-    orient: def.orient
-  };
 
   ['axis', 'grid', 'labels', 'title'].forEach(function(property) {
-    var value = axis.properties[property](encoding, name, properties[property], layout, opt);
+    var value = axis.properties[property](encoding, name, properties[property], layout, def);
     if (value !== undefined) {
       def.properties = def.properties || {};
       def.properties[property] = value;
@@ -186,10 +181,10 @@ axis.properties.axis = function(encoding, name, spec) {
 };
 
 
-axis.properties.grid = function(encoding, name, spec, layout, opt) {
+axis.properties.grid = function(encoding, name, spec, layout, def) {
   var cellPadding = layout.cellPadding;
 
-  if (opt.grid) {
+  if (def.grid) {
     if (name == COL) {
       // set grid property -- put the lines on the right the cell
       var yOffset = encoding.config('cellGridOffset');
@@ -225,11 +220,11 @@ axis.properties.grid = function(encoding, name, spec, layout, opt) {
           field: 'data'
         },
         x: {
-          value: opt.offset - xOffset
+          value: def.offset - xOffset
         },
         x2: {
           field: {group: 'mark.group.width'},
-          offset: opt.offset + xOffset,
+          offset: def.offset + xOffset,
           // default value(s) -- vega doesn't do recursive merge
           mult: 1
         },
@@ -258,7 +253,7 @@ axis.properties.title = function(encoding, name, spec, layout) {
   return spec || undefined;
 };
 
-axis.properties.labels = function(encoding, name, spec, layout, opt) {
+axis.properties.labels = function(encoding, name, spec, layout, def) {
   var timeUnit = encoding.encDef(name).timeUnit;
   if (encoding.isType(name, T) && timeUnit && (time.hasScale(timeUnit))) {
     spec = util.extend({
@@ -280,7 +275,7 @@ axis.properties.labels = function(encoding, name, spec, layout, opt) {
     if ((encoding.isDimension(X) || encoding.isType(X, T))) {
       spec = util.extend({
         angle: {value: 270},
-        align: {value: opt.orient === 'top' ? 'left': 'right'},
+        align: {value: def.orient === 'top' ? 'left': 'right'},
         baseline: {value: 'middle'}
       }, spec || {});
     }

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -3,7 +3,6 @@
 require('../globals');
 
 var util = require('../util'),
-  getter = util.getter,
   time = require('./time');
 
 var axis = module.exports = {};
@@ -21,7 +20,7 @@ axis.def = function(name, encoding, layout, stats) {
   // Add optional properties
   [
     // properties with special rules (so it has axis[property] methods) -- call rule functions
-    'format', 'grid', 'orient', 'tickSize', 'ticks', 'title', 'titleOffset',
+    'format', 'grid', 'offset', 'orient', 'tickSize', 'ticks', 'title', 'titleOffset',
     // Otherwise, only produce default values in the schema, or explicit value if specified
     'layer', 'tickPadding', 'tickSize', 'tickSizeMajor', 'tickSizeMinor', 'tickSizeEnd',
     'values', 'subdivide'
@@ -33,9 +32,6 @@ axis.def = function(name, encoding, layout, stats) {
       def[property] = value;
     }
   });
-
-  // FIXME move offset to above
-  if(isRow) def.offset = axis.titleOffset(encoding, Y, layout) + 20;
 
   // Add properties under axis.properties
   var properties = encoding.encDef(name).axis.properties || {};
@@ -87,6 +83,18 @@ axis.grid = function(encoding, name) {
   // Otherwise, the default value is `false`.
   return name === ROW || name === COL ||
     (encoding.isTypes(name, [Q, T]) && !encoding.encDef(name).bin);
+};
+
+axis.offset = function(encoding, name, layout) {
+  var offset = encoding.encDef(name).axis.offset;
+  if (offset) {
+    return offset;
+  }
+
+  if(name === ROW) {
+   return layout.y.axisTitleOffset + 20;
+  }
+  return undefined;
 };
 
 axis.orient = function(encoding, name, layout, stats) {
@@ -151,7 +159,7 @@ axis.title = function (encoding, name, layout) {
 };
 
 
-axis.titleOffset = function (encoding, name, layout) {
+axis.titleOffset = function (encoding, name) {
   // return specified value if specified
   var value = encoding.axis(name).titleOffset;
   if (value)  return value;
@@ -160,7 +168,7 @@ axis.titleOffset = function (encoding, name, layout) {
     case ROW: return 0;
     case COL: return 35;
   }
-  return getter(layout, [name, 'axisTitleOffset']);
+  return undefined;
 };
 
 // PROPERTIES

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -36,8 +36,13 @@ axis.def = function(name, encoding, layout, stats) {
   // Add properties under axis.properties
   var properties = encoding.encDef(name).axis.properties || {};
 
-  ['axis', 'grid', 'labels', 'title'].forEach(function(property) {
-    var value = axis.properties[property](encoding, name, properties[property], layout, def);
+  [
+    'axis', 'grid', 'labels', 'title', // have special rules
+    'ticks', 'majorTicks', 'minorTicks' // only default values
+  ].forEach(function(property) {
+    var value = axis.properties[property] ?
+      axis.properties[property](encoding, name, properties[property], layout, def) :
+      properties[property];
     if (value !== undefined) {
       def.properties = def.properties || {};
       def.properties[property] = value;

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -274,13 +274,6 @@ var axisMixin = {
           minimum: 0,
           description: 'Truncate labels that are too long.'
         },
-        labelAngle: {
-          type: 'integer',
-          default: undefined, // auto
-          minimum: 0,
-          maximum: 360,
-          description: 'Angle by which to rotate labels. Set to 0 to force horizontal.'
-        },
         titleMaxLength: {
           type: 'integer',
           default: undefined,

--- a/src/schema/schema.js
+++ b/src/schema/schema.js
@@ -257,7 +257,7 @@ var axisMixin = {
         },
         ticks: {
           type: 'integer',
-          default: 5,
+          default: undefined,
           minimum: 0,
           description: 'A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are "nice" (multiples of 2, 5, 10) and lie within the underlying scale\'s range.'
         },

--- a/test/compiler/axis.test.js
+++ b/test/compiler/axis.test.js
@@ -48,19 +48,6 @@ describe('Axis', function() {
     // FIXME(kanitw): Jul 19, 2015 - write test
   });
 
-  describe('hideTicks()', function () {
-    var def = axis.hideTicks({properties:{}});
-    it('should adjust ticks', function () {
-      expect(def.properties.ticks).to.eql({opacity: {value: 0}});
-    });
-    it('should adjust majorTicks', function () {
-      expect(def.properties.majorTicks).to.eql({opacity: {value: 0}});
-    });
-    it('should adjust axis', function () {
-      expect(def.properties.axis).to.eql({opacity: {value: 0}});
-    });
-  });
-
   describe('labels.scale()', function () {
     // FIXME(kanitw): Jul 19, 2015 - write test
   });
@@ -90,7 +77,7 @@ describe('Axis', function() {
           encoding: {
             x: {name: 'a', axis:{orient: 'bottom'}}
           }
-        }), 'x', stats);
+        }), 'x', {}, stats);
       expect(orient).to.eql('bottom');
     });
 
@@ -99,7 +86,7 @@ describe('Axis', function() {
           encoding: {
             x: {name: 'a'}
           }
-        }), 'x', stats);
+        }), 'x', {}, stats);
       expect(orient).to.eql(undefined);
     });
 
@@ -109,7 +96,7 @@ describe('Axis', function() {
             x: {name: 'a'},
             col: {name: 'a'}
           }
-        }), 'col', stats);
+        }), 'col', {}, stats);
       expect(orient).to.eql('top');
     });
 
@@ -119,56 +106,56 @@ describe('Axis', function() {
             x: {name: 'a'},
             y: {name: 'b', type: 'O'}
           }
-        }), 'x', stats);
+        }), 'x', {}, stats);
       expect(orient).to.eql('top');
     });
   });
 
   describe('title()', function () {
     it('should add explicitly specified title', function () {
-      var def = axis.title({}, Encoding.fromSpec({
+      var title = axis.title(Encoding.fromSpec({
           encoding: {
             x: {name: 'a', axis: {title: 'Custom'}}
           }
         }), 'x', stats, layout);
-      expect(def.title).to.eql('Custom');
+      expect(title).to.eql('Custom');
     });
 
     it('should add return fieldTitle by default', function () {
-      var def = axis.title({}, Encoding.fromSpec({
+      var title = axis.title(Encoding.fromSpec({
           encoding: {
             x: {name: 'a', axis: {titleMaxLength: '3'}}
           }
         }), 'x', layout);
-      expect(def.title).to.eql('a');
+      expect(title).to.eql('a');
     });
 
     it('should add return fieldTitle by default', function () {
-      var def = axis.title({}, Encoding.fromSpec({
+      var title = axis.title(Encoding.fromSpec({
           encoding: {
             x: {name: 'a', aggregate: 'sum', axis: {titleMaxLength: '10'}}
           }
         }), 'x', layout);
-      expect(def.title).to.eql('SUM(a)');
+      expect(title).to.eql('SUM(a)');
     });
 
     it('should add return fieldTitle by default and truncate', function () {
-      var def = axis.title({}, Encoding.fromSpec({
+      var title = axis.title(Encoding.fromSpec({
           encoding: {
             x: {name: 'a', aggregate: 'sum', axis: {titleMaxLength: '3'}}
           }
         }), 'x', layout);
-      expect(def.title).to.eql('SU…');
+      expect(title).to.eql('SU…');
     });
 
 
     it('should add return fieldTitle by default and truncate', function () {
-      var def = axis.title({}, Encoding.fromSpec({
+      var title = axis.title(Encoding.fromSpec({
           encoding: {
             x: {name: 'abcdefghijkl'}
           }
         }), 'x', layout);
-      expect(def.title).to.eql('abcdefghi…');
+      expect(title).to.eql('abcdefghi…');
     });
   });
 

--- a/test/compiler/axis.test.js
+++ b/test/compiler/axis.test.js
@@ -48,29 +48,6 @@ describe('Axis', function() {
     // FIXME(kanitw): Jul 19, 2015 - write test
   });
 
-  describe('labels.scale()', function () {
-    // FIXME(kanitw): Jul 19, 2015 - write test
-  });
-
-  describe('labels.format()', function () {
-    // FIXME(kanitw): Jul 19, 2015 - write test
-  });
-
-  describe('labels.angle()', function () {
-    it('should set explicitly specified angle', function () {
-      var def = axis.labels.angle({}, Encoding.fromSpec({
-        encoding: {
-          x: {name: 'a', type: 'T', axis:{labelAngle: 90}}
-        }
-      }), 'x');
-      expect(def.properties.labels.angle).to.eql({value: 90});
-    });
-  });
-
-  describe('labels.rotate()', function () {
-    // FIXME(kanitw): Jul 19, 2015 - write test
-  });
-
   describe('orient()', function () {
     it('should return specified orient', function () {
       var orient = axis.orient(Encoding.fromSpec({


### PR DESCRIPTION
- All produced properties that have special rules are organized in methods with the following patterns: `axis.<propertyName>` and `axis.properties.<propertyGroup>`
- #181 now support explicit specification of all Vega’s __axis properties__ (`'format', 'grid', 'offset', 'orient', 'tickSize', 'ticks', 'title', ‘titleOffset', 'layer', 'tickPadding', 'tickSize', 'tickSizeMajor', 'tickSizeMinor', 'tickSizeEnd',
    'values', ‘subdivide’`) and __property groups__ (`'axis', 'grid', 'labels', 'title', 'ticks', 'majorTicks', 'minorTicks’`)
- Output spec should remain the same except
  - `titleOffset` is set to `undefined` (auto) for `x` and `y` — so we can just rely on the [new Vega’s axis auto title offset](https://github.com/vega/vega/pull/421) — __This mean we need to wait until Vega releases new version before we can release one.__