### PR TITLE
fix for charts with rows with bin aggregation

### DIFF
--- a/src/compiler/scale.js
+++ b/src/compiler/scale.js
@@ -292,6 +292,8 @@ scale.range = function (encoding, name, type, layout, stats) {
       return 'shapes';
     case COLOR:
       return scale.color(encoding, name, type, stats);
+    case ROW:
+      return [0, layout.height];
   }
 
   return undefined;


### PR DESCRIPTION
There was an error on this type of vlSpec:

```json
{
 "encoding": {
  "row": {"name": "Acceleration","type": "Q","bin": true},
  "text": {
   "name": "*",
   "aggregate": "count",
   "type": "Q",
   "displayName": "Number of Records"
  },
  "color": {
   "name": "*",
   "aggregate": "count",
   "type": "Q",
   "displayName": "Number of Records"
  }
 },
 "marktype": "text",
 "data": {
  "formatType": "json",
  "url": "data/cars.json"
 }
}
```

I don't think this is the correct fix but at least it is working for me now. 
