### PR TITLE
A step toward making row's `axis.orient = 'right'` correct

### DIFF
--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -214,6 +214,8 @@ axis.properties.grid = function(encoding, name, spec, layout, def) {
     } else if (name == ROW) {
       var xOffset = encoding.config('cellGridOffset');
 
+      var sign = encoding.encDef(name).axis.orient === 'right' ? -1 : 1;
+
       // TODO(#677): this should depend on orient
       // set grid property -- put the lines on the top
       return util.extend({
@@ -224,13 +226,13 @@ axis.properties.grid = function(encoding, name, spec, layout, def) {
           field: 'data'
         },
         x: {
-          value: def.offset - xOffset
+          value: sign * (def.offset - xOffset)
         },
         x2: {
           field: {group: 'mark.group.width'},
-          offset: def.offset + xOffset,
+          offset: sign * (def.offset + xOffset),
           // default value(s) -- vega doesn't do recursive merge
-          mult: 1
+          mult: sign
         },
         stroke: { value: encoding.config('cellGridColor') },
         strokeOpacity: { value: encoding.config('cellGridOpacity') }

--- a/src/compiler/axis.js
+++ b/src/compiler/axis.js
@@ -193,6 +193,8 @@ axis.properties.grid = function(encoding, name, spec, layout, def) {
       // set grid property -- put the lines on the right the cell
       var yOffset = encoding.config('cellGridOffset');
 
+      var sign = encoding.encDef(name).axis.orient === 'bottom' ? -1 : 1;
+
       // TODO(#677): this should depend on orient
       return util.extend({
         x: {
@@ -202,11 +204,12 @@ axis.properties.grid = function(encoding, name, spec, layout, def) {
           field: 'data'
         },
         y: {
-          value: -yOffset,
+          value: - sign * yOffset,
         },
         y2: {
           field: {group: 'mark.group.height'},
-          offset: yOffset
+          offset: sign * yOffset,
+          mult: sign
         },
         stroke: { value: encoding.config('cellGridColor') },
         strokeOpacity: { value: encoding.config('cellGridOpacity') }


### PR DESCRIPTION
As @jpocom reported, that this spec
```
{
 "encoding": {
   "row": {
     "name": "Year",
     "type": "T",
     "timeUnit": "year",
     "axis": {
        "orient": "right"
     }
   },
   "text": {
     "name": "*",
     "aggregate": "count",
     "type": "Q",
     "displayName": "Number of Records"
   },
   "color": {
     "name": "*",
     "aggregate": "count",
     "type": "Q",
     "displayName": "Number of Records"
   }
 },
 "marktype": "text",
 "data": {
   "formatType": "json",
   "url": "data/cars.json"
 }
}
```
produces:
![vega_editor](https://cloud.githubusercontent.com/assets/111269/11133166/f6dcb568-8948-11e5-9dc5-523f0b3757c5.png)


With this fix, now it is slightly better: 

![vega_editor](https://cloud.githubusercontent.com/assets/111269/11133156/e7e230d8-8948-11e5-967b-f463a3fddc08.png)

