### PR TITLE
Make compiler return an object containing spec rather than just the spec.

### DIFF
--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -70,7 +70,7 @@ var vlspec = {
       }
     };
 
-var vgspec = vl.compile(vlspec);
+var vgspec = vl.compile(vlspec).spec;
 parse(vgspec);
 
 </script>
@@ -100,7 +100,7 @@ Note that the need to call `vl.data.stats()` will be eliminated very soon (befor
 
 function render(vlSpec) {
   var callback = function(stats) {
-    var vgSpec = vl.compile(vlSpec, stats);
+    var vgSpec = vl.compile(vlSpec, stats).spec;
 
     vg.parse.spec(vgSpec, function(chart) {
       var view = chart({el: '#vis', renderer: 'svg'});

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -129,5 +129,8 @@ export function compile(spec, stats, theme?) {
     }
   }
 
-  return output;
+  return {
+    spec: output
+    // TODO: add warning / errors here
+  };
 }

--- a/test/compiler/stack.test.ts
+++ b/test/compiler/stack.test.ts
@@ -29,7 +29,7 @@ describe('vl.compile.stack()', function () {
   describe('bin-x', function () {
     it('should put stack on y', function () {
       // FIXME don't run the whole compile
-      var vgSpec = compile(fixtures.binX, stats);
+      var vgSpec = compile(fixtures.binX, stats).spec;
 
       var tableData = vgSpec.data.filter(function(data) {
         return data.name === SUMMARY;
@@ -54,7 +54,7 @@ describe('vl.compile.stack()', function () {
   describe('bin-y', function () {
     it('should put stack on x', function () {
       // FIXME don't run the whole compile
-      var vgSpec = compile(fixtures.binY, stats);
+      var vgSpec = compile(fixtures.binY, stats).spec;
 
       var tableData = vgSpec.data.filter(function(data) {
         return data.name === SUMMARY;


### PR DESCRIPTION
Make compiler return an object containing spec rather than just the spec. -- fixes #727