### PR TITLE
Kw/model

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ __Try using Vega-Lite in the online [Vega Editor](http://vega.github.io/vega-edi
 The complete schema for specifications as [JSON schema](http://json-schema.org/) is at [vega-lite-schema.json](https://vega.github.io/vega-lite/vega-lite-schema.json).
 
 **Note: Vega-Lite is still in alpha phase and we are working on improving the code and [documentation](docs/Documentation.md).
-Our syntax might change slightly before we release 1.0.**  See our wiki pages for [the development roadmap](https://github.com/vega/vega-lite/wiki/Roadmap) and [how you can contribute](https://github.com/vega/vega-lite/wiki/Contribute). 
+Our syntax might change slightly before we release 1.0.**  See our wiki pages for [the development roadmap](https://github.com/vega/vega-lite/wiki/Roadmap) and [how you can contribute](https://github.com/vega/vega-lite/wiki/Contribute).
 If you find a bug or have a feature request, please [create an issue](https://github.com/vega/vega-lite/issues/new).
 
 
@@ -28,14 +28,14 @@ We have more example visualizations in our [gallery](https://vega.github.io/vega
   "data": {"url": "data/barley.json"},
   "marktype": "point",
   "encoding": {
-    "x": {"type": "quantitative","name": "yield","aggregate": "mean"},
+    "x": {"type": "quantitative", "field": "yield","aggregate": "mean"},
     "y": {
-      "sort": {"name": "yield","aggregate": "mean","reverse": false},
+      "sort": {"field": "yield", "aggregate": "mean", "reverse": false},
       "type": "ordinal",
-      "name": "variety"
+      "field": "variety"
     },
-    "row": {"type": "ordinal","name": "site"},
-    "color": {"type": "ordinal","name": "year"}
+    "row": {"type": "ordinal", "field": "site"},
+    "color": {"type": "ordinal", "field": "year"}
   }
 }
 ```
@@ -55,8 +55,8 @@ This is a similar chart as one of the Vega examples in https://github.com/trifac
   },
   "marktype": "bar",
   "encoding": {
-    "x": {"type": "ordinal","name": "a"},
-    "y": {"type": "quantitative","name": "b"}
+    "x": {"type": "ordinal", "field": "a"},
+    "y": {"type": "quantitative", "field": "b"}
   }
 }
 ```
@@ -76,7 +76,7 @@ npm install
 
 You can run `npm run build` to compile Vega-Lite.
 
-You can `npm run watch` to start a watcher task that 
+You can `npm run watch` to start a watcher task that
 - re-compile Vega-Lite
 - regenerate the `vega-lite-schema.json` file whenever `schema.js` changes
 - lints and tests all JS files when any `.js` file in `test/` or `src/` changes.

--- a/docs/Data.md
+++ b/docs/Data.md
@@ -57,7 +57,7 @@ Each formula object in the `calculate` array has two properties:
 
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
-| field         | String        | The property name in which to store the computed formula value. |
+| field         | String        | The field name in which to store the computed formula value. |
 | expr          | String        | A string containing an expression for the formula. Use the variable `datum` to to refer to the current data object. |
 
 ### Binning, Time Unit Conversion, Aggregation

--- a/docs/Documentation.md
+++ b/docs/Documentation.md
@@ -65,8 +65,8 @@ var vlspec = {
       },
       "marktype": "bar",
       "encoding": {
-        "x": {"type": "ordinal","name": "a"},
-        "y": {"type": "quantitative","name": "b"}
+        "x": {"type": "ordinal","field": "a"},
+        "y": {"type": "quantitative","field": "b"}
       }
     };
 
@@ -123,8 +123,8 @@ var vlspec = {
       "data": {"url": "data/cars.json"},
       "marktype": "point",
       "encoding": {
-        "x": {"type": "ordinal","name": "Origin"},
-        "y": {"type": "quantitative","name": "Acceleration"}
+        "x": {"type": "ordinal","field": "Origin"},
+        "y": {"type": "quantitative","field": "Acceleration"}
       }
     };
 

--- a/docs/Encoding-Mapping.md
+++ b/docs/Encoding-Mapping.md
@@ -4,7 +4,7 @@ encoding channels (`x`,`y`, `row`, `column`, `color`, `size`, `shape`, `text`,
 
 Each encoding definition object contains:
 - A field's definition
-  - A field reference to the variable by `name` or a constant value `value`
+  - A field reference to the variable by `field` or a constant value `value`
   - The variable's data `type`
   - Its inline transformation including aggregation (`aggregate`), binning (`bin`), and time unit conversion (`timeUnit`).
 - Optional configuration properties for `scale`, `axis`, and `legends`, `stack` of the encoding channel.
@@ -17,9 +17,9 @@ Here are the list of properties of the encoding property definition object:
 
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
-| name __<sup>1</sup>__ | String        | Name of the field/variable from which to pull a data value.    |
+| field         | String        | Name of the field from which to pull a data value.    |
 | value         | String,Integer | A constant value |
-| type          | String        | Data type of the field.  This property accepts both a full type name (`'quantitative'`, `'temporal'`, `'ordinal'`,  and `'nominal'`), or an initial character of the type name (`'Q'`, `'T'`, `'O'`, `'N'`).  This property is case insensitive.  __<sup>2</sup>__ |
+| type          | String        | Data type of the field.  This property accepts both a full type name (`'quantitative'`, `'temporal'`, `'ordinal'`,  and `'nominal'`), or an initial character of the type name (`'Q'`, `'T'`, `'O'`, `'N'`).  This property is case insensitive.  __<sup>1</sup>__ |
 | [aggregate](#aggregate) | String        | Aggregation function for the field (e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).  |
 | [bin](#bin)          | Boolean \| Object        | Boolean flag / configuration object for binning.  See [Binning](#Binning) |
 | [timeUnit](#timeunit)| String        | Property for converting time unit            |
@@ -29,11 +29,7 @@ Here are the list of properties of the encoding property definition object:
 | [scale](#scale)      | Object        | Configuration object for the encoding's scale   |
 | [stack](#stack)      | Boolean \| Object        | Boolean flag / configuration object for stacking (only for bar and area marks). See [Stack](#stack).  |
 
-
 __<sup>1</sup>__ __Pending Revision__
-`name` properties will be renamed to `field` to be consistent with the rest of Vega projects.  [#480](/vega/vega-lite/issues/480)
-
-__<sup>2</sup>__ __Pending Revision__
 We are considering other properties of variables including specifying primitive type.
 
 ## bin

--- a/gallery/examples.js
+++ b/gallery/examples.js
@@ -15,8 +15,8 @@ var EXAMPLES = [
       },
       marktype: 'bar',
       encoding: {
-        y: {type: 'quantitative', name: 'y'},
-        x: {type: 'ordinal', name: 'x'}
+        y: {type: 'quantitative', field: 'y'},
+        x: {type: 'ordinal', field: 'x'}
       }
     }
   },{
@@ -34,8 +34,8 @@ var EXAMPLES = [
       },
       marktype: 'bar',
       encoding: {
-        y: {type: 'quantitative', name: 'y'},
-        x: {type: 'ordinal', name: 'x'}
+        y: {type: 'quantitative', field: 'y'},
+        x: {type: 'ordinal', field: 'x'}
       }
     }
   },{
@@ -43,8 +43,8 @@ var EXAMPLES = [
     spec: {
       'marktype': 'bar',
       'encoding': {
-        'x': {'name': 'Cylinders','type': 'ordinal'},
-        'y': {'name': 'Acceleration','type': 'quantitative','aggregate': 'mean'}
+        'x': {'field': 'Cylinders','type': 'ordinal'},
+        'y': {'field': 'Acceleration','type': 'quantitative','aggregate': 'mean'}
       },
       'data': {'url': 'data/cars.json'}
     }
@@ -53,11 +53,11 @@ var EXAMPLES = [
     spec: {
       marktype: 'bar',
       encoding: {
-        x: {name: 'Origin', type: 'nominal'},
-        y: {name: 'Acceleration', type: 'quantitative', aggregate: 'mean'},
-        column: {name: 'Cylinders', type: 'ordinal'},
+        x: {field: 'Origin', type: 'nominal'},
+        y: {field: 'Acceleration', type: 'quantitative', aggregate: 'mean'},
+        column: {field: 'Cylinders', type: 'ordinal'},
         color: {
-          name: 'Origin',
+          field: 'Origin',
           type: 'nominal'
         }
       },
@@ -69,8 +69,8 @@ var EXAMPLES = [
     spec: {
       marktype: 'point',
       encoding: {
-        x: {'name': 'Horsepower','type': 'quantitative'},
-        y: {'name': 'Miles_per_Gallon','type': 'quantitative'}
+        x: {'field': 'Horsepower','type': 'quantitative'},
+        y: {'field': 'Miles_per_Gallon','type': 'quantitative'}
       },
       data: {'url': 'data/cars.json'}
     }
@@ -79,10 +79,10 @@ var EXAMPLES = [
     spec: {
       'marktype': 'point',
       'encoding': {
-        'x': {'bin': true,'name': 'Displacement','type': 'quantitative'},
-        'y': {'bin': true,'name': 'Miles_per_Gallon','type': 'quantitative'},
+        'x': {'bin': true,'field': 'Displacement','type': 'quantitative'},
+        'y': {'bin': true,'field': 'Miles_per_Gallon','type': 'quantitative'},
         'size': {
-          'name': '*',
+          'field': '*',
           'aggregate': 'count',
           'type': 'quantitative',
           'displayName': 'Number of Records'
@@ -95,8 +95,8 @@ var EXAMPLES = [
     spec: {
       'marktype': 'point',
       'encoding': {
-        'x': {'name': 'MPAA_Rating','type': 'nominal'},
-        'y': {'name': 'Release_Date','type': 'nominal'}
+        'x': {'field': 'MPAA_Rating','type': 'nominal'},
+        'y': {'field': 'Release_Date','type': 'nominal'}
       },
       'data': {'url': 'data/movies.json'}
     }
@@ -106,8 +106,8 @@ var EXAMPLES = [
     spec: {
       marktype: 'line',
       encoding: {
-        x: {'name': 'Year','type': 'temporal','timeUnit': 'year'},
-        y: {'name': 'Horsepower','type': 'quantitative','aggregate': 'mean'}
+        x: {'field': 'Year','type': 'temporal','timeUnit': 'year'},
+        y: {'field': 'Horsepower','type': 'quantitative','aggregate': 'mean'}
       },
       data: {'url': 'data/cars.json'}
     }
@@ -116,8 +116,8 @@ var EXAMPLES = [
     spec: {
       marktype: 'bar',
       encoding: {
-        x: {'bin': {'maxbins': 15},'name': 'Horsepower','type': 'quantitative'},
-        y: {'name': '*','type': 'quantitative','aggregate': 'count'}
+        x: {'bin': {'maxbins': 15},'field': 'Horsepower','type': 'quantitative'},
+        y: {'field': '*','type': 'quantitative','aggregate': 'count'}
       },
       data: {'url': 'data/cars.json'}
     }
@@ -127,9 +127,9 @@ var EXAMPLES = [
     spec: {
       marktype: 'bar',
       encoding: {
-        x: {'bin': {'maxbins': 15},'name': 'Horsepower','type': 'quantitative'},
-        y: {'name': '*','type': 'quantitative','aggregate': 'count'},
-        color: {'name': 'Cylinders','type': 'nominal'}
+        x: {'bin': {'maxbins': 15},'field': 'Horsepower','type': 'quantitative'},
+        y: {'field': '*','type': 'quantitative','aggregate': 'count'},
+        color: {'field': 'Cylinders','type': 'nominal'}
       },
       data: {'url': 'data/cars.json'}
     }
@@ -138,8 +138,8 @@ var EXAMPLES = [
     spec: {
       'marktype': 'area',
       'encoding': {
-        'x': {'name': 'Year','type': 'temporal','timeUnit': 'year'},
-        'y': {'name': 'Weight_in_lbs','type': 'quantitative','aggregate': 'sum'}
+        'x': {'field': 'Year','type': 'temporal','timeUnit': 'year'},
+        'y': {'field': 'Weight_in_lbs','type': 'quantitative','aggregate': 'sum'}
       },
       'data': {'url': 'data/cars.json'}
     }
@@ -148,9 +148,9 @@ var EXAMPLES = [
     spec: {
       'marktype': 'area',
       'encoding': {
-        'x': {'name': 'Year','type': 'temporal','timeUnit': 'year'},
-        'y': {'name': 'Weight_in_lbs','type': 'quantitative','aggregate': 'sum'},
-        'color': {'name': 'Cylinders', 'type': 'ordinal'}
+        'x': {'field': 'Year','type': 'temporal','timeUnit': 'year'},
+        'y': {'field': 'Weight_in_lbs','type': 'quantitative','aggregate': 'sum'},
+        'color': {'field': 'Cylinders', 'type': 'ordinal'}
       },
       'data': {'url': 'data/cars.json'}
     }
@@ -159,9 +159,9 @@ var EXAMPLES = [
     spec: {
       'marktype': 'area',
       'encoding': {
-        'x': {'name': 'Year','type': 'temporal','timeUnit': 'year'},
-        'y': {'name': 'Weight_in_lbs','type': 'quantitative','aggregate': 'sum'},
-        'column': {'name': 'Cylinders', 'type': 'ordinal'}
+        'x': {'field': 'Year','type': 'temporal','timeUnit': 'year'},
+        'y': {'field': 'Weight_in_lbs','type': 'quantitative','aggregate': 'sum'},
+        'column': {'field': 'Cylinders', 'type': 'ordinal'}
       },
       'data': {'url': 'data/cars.json'}
     }
@@ -170,9 +170,9 @@ var EXAMPLES = [
     spec: {
       'marktype': 'bar',
       'encoding': {
-        'x': {'name': 'yield','type': 'quantitative','aggregate': 'sum'},
-        'y': {'name': 'variety','type': 'nominal'},
-        'color': {'name': 'site', 'type': 'nominal'}
+        'x': {'field': 'yield','type': 'quantitative','aggregate': 'sum'},
+        'y': {'field': 'variety','type': 'nominal'},
+        'color': {'field': 'site', 'type': 'nominal'}
       },
       'data': {'url': 'data/barley.json'}
     }
@@ -181,9 +181,9 @@ var EXAMPLES = [
     spec: {
       'marktype': 'bar',
       'encoding': {
-        'y': {'name': 'yield','type': 'quantitative','aggregate': 'sum'},
-        'x': {'name': 'variety','type': 'nominal'},
-        'color': {'name': 'site', 'type': 'nominal'}
+        'y': {'field': 'yield','type': 'quantitative','aggregate': 'sum'},
+        'x': {'field': 'variety','type': 'nominal'},
+        'color': {'field': 'site', 'type': 'nominal'}
       },
       'data': {'url': 'data/barley.json'}
     }
@@ -192,9 +192,9 @@ var EXAMPLES = [
     spec: {
       'marktype': 'bar',
       'encoding': {
-        'x': {'name': 'Acceleration','type': 'quantitative','aggregate': 'sum'},
+        'x': {'field': 'Acceleration','type': 'quantitative','aggregate': 'sum'},
         'color': {
-          'name': 'Origin',
+          'field': 'Origin',
           'type': 'nominal'
         }
       },
@@ -205,10 +205,10 @@ var EXAMPLES = [
     spec: {
       'marktype': 'bar',
       'encoding': {
-        'x': {'name': 'yield','type': 'quantitative','aggregate': 'sum'},
-        'y': {'name': 'variety','type': 'nominal'},
-        'column': {'name': 'year','type': 'ordinal'},
-        'color': {'name': 'site', 'type': 'nominal'}
+        'x': {'field': 'yield','type': 'quantitative','aggregate': 'sum'},
+        'y': {'field': 'variety','type': 'nominal'},
+        'column': {'field': 'year','type': 'ordinal'},
+        'color': {'field': 'site', 'type': 'nominal'}
       },
       'data': {'url': 'data/barley.json'}
     }
@@ -217,9 +217,9 @@ var EXAMPLES = [
     spec: {
       'marktype': 'point',
       'encoding': {
-        'x': {'name': 'Worldwide_Gross','type': 'quantitative'},
-        'y': {'name': 'US_DVD_Sales','type': 'quantitative'},
-        'column': {'name': 'MPAA_Rating','type': 'ordinal'}
+        'x': {'field': 'Worldwide_Gross','type': 'quantitative'},
+        'y': {'field': 'US_DVD_Sales','type': 'quantitative'},
+        'column': {'field': 'MPAA_Rating','type': 'ordinal'}
       },
       'data': {'url': 'data/movies.json'}
     }
@@ -231,14 +231,14 @@ var EXAMPLES = [
       data: {url: 'data/barley.json'},
       marktype: 'point',
       encoding: {
-        x: {type: 'quantitative',name: 'yield', aggregate: 'mean'},
+        x: {type: 'quantitative',field: 'yield', aggregate: 'mean'},
         y: {
           sort: {field: 'yield', op: 'mean'},
           type: 'ordinal',
-          name: 'variety'
+          field: 'variety'
         },
-        row: {type: 'ordinal',name: 'site'},
-        color: {type: 'nominal',name: 'year'}
+        row: {type: 'ordinal', field: 'site'},
+        color: {type: 'nominal', field: 'year'}
       }
     }
   },{
@@ -246,10 +246,10 @@ var EXAMPLES = [
     spec: {
       'marktype': 'text',
       'encoding': {
-        'row': {'name': 'Origin','type': 'ordinal'},
-        'column': {'name': 'Cylinders','type': 'ordinal'},
-        'color': {'name': 'Horsepower','type': 'quantitative','aggregate': 'mean'},
-        'text': {'name': '*','type': 'quantitative','aggregate': 'count'}
+        'row': {'field': 'Origin', 'type': 'ordinal'},
+        'column': {'field': 'Cylinders', 'type': 'ordinal'},
+        'color': {'field': 'Horsepower', 'type': 'quantitative','aggregate': 'mean'},
+        'text': {'field': '*', 'type': 'quantitative', 'aggregate': 'count'}
       },
       'data': {'url': 'data/cars.json'}
     }
@@ -258,9 +258,9 @@ var EXAMPLES = [
     spec: {
       "marktype": "bar",
       "encoding": {
-        "x": {"bin": true,"name": "Acceleration","type": "quantitative"},
+        "x": {"bin": true, "field": "Acceleration","type": "quantitative"},
         "y": {
-          "name": "*",
+          "field": "*",
           "aggregate": "count",
           "type": "quantitative",
           "displayName": "Number of Records"
@@ -273,9 +273,9 @@ var EXAMPLES = [
     spec: {
       "marktype": "bar",
       "encoding": {
-        "y": {"bin": true,"name": "Acceleration","type": "quantitative"},
+        "y": {"bin": true, "field": "Acceleration","type": "quantitative"},
         "x": {
-          "name": "*",
+          "field": "*",
           "aggregate": "count",
           "type": "quantitative",
           "displayName": "Number of Records"
@@ -288,9 +288,9 @@ var EXAMPLES = [
     spec: {
       "marktype": "point",
       "encoding": {
-        "x": {"bin": true,"name": "Acceleration","type": "quantitative"},
+        "x": {"bin": true,"field": "Acceleration","type": "quantitative"},
         "y": {
-          "name": "*",
+          "field": "*",
           "aggregate": "count",
           "type": "quantitative",
           "displayName": "Number of Records"
@@ -303,9 +303,9 @@ var EXAMPLES = [
     spec: {
       "marktype": "line",
       "encoding": {
-        "x": {"bin": true,"name": "Acceleration","type": "quantitative"},
+        "x": {"bin": true,"field": "Acceleration","type": "quantitative"},
         "y": {
-          "name": "*",
+          "field": "*",
           "aggregate": "count",
           "type": "quantitative",
           "displayName": "Number of Records"
@@ -318,9 +318,9 @@ var EXAMPLES = [
     spec: {
       "marktype": "area",
       "encoding": {
-        "x": {"bin": true,"name": "Acceleration","type": "quantitative"},
+        "x": {"bin": true,"field": "Acceleration","type": "quantitative"},
         "y": {
-          "name": "*",
+          "field": "*",
           "aggregate": "count",
           "type": "quantitative",
           "displayName": "Number of Records"
@@ -375,10 +375,10 @@ var EXAMPLES = [
         "y": {
           "scale": {"type": "log"},
           "type": "quantitative",
-          "name": "m_teps",
+          "field": "m_teps",
           "axis": {"title": "MTEPS"}
         },
-        "x": {"type": "ordinal","name": "dataset"}
+        "x": {"type": "ordinal","field": "dataset"}
       }
     }
   }

--- a/src/aggregate.ts
+++ b/src/aggregate.ts
@@ -5,4 +5,8 @@ export const AGGREGATE_OPS = [
   'argmin', 'argmax'
 ];
 
+export const SHARED_DOMAIN_OPS = [
+  'mean', 'average', 'stdev', 'stdevp', 'median', 'q1', 'q3', 'min', 'max'
+];
+
 // TODO: move supportedTypes, supportedEnums from schema to here

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -98,10 +98,6 @@ export class Model {
     }
   }
 
-  scale(channel: Channel) {
-    return this._spec.encoding[channel].scale || {};
-  }
-
   axis(channel: Channel) {
     return this._spec.encoding[channel].axis || {};
   }

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -137,10 +137,6 @@ export class Model {
     return bin;
   }
 
-  value(channel: Channel) {
-    return this._spec.encoding[channel].value;
-  }
-
   numberFormat = function(channel?: Channel) {
     // TODO(#497): have different number format based on numberType (discrete/continuous)
     return this.config('numberFormat');

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -73,7 +73,7 @@ export class Model {
 
   has(channel: Channel) {
     // equivalent to calling vlenc.has(this._encoding, channel)
-    return this._encoding[channel].name !== undefined;
+    return this._encoding[channel].field !== undefined;
   }
 
   fieldDef(channel: Channel) {
@@ -99,9 +99,9 @@ export class Model {
     }
     var fn = this._encoding[channel].aggregate || this._encoding[channel].timeUnit || (this._encoding[channel].bin && 'bin');
     if (fn) {
-      return fn.toUpperCase() + '(' + this._encoding[channel].name + ')';
+      return fn.toUpperCase() + '(' + this._encoding[channel].field + ')';
     } else {
-      return this._encoding[channel].name;
+      return this._encoding[channel].field;
     }
   }
 

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -98,10 +98,6 @@ export class Model {
     }
   }
 
-  axis(channel: Channel) {
-    return this._spec.encoding[channel].axis || {};
-  }
-
   bandWidth(channel: Channel, useSmallBand?: boolean) {
     if (this.fieldDef(channel).scale.bandWidth !== undefined) {
       // explicit value

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -5,12 +5,13 @@ import {FieldDef} from '../schema/fielddef.schema';
 import {MAXBINS_DEFAULT} from '../bin';
 import {COLUMN, ROW, X, Y, COLOR, DETAIL, Channel} from '../channel';
 import {SOURCE, SUMMARY} from '../data';
-import * as util from '../util';
 import * as vlFieldDef from '../fielddef';
 import * as vlEncoding from '../encoding';
+import {AREA, BAR} from '../marktype';
 import * as schema from '../schema/schema';
 import * as schemaUtil from '../schema/schemautil';
 import {getFullName} from '../type';
+import * as util from '../util';
 
 /**
  * Internal model of Vega-Lite specification for the compiler.
@@ -218,7 +219,7 @@ export class Model {
       this.fieldDef(stack).stack :
       {};
 
-    if ((this.is('bar') || this.is('area')) && stack && this.isAggregate()) {
+    if ((this.is(BAR) || this.is(AREA)) && stack && this.isAggregate()) {
 
       var isXMeasure = this.isMeasure(X);
       var isYMeasure = this.isMeasure(Y);

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -247,10 +247,6 @@ export class Model {
     return vlFieldDef.cardinality(this.fieldDef(channel), stats, this.config('filterNull'));
   }
 
-  isRaw() {
-    return !this.isAggregate();
-  }
-
   data() {
     return this._spec.data;
   }

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -18,24 +18,16 @@ import * as util from '../util';
  */
 
 export class Model {
-  _data: any;
-  _marktype: string;
-  _encoding: any;
-  _config: any;
+  _spec: Spec;
 
   // TODO: include _stack, _layout, _style, etc.
 
   constructor(spec: Spec, theme?) {
     var defaults = schema.instantiate();
-    var specExtended = schemaUtil.merge(defaults, theme || {}, spec);
-
-    this._data = specExtended.data;
-    this._marktype = specExtended.marktype;
-    this._encoding = specExtended.encoding;
-    this._config = specExtended.config;
+    this._spec = schemaUtil.merge(defaults, theme || {}, spec);
 
     // convert short type to full type
-    vlEncoding.forEach(this._encoding, function(fieldDef) {
+    vlEncoding.forEach(this._spec.encoding, function(fieldDef) {
       if (fieldDef.type) {
         fieldDef.type = getFullName(fieldDef.type);
       }
@@ -43,20 +35,20 @@ export class Model {
   }
 
   toSpec(excludeConfig?, excludeData?) {
-    var encoding = util.duplicate(this._encoding),
+    var encoding = util.duplicate(this._spec.encoding),
       spec: any;
 
     spec = {
-      marktype: this._marktype,
+      marktype: this._spec.marktype,
       encoding: encoding
     };
 
     if (!excludeConfig) {
-      spec.config = util.duplicate(this._config);
+      spec.config = util.duplicate(this._spec.config);
     }
 
     if (!excludeData) {
-      spec.data = util.duplicate(this._data);
+      spec.data = util.duplicate(this._spec.data);
     }
 
     // remove defaults
@@ -65,53 +57,53 @@ export class Model {
   }
 
   marktype() {
-    return this._marktype;
+    return this._spec.marktype;
   }
 
   is(m) {
-    return this._marktype === m;
+    return this._spec.marktype === m;
   }
 
   has(channel: Channel) {
-    // equivalent to calling vlenc.has(this._encoding, channel)
-    return this._encoding[channel].field !== undefined;
+    // equivalent to calling vlenc.has(this._spec.encoding, channel)
+    return this._spec.encoding[channel].field !== undefined;
   }
 
   fieldDef(channel: Channel) {
-    return this._encoding[channel];
+    return this._spec.encoding[channel];
   }
 
   // get "field" reference for vega
   fieldRef(channel: Channel, opt?) {
     opt = opt || {};
-    return vlFieldDef.fieldRef(this._encoding[channel], opt);
+    return vlFieldDef.fieldRef(this._spec.encoding[channel], opt);
   }
 
   /*
    * return key-value pairs of field name and list of fields of that field name
    */
   fields() {
-    return vlEncoding.fields(this._encoding);
+    return vlEncoding.fields(this._spec.encoding);
   }
 
   fieldTitle(channel: Channel) {
-    if (vlFieldDef.isCount(this._encoding[channel])) {
+    if (vlFieldDef.isCount(this._spec.encoding[channel])) {
       return vlFieldDef.COUNT_DISPLAYNAME;
     }
-    var fn = this._encoding[channel].aggregate || this._encoding[channel].timeUnit || (this._encoding[channel].bin && 'bin');
+    var fn = this._spec.encoding[channel].aggregate || this._spec.encoding[channel].timeUnit || (this._spec.encoding[channel].bin && 'bin');
     if (fn) {
-      return fn.toUpperCase() + '(' + this._encoding[channel].field + ')';
+      return fn.toUpperCase() + '(' + this._spec.encoding[channel].field + ')';
     } else {
-      return this._encoding[channel].field;
+      return this._spec.encoding[channel].field;
     }
   }
 
   scale(channel: Channel) {
-    return this._encoding[channel].scale || {};
+    return this._spec.encoding[channel].scale || {};
   }
 
   axis(channel: Channel) {
-    return this._encoding[channel].axis || {};
+    return this._spec.encoding[channel].axis || {};
   }
 
   bandWidth(channel: Channel, useSmallBand?: boolean) {
@@ -143,7 +135,7 @@ export class Model {
 
   // returns false if binning is disabled, otherwise an object with binning properties
   bin(channel: Channel): Bin | boolean {
-    var bin = this._encoding[channel].bin;
+    var bin = this._spec.encoding[channel].bin;
     if (bin === {})
       return false;
     if (bin === true)
@@ -154,7 +146,7 @@ export class Model {
   }
 
   value(channel: Channel) {
-    return this._encoding[channel].value;
+    return this._spec.encoding[channel].value;
   }
 
   numberFormat = function(channel?: Channel) {
@@ -163,15 +155,15 @@ export class Model {
   };
 
   map(f) {
-    return vlEncoding.map(this._encoding, f);
+    return vlEncoding.map(this._spec.encoding, f);
   }
 
   reduce(f, init) {
-    return vlEncoding.reduce(this._encoding, f, init);
+    return vlEncoding.reduce(this._spec.encoding, f, init);
   }
 
   forEach(f) {
-    return vlEncoding.forEach(this._encoding, f);
+    return vlEncoding.forEach(this._spec.encoding, f);
   }
 
   isTypes(channel: Channel, type: Array<any>) {
@@ -196,14 +188,14 @@ export class Model {
   }
 
   isAggregate() {
-    return vlEncoding.isAggregate(this._encoding);
+    return vlEncoding.isAggregate(this._spec.encoding);
   }
 
   dataTable() {
     return this.isAggregate() ? SUMMARY : SOURCE;
   }
 
-  // TODO: calculate this and store it in this._stack so it can be called multiple times.
+  // TODO: calculate this and store it in this._spec.stack so it can be called multiple times.
   /**
    * Check if the encoding should be stacked and return the stack dimenstion and value fields.
    * @return {Object} An object containing two properties:
@@ -272,7 +264,7 @@ export class Model {
   }
 
   data() {
-    return this._data;
+    return this._spec.data;
   }
 
   // returns whether the encoding has values embedded
@@ -282,6 +274,6 @@ export class Model {
   }
 
   config(name: string) {
-    return this._config[name];
+    return this._spec.config[name];
   }
 }

--- a/src/compiler/axis.ts
+++ b/src/compiler/axis.ts
@@ -179,7 +179,7 @@ export function title(model: Model, channel: Channel, layout) {
 
 export function titleOffset(model: Model, channel: Channel) {
   // return specified value if specified
-  var value = model.axis(channel).titleOffset;
+  var value = model.fieldDef(channel).axis.titleOffset;
   if (value)  return value;
 
   switch (channel) {

--- a/src/compiler/axis.ts
+++ b/src/compiler/axis.ts
@@ -58,7 +58,7 @@ export function def(channel: Channel, model: Model, layout, stats) {
 }
 
 export function format(model: Model, channel: Channel) {
-  let fieldDef = model.fieldDef(channel);
+  const fieldDef = model.fieldDef(channel);
   var format = fieldDef.axis.format;
   if (format !== undefined)  {
     return format;
@@ -67,7 +67,7 @@ export function format(model: Model, channel: Channel) {
   if (fieldDef.type === QUANTITATIVE) {
     return model.numberFormat(channel);
   } else if (fieldDef.type === TEMPORAL) {
-    var timeUnit = model.fieldDef(channel).timeUnit;
+    const timeUnit = fieldDef.timeUnit;
     if (!timeUnit) {
       return model.config('timeFormat');
     } else if (timeUnit === 'year') {
@@ -78,7 +78,7 @@ export function format(model: Model, channel: Channel) {
 }
 
 export function grid(model: Model, channel: Channel) {
-  var grid = model.axis(channel).grid;
+  var grid = model.fieldDef(channel).axis.grid;
   if (grid !== undefined) {
     return grid;
   }
@@ -92,7 +92,7 @@ export function grid(model: Model, channel: Channel) {
 }
 
 export function layer(model: Model, channel: Channel, layout, stats, def) {
-  var layer = model.axis(channel).layer;
+  var layer = model.fieldDef(channel).axis.layer;
   if (layer !== undefined) {
     return layer;
   }
@@ -274,11 +274,11 @@ namespace properties {
       }, spec || {});
     }
 
-    if (model.isTypes(channel, [NOMINAL, ORDINAL]) && model.axis(channel).labelMaxLength) {
+    if (model.isTypes(channel, [NOMINAL, ORDINAL]) && fieldDef.axis.labelMaxLength) {
       // TODO replace this with Vega's labelMaxLength once it is introduced
       spec = util.extend({
         text: {
-          template: '{{ datum.data | truncate:' + model.axis(channel).labelMaxLength + '}}'
+          template: '{{ datum.data | truncate:' + fieldDef.axis.labelMaxLength + '}}'
         }
       }, spec || {});
     }

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -1,6 +1,7 @@
 import * as vlFieldDef from '../fielddef';
 import * as util from '../util';
 import {Model} from './Model';
+import {FieldDef} from '../schema/fielddef.schema';
 
 import {MAXBINS_DEFAULT} from '../bin';
 import {Channel} from '../channel';
@@ -75,14 +76,14 @@ export namespace source {
   function formatParse(model: Model) {
     var parse;
 
-    model.forEach(function(fieldDef) {
+    model.forEach(function(fieldDef: FieldDef) {
       if (fieldDef.type === TEMPORAL) {
         parse = parse || {};
-        parse[fieldDef.name] = 'date';
+        parse[fieldDef.field] = 'date';
       } else if (fieldDef.type === QUANTITATIVE) {
         if (vlFieldDef.isCount(fieldDef)) return;
         parse = parse || {};
-        parse[fieldDef.name] = 'number';
+        parse[fieldDef.field] = 'number';
       }
     });
 
@@ -105,7 +106,7 @@ export namespace source {
   }
 
   export function timeTransform(model: Model) {
-    return model.reduce(function(transform, fieldDef, channel) {
+    return model.reduce(function(transform, fieldDef: FieldDef, channel: Channel) {
       if (fieldDef.type === TEMPORAL && fieldDef.timeUnit) {
         var fieldRef = model.fieldRef(channel, {nofn: true, datum: true});
 
@@ -120,12 +121,12 @@ export namespace source {
   }
 
   export function binTransform(model: Model) {
-    return model.reduce(function(transform, fieldDef, channel) {
+    return model.reduce(function(transform, fieldDef: FieldDef, channel: Channel) {
       const bin = model.bin(channel);
       if (bin) {
         transform.push({
           type: 'bin',
-          field: fieldDef.name,
+          field: fieldDef.field,
           output: {
             start: model.fieldRef(channel, {binSuffix: '_start'}),
             end: model.fieldRef(channel, {binSuffix: '_end'})
@@ -209,8 +210,8 @@ export namespace summary {
           meas['*'] = meas['*'] || {};
           meas['*'].count = true;
         } else {
-          meas[fieldDef.name] = meas[fieldDef.name] || {};
-          meas[fieldDef.name][fieldDef.aggregate] = true;
+          meas[fieldDef.field] = meas[fieldDef.field] || {};
+          meas[fieldDef.field][fieldDef.aggregate] = true;
         }
       } else {
         if (fieldDef.bin) {
@@ -219,7 +220,7 @@ export namespace summary {
           dims[model.fieldRef(channel, {binSuffix: '_mid'})] = model.fieldRef(channel, {binSuffix: '_mid'});
           dims[model.fieldRef(channel, {binSuffix: '_end'})] = model.fieldRef(channel, {binSuffix: '_end'});
         } else {
-          dims[fieldDef.name] = model.fieldRef(channel);
+          dims[fieldDef.field] = model.fieldRef(channel);
         }
 
       }

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -186,8 +186,7 @@ export namespace source {
     }
 
     return calculate.reduce(function(transform, formula) {
-      formula.type = 'formula';
-      transform.push(formula);
+      transform.push(util.extend({type: formula}, formula));
       return transform;
     }, []);
   }

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -286,7 +286,7 @@ export namespace stack {
 
 export function filterNonPositive(dataTable, model: Model) {
   model.forEach(function(_, channel) {
-    if (model.scale(channel).type === 'log') {
+    if (model.fieldDef(channel).scale.type === 'log') {
       dataTable.transform.push({
         type: 'filter',
         test: model.fieldRef(channel, {datum: 1}) + ' > 0'

--- a/src/compiler/layout.ts
+++ b/src/compiler/layout.ts
@@ -112,7 +112,7 @@ function getMaxLength(model: Model, stats, channel: Channel) {
     if(fieldStats.type === 'number') {
       return getMaxNumberLength(model, channel, fieldStats);
     } else {
-      return Math.min(fieldStats.max, model.axis(channel).labelMaxLength || Infinity);
+      return Math.min(fieldStats.max, fieldDef.axis.labelMaxLength || Infinity);
     }
   }
 }

--- a/src/compiler/layout.ts
+++ b/src/compiler/layout.ts
@@ -96,8 +96,8 @@ function getMaxNumberLength(model: Model, channel: Channel, fieldStats) {
 
 // TODO(#600) revise this
 function getMaxLength(model: Model, stats, channel: Channel) {
-  var fieldDef = model.fieldDef(channel),
-    fieldStats = stats[fieldDef.name];
+  var fieldDef: FieldDef = model.fieldDef(channel),
+    fieldStats = stats[fieldDef.field];
 
   if (fieldDef.bin) {
     // TODO once bin support range, need to update this

--- a/src/compiler/layout.ts
+++ b/src/compiler/layout.ts
@@ -1,5 +1,7 @@
 /// <reference path="../../typings/d3-format.d.ts"/>
 
+import {FieldDef} from '../schema/fielddef.schema';
+
 import * as d3_format from 'd3-format';
 import {setter} from '../util';
 import {COLUMN, ROW, X, Y, TEXT, Channel} from '../channel';

--- a/src/compiler/legend.ts
+++ b/src/compiler/legend.ts
@@ -101,14 +101,14 @@ namespace properties {
           if (model.has(COLOR) && channel === COLOR) {
             symbols.fill = {scale: COLOR, field: 'data'};
           } else {
-            symbols.fill = {value: model.value(COLOR)};
+            symbols.fill = {value: model.fieldDef(COLOR).value};
           }
           symbols.stroke = {value: 'transparent'};
         } else {
           if (model.has(COLOR) && channel === COLOR) {
             symbols.stroke = {scale: COLOR, field: 'data'};
           } else {
-            symbols.stroke = {value: model.value(COLOR)};
+            symbols.stroke = {value: model.fieldDef(COLOR).value};
           }
           symbols.fill = {value: 'transparent'};
           symbols.strokeWidth = {value: model.config('strokeWidth')};

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -147,7 +147,7 @@ function bar_props(e: Model, layout, style) {
   if (e.has(COLOR)) {
     p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
   } else {
-    p.fill = {value: e.value(COLOR)};
+    p.fill = {value: e.fieldDef(COLOR).value};
   }
 
   // opacity
@@ -179,14 +179,14 @@ function point_props(e: Model, layout, style) {
   if (e.has(SIZE)) {
     p.size = {scale: SIZE, field: e.fieldRef(SIZE)};
   } else if (!e.has(SIZE)) {
-    p.size = {value: e.value(SIZE)};
+    p.size = {value: e.fieldDef(SIZE).value};
   }
 
   // shape
   if (e.has(SHAPE)) {
     p.shape = {scale: SHAPE, field: e.fieldRef(SHAPE)};
   } else if (!e.has(SHAPE)) {
-    p.shape = {value: e.value(SHAPE)};
+    p.shape = {value: e.fieldDef(SHAPE).value};
   }
 
   // fill or stroke
@@ -194,13 +194,13 @@ function point_props(e: Model, layout, style) {
     if (e.has(COLOR)) {
       p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
     } else if (!e.has(COLOR)) {
-      p.fill = {value: e.value(COLOR)};
+      p.fill = {value: e.fieldDef(COLOR).value};
     }
   } else {
     if (e.has(COLOR)) {
       p.stroke = {scale: COLOR, field: e.fieldRef(COLOR)};
     } else if (!e.has(COLOR)) {
-      p.stroke = {value: e.value(COLOR)};
+      p.stroke = {value: e.fieldDef(COLOR).value};
     }
     p.strokeWidth = {value: e.config('strokeWidth')};
   }
@@ -234,7 +234,7 @@ function line_props(e: Model,layout, style) {
   if (e.has(COLOR)) {
     p.stroke = {scale: COLOR, field: e.fieldRef(COLOR)};
   } else if (!e.has(COLOR)) {
-    p.stroke = {value: e.value(COLOR)};
+    p.stroke = {value: e.fieldDef(COLOR).value};
   }
 
   var opacity = e.fieldDef(COLOR).opacity;
@@ -277,7 +277,7 @@ function area_props(e: Model, layout, style) {
   if (e.has(COLOR)) {
     p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
   } else if (!e.has(COLOR)) {
-    p.fill = {value: e.value(COLOR)};
+    p.fill = {value: e.fieldDef(COLOR).value};
   }
 
   var opacity = e.fieldDef(COLOR).opacity;
@@ -330,7 +330,7 @@ function tick_props(e: Model, layout, style) {
   if (e.has(COLOR)) {
     p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
   } else {
-    p.fill = {value: e.value(COLOR)};
+    p.fill = {value: e.fieldDef(COLOR).value};
   }
 
   var opacity = e.fieldDef(COLOR).opacity  || style.opacity;
@@ -362,7 +362,7 @@ function filled_point_props(shape) {
     if (e.has(SIZE)) {
       p.size = {scale: SIZE, field: e.fieldRef(SIZE)};
     } else if (!e.has(X)) {
-      p.size = {value: e.value(SIZE)};
+      p.size = {value: e.fieldDef(SIZE).value};
     }
 
     // shape
@@ -372,7 +372,7 @@ function filled_point_props(shape) {
     if (e.has(COLOR)) {
       p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
     } else if (!e.has(COLOR)) {
-      p.fill = {value: e.value(COLOR)};
+      p.fill = {value: e.fieldDef(COLOR).value};
     }
 
     var opacity = e.fieldDef(COLOR).opacity  || style.opacity;

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -9,6 +9,7 @@ import {interpolateHsl} from 'd3-color';
 
 import * as util from '../util';
 import {Model} from './Model';
+import {SHARED_DOMAIN_OPS} from '../aggregate';
 import {COLUMN, ROW, X, Y, SHAPE, SIZE, COLOR, TEXT, Channel} from '../channel';
 import {SOURCE, STACKED} from '../data';
 import * as time from './time';
@@ -150,8 +151,6 @@ export function reverse(model: Model, channel: Channel) {
   return sort && (sort === 'descending' || (sort.order === 'descending')) ? true : undefined;
 }
 
-var sharedDomainAggregate = ['mean', 'average', 'stdev', 'stdevp', 'median', 'q1', 'q3', 'min', 'max'];
-
 /**
  * Determine if useRawDomain should be activated for this scale.
  * @return {Boolean} Returns true if all of the following conditons applies:
@@ -174,7 +173,7 @@ export function _useRawDomain (model: Model, channel: Channel) {
     // only applied to aggregate table
     fieldDef.aggregate &&
     // only activated if used with aggregate functions that produces values ranging in the domain of the source data
-    sharedDomainAggregate.indexOf(fieldDef.aggregate) >= 0 &&
+    SHARED_DOMAIN_OPS.indexOf(fieldDef.aggregate) >= 0 &&
     (
       // Q always uses quantitative scale except when it's binned.
       // Binned field has similar values in both the source table and the summary table

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -52,19 +52,18 @@ export function defs(names: Array<string>, model: Model, layout, stats, facet?) 
 }
 
 export function type(channel: Channel, model: Model) {
-  var type = model.fieldDef(channel).type;
-  switch (type) {
+  const fieldDef = model.fieldDef(channel);
+  switch (fieldDef.type) {
     case NOMINAL: //fall through
     case ORDINAL:
       return 'ordinal';
     case TEMPORAL:
-      var timeUnit = model.fieldDef(channel).timeUnit;
-      return timeUnit ? time.scale.type(timeUnit, channel) : 'time';
+      return fieldDef.timeUnit ? time.scale.type(fieldDef.timeUnit, channel) : 'time';
     case QUANTITATIVE:
       if (model.bin(channel)) {
         return channel === ROW || channel === COLUMN || channel === SHAPE ? 'ordinal' : 'linear';
       }
-      return model.scale(channel).type;
+      return fieldDef.scale.type;
   }
 }
 
@@ -159,10 +158,8 @@ export function reverse(model: Model, channel: Channel) {
  * 3. The scale is quantitative or time scale.
  */
 export function _useRawDomain (model: Model, channel: Channel) {
-  var fieldDef = model.fieldDef(channel);
-
-  // scale value
-  var scaleUseRawDomain = model.scale(channel).useRawDomain;
+  const fieldDef = model.fieldDef(channel);
+  const scaleUseRawDomain = fieldDef.scale.useRawDomain;
 
   // Determine if useRawDomain is enabled. If scale value is specified, use scale value.
   // Otherwise, use config value.
@@ -358,10 +355,12 @@ export function zero(model: Model, channel: Channel) {
 }
 
 export function color(model: Model, channel: Channel, scaleType, stats) {
-  var colorScale = model.scale(COLOR),
-    range = colorScale.range,
+  const fieldDef = model.fieldDef(COLOR),
+    colorScale = fieldDef.scale,
     cardinality = model.cardinality(COLOR, stats),
-    type = model.fieldDef(COLOR).type;
+    type = fieldDef.type;
+
+  let range = colorScale.range;
 
   if (range === undefined) {
     var ordinalPalette = colorScale.ordinalPalette,

--- a/src/compiler/time.ts
+++ b/src/compiler/time.ts
@@ -24,8 +24,8 @@ export function cardinality(fieldDef: FieldDef, stats, filterNull, type) {
     case 'date': return 31;
     case 'month': return 12;
     case 'year':
-      var stat = stats[fieldDef.name],
-        yearstat = stats['year_' + fieldDef.name];
+      var stat = stats[fieldDef.field],
+        yearstat = stats['year_' + fieldDef.field];
 
       if (!yearstat) { return null; }
 

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -15,8 +15,8 @@ export function countRetinal(encoding: Encoding) {
 }
 
 export function has(encoding: Encoding, channel: Channel) {
-  var fieldDef = encoding && encoding[channel];
-  return fieldDef && fieldDef.name;
+  var fieldDef: FieldDef = encoding && encoding[channel];
+  return fieldDef && fieldDef.field;
 }
 
 export function isAggregate(encoding: Encoding) {
@@ -67,7 +67,7 @@ export function reduce(encoding: Encoding,
  */
 export function fields(encoding: Encoding) {
   return reduce(encoding, function (m, fieldDef: FieldDef) {
-    var fieldList = m[fieldDef.name] = m[fieldDef.name] || [];
+    var fieldList = m[fieldDef.field] = m[fieldDef.field] || [];
     var containsType = fieldList.containsType = fieldList.containsType || {};
 
     if (fieldList.indexOf(fieldDef) === -1) {

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -35,21 +35,21 @@ export function fieldRef(fieldDef: FieldDef, opt?: FieldRefOption) {
   opt = opt || {};
 
   var f = (opt.datum ? 'datum.' : '') + (opt.prefn || ''),
-    name = fieldDef.name;
+    field = fieldDef.field;
 
   if (isCount(fieldDef)) {
     return f + 'count';
   } else if (opt.fn) {
-    return f + opt.fn + '_' + name;
+    return f + opt.fn + '_' + field;
   } else if (!opt.nofn && fieldDef.bin) {
     var binSuffix = opt.binSuffix || '_start';
-    return f + 'bin_' + name + binSuffix;
+    return f + 'bin_' + field + binSuffix;
   } else if (!opt.nofn && !opt.noAggregate && fieldDef.aggregate) {
-    return f + fieldDef.aggregate + '_' + name;
+    return f + fieldDef.aggregate + '_' + field;
   } else if (!opt.nofn && fieldDef.timeUnit) {
-    return f + fieldDef.timeUnit + '_' + name;
+    return f + fieldDef.timeUnit + '_' + field;
   }  else {
-    return f + name;
+    return f + field;
   }
 }
 
@@ -86,8 +86,8 @@ export function isMeasure(fieldDef: FieldDef) {
   return fieldDef && !_isFieldDimension(fieldDef);
 }
 
-export function count() {
-  return {name:'*', aggregate: 'count', type: QUANTITATIVE, displayName: COUNT_DISPLAYNAME};
+export function count(): FieldDef {
+  return {field:'*', aggregate: 'count', type: QUANTITATIVE, displayName: COUNT_DISPLAYNAME};
 }
 
 export const COUNT_DISPLAYNAME = 'Number of Records';
@@ -99,7 +99,7 @@ export function isCount(fieldDef: FieldDef) {
 export function cardinality(fieldDef: FieldDef, stats, filterNull = {}) {
   // FIXME need to take filter into account
 
-  var stat = stats[fieldDef.name];
+  var stat = stats[fieldDef.field];
   var type = fieldDef.type;
 
   if (fieldDef.bin) {

--- a/src/marktype.ts
+++ b/src/marktype.ts
@@ -1,0 +1,6 @@
+export const AREA = 'area';
+export const BAR = 'bar';
+export const LINE = 'line';
+export const POINT = 'point';
+export const TEXT = 'text';
+export const TICK = 'tick';

--- a/src/schema/data.schema.ts
+++ b/src/schema/data.schema.ts
@@ -50,7 +50,7 @@ export var data = {
         properties: {
           field: {
             type: 'string',
-            description: 'The property name in which to store the computed formula value.'
+            description: 'The field in which to store the computed formula value.'
           },
           expr: {
             type: 'string',

--- a/src/schema/encoding.schema.ts
+++ b/src/schema/encoding.schema.ts
@@ -26,7 +26,7 @@ export interface Encoding {
 
 // TODO: remove if possible
 var requiredNameType = {
-  required: ['name', 'type']
+  required: ['field', 'type']
 };
 
 var x = merge(duplicate(typicalField), requiredNameType, {

--- a/src/schema/fielddef.schema.ts
+++ b/src/schema/fielddef.schema.ts
@@ -11,7 +11,7 @@ import {TIMEUNITS} from '../timeunit';
 import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../type';
 
 export interface FieldDef {
-  name?: string;
+  field?: string;
   type?: string;
   value?: any;
 
@@ -42,7 +42,7 @@ export interface FieldDef {
 export var fieldDef = {
   type: 'object',
   properties: {
-    name: {
+    field: {
       type: 'string'
     },
     type: {

--- a/src/schema/fielddef.schema.ts
+++ b/src/schema/fielddef.schema.ts
@@ -14,13 +14,14 @@ export interface FieldDef {
   field?: string;
   type?: string;
   value?: any;
+  displayName?: string;
 
   // function
   aggregate?: string;
   timeUnit?: string;
   bin?: boolean | Bin;
 
-  //
+
   sort?: Sort | string;
 
   // override

--- a/src/shorthand.ts
+++ b/src/shorthand.ts
@@ -61,7 +61,7 @@ export function shortenFieldDef(fieldDef: FieldDef): string {
   return (fieldDef.aggregate ? fieldDef.aggregate + FUNC : '') +
     (fieldDef.timeUnit ? fieldDef.timeUnit + FUNC : '') +
     (fieldDef.bin ? 'bin' + FUNC : '') +
-    (fieldDef.name || '') + TYPE + SHORT_TYPE[fieldDef.type];
+    (fieldDef.field || '') + TYPE + SHORT_TYPE[fieldDef.type];
 }
 
 export function shortenFieldDefs(fieldDefs: FieldDef[], delim = DELIM): string {
@@ -71,17 +71,17 @@ export function shortenFieldDefs(fieldDefs: FieldDef[], delim = DELIM): string {
 export function parseFieldDef(fieldDefShorthand: string): FieldDef {
   var split = fieldDefShorthand.split(TYPE), i;
 
-  var fieldDef: any = {
-    name: split[0].trim(),
+  var fieldDef: FieldDef = {
+    field: split[0].trim(),
     type: TYPE_FROM_SHORT_TYPE[split[1].trim()]
   };
 
   // check aggregate type
   for (i in AGGREGATE_OPS) {
     var a = AGGREGATE_OPS[i];
-    if (fieldDef.name.indexOf(a + '_') === 0) {
-      fieldDef.name = fieldDef.name.substr(a.length + 1);
-      if (a === 'count' && fieldDef.name.length === 0) fieldDef.name = '*';
+    if (fieldDef.field.indexOf(a + '_') === 0) {
+      fieldDef.field = fieldDef.field.substr(a.length + 1);
+      if (a === 'count' && fieldDef.field.length === 0) fieldDef.field = '*';
       fieldDef.aggregate = a;
       break;
     }
@@ -89,16 +89,16 @@ export function parseFieldDef(fieldDefShorthand: string): FieldDef {
 
   for (i in TIMEUNITS) {
     var tu = TIMEUNITS[i];
-    if (fieldDef.name && fieldDef.name.indexOf(tu + '_') === 0) {
-      fieldDef.name = fieldDef.name.substr(fieldDef.name.length + 1);
+    if (fieldDef.field && fieldDef.field.indexOf(tu + '_') === 0) {
+      fieldDef.field = fieldDef.field.substr(fieldDef.field.length + 1);
       fieldDef.timeUnit = tu;
       break;
     }
   }
 
   // check bin
-  if (fieldDef.name && fieldDef.name.indexOf('bin_') === 0) {
-    fieldDef.name = fieldDef.name.substr(4);
+  if (fieldDef.field && fieldDef.field.indexOf('bin_') === 0) {
+    fieldDef.field = fieldDef.field.substr(4);
     fieldDef.bin = true;
   }
 

--- a/test/compiler/axis.test.ts
+++ b/test/compiler/axis.test.ts
@@ -16,7 +16,7 @@ describe('Axis', function() {
       encoding = new Model({
         marktype: 'line',
         encoding: {
-          x: {name: field, type: 'temporal', timeUnit: timeUnit}
+          x: {field: field, type: 'temporal', timeUnit: timeUnit}
         }
       });
     var _axis = axis.def('x', encoding, {
@@ -51,7 +51,7 @@ describe('Axis', function() {
     it('should return specified orient', function () {
       var orient = axis.orient(new Model({
           encoding: {
-            x: {name: 'a', axis:{orient: 'bottom'}}
+            x: {field: 'a', axis:{orient: 'bottom'}}
           }
         }), 'x', {}, stats);
       expect(orient).to.eql('bottom');
@@ -60,7 +60,7 @@ describe('Axis', function() {
     it('should return undefined by default', function () {
       var orient = axis.orient(new Model({
           encoding: {
-            x: {name: 'a'}
+            x: {field: 'a'}
           }
         }), 'x', {}, stats);
       expect(orient).to.eql(undefined);
@@ -69,8 +69,8 @@ describe('Axis', function() {
     it('should return top for COL', function () {
       var orient = axis.orient(new Model({
           encoding: {
-            x: {name: 'a'},
-            column: {name: 'a'}
+            x: {field: 'a'},
+            column: {field: 'a'}
           }
         }), 'column', {}, stats);
       expect(orient).to.eql('top');
@@ -79,8 +79,8 @@ describe('Axis', function() {
     it('should return top for X with high cardinality, ordinal Y', function () {
       var orient = axis.orient(new Model({
           encoding: {
-            x: {name: 'a'},
-            y: {name: 'b', type: 'ordinal'}
+            x: {field: 'a'},
+            y: {field: 'b', type: 'ordinal'}
           }
         }), 'x', {}, stats);
       expect(orient).to.eql('top');
@@ -91,7 +91,7 @@ describe('Axis', function() {
     it('should add explicitly specified title', function () {
       var title = axis.title(new Model({
           encoding: {
-            x: {name: 'a', axis: {title: 'Custom'}}
+            x: {field: 'a', axis: {title: 'Custom'}}
           }
         }), 'x', layout);
       expect(title).to.eql('Custom');
@@ -100,7 +100,7 @@ describe('Axis', function() {
     it('should add return fieldTitle by default', function () {
       var title = axis.title(new Model({
           encoding: {
-            x: {name: 'a', type: 'Q', axis: {titleMaxLength: 3}}
+            x: {field: 'a', type: 'Q', axis: {titleMaxLength: 3}}
           }
         }), 'x', layout);
       expect(title).to.eql('a');
@@ -109,7 +109,7 @@ describe('Axis', function() {
     it('should add return fieldTitle by default', function () {
       var title = axis.title(new Model({
           encoding: {
-            x: {name: 'a', type: 'Q', aggregate: 'sum', axis: {titleMaxLength: 10}}
+            x: {field: 'a', type: 'Q', aggregate: 'sum', axis: {titleMaxLength: 10}}
           }
         }), 'x', layout);
       expect(title).to.eql('SUM(a)');
@@ -118,7 +118,7 @@ describe('Axis', function() {
     it('should add return fieldTitle by default and truncate', function () {
       var title = axis.title(new Model({
           encoding: {
-            x: {name: 'a', type: 'Q', aggregate: 'sum', axis: {titleMaxLength: 3}}
+            x: {field: 'a', type: 'Q', aggregate: 'sum', axis: {titleMaxLength: 3}}
           }
         }), 'x', layout);
       expect(title).to.eql('SU…');
@@ -128,7 +128,7 @@ describe('Axis', function() {
     it('should add return fieldTitle by default and truncate', function () {
       var title = axis.title(new Model({
           encoding: {
-            x: {name: 'abcdefghijkl'}
+            x: {field: 'abcdefghijkl'}
           }
         }), 'x', layout);
       expect(title).to.eql('abcdefghi…');

--- a/test/compiler/data.test.ts
+++ b/test/compiler/data.test.ts
@@ -9,8 +9,8 @@ describe('data', function () {
     it('should contain two tables', function() {
       var encoding = new Model({
           encoding: {
-            x: {name: 'a', type: 'temporal'},
-            y: {name: 'b', type: 'quantitative', scale: {type: 'log'}, aggregate: 'sum'}
+            x: {field: 'a', type: 'temporal'},
+            y: {field: 'b', type: 'quantitative', scale: {type: 'log'}, aggregate: 'sum'}
           }
         });
 
@@ -22,8 +22,8 @@ describe('data', function () {
   describe('when contains log in non-aggregate', function () {
     var rawEncodingWithLog = new Model({
         encoding: {
-          x: {name: 'a', type: 'temporal'},
-          y: {name: 'b', type: 'quantitative', scale: {type: 'log'}}
+          x: {field: 'a', type: 'temporal'},
+          y: {field: 'b', type: 'quantitative', scale: {type: 'log'}}
         }
       });
 
@@ -83,9 +83,9 @@ describe('data.source', function() {
     it('should have correct parse', function() {
       var encoding = new Model({
           encoding: {
-            x: {name: 'a', type: 'temporal'},
-            y: {name: 'b', type: 'quantitative'},
-            color: {name: '*', type: 'quantitative', aggregate: 'count'}
+            x: {field: 'a', type: 'temporal'},
+            y: {field: 'b', type: 'quantitative'},
+            color: {field: '*', type: 'quantitative', aggregate: 'count'}
           }
         });
 
@@ -103,10 +103,10 @@ describe('data.source', function() {
         filter: 'datum.a > datum.b && datum.c === datum.d'
       },
       encoding: {
-        x: {name: 'a', type:'temporal', timeUnit: 'year'},
+        x: {field: 'a', type:'temporal', timeUnit: 'year'},
         y: {
           'bin': {'maxbins': 15},
-          'name': 'Acceleration',
+          'field': 'Acceleration',
           'type': 'quantitative'
         }
       }
@@ -129,9 +129,9 @@ describe('data.source', function() {
       var spec = {
           marktype: 'point',
           encoding: {
-            y: {name: 'qq', type:'quantitative'},
-            x: {name: 'tt', type:'temporal'},
-            color: {name: 'oo', type:'ordinal'}
+            y: {field: 'qq', type:'quantitative'},
+            x: {field: 'tt', type:'temporal'},
+            color: {field: 'oo', type:'ordinal'}
           }
         };
 
@@ -199,14 +199,14 @@ describe('data.summary', function () {
         encoding: {
           'y': {
             'aggregate': 'sum',
-            'name': 'Acceleration',
+            'field': 'Acceleration',
             'type': 'quantitative'
           },
           'x': {
-            'name': 'origin',
+            'field': 'origin',
             'type': 'ordinal'
           },
-          color: {name: '*', type: 'quantitative', aggregate: 'count'}
+          color: {field: '*', type: 'quantitative', aggregate: 'count'}
         }
       });
 

--- a/test/compiler/legend.test.ts
+++ b/test/compiler/legend.test.ts
@@ -8,7 +8,7 @@ describe('Legend', function() {
     it('should add explicitly specified title', function () {
       var title = legend.title(new Model({
           encoding: {
-            color: {name: 'a', legend: {title: 'Custom'}}
+            color: {field: 'a', legend: {title: 'Custom'}}
           }
         }), 'color');
       expect(title).to.eql('Custom');
@@ -17,7 +17,7 @@ describe('Legend', function() {
     it('should add return fieldTitle by default', function () {
       var encoding = new Model({
           encoding: {
-            color: {name: 'a', legend: {}}
+            color: {field: 'a', legend: {}}
           }
         });
 

--- a/test/compiler/scale.test.ts
+++ b/test/compiler/scale.test.ts
@@ -20,10 +20,10 @@ describe('vl.compile.scale', function() {
           encoding: {
             y: {
               aggregate: 'sum',
-              name: 'origin'
+              field: 'origin'
             },
-            x: {name: 'x', type: 'ordinal'},
-            color: {name: 'color', type: 'ordinal'}
+            x: {field: 'x', type: 'ordinal'},
+            color: {field: 'color', type: 'ordinal'}
           }
         }), 'y', 'linear', true);
 
@@ -39,10 +39,10 @@ describe('vl.compile.scale', function() {
           encoding: {
             y: {
               aggregate: 'sum',
-              name: 'origin'
+              field: 'origin'
             },
-            x: {name: 'x', type: 'ordinal'},
-            color: {name: 'color', type: 'ordinal'}
+            x: {field: 'x', type: 'ordinal'},
+            color: {field: 'color', type: 'ordinal'}
           }
         }), 'y', 'linear', true);
 
@@ -60,7 +60,7 @@ describe('vl.compile.scale', function() {
             encoding: {
               y: {
                 bin: {maxbins: 15},
-                name: 'origin',
+                field: 'origin',
                 scale: {useRawDomain: true},
                 type: QUANTITATIVE
               }
@@ -79,7 +79,7 @@ describe('vl.compile.scale', function() {
             encoding: {
               y: {
                 aggregate: 'mean',
-                name: 'origin',
+                field: 'origin',
                 scale: {useRawDomain: true},
                 type: 'quantitative'
               }
@@ -95,7 +95,7 @@ describe('vl.compile.scale', function() {
             encoding: {
               y: {
                 aggregate: 'sum',
-                name: 'origin',
+                field: 'origin',
                 scale: {useRawDomain: true},
                 type: QUANTITATIVE
               }
@@ -111,7 +111,7 @@ describe('vl.compile.scale', function() {
             encoding: {
               y: {
                 aggregate: 'min',
-                name: 'origin',
+                field: 'origin',
                 scale: {useRawDomain: false},
                 type: QUANTITATIVE
               }
@@ -128,7 +128,7 @@ describe('vl.compile.scale', function() {
           var domain = vlscale.domain(new Model({
             encoding: {
               y: {
-                name: 'origin',
+                field: 'origin',
                 scale: {useRawDomain: true},
                 type: TEMPORAL
               }
@@ -143,7 +143,7 @@ describe('vl.compile.scale', function() {
           var domain = vlscale.domain(new Model({
             encoding: {
               y: {
-                name: 'origin',
+                field: 'origin',
                 scale: {useRawDomain: true},
                 type: 'temporal',
                 timeUnit: 'year'
@@ -160,7 +160,7 @@ describe('vl.compile.scale', function() {
           var domain = vlscale.domain(new Model({
             encoding: {
               y: {
-                name: 'origin',
+                field: 'origin',
                 scale: {useRawDomain: true},
                 type: 'temporal',
                 timeUnit: 'month'
@@ -177,7 +177,7 @@ describe('vl.compile.scale', function() {
         var sortDef = {op: 'min', field:'Acceleration'};
         var encoding = new Model({
             encoding: {
-              y: { name: 'origin', type: ORDINAL, sort: sortDef}
+              y: { field: 'origin', type: ORDINAL, sort: sortDef}
             }
           });
 
@@ -192,7 +192,7 @@ describe('vl.compile.scale', function() {
       it('should return correct domain without sort if sort is not provided', function() {
         var encoding = new Model({
             encoding: {
-              y: { name: 'origin', type: ORDINAL}
+              y: { field: 'origin', type: ORDINAL}
             }
           });
 

--- a/test/compiler/time.test.ts
+++ b/test/compiler/time.test.ts
@@ -8,7 +8,7 @@ describe('time', function() {
     timeUnit = 'month',
     encoding = new Model({
       encoding: {
-        x: {name: field, type: 'temporal', timeUnit: timeUnit}
+        x: {field: field, type: 'temporal', timeUnit: timeUnit}
       }
     }),
     scales = time.scales(encoding);

--- a/test/fielddef.test.ts
+++ b/test/fielddef.test.ts
@@ -7,7 +7,7 @@ import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../src/type';
 describe('vl.fieldDef.cardinality()', function () {
   describe('for Q', function () {
     it('should return cardinality', function() {
-      var fieldDef = {name: '2', type: 'quantitative'};
+      var fieldDef = {field: '2', type: 'quantitative'};
       var stats = {2:{distinct: 10, min:0, max:150}};
       var cardinality = vlFieldDef.cardinality(fieldDef, stats);
       expect(cardinality).to.equal(10);
@@ -16,7 +16,7 @@ describe('vl.fieldDef.cardinality()', function () {
 
   describe('for B(Q)', function(){
     it('should return cardinality', function() {
-      var fieldDef = {name: '2', type: 'quantitative', bin: {maxbins: 15}};
+      var fieldDef = {field: '2', type: 'quantitative', bin: {maxbins: 15}};
       var stats = {2:{distinct: 10, min:0, max:150}};
       var cardinality = vlFieldDef.cardinality(fieldDef, stats);
       expect(cardinality).to.equal(15);
@@ -26,7 +26,7 @@ describe('vl.fieldDef.cardinality()', function () {
 
 describe('vl.fieldDef.isTypes', function () {
   it('should return correct type checking', function() {
-    var qDef = {name: 'number', type:'quantitative'};
+    var qDef = {field: 'number', type:'quantitative'};
     expect(qDef.type === QUANTITATIVE).to.eql(true);
     expect(vlFieldDef.isTypes(qDef, [QUANTITATIVE])).to.eql(true);
     expect(vlFieldDef.isTypes(qDef, [QUANTITATIVE, ORDINAL])).to.eql(true);

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -7,8 +7,8 @@ f.bars = {};
 f.bars.log_ver = {
   'marktype': 'bar',
   'encoding': {
-    'x': {'bin': {'maxbins': 15},'type': 'quantitative','name': 'IMDB_Rating'},
-    'y': {'scale': {'type': 'log'},'type': 'quantitative','name': 'US_Gross','aggregate': 'mean'}
+    'x': {'bin': {'maxbins': 15},'type': 'quantitative','field': 'IMDB_Rating'},
+    'y': {'scale': {'type': 'log'},'type': 'quantitative','field': 'US_Gross','aggregate': 'mean'}
   },
   'data': {'url': 'data/movies.json'}
 };
@@ -16,22 +16,22 @@ f.bars.log_ver = {
 f.bars.log_hor = {
   'marktype': 'bar',
   'encoding': {
-    'y': {'bin': {'maxbins': 15},'type': 'quantitative','name': 'IMDB_Rating'},
-    'x': {'scale': {'type': 'log'},'type': 'quantitative','name': 'US_Gross','aggregate': 'mean'}
+    'y': {'bin': {'maxbins': 15},'type': 'quantitative','field': 'IMDB_Rating'},
+    'x': {'scale': {'type': 'log'},'type': 'quantitative','field': 'US_Gross','aggregate': 'mean'}
   },
   'data': {'url': 'data/movies.json'}
 };
 
 f.bars['1d_hor'] = {
   'marktype': 'bar',
-  'encoding': {'x': {'type': 'quantitative','name': 'US_Gross','aggregate': 'sum'}},
+  'encoding': {'x': {'type': 'quantitative','field': 'US_Gross','aggregate': 'sum'}},
   'data': {'url': 'data/movies.json'}
 };
 
 
 f.bars['1d_ver'] = {
   'marktype': 'bar',
-  'encoding': {'y': {'type': 'quantitative','name': 'US_Gross','aggregate': 'sum'}},
+  'encoding': {'y': {'type': 'quantitative','field': 'US_Gross','aggregate': 'sum'}},
   'data': {'url': 'data/movies.json'}
 };
 
@@ -42,17 +42,17 @@ f.stack = {};
 f.stack.binY = {
   'marktype': 'bar',
   'encoding': {
-    'x': {'type': 'quantitative','name': 'Cost__Other','aggregate': 'mean'},
-    'y': {'bin': true,'type': 'quantitative','name': 'Cost__Total_$'},
-    'color': {'type': 'ordinal','name': 'Effect__Amount_of_damage'}
+    'x': {'type': 'quantitative','field': 'Cost__Other','aggregate': 'mean'},
+    'y': {'bin': true,'type': 'quantitative','field': 'Cost__Total_$'},
+    'color': {'type': 'ordinal','field': 'Effect__Amount_of_damage'}
   }
 };
 f.stack.binX = {
   'marktype': 'bar',
   'encoding': {
-    'y': {'type': 'quantitative','name': 'Cost__Other','aggregate': 'mean'},
-    'x': {'bin': true,'type': 'quantitative','name': 'Cost__Total_$'},
-    'color': {'type': 'ordinal','name': 'Effect__Amount_of_damage'}
+    'y': {'type': 'quantitative','field': 'Cost__Other','aggregate': 'mean'},
+    'x': {'bin': true,'type': 'quantitative','field': 'Cost__Total_$'},
+    'color': {'type': 'ordinal','field': 'Effect__Amount_of_damage'}
   }
 };
 
@@ -62,28 +62,28 @@ f.points = {};
 
 f.points['1d_hor'] = {
   'marktype': 'point',
-  'encoding': {'x': {'name': 'year','type': 'ordinal'}},
+  'encoding': {'x': {'field': 'year','type': 'ordinal'}},
   'data': {'url': 'data/barley.json'}
 };
 
 f.points['1d_ver'] = {
   'marktype': 'point',
-  'encoding': {'y': {'name': 'year','type': 'ordinal'}},
+  'encoding': {'y': {'field': 'year','type': 'ordinal'}},
   'data': {'url': 'data/barley.json'}
 };
 
 f.points['x,y'] = {
   'marktype': 'point',
-  'encoding': {'x': {'name': 'year','type': 'ordinal'},'y': {'name': 'yield','type': 'quantitative'}},
+  'encoding': {'x': {'field': 'year','type': 'ordinal'},'y': {'field': 'yield','type': 'quantitative'}},
   'data': {'url': 'data/barley.json'}
 };
 
 f.points['x,y,size'] = {
   'marktype': 'point',
   'encoding': {
-    'x': {'name': 'year','type': 'ordinal'},
-    'y': {'name': 'yield','type': 'quantitative'},
-    'size': {'name': '*','type': 'quantitative','aggregate': 'count'}
+    'x': {'field': 'year','type': 'ordinal'},
+    'y': {'field': 'yield','type': 'quantitative'},
+    'size': {'field': '*','type': 'quantitative','aggregate': 'count'}
   },
   'data': {'url': 'data/barley.json'}
 };
@@ -91,9 +91,9 @@ f.points['x,y,size'] = {
 f.points['x,y,stroke'] = {
   'marktype': 'point',
   'encoding': {
-    'x': {'name': 'year','type': 'ordinal'},
-    'y': {'name': 'yield','type': 'quantitative'},
-    'color': {'name': 'yield','type': 'quantitative'}
+    'x': {'field': 'year','type': 'ordinal'},
+    'y': {'field': 'yield','type': 'quantitative'},
+    'color': {'field': 'yield','type': 'quantitative'}
   },
   'data': {'url': 'data/barley.json'}
 };
@@ -101,9 +101,9 @@ f.points['x,y,stroke'] = {
 f.points['x,y,shape'] = {
   'marktype': 'point',
   'encoding': {
-    'x': {'name': 'year','type': 'ordinal'},
-    'y': {'name': 'yield','type': 'quantitative'},
-    'shape': {'bin': {'maxbins': 15},'name': 'yield','type': 'quantitative'}
+    'x': {'field': 'year','type': 'ordinal'},
+    'y': {'field': 'yield','type': 'quantitative'},
+    'shape': {'bin': {'maxbins': 15},'field': 'yield','type': 'quantitative'}
   },
   'data': {'url': 'data/barley.json'}
 };
@@ -114,16 +114,19 @@ f.lines = {};
 
 f.lines['x,y'] = {
   'marktype': 'line',
-  'encoding': {'x': {'name': 'year','type': 'ordinal'},'y': {'name': 'yield','type': 'quantitative'}},
+  'encoding': {
+    'x': {'field': 'year','type': 'ordinal'},
+    'y': {'field': 'yield','type': 'quantitative'}
+  },
   'data': {'url': 'data/barley.json'}
 };
 
 f.lines['x,y,stroke'] = {
   'marktype': 'line',
   'encoding': {
-    'x': {'name': 'Name','type': 'nominal'},
-    'y': {'name': 'Cylinders','type': 'ordinal'},
-    'color': {'name': 'Acceleration','type': 'quantitative'}
+    'x': {'field': 'Name','type': 'nominal'},
+    'y': {'field': 'Cylinders','type': 'ordinal'},
+    'color': {'field': 'Acceleration','type': 'quantitative'}
   },
   'data': {'url': 'data/cars.json'}
 };
@@ -135,8 +138,8 @@ f.area = {};
 f.area['x,y'] = {
   'marktype': 'area',
   'encoding': {
-    'x': {'name': 'Displacement','type': 'quantitative'},
-    'y': {'name': 'Acceleration','type': 'quantitative'}
+    'x': {'field': 'Displacement','type': 'quantitative'},
+    'y': {'field': 'Acceleration','type': 'quantitative'}
   },
   'data': {'url': 'data/cars.json'}
 };
@@ -144,9 +147,9 @@ f.area['x,y'] = {
 f.area['x,y,stroke'] = {
   'marktype': 'area',
   'encoding': {
-    'x': {'name': 'Displacement','type': 'quantitative'},
-    'y': {'name': 'Acceleration','type': 'quantitative'},
-    'color': {'name': 'Miles_per_Gallon','type': 'quantitative'}
+    'x': {'field': 'Displacement','type': 'quantitative'},
+    'y': {'field': 'Acceleration','type': 'quantitative'},
+    'color': {'field': 'Miles_per_Gallon','type': 'quantitative'}
   },
   'data': {'url': 'data/cars.json'}
 };

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -45,9 +45,9 @@ describe('Util', function() {
     var spec = {
       marktype: 'point',
       encoding: {
-        x: { name: 'dsp', type: 'quantitative', scale: {type: 'linear'}
+        x: { field: 'dsp', type: 'quantitative', scale: {type: 'linear'}
       },
-        color: { name: 'cyl', type: 'ordinal' }
+        color: { field: 'cyl', type: 'ordinal' }
       },
       data: {
         formatType: 'json',
@@ -58,8 +58,8 @@ describe('Util', function() {
     var expected = {
       marktype: 'point',
       encoding: {
-        x: { name: 'dsp', type: 'quantitative' },
-        color: { name: 'cyl', type: 'ordinal' }
+        x: { field: 'dsp', type: 'quantitative' },
+        color: { field: 'cyl', type: 'ordinal' }
       },
       data: {
         url: 'data/cars.json'

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -16,23 +16,23 @@ describe('vl.validate', function() {
       expect(getEncodingMappingError({
         marktype: 'bar',
         encoding: {
-          x: {name: 'a'}
+          x: {field: 'a'}
         }
       })).to.be.null;
 
       expect(getEncodingMappingError({
         marktype: 'line',
         encoding: {
-          x: {name: 'b'},
-          y: {name: 'a'}
+          x: {field: 'b'},
+          y: {field: 'a'}
         }
       })).to.be.null;
 
       expect(getEncodingMappingError({
         marktype: 'area',
         encoding: {
-          x: {name: 'a'},
-          y: {name: 'b'}
+          x: {field: 'a'},
+          y: {field: 'b'}
         }
       })).to.be.null;
     });
@@ -41,42 +41,42 @@ describe('vl.validate', function() {
       expect(getEncodingMappingError({
         marktype: 'line',
         encoding: {
-          x: {name: 'b'} // missing y
+          x: {field: 'b'} // missing y
         }
       })).to.be.ok;
 
       expect(getEncodingMappingError({
         marktype: 'area',
         encoding: {
-          y: {name: 'b'} // missing x
+          y: {field: 'b'} // missing x
         }
       })).to.be.ok;
 
       expect(getEncodingMappingError({
         marktype: 'text',
         encoding: {
-          y: {name: 'b'} // missing text
+          y: {field: 'b'} // missing text
         }
       })).to.be.ok;
 
       expect(getEncodingMappingError({
         marktype: 'line',
         encoding: {
-          shape: {name: 'b'} // using shape with line
+          shape: {field: 'b'} // using shape with line
         }
       })).to.be.ok;
 
       expect(getEncodingMappingError({
         marktype: 'area',
         encoding: {
-          shape: {name: 'b'} // using shape with area
+          shape: {field: 'b'} // using shape with area
         }
       })).to.be.ok;
 
       expect(getEncodingMappingError({
         marktype: 'bar',
         encoding: {
-          shape: {name: 'b'} // using shape with bar
+          shape: {field: 'b'} // using shape with bar
         }
       })).to.be.ok;
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,7 @@
         "src/data.ts",
         "src/encoding.ts",
         "src/fielddef.ts",
+        "src/marktype.ts",
         "src/schema/axis.schema.ts",
         "src/schema/bin.schema.ts",
         "src/schema/config.schema.ts",


### PR DESCRIPTION
- simplify model -- just have one `_spec` inside the model
- get rid of `model.scale|axis|value|isRaw`

Please merge #761 first !  (See [Branch Specific Diff](https://github.com/uwdata/vega-lite/compare/kw/consts...kw/model))