### PR TITLE
Fix stack 

### DIFF
--- a/bin/vl2vg
+++ b/bin/vl2vg
@@ -50,7 +50,9 @@ fs.readFile(specFile, 'utf8', function(err, text) {
 });
 
 function compile(vlSpec, stats) {
-  var vgSpec = vl.compile(vlSpec, stats);
+  var result =  vl.compile(vlSpec, stats);
+  // TODO: deal with error 
+  var vgSpec = result.spec;
   if (args.p) {
     process.stdout.write(JSON.stringify(vgSpec, null, 4));
   } else {

--- a/docs/Config.md
+++ b/docs/Config.md
@@ -1,0 +1,29 @@
+# Layout
+
+## Facet Layout
+
+__Coming Soon!__
+
+## Stack Layout
+
+When either `"bar"` or `"area"` mark type is used with either `"color"` or `"detail"`
+channel, a stacked (bar or area) chart is automatically created.
+
+| Property      | Type          | Description    |
+| :------------ |:-------------:| :------------- |
+| _stack_       | String        | `stack` can be used to customize stacking behavior in Vega-Lite.  If `"stack"` is `false`, stacking is disabled.  Otherwise, if `"stack"` is either `true` or a stack property object, stacking is enabled.|
+
+
+### Stack Config Object
+
+A stack property object contains the following properties for customizing:
+
+| Property      | Type          | Description    |
+| :------------ |:-------------:| :------------- |
+| _stack.offset_ | String        | The baseline offset style. One of `"zero"` (default), `"center"` <!--, or `"normalize"` -->. The `"center"` offset will center the stacks. The `"normalize"` offset will compute percentage values for each stack point; the output values will be in the range [0,1].|
+| _stack.sort_ | String &#124; Array<field> | Order of the stack.  This can be either a string (either "descending" or "ascending") or a list of fields to determine the order of stack layers.By default, stack uses descending order. |
+
+
+# Other Config
+
+__Coming Soon!__

--- a/docs/Encoding-Mapping.md
+++ b/docs/Encoding-Mapping.md
@@ -27,7 +27,6 @@ Here are the list of properties of the encoding property definition object:
 | [axis](#axis)        | Object        | Configuration object for the encoding's axis    |
 | [legends](#legends)  | Object        | Configuration object for the encoding's legends |
 | [scale](#scale)      | Object        | Configuration object for the encoding's scale   |
-| [stack](#stack)      | Boolean \| Object        | Boolean flag / configuration object for stacking (only for bar and area marks). See [Stack](#stack).  |
 
 __<sup>1</sup>__ __Pending Revision__
 We are considering other properties of variables including specifying primitive type.
@@ -160,32 +159,6 @@ For `color`, `shape`, `size` and `detail`, this determines the layer order
 | _sort.op_     | String        | A valid [aggregation operation](Data-Transforms#-aggregate) (e.g., `mean`, `median`, etc.).|
 | _sort.order_  | String        | `'ascending'` or `'descending'` order. |
 
-
-
-
 # Channel Specific Properties
-
-## Stack
-
-Stacked bar chart and stacked area chart can be specified using `'stack'`
-property in the `'color'` encoding channel.
-Stack is only applicable only for bar and area marks.  Otherwise, stack property is
-ignored.
-
-When applicable, `'stack'` property can be either boolean or a definition
-object.  When specified as `'boolean'`, default properties are applied.
-`'stack'` definition object has the following properties:
-
-
-
-| Property      | Type          | Description    |
-| :------------ |:-------------:| :------------- |
-| _stack.offset_| String        | The baseline offset style. One of `"zero"` (default), `"center"`, or `"normalize"`. The `"center"` offset will center the stacks. The `"normalize"` offset will compute percentage values for each stack point; the output values will be in the range [0,1].|
-
-__TODO: order or reverse?__
-
-
-
-## Other
 
 _(Coming Soon)_

--- a/gallery/gallery.js
+++ b/gallery/gallery.js
@@ -28,7 +28,7 @@ app.directive('vlPlot', function() {
       var vlElement = element[0];
 
       var callback = function(stats) {
-        var spec = vl.compile(scope.vlSpec, stats);
+        var spec = vl.compile(scope.vlSpec, stats).spec;
 
         vg.parse.spec(spec, function(chart) {
           var view = chart({el: vlElement, renderer: 'svg'});

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -10,6 +10,7 @@ import * as vlFieldDef from '../fielddef';
 import * as vlEncoding from '../encoding';
 import * as schema from '../schema/schema';
 import * as schemaUtil from '../schema/schemautil';
+import {StackDef} from './stack';
 import {getFullName} from '../type';
 
 /**
@@ -209,7 +210,7 @@ export class Model {
    * - dimension - the dimension field
    * - value - the value field
    */
-  stack() {
+  stack(): StackDef {
     var stack = (this.has(COLOR) && this.fieldDef(COLOR).stack) ? COLOR :
       (this.has(DETAIL) && this.fieldDef(DETAIL).stack) ? DETAIL :
         null;

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -10,7 +10,7 @@ import * as vlEncoding from '../encoding';
 import {AREA, BAR} from '../marktype';
 import * as schema from '../schema/schema';
 import * as schemaUtil from '../schema/schemautil';
-import {StackDef} from './stack';
+import {StackProperties} from './stack';
 import {getFullName} from '../type';
 import * as util from '../util';
 
@@ -20,14 +20,14 @@ import * as util from '../util';
 
 export class Model {
   _spec: Spec;
-  _stack: StackDef;
+  _stack: StackProperties;
 
   // TODO: include _stack, _layout, _style, etc.
 
   constructor(spec: Spec, theme?) {
     var defaults = schema.instantiate();
     this._spec = schemaUtil.merge(defaults, theme || {}, spec);
-    this._stack = this.getStackDef();
+    this._stack = this.getStackProperties();
 
     // convert short type to full type
     vlEncoding.forEach(this._spec.encoding, function(fieldDef) {
@@ -39,7 +39,7 @@ export class Model {
     // calculate stack
   }
 
-  private getStackDef(): StackDef {
+  private getStackProperties(): StackProperties {
     var stack = (this.has(COLOR)) ? COLOR : (this.has(DETAIL)) ? DETAIL : null;
 
     if (stack &&
@@ -68,7 +68,7 @@ export class Model {
     return null;
   }
 
-  stack(): StackDef {
+  stack(): StackProperties {
     return this._stack;
   }
 

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -20,6 +20,7 @@ import * as util from '../util';
 
 export class Model {
   _spec: Spec;
+  _stackDef: StackDef;
 
   // TODO: include _stack, _layout, _style, etc.
 
@@ -33,6 +34,8 @@ export class Model {
         fieldDef.type = getFullName(fieldDef.type);
       }
     });
+
+    // calculate stack
   }
 
   toSpec(excludeConfig?, excludeData?) {
@@ -206,14 +209,14 @@ export class Model {
           groupby: Y,
           value: X,
           stack: stack,
-          properties: this.config('stack')
+          config: this.config('stack')
         };
       } else if (isYMeasure && !isXMeasure) {
         return {
           groupby: X,
           value: Y,
           stack: stack,
-          properties: this.config('stack')
+          config: this.config('stack')
         };
       }
     }

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -195,9 +195,7 @@ export class Model {
    * - value - the value field
    */
   stack(): StackDef {
-    var stack = (this.has(COLOR) && this.fieldDef(COLOR).stack) ? COLOR :
-      (this.has(DETAIL) && this.fieldDef(DETAIL).stack) ? DETAIL :
-        null;
+    var stack = (this.has(COLOR)) ? COLOR : (this.has(DETAIL)) ? DETAIL : null;
 
     if ((this.is(BAR) || this.is(AREA)) && stack && this.isAggregate()) {
 

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -204,15 +204,15 @@ export class Model {
 
       if (isXMeasure && !isYMeasure) {
         return {
-          groupby: Y,
-          value: X,
+          groupbyChannel: Y,
+          fieldChannel: X,
           stack: stack,
           config: this.config('stack')
         };
       } else if (isYMeasure && !isXMeasure) {
         return {
-          groupby: X,
-          value: Y,
+          groupbyChannel: X,
+          fieldChannel: Y,
           stack: stack,
           config: this.config('stack')
         };

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -196,10 +196,6 @@ export class Model {
       (this.has(DETAIL) && this.fieldDef(DETAIL).stack) ? DETAIL :
         null;
 
-    var properties = stack && this.fieldDef(stack).stack !== true ?
-      this.fieldDef(stack).stack :
-      {};
-
     if ((this.is(BAR) || this.is(AREA)) && stack && this.isAggregate()) {
 
       var isXMeasure = this.isMeasure(X);
@@ -210,14 +206,14 @@ export class Model {
           groupby: Y,
           value: X,
           stack: stack,
-          properties: properties
+          properties: this.config('stack')
         };
       } else if (isYMeasure && !isXMeasure) {
         return {
           groupby: X,
           value: Y,
           stack: stack,
-          properties: properties
+          properties: this.config('stack')
         };
       }
     }

--- a/src/compiler/axis.ts
+++ b/src/compiler/axis.ts
@@ -179,7 +179,7 @@ export function title(model: Model, channel: Channel, layout) {
 
 export function titleOffset(model: Model, channel: Channel) {
   // return specified value if specified
-  var value = model.axis(channel).titleOffset;
+  var value = model.fieldDef(channel).axis.titleOffset;
   if (value)  return value;
 
   switch (channel) {

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -1,8 +1,6 @@
 /**
  * Module for compiling Vega-lite spec into Vega spec.
  */
-
-import {summary} from '../util';
 import {Model} from './Model';
 
 import * as vlScale from './scale';
@@ -10,12 +8,14 @@ import * as vlTime from './time';
 import * as vlAxis from './axis';
 import * as vlLegend from './legend';
 import * as vlMarks from './marks';
-import vlData from './data';
+import {def as dataDef} from './data';
 import vlFacet from './facet';
 import vlLayout from './layout';
 import vlStack from './stack';
 import vlStyle from './style';
 import vlSubfacet from './subfacet';
+
+import * as vlData from '../data';
 import {COLUMN, ROW, X, Y} from '../channel';
 
 export {Model} from './Model';
@@ -25,10 +25,7 @@ export function compile(spec, stats, theme?) {
   // no need to pass stats if you pass in the data
   if (!stats) {
     if (model.hasValues()) {
-        stats = summary(model.data().values).reduce(function(s, p) {
-        s[p.field] = p;
-        return s;
-      }, {});
+        stats = vlData.stats(model.data().values);
     } else {
       console.error('No stats provided and data is not embedded.');
     }
@@ -41,7 +38,7 @@ export function compile(spec, stats, theme?) {
       width: layout.width,
       height: layout.height,
       padding: 'auto',
-      data: vlData(model),
+      data: dataDef(model),
       marks: [{
         name: 'cell',
         type: 'group',

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -17,7 +17,7 @@ import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../type';
  *                 If the encoding contains aggregate value, this will also create
  *                 aggregate table as well.
  */
-export default function(model: Model) {
+export function def(model: Model) {
   var def = [source.def(model)];
 
   var summaryDef = summary.def(model);

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -2,6 +2,7 @@ import * as vlFieldDef from '../fielddef';
 import * as util from '../util';
 import {Model} from './Model';
 import {FieldDef} from '../schema/fielddef.schema';
+import {StackDef} from './stack';
 
 import {MAXBINS_DEFAULT} from '../bin';
 import {Channel} from '../channel';
@@ -32,9 +33,9 @@ export function def(model: Model) {
   filterNonPositive(def[def.length - 1], model);
 
   // Stack
-  var stackCfg = model.stack();
-  if (stackCfg) {
-    def.push(stack.def(model, stackCfg));
+  var stackDef = model.stack();
+  if (stackDef) {
+    def.push(stack.def(model, stackDef));
   }
 
   return def;
@@ -254,9 +255,9 @@ export namespace stack {
   /**
    * Add stacked data source, for feeding the shared scale.
    */
-  export function def(model: Model, stackCfg):VgData {
-    var dim = stackCfg.groupby;
-    var val = stackCfg.value;
+  export function def(model: Model, stackDef: StackDef):VgData {
+    var groupbyChannel = stackDef.groupbyChannel;
+    var fieldChannel = stackDef.fieldChannel;
     var facets = model.facets();
 
     var stacked:VgData = {
@@ -264,8 +265,9 @@ export namespace stack {
       source: model.dataTable(),
       transform: [{
         type: 'aggregate',
-        groupby: [model.fieldRef(dim)].concat(facets), // dim and other facets
-        summarize: [{ops: ['sum'], field: model.fieldRef(val)}]
+        // group by channel and other facets
+        groupby: [model.fieldRef(groupbyChannel)].concat(facets),
+        summarize: [{ops: ['sum'], field: model.fieldRef(fieldChannel)}]
       }]
     };
 
@@ -276,7 +278,7 @@ export namespace stack {
         summarize: [{
           ops: ['max'],
           // we want max of sum from above transform
-          field: model.fieldRef(val, {prefn: 'sum_'})
+          field: model.fieldRef(fieldChannel, {prefn: 'sum_'})
         }]
       });
     }

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -2,7 +2,7 @@ import * as vlFieldDef from '../fielddef';
 import * as util from '../util';
 import {Model} from './Model';
 import {FieldDef} from '../schema/fielddef.schema';
-import {StackDef} from './stack';
+import {StackProperties} from './stack';
 
 import {MAXBINS_DEFAULT} from '../bin';
 import {Channel} from '../channel';
@@ -255,9 +255,9 @@ export namespace stack {
   /**
    * Add stacked data source, for feeding the shared scale.
    */
-  export function def(model: Model, stackDef: StackDef):VgData {
-    var groupbyChannel = stackDef.groupbyChannel;
-    var fieldChannel = stackDef.fieldChannel;
+  export function def(model: Model, stackProps: StackProperties):VgData {
+    var groupbyChannel = stackProps.groupbyChannel;
+    var fieldChannel = stackProps.fieldChannel;
     var facets = model.facets();
 
     var stacked:VgData = {

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -82,7 +82,7 @@ export function domain(model: Model, channel:Channel, type, facet:boolean = fals
 
   // For stack, use STACKED data.
   var stack = model.stack();
-  if (stack && channel === stack.value) {
+  if (stack && channel === stack.fieldChannel) {
     return {
       data: STACKED,
       field: model.fieldRef(channel, {

--- a/src/compiler/stack.ts
+++ b/src/compiler/stack.ts
@@ -1,6 +1,24 @@
 import {Model} from './Model';
+import {Channel} from '../channel';
 
-export default function(model: Model, mdef, stack) {
+export interface StackDef {
+  groupby: Channel;
+  value: Channel;
+  stack: Channel; // COLOR or DETAIL
+  properties: any;
+}
+
+// TODO: put all vega interface in one place
+interface StackTransform {
+  type: string;
+  offset?: any;
+  groupby: any;
+  field: any;
+  sortby: any;
+  output: any;
+}
+
+export default function(model: Model, mdef, stack: StackDef) {
   var groupby = stack.groupby;
   var fieldChannel = stack.value;
 
@@ -20,16 +38,6 @@ export default function(model: Model, mdef, stack) {
       method: 'value',
       value: 0
     });
-  }
-
-  // TODO: put all vega interface in one place
-  interface StackTransform {
-    type: string;
-    offset?: any;
-    groupby: any;
-    field: any;
-    sortby: any;
-    output: any;
   }
 
   // add stack transform to mark

--- a/src/compiler/stack.ts
+++ b/src/compiler/stack.ts
@@ -3,8 +3,8 @@ import {Channel} from '../channel';
 import * as util from '../util';
 
 export interface StackDef {
-  groupby: Channel;
-  value: Channel;
+  groupbyChannel: Channel;
+  fieldChannel: Channel;
   stack: Channel; // COLOR or DETAIL
   config: any;
 }
@@ -20,8 +20,8 @@ interface StackTransform {
 }
 
 export default function(model: Model, mdef, stack: StackDef) {
-  var groupby = stack.groupby;
-  var fieldChannel = stack.value;
+  var groupby = stack.groupbyChannel;
+  var fieldChannel = stack.fieldChannel;
 
   var valName = model.fieldRef(fieldChannel);
   var startField = valName + '_start';

--- a/src/compiler/stack.ts
+++ b/src/compiler/stack.ts
@@ -1,11 +1,12 @@
 import {Model} from './Model';
 import {Channel} from '../channel';
+import * as util from '../util';
 
 export interface StackDef {
   groupby: Channel;
   value: Channel;
   stack: Channel; // COLOR or DETAIL
-  properties: any;
+  config: any;
 }
 
 // TODO: put all vega interface in one place
@@ -40,17 +41,25 @@ export default function(model: Model, mdef, stack: StackDef) {
     });
   }
 
+  const sortby = stack.config.sort === 'descending' ?
+                   '-' + model.fieldRef(stack.stack) :
+                 stack.config.sort === 'ascending' ?
+                   model.fieldRef(stack.stack) :
+                 util.isObject(stack.config.sort) ?
+                   stack.config.sort :
+                   '-' + model.fieldRef(stack.stack); // default
+
   // add stack transform to mark
   var stackTransform: StackTransform = {
     type: 'stack',
     groupby: [model.fieldRef(groupby)],
     field: model.fieldRef(fieldChannel),
-    sortby: [(stack.properties.reverse ? '' : '-') + model.fieldRef(stack.stack)],
+    sortby: sortby,
     output: {start: startField, end: endField}
   };
 
-  if (stack.properties.offset) {
-    stackTransform.offset = stack.properties.offset;
+  if (stack.config.offset) {
+    stackTransform.offset = stack.config.offset;
   }
 
   transforms.push(stackTransform);

--- a/src/compiler/stack.ts
+++ b/src/compiler/stack.ts
@@ -37,7 +37,7 @@ export default function(model: Model, mdef, stack) {
     type: 'stack',
     groupby: [model.fieldRef(groupby)],
     field: model.fieldRef(fieldChannel),
-    sortby: [(stack.properties.reverse ? '-' : '') + model.fieldRef(stack.stack)],
+    sortby: [(stack.properties.reverse ? '' : '-') + model.fieldRef(stack.stack)],
     output: {start: startField, end: endField}
   };
 

--- a/src/compiler/stack.ts
+++ b/src/compiler/stack.ts
@@ -5,7 +5,7 @@ import * as util from '../util';
 export interface StackDef {
   groupbyChannel: Channel;
   fieldChannel: Channel;
-  stack: Channel; // COLOR or DETAIL
+  stackChannel: Channel; // COLOR or DETAIL
   config: any;
 }
 
@@ -34,7 +34,7 @@ export default function(model: Model, mdef, stack: StackDef) {
     transforms.push({
       type: 'impute',
       field: model.fieldRef(fieldChannel),
-      groupby: [model.fieldRef(stack.stack)],
+      groupby: [model.fieldRef(stack.stackChannel)],
       orderby: [model.fieldRef(groupby)],
       method: 'value',
       value: 0
@@ -42,12 +42,12 @@ export default function(model: Model, mdef, stack: StackDef) {
   }
 
   const sortby = stack.config.sort === 'descending' ?
-                   '-' + model.fieldRef(stack.stack) :
+                   '-' + model.fieldRef(stack.stackChannel) :
                  stack.config.sort === 'ascending' ?
-                   model.fieldRef(stack.stack) :
+                   model.fieldRef(stack.stackChannel) :
                  util.isObject(stack.config.sort) ?
                    stack.config.sort :
-                   '-' + model.fieldRef(stack.stack); // default
+                   '-' + model.fieldRef(stack.stackChannel); // default
 
   // add stack transform to mark
   var stackTransform: StackTransform = {

--- a/src/compiler/stack.ts
+++ b/src/compiler/stack.ts
@@ -2,7 +2,7 @@ import {Model} from './Model';
 import {Channel} from '../channel';
 import * as util from '../util';
 
-export interface StackDef {
+export interface StackProperties {
   groupbyChannel: Channel;
   fieldChannel: Channel;
   stackChannel: Channel; // COLOR or DETAIL
@@ -19,9 +19,9 @@ interface StackTransform {
   output: any;
 }
 
-export default function(model: Model, mdef, stack: StackDef) {
-  var groupby = stack.groupbyChannel;
-  var fieldChannel = stack.fieldChannel;
+export default function(model: Model, mdef, stackProps: StackProperties) {
+  var groupby = stackProps.groupbyChannel;
+  var fieldChannel = stackProps.fieldChannel;
 
   var valName = model.fieldRef(fieldChannel);
   var startField = valName + '_start';
@@ -34,20 +34,20 @@ export default function(model: Model, mdef, stack: StackDef) {
     transforms.push({
       type: 'impute',
       field: model.fieldRef(fieldChannel),
-      groupby: [model.fieldRef(stack.stackChannel)],
+      groupby: [model.fieldRef(stackProps.stackChannel)],
       orderby: [model.fieldRef(groupby)],
       method: 'value',
       value: 0
     });
   }
 
-  const sortby = stack.config.sort === 'descending' ?
-                   '-' + model.fieldRef(stack.stackChannel) :
-                 stack.config.sort === 'ascending' ?
-                   model.fieldRef(stack.stackChannel) :
-                 util.isObject(stack.config.sort) ?
-                   stack.config.sort :
-                   '-' + model.fieldRef(stack.stackChannel); // default
+  const sortby = stackProps.config.sort === 'descending' ?
+                   '-' + model.fieldRef(stackProps.stackChannel) :
+                 stackProps.config.sort === 'ascending' ?
+                   model.fieldRef(stackProps.stackChannel) :
+                 util.isObject(stackProps.config.sort) ?
+                   stackProps.config.sort :
+                   '-' + model.fieldRef(stackProps.stackChannel); // default
 
   // add stack transform to mark
   var stackTransform: StackTransform = {
@@ -58,8 +58,8 @@ export default function(model: Model, mdef, stack: StackDef) {
     output: {start: startField, end: endField}
   };
 
-  if (stack.config.offset) {
-    stackTransform.offset = stack.config.offset;
+  if (stackProps.config.offset) {
+    stackTransform.offset = stackProps.config.offset;
   }
 
   transforms.push(stackTransform);

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -116,12 +116,21 @@ export var config = {
     // layout
     stack: {
       type: ['boolean', 'object'],
-      default: true,
       description: 'Enable stacking (for bar and area marks only).',
       properties: {
-        reverse: {
-          type: 'boolean',
-          description: 'Whether to reverse the stack\'s sortby.'
+        sort: {
+          default: 'descending',
+          oneOf: [{
+            type: 'string',
+            enum: ['ascending', 'descending']
+          },{
+            type: 'array',
+            items: {type: 'string'},
+          }],
+          description: 'Order of the stack. ' +
+            'This can be either a string (either "descending" or "ascending")' +
+            'or a list of fields to determine the order of stack layers.' +
+            'By default, stack uses descending order.'
         },
         offset: {
           type: 'string',

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -113,6 +113,25 @@ export var config = {
       minimum: 0
     },
 
+    // layout
+    stack: {
+      type: ['boolean', 'object'],
+      default: true,
+      description: 'Enable stacking (for bar and area marks only).',
+      properties: {
+        reverse: {
+          type: 'boolean',
+          description: 'Whether to reverse the stack\'s sortby.'
+        },
+        offset: {
+          type: 'string',
+          enum: ['zero', 'center', 'normalize']
+          // TODO(#620) refer to Vega spec once it doesn't throw error
+          // enum: vgStackSchema.properties.offset.oneOf[0].enum
+        }
+      }
+    },
+
     // marks
     strokeWidth: {
       type: 'integer',

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -116,10 +116,10 @@ export var config = {
     // layout
     stack: {
       type: ['boolean', 'object'],
+      default: {},
       description: 'Enable stacking (for bar and area marks only).',
       properties: {
         sort: {
-          default: 'descending',
           oneOf: [{
             type: 'string',
             enum: ['ascending', 'descending']

--- a/src/schema/encoding.schema.ts
+++ b/src/schema/encoding.schema.ts
@@ -10,7 +10,7 @@ import {axis} from './axis.schema';
 import {FieldDef} from './fielddef.schema';
 import {legend} from './legend.schema';
 import {sort} from './sort.schema';
-import {typicalField, onlyOrdinalField, stack} from './fielddef.schema';
+import {typicalField, onlyOrdinalField} from './fielddef.schema';
 
 export interface Encoding {
   x?: FieldDef;
@@ -87,7 +87,6 @@ var color = merge(duplicate(typicalField), {
   properties: {
     legend: legend,
     sort: sort,
-    stack: stack,
     value: {
       type: 'string',
       role: 'color',
@@ -171,8 +170,7 @@ var shape = merge(duplicate(onlyOrdinalField), {
 var detail = merge(duplicate(onlyOrdinalField), {
   supportedMarktypes: {point: true, tick: true, line: true, circle: true, square: true},
   properties: {
-    sort: sort,
-    stack: stack
+    sort: sort
   }
 });
 

--- a/src/schema/fielddef.schema.ts
+++ b/src/schema/fielddef.schema.ts
@@ -96,12 +96,10 @@ export var stack = {
   properties: {
     reverse: {
       type: 'boolean',
-      default: false,
       description: 'Whether to reverse the stack\'s sortby.'
     },
     offset: {
       type: 'string',
-      default: undefined,
       enum: ['zero', 'center', 'normalize']
       // TODO(#620) refer to Vega spec once it doesn't throw error
       // enum: vgStackSchema.properties.offset.oneOf[0].enum

--- a/src/schema/fielddef.schema.ts
+++ b/src/schema/fielddef.schema.ts
@@ -21,14 +21,12 @@ export interface FieldDef {
   timeUnit?: string;
   bin?: boolean | Bin;
 
-
   sort?: Sort | string;
 
-  // override
+  // override vega components
   axis?: Axis;
   legend?: Legend;
   scale?: Scale;
-  stack?: any;// TODO move this to config
 
   // text
   align?: string;
@@ -89,21 +87,3 @@ export var onlyOrdinalField = merge(duplicate(fieldDef), {
     scale: ordinalOnlyScale
   }
 });
-
-export var stack = {
-  type: ['boolean', 'object'],
-  default: true,
-  description: 'Enable stacking (for bar and area marks only).',
-  properties: {
-    reverse: {
-      type: 'boolean',
-      description: 'Whether to reverse the stack\'s sortby.'
-    },
-    offset: {
-      type: 'string',
-      enum: ['zero', 'center', 'normalize']
-      // TODO(#620) refer to Vega spec once it doesn't throw error
-      // enum: vgStackSchema.properties.offset.oneOf[0].enum
-    }
-  }
-};

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -4,6 +4,8 @@ import * as vlEncoding from './encoding';
 import * as util from './util';
 import {Model} from './compiler/Model';
 import {Spec} from './schema/schema';
+import {COLOR, DETAIL} from './channel';
+import {BAR, AREA} from './marktype';
 
 // TODO: add vl.spec.validate & move stuff from vl.validate to here
 
@@ -17,11 +19,11 @@ export function getCleanSpec(spec: Spec): Spec {
   return new Model(spec).toSpec(true);
 }
 
-
-export function isStack(spec): boolean {
-  // FIXME update this once we have control for stack ...
-  return (spec.marktype === 'bar' || spec.marktype === 'area') &&
-    !!spec.encoding.color;
+export function isStack(spec: Spec): boolean {
+  return (spec.encoding[COLOR].field || spec.encoding[DETAIL].field) &&
+    (spec.marktype === BAR || spec.marktype === AREA) &&
+    (!spec.config || !spec.config.stack !== false) &&
+    vlEncoding.isAggregate(spec.encoding);
 }
 
 // TODO revise

--- a/test/compiler/data.test.ts
+++ b/test/compiler/data.test.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 
-import data, {source, summary} from '../../src/compiler/data';
+import {def as dataDef, source, summary} from '../../src/compiler/data';
 import {SUMMARY} from '../../src/data';
 import {Model} from '../../src/compiler/Model';
 
@@ -14,7 +14,7 @@ describe('data', function () {
           }
         });
 
-      var _data = data(encoding);
+      var _data = dataDef(encoding);
       expect(_data.length).to.equal(2);
     });
   });
@@ -27,7 +27,7 @@ describe('data', function () {
         }
       });
 
-    var _data = data(rawEncodingWithLog);
+    var _data = dataDef(rawEncodingWithLog);
     it('should contains one table', function() {
       expect(_data.length).to.equal(1);
     });


### PR DESCRIPTION
__Please merge #764 first !  (See [Branch Specific Diff](https://github.com/uwdata/vega-lite/compare/kw/model...kw/stack))__

Fixes #683 

## syntax 
- move `stack` property from `color`/`detail` to `config`
  - make `stack` config supports an array of fields. 

## output 
- make stack uses descending by default 

## API 
- update `vl.spec.isStack()`

## Internal
- add StackDef interface
- calculate `_stack` only once in model 

## Docs
- Add docs for stack in `Config.md` 
——
