### PR TITLE
Replace def(), defs() with compileXXX() methods and remove export default where it’s not necessary 

### DIFF
--- a/src/compiler/axis.ts
+++ b/src/compiler/axis.ts
@@ -7,7 +7,7 @@ import * as time from './time';
 // https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#11-ambient-declarations
 declare var exports;
 
-export function def(channel: Channel, model: Model, layout, stats) {
+export function compileAxis(channel: Channel, model: Model, layout, stats) {
   var isCol = channel === COLUMN,
     isRow = channel === ROW,
     type = isCol ? 'x' : isRow ? 'y': channel;

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -15,7 +15,7 @@ import vlStack from './stack';
 import vlStyle from './style';
 import vlSubfacet from './subfacet';
 
-import * as vlData from '../data';
+import {stats as vlDataStats} from '../data';
 import {COLUMN, ROW, X, Y} from '../channel';
 
 export {Model} from './Model';
@@ -25,7 +25,7 @@ export function compile(spec, stats, theme?) {
   // no need to pass stats if you pass in the data
   if (!stats) {
     if (model.hasValues()) {
-        stats = vlData.stats(model.data().values);
+        stats = vlDataStats(model.data().values);
     } else {
       console.error('No stats provided and data is not embedded.');
     }

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -7,7 +7,7 @@ import * as vlScale from './scale';
 import * as vlTime from './time';
 import {compileAxis} from './axis';
 import {compileData} from './data';
-import * as vlLegend from './legend';
+import {compileLegends} from './legend';
 import * as vlMarks from './marks';
 import vlFacet from './facet';
 import vlLayout from './layout';
@@ -99,7 +99,7 @@ export function compile(spec, stats, theme?) {
     return vlScale.names(markProps.properties.update);
   }));
 
-  var legends = vlLegend.defs(model, styleCfg);
+  var legends = compileLegends(model, styleCfg);
 
   // Small Multiples
   if (model.has(ROW) || model.has(COLUMN)) {

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -8,7 +8,7 @@ import * as vlTime from './time';
 import * as vlAxis from './axis';
 import * as vlLegend from './legend';
 import * as vlMarks from './marks';
-import {def as dataDef} from './data';
+import {compileData} from './data';
 import vlFacet from './facet';
 import vlLayout from './layout';
 import vlStack from './stack';
@@ -38,7 +38,7 @@ export function compile(spec, stats, theme?) {
       width: layout.width,
       height: layout.height,
       padding: 'auto',
-      data: dataDef(model),
+      data: compileData(model),
       marks: [{
         name: 'cell',
         type: 'group',

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -3,12 +3,14 @@
  */
 import {Model} from './Model';
 
-import * as vlScale from './scale';
 import * as vlTime from './time';
 import {compileAxis} from './axis';
 import {compileData} from './data';
 import {compileLegends} from './legend';
 import {compileMarks} from './marks';
+import {compileScales, compileScaleNames} from './scale';
+
+// TODO: stop using default if we were to keep these files
 import vlFacet from './facet';
 import vlLayout from './layout';
 import vlStack from './stack';
@@ -97,7 +99,7 @@ export function compile(spec, stats, theme?) {
 
   // get a flattened list of all scale names that are used in the vl spec
   var singleScaleNames = [].concat.apply([], mdefs.map(function(markProps) {
-    return vlScale.names(markProps.properties.update);
+    return compileScaleNames(markProps.properties.update);
   }));
 
   var legends = compileLegends(model, styleCfg);
@@ -109,7 +111,7 @@ export function compile(spec, stats, theme?) {
       output.legends = legends;
     }
   } else {
-    group.scales = vlScale.defs(singleScaleNames, model, layout, stats);
+    group.scales = compileScales(singleScaleNames, model, layout, stats);
 
     var axes = [];
     if (model.has(X)) {

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -5,10 +5,10 @@ import {Model} from './Model';
 
 import * as vlScale from './scale';
 import * as vlTime from './time';
-import * as vlAxis from './axis';
+import {compileAxis} from './axis';
+import {compileData} from './data';
 import * as vlLegend from './legend';
 import * as vlMarks from './marks';
-import {compileData} from './data';
 import vlFacet from './facet';
 import vlLayout from './layout';
 import vlStack from './stack';
@@ -112,10 +112,10 @@ export function compile(spec, stats, theme?) {
 
     var axes = [];
     if (model.has(X)) {
-      axes.push(vlAxis.def(X, model, layout, stats));
+      axes.push(compileAxis(X, model, layout, stats));
     }
     if (model.has(Y)) {
-      axes.push(vlAxis.def(Y, model, layout, stats));
+      axes.push(compileAxis(Y, model, layout, stats));
     }
     if (axes.length > 0) {
       group.axes = axes;

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -8,7 +8,7 @@ import * as vlTime from './time';
 import {compileAxis} from './axis';
 import {compileData} from './data';
 import {compileLegends} from './legend';
-import * as vlMarks from './marks';
+import {compileMarks} from './marks';
 import vlFacet from './facet';
 import vlLayout from './layout';
 import vlStack from './stack';
@@ -65,7 +65,7 @@ export function compile(spec, stats, theme?) {
 
   // marks
   var styleCfg = vlStyle(model, stats),
-    mdefs = group.marks = vlMarks.defs(model, layout, styleCfg),
+    mdefs = group.marks = compileMarks(model, layout, styleCfg),
     mdef = mdefs[mdefs.length - 1];  // TODO: remove this dirty hack by refactoring the whole flow
 
   var stack = model.stack();
@@ -74,18 +74,19 @@ export function compile(spec, stats, theme?) {
     vlStack(model, mdef, stack);
   }
 
-  var lineType = vlMarks[model.marktype()].line;
+  const marktype = model.marktype();
+  const isLineType = marktype === 'line' || marktype === 'area';
 
   // handle subfacets
   var details = model.details();
 
-  if (details.length > 0 && lineType) {
+  if (details.length > 0 && isLineType) {
     //subfacet to group area / line together in one group
     vlSubfacet(group, mdef, details);
   }
 
   // auto-sort line/area values
-  if (lineType && model.config('autoSortLine')) {
+  if (isLineType && model.config('autoSortLine')) { // TODO: remove autoSortLine
     var f = (model.isMeasure(X) && model.isDimension(Y)) ? Y : X;
     if (!mdef.from) {
       mdef.from = {};

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -19,7 +19,7 @@ import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../type';
  *                 If the encoding contains aggregate value, this will also create
  *                 aggregate table as well.
  */
-export function def(model: Model) {
+export function compileData(model: Model) {
   var def = [source.def(model)];
 
   var summaryDef = summary.def(model);

--- a/src/compiler/facet.ts
+++ b/src/compiler/facet.ts
@@ -3,7 +3,7 @@ import {COLUMN, ROW, X, Y} from '../channel';
 import {Model} from './Model';
 
 import {compileAxis} from './axis';
-import * as vlScale from './scale';
+import {compileScales, compileScaleNames} from './scale';
 
 function groupdef(name, opt) {
   opt = opt || {};
@@ -123,8 +123,8 @@ export default function(group, model: Model, layout, output, singleScaleNames, s
 
   // assuming equal cellWidth here
   // TODO: support heterogenous cellWidth (maybe by using multiple scales?)
-  output.scales = (output.scales || []).concat(vlScale.defs(
-    vlScale.names(enter).concat(singleScaleNames),
+  output.scales = (output.scales || []).concat(compileScales(
+    compileScaleNames(enter).concat(singleScaleNames),
     model,
     layout,
     stats,

--- a/src/compiler/facet.ts
+++ b/src/compiler/facet.ts
@@ -2,7 +2,7 @@ import * as util from '../util';
 import {COLUMN, ROW, X, Y} from '../channel';
 import {Model} from './Model';
 
-import * as vlAxis from './axis';
+import {compileAxis} from './axis';
 import * as vlScale from './scale';
 
 function groupdef(name, opt) {
@@ -73,7 +73,7 @@ export default function(group, model: Model, layout, output, singleScaleNames, s
     }
 
     axesGrp = groupdef('x-axes', {
-        axes: model.has(X) ? [vlAxis.def(X, model, layout, stats)] : undefined,
+        axes: model.has(X) ? [compileAxis(X, model, layout, stats)] : undefined,
         x: hasCol ? {scale: COLUMN, field: model.fieldRef(COLUMN)} : {value: 0},
         width: hasCol && {'value': layout.cellWidth}, //HACK?
         from: from
@@ -81,11 +81,11 @@ export default function(group, model: Model, layout, output, singleScaleNames, s
 
     output.marks.unshift(axesGrp); // need to prepend so it appears under the plots
     (output.axes = output.axes || []);
-    output.axes.push(vlAxis.def(ROW, model, layout, stats));
+    output.axes.push(compileAxis(ROW, model, layout, stats));
   } else { // doesn't have row
     if (model.has(X)) {
       //keep x axis in the cell
-      cellAxes.push(vlAxis.def(X, model, layout, stats));
+      cellAxes.push(compileAxis(X, model, layout, stats));
     }
   }
 
@@ -105,7 +105,7 @@ export default function(group, model: Model, layout, output, singleScaleNames, s
     }
 
     axesGrp = groupdef('y-axes', {
-      axes: model.has(Y) ? [vlAxis.def(Y, model, layout, stats)] : undefined,
+      axes: model.has(Y) ? [compileAxis(Y, model, layout, stats)] : undefined,
       y: hasRow && {scale: ROW, field: model.fieldRef(ROW)},
       x: hasRow && {value: 0},
       height: hasRow && {'value': layout.cellHeight}, //HACK?
@@ -114,10 +114,10 @@ export default function(group, model: Model, layout, output, singleScaleNames, s
 
     output.marks.unshift(axesGrp); // need to prepend so it appears under the plots
     (output.axes = output.axes || []);
-    output.axes.push(vlAxis.def(COLUMN, model, layout, stats));
+    output.axes.push(compileAxis(COLUMN, model, layout, stats));
   } else { // doesn't have column
     if (model.has(Y)) {
-      cellAxes.push(vlAxis.def(Y, model, layout, stats));
+      cellAxes.push(compileAxis(Y, model, layout, stats));
     }
   }
 

--- a/src/compiler/legend.ts
+++ b/src/compiler/legend.ts
@@ -4,31 +4,31 @@ import {Model} from './Model';
 import * as time from './time';
 import {TEMPORAL} from '../type';
 
-export function defs(model: Model, styleCfg) {
+export function compileLegends(model: Model, styleCfg) {
   var defs = [];
 
   if (model.has(COLOR) && model.fieldDef(COLOR).legend) {
-    defs.push(def(model, COLOR, {
+    defs.push(compileLegend(model, COLOR, {
       fill: COLOR
       // TODO: consider if this should be stroke for line
     }, styleCfg));
   }
 
   if (model.has(SIZE) && model.fieldDef(SIZE).legend) {
-    defs.push(def(model, SIZE, {
+    defs.push(compileLegend(model, SIZE, {
       size: SIZE
     }, styleCfg));
   }
 
   if (model.has(SHAPE) && model.fieldDef(SHAPE).legend) {
-    defs.push(def(model, SHAPE, {
+    defs.push(compileLegend(model, SHAPE, {
       shape: SHAPE
     }, styleCfg));
   }
   return defs;
 }
 
-export function def(model: Model, channel: Channel, def, styleCfg) {
+export function compileLegend(model: Model, channel: Channel, def, styleCfg) {
   let legend = model.fieldDef(channel).legend;
 
   // 1.1 Add properties with special rules

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -5,7 +5,7 @@ import {QUANTITATIVE} from '../type';
 // https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#11-ambient-declarations
 declare var exports;
 
-export function defs(model: Model, layout, style) {
+export function compileMarks(model: Model, layout, style) {
   var defs = [],
     mark = exports[model.marktype()],
     from = model.dataTable();
@@ -44,13 +44,11 @@ export const bar = {
 
 export const line = {
   type: 'line',
-  line: true,
   prop: line_props
 };
 
 export const area = {
   type: 'area',
-  line: true,
   prop: area_props
 };
 

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -15,14 +15,15 @@ import {SOURCE, STACKED} from '../data';
 import * as time from './time';
 import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../type';
 
-export function names(props) {
+// TODO: consider if we can remove this and simplify the codebase
+export function compileScaleNames(props) {
   return util.keys(util.keys(props).reduce(function(a, x) {
     if (props[x] && props[x].scale) a[props[x].scale] = 1;
     return a;
   }, {}));
 }
 
-export function defs(names: Array<string>, model: Model, layout, stats, facet?) {
+export function compileScales(names: Array<string>, model: Model, layout, stats, facet?) {
   return names.reduce(function(a, channel: Channel) {
     var scaleDef: any = {};
 

--- a/test/compiler/axis.test.ts
+++ b/test/compiler/axis.test.ts
@@ -19,7 +19,7 @@ describe('Axis', function() {
           x: {field: field, type: 'temporal', timeUnit: timeUnit}
         }
       });
-    var _axis = axis.def('x', encoding, {
+    var _axis = axis.compileAxis('x', encoding, {
       width: 200,
       height: 200,
       cellWidth: 200,

--- a/test/compiler/data.test.ts
+++ b/test/compiler/data.test.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 
-import {def as dataDef, source, summary} from '../../src/compiler/data';
+import {compileData, source, summary} from '../../src/compiler/data';
 import {SUMMARY} from '../../src/data';
 import {Model} from '../../src/compiler/Model';
 
@@ -14,7 +14,7 @@ describe('data', function () {
           }
         });
 
-      var _data = dataDef(encoding);
+      var _data = compileData(encoding);
       expect(_data.length).to.equal(2);
     });
   });
@@ -27,7 +27,7 @@ describe('data', function () {
         }
       });
 
-    var _data = dataDef(rawEncodingWithLog);
+    var _data = compileData(rawEncodingWithLog);
     it('should contains one table', function() {
       expect(_data.length).to.equal(1);
     });


### PR DESCRIPTION
Note that I leave `facet`, `layout`, `stack`, `style`, `subfacet`, and `time` since these will be further refactored to simplify flow (#276) and some of them might be removed so I don’t want to waste time refactoring them now.  