### PR TITLE
Do not pollute `vl.` with util methods by moving them to `vl.util`.

### DIFF
--- a/src/vl.ts
+++ b/src/vl.ts
@@ -10,18 +10,15 @@ import * as vlSpec from './spec';
 import * as vlTimeUnit from './timeunit';
 import * as vlType from './type';
 import * as vlValidate from './validate';
+import * as vlUtil from './util';
 
-// TODO: remove this
-import {format as d3Format} from 'd3-format';
 
-export * from './util';
 
 export var bin = vlBin;
 export var channel = vlChannel;
 export var compiler = vlCompiler;
 export var compile = vlCompiler.compile;
 export var data = vlData;
-// TODO(#727) rename to encoding
 export var encoding = vlEncoding;
 export var fieldDef = vlFieldDef;
 export var schema = vlSchema;
@@ -29,7 +26,7 @@ export var shorthand = vlShorthand;
 export var spec = vlSpec;
 export var timeUnit = vlTimeUnit;
 export var type = vlType;
-export var format = d3Format;
+export var util = vlUtil;
 export var validate = vlValidate;
 
 export const version = '__VERSION__';


### PR DESCRIPTION
Also removing vl.format