### PR TITLE
Make marks.ts far less confusing + Use Update instead of enter for root 

### DIFF
--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -45,11 +45,11 @@ export function compile(spec, stats, theme?) {
         name: 'cell',
         type: 'group',
         properties: {
-          enter: {
-            width: layout.cellWidth ?
+          update: {
+            width: model.has(COLUMN) ?
                      {value: layout.cellWidth} :
                      {field: {group: 'width'}},
-            height: layout.cellHeight ?
+            height: model.has(ROW) ?
                     {value: layout.cellHeight} :
                     {field: {group: 'height'}}
           }

--- a/src/compiler/facet.ts
+++ b/src/compiler/facet.ts
@@ -37,12 +37,12 @@ function groupdef(name, opt) {
 }
 
 export default function(group, model: Model, layout, output, singleScaleNames, stats) {
-  var enter = group.properties.enter;
+  var update = group.properties.update;
   var facetKeys = [], cellAxes = [], from, axesGrp;
 
   var hasRow = model.has(ROW), hasCol = model.has(COLUMN);
 
-  enter.fill = {value: model.config('cellBackgroundColor')};
+  update.fill = {value: model.config('cellBackgroundColor')};
 
   //move "from" to cell level and add facet transform
   group.from = {data: group.marks[0].from.data};
@@ -61,8 +61,8 @@ export default function(group, model: Model, layout, output, singleScaleNames, s
     if (!model.isDimension(ROW)) {
       util.error('Row encoding should be ordinal.');
     }
-    enter.y = {scale: ROW, field: model.fieldRef(ROW)};
-    enter.height = {'value': layout.cellHeight}; // HACK
+    update.y = {scale: ROW, field: model.fieldRef(ROW)};
+    update.height = {'value': layout.cellHeight}; // HACK
 
     facetKeys.push(model.fieldRef(ROW));
 
@@ -93,8 +93,8 @@ export default function(group, model: Model, layout, output, singleScaleNames, s
     if (!model.isDimension(COLUMN)) {
       util.error('Col encoding should be ordinal.');
     }
-    enter.x = {scale: COLUMN, field: model.fieldRef(COLUMN)};
-    enter.width = {'value': layout.cellWidth}; // HACK
+    update.x = {scale: COLUMN, field: model.fieldRef(COLUMN)};
+    update.width = {'value': layout.cellWidth}; // HACK
 
     facetKeys.push(model.fieldRef(COLUMN));
 
@@ -124,7 +124,7 @@ export default function(group, model: Model, layout, output, singleScaleNames, s
   // assuming equal cellWidth here
   // TODO: support heterogenous cellWidth (maybe by using multiple scales?)
   output.scales = (output.scales || []).concat(compileScales(
-    compileScaleNames(enter).concat(singleScaleNames),
+    compileScaleNames(update).concat(singleScaleNames),
     model,
     layout,
     stats,

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -217,41 +217,41 @@ export function line(model: Model,layout, style) {
 }
 
 // TODO(#694): optimize area's usage with bin
-export function area(e: Model, layout, style) {
+export function area(model: Model, layout, style) {
   // TODO Use Vega's marks properties interface
   var p:any = {};
 
   // x
-  if (e.isMeasure(X)) {
-    p.x = {scale: X, field: e.fieldRef(X)};
-    if (e.isDimension(Y)) {
+  if (model.isMeasure(X)) {
+    p.x = {scale: X, field: model.fieldRef(X)};
+    if (model.isDimension(Y)) {
       p.x2 = {scale: X, value: 0};
       p.orient = {value: 'horizontal'};
     }
-  } else if (e.has(X)) {
-    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
+  } else if (model.has(X)) {
+    p.x = {scale: X, field: model.fieldRef(X, {binSuffix: '_mid'})};
   } else {
     p.x = {value: 0};
   }
 
   // y
-  if (e.isMeasure(Y)) {
-    p.y = {scale: Y, field: e.fieldRef(Y)};
+  if (model.isMeasure(Y)) {
+    p.y = {scale: Y, field: model.fieldRef(Y)};
     p.y2 = {scale: Y, value: 0};
-  } else if (e.has(Y)) {
-    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
+  } else if (model.has(Y)) {
+    p.y = {scale: Y, field: model.fieldRef(Y, {binSuffix: '_mid'})};
   } else {
     p.y = {field: {group: 'height'}};
   }
 
   // fill
-  if (e.has(COLOR)) {
-    p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
-  } else if (!e.has(COLOR)) {
-    p.fill = {value: e.fieldDef(COLOR).value};
+  if (model.has(COLOR)) {
+    p.fill = {scale: COLOR, field: model.fieldRef(COLOR)};
+  } else if (!model.has(COLOR)) {
+    p.fill = {value: model.fieldDef(COLOR).value};
   }
 
-  var opacity = e.fieldDef(COLOR).opacity;
+  var opacity = model.fieldDef(COLOR).opacity;
   if (opacity) p.opacity = {value: opacity};
 
   return p;

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -20,7 +20,7 @@ const MARKTYPES_MAP = {
 
 export function compileMarks(model: Model, layout, style) {
   const marktype = model.marktype();
-  const from = {from: model.dataTable()};
+  const from = {data: model.dataTable()};
   let defs = [];
 
   switch (marktype) {
@@ -217,41 +217,41 @@ export function line(model: Model,layout, style) {
 }
 
 // TODO(#694): optimize area's usage with bin
-export function area(model: Model, layout, style) {
+export function area(e: Model, layout, style) {
   // TODO Use Vega's marks properties interface
   var p:any = {};
 
   // x
-  if (model.isMeasure(X)) {
-    p.x = {scale: X, field: model.fieldRef(X)};
-    if (model.isDimension(Y)) {
+  if (e.isMeasure(X)) {
+    p.x = {scale: X, field: e.fieldRef(X)};
+    if (e.isDimension(Y)) {
       p.x2 = {scale: X, value: 0};
       p.orient = {value: 'horizontal'};
     }
-  } else if (model.has(X)) {
-    p.x = {scale: X, field: model.fieldRef(X, {binSuffix: '_mid'})};
+  } else if (e.has(X)) {
+    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
   } else {
     p.x = {value: 0};
   }
 
   // y
-  if (model.isMeasure(Y)) {
-    p.y = {scale: Y, field: model.fieldRef(Y)};
+  if (e.isMeasure(Y)) {
+    p.y = {scale: Y, field: e.fieldRef(Y)};
     p.y2 = {scale: Y, value: 0};
-  } else if (model.has(Y)) {
-    p.y = {scale: Y, field: model.fieldRef(Y, {binSuffix: '_mid'})};
+  } else if (e.has(Y)) {
+    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
   } else {
     p.y = {field: {group: 'height'}};
   }
 
   // fill
-  if (model.has(COLOR)) {
-    p.fill = {scale: COLOR, field: model.fieldRef(COLOR)};
-  } else if (!model.has(COLOR)) {
-    p.fill = {value: model.fieldDef(COLOR).value};
+  if (e.has(COLOR)) {
+    p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
+  } else if (!e.has(COLOR)) {
+    p.fill = {value: e.fieldDef(COLOR).value};
   }
 
-  var opacity = model.fieldDef(COLOR).opacity;
+  var opacity = e.fieldDef(COLOR).opacity;
   if (opacity) p.opacity = {value: opacity};
 
   return p;

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -1,344 +1,134 @@
 import {Model} from './Model';
 import {COLUMN, ROW, X, Y, COLOR, TEXT, SIZE, SHAPE} from '../channel';
+import {AREA, BAR, LINE, POINT, TEXT as TEXTMARKS, TICK, CIRCLE, SQUARE} from '../marktype';
 import {QUANTITATIVE} from '../type';
 
 // https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#11-ambient-declarations
 declare var exports;
 
+/* mapping from vega-lite's mark types to vega's mark types */
+const MARKTYPES_MAP = {
+  bar: 'rect',
+  tick: 'rect',
+  point: 'symbol',
+  line: 'line',
+  area: 'area',
+  text: 'text',
+  circle: 'symbol',
+  square: 'symbol'
+};
+
 export function compileMarks(model: Model, layout, style) {
-  var defs = [],
-    mark = exports[model.marktype()],
-    from = model.dataTable();
+  const marktype = model.marktype();
+  const from = {from: model.dataTable()};
+  let defs = [];
 
-  // to add a background to text, we need to add it before the text
-  if (model.marktype() === TEXT && model.has(COLOR)) {
-    var bg = {
-      x: {value: 0},
-      y: {value: 0},
-      x2: {value: layout.cellWidth},
-      y2: {value: layout.cellHeight},
-      fill: {scale: COLOR, field: model.fieldRef(COLOR)}
-    };
-    defs.push({
-      type: 'rect',
-      from: {data: from},
-      properties: {enter: bg, update: bg}
-    });
-  }
+  switch (marktype) {
+    case TEXTMARKS:
+      if (model.has(COLOR)) {
+        defs.push({
+          type: 'rect',
+          from: from,
+          properties: {update: properties.textBackground(model, layout)}
+        });
+      }
+      break;
+    case LINE:
+    case AREA:
+      // TODO: move subfacets and line sort logic here
+  };
 
-  // add the mark def for the main thing
-  var p = mark.prop(model, layout, style);
   defs.push({
-    type: mark.type,
-    from: {data: from},
-    properties: {update: p}
+    type: MARKTYPES_MAP[marktype],
+    from: from,
+    properties: {
+      update: properties[marktype](model, layout, style)
+    }
   });
 
   return defs;
 }
 
-export const bar = {
-  type: 'rect',
-  prop: bar_props
-};
+export namespace properties {
+  export function bar(e: Model, layout, style) {
+    // TODO Use Vega's marks properties interface
+    var p:any = {};
 
-export const line = {
-  type: 'line',
-  prop: line_props
-};
-
-export const area = {
-  type: 'area',
-  prop: area_props
-};
-
-export const tick = {
-  type: 'rect',
-  prop: tick_props
-};
-
-export const circle = {
-  type: 'symbol',
-  prop: filled_point_props('circle')
-};
-
-export const square = {
-  type: 'symbol',
-  prop: filled_point_props('square')
-};
-
-export const point = {
-  type: 'symbol',
-  prop: point_props
-};
-
-export const text = {
-  type: 'text',
-  prop: text_props
-};
-
-function bar_props(e: Model, layout, style) {
-  // TODO Use Vega's marks properties interface
-  var p:any = {};
-
-  // x's and width
-  if (e.fieldDef(X).bin) {
-    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_start'}), offset: 1};
-    p.x2 = {scale: X, field: e.fieldRef(X, {binSuffix: '_end'})};
-  } else if (e.isMeasure(X)) {
-    p.x = {scale: X, field: e.fieldRef(X)};
-    if (!e.has(Y) || e.isDimension(Y)) {
-      p.x2 = {value: 0};
-    }
-  } else {
-    if (e.has(X)) { // is ordinal
-       p.xc = {scale: X, field: e.fieldRef(X)};
+    // x's and width
+    if (e.fieldDef(X).bin) {
+      p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_start'}), offset: 1};
+      p.x2 = {scale: X, field: e.fieldRef(X, {binSuffix: '_end'})};
+    } else if (e.isMeasure(X)) {
+      p.x = {scale: X, field: e.fieldRef(X)};
+      if (!e.has(Y) || e.isDimension(Y)) {
+        p.x2 = {value: 0};
+      }
     } else {
-       p.x = {value: 0, offset: e.config('singleBarOffset')};
-    }
-  }
-
-  // width
-  if (!p.x2) {
-    if (!e.has(X) || e.isOrdinalScale(X)) { // no X or X is ordinal
-      if (e.has(SIZE)) {
-        p.width = {scale: SIZE, field: e.fieldRef(SIZE)};
+      if (e.has(X)) { // is ordinal
+         p.xc = {scale: X, field: e.fieldRef(X)};
       } else {
-        p.width = {
-          value: e.bandWidth(X, layout.x.useSmallBand),
+         p.x = {value: 0, offset: e.config('singleBarOffset')};
+      }
+    }
+
+    // width
+    if (!p.x2) {
+      if (!e.has(X) || e.isOrdinalScale(X)) { // no X or X is ordinal
+        if (e.has(SIZE)) {
+          p.width = {scale: SIZE, field: e.fieldRef(SIZE)};
+        } else {
+          p.width = {
+            value: e.bandWidth(X, layout.x.useSmallBand),
+            offset: -1
+          };
+        }
+      } else { // X is Quant or Time Scale
+        p.width = {value: 2};
+      }
+    }
+
+    // y's & height
+    if (e.fieldDef(Y).bin) {
+      p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_start'})};
+      p.y2 = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_end'}), offset: 1};
+    } else if (e.isMeasure(Y)) {
+      p.y = {scale: Y, field: e.fieldRef(Y)};
+      p.y2 = {field: {group: 'height'}};
+    } else {
+      if (e.has(Y)) { // is ordinal
+        p.yc = {scale: Y, field: e.fieldRef(Y)};
+      } else {
+        p.y2 = {
+          field: {group: 'height'},
+          offset: -e.config('singleBarOffset')
+        };
+      }
+
+      if (e.has(SIZE)) {
+        p.height = {scale: SIZE, field: e.fieldRef(SIZE)};
+      } else {
+        p.height = {
+          value: e.bandWidth(Y, layout.y.useSmallBand),
           offset: -1
         };
       }
-    } else { // X is Quant or Time Scale
-      p.width = {value: 2};
-    }
-  }
-
-  // y's & height
-  if (e.fieldDef(Y).bin) {
-    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_start'})};
-    p.y2 = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_end'}), offset: 1};
-  } else if (e.isMeasure(Y)) {
-    p.y = {scale: Y, field: e.fieldRef(Y)};
-    p.y2 = {field: {group: 'height'}};
-  } else {
-    if (e.has(Y)) { // is ordinal
-      p.yc = {scale: Y, field: e.fieldRef(Y)};
-    } else {
-      p.y2 = {
-        field: {group: 'height'},
-        offset: -e.config('singleBarOffset')
-      };
     }
 
-    if (e.has(SIZE)) {
-      p.height = {scale: SIZE, field: e.fieldRef(SIZE)};
-    } else {
-      p.height = {
-        value: e.bandWidth(Y, layout.y.useSmallBand),
-        offset: -1
-      };
-    }
-  }
-
-  // fill
-  if (e.has(COLOR)) {
-    p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
-  } else {
-    p.fill = {value: e.fieldDef(COLOR).value};
-  }
-
-  // opacity
-  var opacity = e.fieldDef(COLOR).opacity;
-  if (opacity) p.opacity = {value: opacity};
-
-  return p;
-}
-
-function point_props(e: Model, layout, style) {
-  // TODO Use Vega's marks properties interface
-  var p:any = {};
-
-  // x
-  if (e.has(X)) {
-    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
-  } else if (!e.has(X)) {
-    p.x = {value: e.bandWidth(X, layout.x.useSmallBand) / 2};
-  }
-
-  // y
-  if (e.has(Y)) {
-    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
-  } else if (!e.has(Y)) {
-    p.y = {value: e.bandWidth(Y, layout.y.useSmallBand) / 2};
-  }
-
-  // size
-  if (e.has(SIZE)) {
-    p.size = {scale: SIZE, field: e.fieldRef(SIZE)};
-  } else if (!e.has(SIZE)) {
-    p.size = {value: e.fieldDef(SIZE).value};
-  }
-
-  // shape
-  if (e.has(SHAPE)) {
-    p.shape = {scale: SHAPE, field: e.fieldRef(SHAPE)};
-  } else if (!e.has(SHAPE)) {
-    p.shape = {value: e.fieldDef(SHAPE).value};
-  }
-
-  // fill or stroke
-  if (e.fieldDef(SHAPE).filled) {
+    // fill
     if (e.has(COLOR)) {
       p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
-    } else if (!e.has(COLOR)) {
+    } else {
       p.fill = {value: e.fieldDef(COLOR).value};
     }
-  } else {
-    if (e.has(COLOR)) {
-      p.stroke = {scale: COLOR, field: e.fieldRef(COLOR)};
-    } else if (!e.has(COLOR)) {
-      p.stroke = {value: e.fieldDef(COLOR).value};
-    }
-    p.strokeWidth = {value: e.config('strokeWidth')};
+
+    // opacity
+    var opacity = e.fieldDef(COLOR).opacity;
+    if (opacity) p.opacity = {value: opacity};
+
+    return p;
   }
 
-  // opacity
-  var opacity = e.fieldDef(COLOR).opacity || style.opacity;
-  if (opacity) p.opacity = {value: opacity};
-
-  return p;
-}
-
-function line_props(e: Model,layout, style) {
-  // TODO Use Vega's marks properties interface
-  var p:any = {};
-
-  // x
-  if (e.has(X)) {
-    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
-  } else if (!e.has(X)) {
-    p.x = {value: 0};
-  }
-
-  // y
-  if (e.has(Y)) {
-    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
-  } else if (!e.has(Y)) {
-    p.y = {field: {group: 'height'}};
-  }
-
-  // stroke
-  if (e.has(COLOR)) {
-    p.stroke = {scale: COLOR, field: e.fieldRef(COLOR)};
-  } else if (!e.has(COLOR)) {
-    p.stroke = {value: e.fieldDef(COLOR).value};
-  }
-
-  var opacity = e.fieldDef(COLOR).opacity;
-  if (opacity) p.opacity = {value: opacity};
-
-  p.strokeWidth = {value: e.config('strokeWidth')};
-
-  return p;
-}
-
-// TODO(#694): optimize area's usage with bin
-function area_props(e: Model, layout, style) {
-  // TODO Use Vega's marks properties interface
-  var p:any = {};
-
-  // x
-  if (e.isMeasure(X)) {
-    p.x = {scale: X, field: e.fieldRef(X)};
-    if (e.isDimension(Y)) {
-      p.x2 = {scale: X, value: 0};
-      p.orient = {value: 'horizontal'};
-    }
-  } else if (e.has(X)) {
-    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
-  } else {
-    p.x = {value: 0};
-  }
-
-  // y
-  if (e.isMeasure(Y)) {
-    p.y = {scale: Y, field: e.fieldRef(Y)};
-    p.y2 = {scale: Y, value: 0};
-  } else if (e.has(Y)) {
-    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
-  } else {
-    p.y = {field: {group: 'height'}};
-  }
-
-  // fill
-  if (e.has(COLOR)) {
-    p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
-  } else if (!e.has(COLOR)) {
-    p.fill = {value: e.fieldDef(COLOR).value};
-  }
-
-  var opacity = e.fieldDef(COLOR).opacity;
-  if (opacity) p.opacity = {value: opacity};
-
-  return p;
-}
-
-function tick_props(e: Model, layout, style) {
-  // TODO Use Vega's marks properties interface
-  var p:any = {};
-
-  // x
-  if (e.has(X)) {
-    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
-    if (e.isDimension(X)) {
-      p.x.offset = -e.bandWidth(X, layout.x.useSmallBand) / 3;
-    }
-  } else if (!e.has(X)) {
-    p.x = {value: 0};
-  }
-
-  // y
-  if (e.has(Y)) {
-    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
-    if (e.isDimension(Y)) {
-      p.y.offset = -e.bandWidth(Y, layout.y.useSmallBand) / 3;
-    }
-  } else if (!e.has(Y)) {
-    p.y = {value: 0};
-  }
-
-  // width
-  if (!e.has(X) || e.isDimension(X)) {
-    // TODO(#694): optimize tick's width for bin
-    p.width = {value: e.bandWidth(X, layout.y.useSmallBand) / 1.5};
-  } else {
-    p.width = {value: 1};
-  }
-
-  // height
-  if (!e.has(Y) || e.isDimension(Y)) {
-    // TODO(#694): optimize tick's height for bin
-    p.height = {value: e.bandWidth(Y, layout.y.useSmallBand) / 1.5};
-  } else {
-    p.height = {value: 1};
-  }
-
-  // fill
-  if (e.has(COLOR)) {
-    p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
-  } else {
-    p.fill = {value: e.fieldDef(COLOR).value};
-  }
-
-  var opacity = e.fieldDef(COLOR).opacity  || style.opacity;
-  if(opacity) p.opacity = {value: opacity};
-
-  return p;
-}
-
-function filled_point_props(shape) {
-  return function(e: Model, layout, style) {
+  export function point(e: Model, layout, style) {
     // TODO Use Vega's marks properties interface
     var p:any = {};
 
@@ -359,12 +149,100 @@ function filled_point_props(shape) {
     // size
     if (e.has(SIZE)) {
       p.size = {scale: SIZE, field: e.fieldRef(SIZE)};
-    } else if (!e.has(X)) {
+    } else if (!e.has(SIZE)) {
       p.size = {value: e.fieldDef(SIZE).value};
     }
 
     // shape
-    p.shape = {value: shape};
+    if (e.has(SHAPE)) {
+      p.shape = {scale: SHAPE, field: e.fieldRef(SHAPE)};
+    } else if (!e.has(SHAPE)) {
+      p.shape = {value: e.fieldDef(SHAPE).value};
+    }
+
+    // fill or stroke
+    if (e.fieldDef(SHAPE).filled) {
+      if (e.has(COLOR)) {
+        p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
+      } else if (!e.has(COLOR)) {
+        p.fill = {value: e.fieldDef(COLOR).value};
+      }
+    } else {
+      if (e.has(COLOR)) {
+        p.stroke = {scale: COLOR, field: e.fieldRef(COLOR)};
+      } else if (!e.has(COLOR)) {
+        p.stroke = {value: e.fieldDef(COLOR).value};
+      }
+      p.strokeWidth = {value: e.config('strokeWidth')};
+    }
+
+    // opacity
+    var opacity = e.fieldDef(COLOR).opacity || style.opacity;
+    if (opacity) p.opacity = {value: opacity};
+
+    return p;
+  }
+
+  export function line(e: Model,layout, style) {
+    // TODO Use Vega's marks properties interface
+    var p:any = {};
+
+    // x
+    if (e.has(X)) {
+      p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
+    } else if (!e.has(X)) {
+      p.x = {value: 0};
+    }
+
+    // y
+    if (e.has(Y)) {
+      p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
+    } else if (!e.has(Y)) {
+      p.y = {field: {group: 'height'}};
+    }
+
+    // stroke
+    if (e.has(COLOR)) {
+      p.stroke = {scale: COLOR, field: e.fieldRef(COLOR)};
+    } else if (!e.has(COLOR)) {
+      p.stroke = {value: e.fieldDef(COLOR).value};
+    }
+
+    var opacity = e.fieldDef(COLOR).opacity;
+    if (opacity) p.opacity = {value: opacity};
+
+    p.strokeWidth = {value: e.config('strokeWidth')};
+
+    return p;
+  }
+
+  // TODO(#694): optimize area's usage with bin
+  export function area(e: Model, layout, style) {
+    // TODO Use Vega's marks properties interface
+    var p:any = {};
+
+    // x
+    if (e.isMeasure(X)) {
+      p.x = {scale: X, field: e.fieldRef(X)};
+      if (e.isDimension(Y)) {
+        p.x2 = {scale: X, value: 0};
+        p.orient = {value: 'horizontal'};
+      }
+    } else if (e.has(X)) {
+      p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
+    } else {
+      p.x = {value: 0};
+    }
+
+    // y
+    if (e.isMeasure(Y)) {
+      p.y = {scale: Y, field: e.fieldRef(Y)};
+      p.y2 = {scale: Y, value: 0};
+    } else if (e.has(Y)) {
+      p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
+    } else {
+      p.y = {field: {group: 'height'}};
+    }
 
     // fill
     if (e.has(COLOR)) {
@@ -373,70 +251,179 @@ function filled_point_props(shape) {
       p.fill = {value: e.fieldDef(COLOR).value};
     }
 
+    var opacity = e.fieldDef(COLOR).opacity;
+    if (opacity) p.opacity = {value: opacity};
+
+    return p;
+  }
+
+  export function tick(e: Model, layout, style) {
+    // TODO Use Vega's marks properties interface
+    var p:any = {};
+
+    // x
+    if (e.has(X)) {
+      p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
+      if (e.isDimension(X)) {
+        p.x.offset = -e.bandWidth(X, layout.x.useSmallBand) / 3;
+      }
+    } else if (!e.has(X)) {
+      p.x = {value: 0};
+    }
+
+    // y
+    if (e.has(Y)) {
+      p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
+      if (e.isDimension(Y)) {
+        p.y.offset = -e.bandWidth(Y, layout.y.useSmallBand) / 3;
+      }
+    } else if (!e.has(Y)) {
+      p.y = {value: 0};
+    }
+
+    // width
+    if (!e.has(X) || e.isDimension(X)) {
+      // TODO(#694): optimize tick's width for bin
+      p.width = {value: e.bandWidth(X, layout.y.useSmallBand) / 1.5};
+    } else {
+      p.width = {value: 1};
+    }
+
+    // height
+    if (!e.has(Y) || e.isDimension(Y)) {
+      // TODO(#694): optimize tick's height for bin
+      p.height = {value: e.bandWidth(Y, layout.y.useSmallBand) / 1.5};
+    } else {
+      p.height = {value: 1};
+    }
+
+    // fill
+    if (e.has(COLOR)) {
+      p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
+    } else {
+      p.fill = {value: e.fieldDef(COLOR).value};
+    }
+
     var opacity = e.fieldDef(COLOR).opacity  || style.opacity;
     if(opacity) p.opacity = {value: opacity};
 
     return p;
-  };
-}
+  }
 
-function text_props(e: Model, layout, style) {
-  // TODO Use Vega's marks properties interface
-  var p:any = {},
-    fieldDef = e.fieldDef(TEXT);
+  function filled_point_props(shape) {
+    return function(e: Model, layout, style) {
+      // TODO Use Vega's marks properties interface
+      var p:any = {};
 
-  // x
-  if (e.has(X)) {
-    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
-  } else if (!e.has(X)) {
-    if (e.has(TEXT) && e.fieldDef(TEXT).type === QUANTITATIVE) {
-      p.x = {value: layout.cellWidth-5};
-    } else {
-      p.x = {value: e.bandWidth(X, layout.x.useSmallBand) / 2};
+      // x
+      if (e.has(X)) {
+        p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
+      } else if (!e.has(X)) {
+        p.x = {value: e.bandWidth(X, layout.x.useSmallBand) / 2};
+      }
+
+      // y
+      if (e.has(Y)) {
+        p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
+      } else if (!e.has(Y)) {
+        p.y = {value: e.bandWidth(Y, layout.y.useSmallBand) / 2};
+      }
+
+      // size
+      if (e.has(SIZE)) {
+        p.size = {scale: SIZE, field: e.fieldRef(SIZE)};
+      } else if (!e.has(X)) {
+        p.size = {value: e.fieldDef(SIZE).value};
+      }
+
+      // shape
+      p.shape = {value: shape};
+
+      // fill
+      if (e.has(COLOR)) {
+        p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
+      } else if (!e.has(COLOR)) {
+        p.fill = {value: e.fieldDef(COLOR).value};
+      }
+
+      var opacity = e.fieldDef(COLOR).opacity  || style.opacity;
+      if(opacity) p.opacity = {value: opacity};
+
+      return p;
+    };
+  }
+
+  export const circle = filled_point_props('circle');
+  export const square = filled_point_props('square');
+
+  export function textBackground(model: Model, layout) {
+    return {
+      x: {value: 0},
+      y: {value: 0},
+      x2: {value: layout.cellWidth},
+      y2: {value: layout.cellHeight},
+      fill: {scale: COLOR, field: model.fieldRef(COLOR)}
+    };
+  }
+
+  export function text(e: Model, layout, style) {
+    // TODO Use Vega's marks properties interface
+    var p:any = {},
+      fieldDef = e.fieldDef(TEXT);
+
+    // x
+    if (e.has(X)) {
+      p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
+    } else if (!e.has(X)) {
+      if (e.has(TEXT) && e.fieldDef(TEXT).type === QUANTITATIVE) {
+        p.x = {value: layout.cellWidth-5};
+      } else {
+        p.x = {value: e.bandWidth(X, layout.x.useSmallBand) / 2};
+      }
     }
-  }
 
-  // y
-  if (e.has(Y)) {
-    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
-  } else if (!e.has(Y)) {
-    p.y = {value: e.bandWidth(Y, layout.y.useSmallBand) / 2};
-  }
-
-  // size
-  if (e.has(SIZE)) {
-    p.fontSize = {scale: SIZE, field: e.fieldRef(SIZE)};
-  } else if (!e.has(SIZE)) {
-    p.fontSize = {value: fieldDef.font.size};
-  }
-
-  // fill
-  // color should be set to background
-  p.fill = {value: fieldDef.color};
-
-  var opacity = e.fieldDef(COLOR).opacity  || style.opacity;
-  if(opacity) p.opacity = {value: opacity};
-
-  // text
-  if (e.has(TEXT)) {
-    if (e.fieldDef(TEXT).type === QUANTITATIVE) {
-      var numberFormat = fieldDef.format !== undefined ?
-                         fieldDef.format : e.numberFormat(TEXT);
-
-      p.text = {template: '{{' + e.fieldRef(TEXT, {datum: true}) + ' | number:\'' +
-        numberFormat +'\'}}'};
-      p.align = {value: fieldDef.align};
-    } else {
-      p.text = {field: e.fieldRef(TEXT)};
+    // y
+    if (e.has(Y)) {
+      p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
+    } else if (!e.has(Y)) {
+      p.y = {value: e.bandWidth(Y, layout.y.useSmallBand) / 2};
     }
-  } else {
-    p.text = {value: fieldDef.placeholder};
+
+    // size
+    if (e.has(SIZE)) {
+      p.fontSize = {scale: SIZE, field: e.fieldRef(SIZE)};
+    } else if (!e.has(SIZE)) {
+      p.fontSize = {value: fieldDef.font.size};
+    }
+
+    // fill
+    // color should be set to background
+    p.fill = {value: fieldDef.color};
+
+    var opacity = e.fieldDef(COLOR).opacity  || style.opacity;
+    if(opacity) p.opacity = {value: opacity};
+
+    // text
+    if (e.has(TEXT)) {
+      if (e.fieldDef(TEXT).type === QUANTITATIVE) {
+        var numberFormat = fieldDef.format !== undefined ?
+                           fieldDef.format : e.numberFormat(TEXT);
+
+        p.text = {template: '{{' + e.fieldRef(TEXT, {datum: true}) + ' | number:\'' +
+          numberFormat +'\'}}'};
+        p.align = {value: fieldDef.align};
+      } else {
+        p.text = {field: e.fieldRef(TEXT)};
+      }
+    } else {
+      p.text = {value: fieldDef.placeholder};
+    }
+
+    p.font = {value: fieldDef.font.family};
+    p.fontWeight = {value: fieldDef.font.weight};
+    p.fontStyle = {value: fieldDef.font.style};
+    p.baseline = {value: fieldDef.baseline};
+
+    return p;
   }
-
-  p.font = {value: fieldDef.font.family};
-  p.fontWeight = {value: fieldDef.font.weight};
-  p.fontStyle = {value: fieldDef.font.style};
-  p.baseline = {value: fieldDef.baseline};
-
-  return p;
 }

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -50,35 +50,35 @@ export function compileMarks(model: Model, layout, style) {
 }
 
 export namespace properties {
-export function bar(e: Model, layout, style) {
+export function bar(model: Model, layout, style) {
   // TODO Use Vega's marks properties interface
   var p:any = {};
 
   // x's and width
-  if (e.fieldDef(X).bin) {
-    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_start'}), offset: 1};
-    p.x2 = {scale: X, field: e.fieldRef(X, {binSuffix: '_end'})};
-  } else if (e.isMeasure(X)) {
-    p.x = {scale: X, field: e.fieldRef(X)};
-    if (!e.has(Y) || e.isDimension(Y)) {
+  if (model.fieldDef(X).bin) {
+    p.x = {scale: X, field: model.fieldRef(X, {binSuffix: '_start'}), offset: 1};
+    p.x2 = {scale: X, field: model.fieldRef(X, {binSuffix: '_end'})};
+  } else if (model.isMeasure(X)) {
+    p.x = {scale: X, field: model.fieldRef(X)};
+    if (!model.has(Y) || model.isDimension(Y)) {
       p.x2 = {value: 0};
     }
   } else {
-    if (e.has(X)) { // is ordinal
-       p.xc = {scale: X, field: e.fieldRef(X)};
+    if (model.has(X)) { // is ordinal
+       p.xc = {scale: X, field: model.fieldRef(X)};
     } else {
-       p.x = {value: 0, offset: e.config('singleBarOffset')};
+       p.x = {value: 0, offset: model.config('singleBarOffset')};
     }
   }
 
   // width
   if (!p.x2) {
-    if (!e.has(X) || e.isOrdinalScale(X)) { // no X or X is ordinal
-      if (e.has(SIZE)) {
-        p.width = {scale: SIZE, field: e.fieldRef(SIZE)};
+    if (!model.has(X) || model.isOrdinalScale(X)) { // no X or X is ordinal
+      if (model.has(SIZE)) {
+        p.width = {scale: SIZE, field: model.fieldRef(SIZE)};
       } else {
         p.width = {
-          value: e.bandWidth(X, layout.x.useSmallBand),
+          value: model.bandWidth(X, layout.x.useSmallBand),
           offset: -1
         };
       }
@@ -88,130 +88,130 @@ export function bar(e: Model, layout, style) {
   }
 
   // y's & height
-  if (e.fieldDef(Y).bin) {
-    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_start'})};
-    p.y2 = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_end'}), offset: 1};
-  } else if (e.isMeasure(Y)) {
-    p.y = {scale: Y, field: e.fieldRef(Y)};
+  if (model.fieldDef(Y).bin) {
+    p.y = {scale: Y, field: model.fieldRef(Y, {binSuffix: '_start'})};
+    p.y2 = {scale: Y, field: model.fieldRef(Y, {binSuffix: '_end'}), offset: 1};
+  } else if (model.isMeasure(Y)) {
+    p.y = {scale: Y, field: model.fieldRef(Y)};
     p.y2 = {field: {group: 'height'}};
   } else {
-    if (e.has(Y)) { // is ordinal
-      p.yc = {scale: Y, field: e.fieldRef(Y)};
+    if (model.has(Y)) { // is ordinal
+      p.yc = {scale: Y, field: model.fieldRef(Y)};
     } else {
       p.y2 = {
         field: {group: 'height'},
-        offset: -e.config('singleBarOffset')
+        offset: -model.config('singleBarOffset')
       };
     }
 
-    if (e.has(SIZE)) {
-      p.height = {scale: SIZE, field: e.fieldRef(SIZE)};
+    if (model.has(SIZE)) {
+      p.height = {scale: SIZE, field: model.fieldRef(SIZE)};
     } else {
       p.height = {
-        value: e.bandWidth(Y, layout.y.useSmallBand),
+        value: model.bandWidth(Y, layout.y.useSmallBand),
         offset: -1
       };
     }
   }
 
   // fill
-  if (e.has(COLOR)) {
-    p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
+  if (model.has(COLOR)) {
+    p.fill = {scale: COLOR, field: model.fieldRef(COLOR)};
   } else {
-    p.fill = {value: e.fieldDef(COLOR).value};
+    p.fill = {value: model.fieldDef(COLOR).value};
   }
 
   // opacity
-  var opacity = e.fieldDef(COLOR).opacity;
+  var opacity = model.fieldDef(COLOR).opacity;
   if (opacity) p.opacity = {value: opacity};
 
   return p;
 }
 
-export function point(e: Model, layout, style) {
+export function point(model: Model, layout, style) {
   // TODO Use Vega's marks properties interface
   var p:any = {};
 
   // x
-  if (e.has(X)) {
-    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
-  } else if (!e.has(X)) {
-    p.x = {value: e.bandWidth(X, layout.x.useSmallBand) / 2};
+  if (model.has(X)) {
+    p.x = {scale: X, field: model.fieldRef(X, {binSuffix: '_mid'})};
+  } else if (!model.has(X)) {
+    p.x = {value: model.bandWidth(X, layout.x.useSmallBand) / 2};
   }
 
   // y
-  if (e.has(Y)) {
-    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
-  } else if (!e.has(Y)) {
-    p.y = {value: e.bandWidth(Y, layout.y.useSmallBand) / 2};
+  if (model.has(Y)) {
+    p.y = {scale: Y, field: model.fieldRef(Y, {binSuffix: '_mid'})};
+  } else if (!model.has(Y)) {
+    p.y = {value: model.bandWidth(Y, layout.y.useSmallBand) / 2};
   }
 
   // size
-  if (e.has(SIZE)) {
-    p.size = {scale: SIZE, field: e.fieldRef(SIZE)};
-  } else if (!e.has(SIZE)) {
-    p.size = {value: e.fieldDef(SIZE).value};
+  if (model.has(SIZE)) {
+    p.size = {scale: SIZE, field: model.fieldRef(SIZE)};
+  } else if (!model.has(SIZE)) {
+    p.size = {value: model.fieldDef(SIZE).value};
   }
 
   // shape
-  if (e.has(SHAPE)) {
-    p.shape = {scale: SHAPE, field: e.fieldRef(SHAPE)};
-  } else if (!e.has(SHAPE)) {
-    p.shape = {value: e.fieldDef(SHAPE).value};
+  if (model.has(SHAPE)) {
+    p.shape = {scale: SHAPE, field: model.fieldRef(SHAPE)};
+  } else if (!model.has(SHAPE)) {
+    p.shape = {value: model.fieldDef(SHAPE).value};
   }
 
   // fill or stroke
-  if (e.fieldDef(SHAPE).filled) {
-    if (e.has(COLOR)) {
-      p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
-    } else if (!e.has(COLOR)) {
-      p.fill = {value: e.fieldDef(COLOR).value};
+  if (model.fieldDef(SHAPE).filled) {
+    if (model.has(COLOR)) {
+      p.fill = {scale: COLOR, field: model.fieldRef(COLOR)};
+    } else if (!model.has(COLOR)) {
+      p.fill = {value: model.fieldDef(COLOR).value};
     }
   } else {
-    if (e.has(COLOR)) {
-      p.stroke = {scale: COLOR, field: e.fieldRef(COLOR)};
-    } else if (!e.has(COLOR)) {
-      p.stroke = {value: e.fieldDef(COLOR).value};
+    if (model.has(COLOR)) {
+      p.stroke = {scale: COLOR, field: model.fieldRef(COLOR)};
+    } else if (!model.has(COLOR)) {
+      p.stroke = {value: model.fieldDef(COLOR).value};
     }
-    p.strokeWidth = {value: e.config('strokeWidth')};
+    p.strokeWidth = {value: model.config('strokeWidth')};
   }
 
   // opacity
-  var opacity = e.fieldDef(COLOR).opacity || style.opacity;
+  var opacity = model.fieldDef(COLOR).opacity || style.opacity;
   if (opacity) p.opacity = {value: opacity};
 
   return p;
 }
 
-export function line(e: Model,layout, style) {
+export function line(model: Model,layout, style) {
   // TODO Use Vega's marks properties interface
   var p:any = {};
 
   // x
-  if (e.has(X)) {
-    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
-  } else if (!e.has(X)) {
+  if (model.has(X)) {
+    p.x = {scale: X, field: model.fieldRef(X, {binSuffix: '_mid'})};
+  } else if (!model.has(X)) {
     p.x = {value: 0};
   }
 
   // y
-  if (e.has(Y)) {
-    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
-  } else if (!e.has(Y)) {
+  if (model.has(Y)) {
+    p.y = {scale: Y, field: model.fieldRef(Y, {binSuffix: '_mid'})};
+  } else if (!model.has(Y)) {
     p.y = {field: {group: 'height'}};
   }
 
   // stroke
-  if (e.has(COLOR)) {
-    p.stroke = {scale: COLOR, field: e.fieldRef(COLOR)};
-  } else if (!e.has(COLOR)) {
-    p.stroke = {value: e.fieldDef(COLOR).value};
+  if (model.has(COLOR)) {
+    p.stroke = {scale: COLOR, field: model.fieldRef(COLOR)};
+  } else if (!model.has(COLOR)) {
+    p.stroke = {value: model.fieldDef(COLOR).value};
   }
 
-  var opacity = e.fieldDef(COLOR).opacity;
+  var opacity = model.fieldDef(COLOR).opacity;
   if (opacity) p.opacity = {value: opacity};
 
-  p.strokeWidth = {value: e.config('strokeWidth')};
+  p.strokeWidth = {value: model.config('strokeWidth')};
 
   return p;
 }
@@ -257,96 +257,96 @@ export function area(e: Model, layout, style) {
   return p;
 }
 
-export function tick(e: Model, layout, style) {
+export function tick(model: Model, layout, style) {
   // TODO Use Vega's marks properties interface
   var p:any = {};
 
   // x
-  if (e.has(X)) {
-    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
-    if (e.isDimension(X)) {
-      p.x.offset = -e.bandWidth(X, layout.x.useSmallBand) / 3;
+  if (model.has(X)) {
+    p.x = {scale: X, field: model.fieldRef(X, {binSuffix: '_mid'})};
+    if (model.isDimension(X)) {
+      p.x.offset = -model.bandWidth(X, layout.x.useSmallBand) / 3;
     }
-  } else if (!e.has(X)) {
+  } else if (!model.has(X)) {
     p.x = {value: 0};
   }
 
   // y
-  if (e.has(Y)) {
-    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
-    if (e.isDimension(Y)) {
-      p.y.offset = -e.bandWidth(Y, layout.y.useSmallBand) / 3;
+  if (model.has(Y)) {
+    p.y = {scale: Y, field: model.fieldRef(Y, {binSuffix: '_mid'})};
+    if (model.isDimension(Y)) {
+      p.y.offset = -model.bandWidth(Y, layout.y.useSmallBand) / 3;
     }
-  } else if (!e.has(Y)) {
+  } else if (!model.has(Y)) {
     p.y = {value: 0};
   }
 
   // width
-  if (!e.has(X) || e.isDimension(X)) {
+  if (!model.has(X) || model.isDimension(X)) {
     // TODO(#694): optimize tick's width for bin
-    p.width = {value: e.bandWidth(X, layout.y.useSmallBand) / 1.5};
+    p.width = {value: model.bandWidth(X, layout.y.useSmallBand) / 1.5};
   } else {
     p.width = {value: 1};
   }
 
   // height
-  if (!e.has(Y) || e.isDimension(Y)) {
+  if (!model.has(Y) || model.isDimension(Y)) {
     // TODO(#694): optimize tick's height for bin
-    p.height = {value: e.bandWidth(Y, layout.y.useSmallBand) / 1.5};
+    p.height = {value: model.bandWidth(Y, layout.y.useSmallBand) / 1.5};
   } else {
     p.height = {value: 1};
   }
 
   // fill
-  if (e.has(COLOR)) {
-    p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
+  if (model.has(COLOR)) {
+    p.fill = {scale: COLOR, field: model.fieldRef(COLOR)};
   } else {
-    p.fill = {value: e.fieldDef(COLOR).value};
+    p.fill = {value: model.fieldDef(COLOR).value};
   }
 
-  var opacity = e.fieldDef(COLOR).opacity  || style.opacity;
+  var opacity = model.fieldDef(COLOR).opacity  || style.opacity;
   if(opacity) p.opacity = {value: opacity};
 
   return p;
 }
 
 function filled_point_props(shape) {
-  return function(e: Model, layout, style) {
+  return function(model: Model, layout, style) {
     // TODO Use Vega's marks properties interface
     var p:any = {};
 
     // x
-    if (e.has(X)) {
-      p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
-    } else if (!e.has(X)) {
-      p.x = {value: e.bandWidth(X, layout.x.useSmallBand) / 2};
+    if (model.has(X)) {
+      p.x = {scale: X, field: model.fieldRef(X, {binSuffix: '_mid'})};
+    } else if (!model.has(X)) {
+      p.x = {value: model.bandWidth(X, layout.x.useSmallBand) / 2};
     }
 
     // y
-    if (e.has(Y)) {
-      p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
-    } else if (!e.has(Y)) {
-      p.y = {value: e.bandWidth(Y, layout.y.useSmallBand) / 2};
+    if (model.has(Y)) {
+      p.y = {scale: Y, field: model.fieldRef(Y, {binSuffix: '_mid'})};
+    } else if (!model.has(Y)) {
+      p.y = {value: model.bandWidth(Y, layout.y.useSmallBand) / 2};
     }
 
     // size
-    if (e.has(SIZE)) {
-      p.size = {scale: SIZE, field: e.fieldRef(SIZE)};
-    } else if (!e.has(X)) {
-      p.size = {value: e.fieldDef(SIZE).value};
+    if (model.has(SIZE)) {
+      p.size = {scale: SIZE, field: model.fieldRef(SIZE)};
+    } else if (!model.has(X)) {
+      p.size = {value: model.fieldDef(SIZE).value};
     }
 
     // shape
     p.shape = {value: shape};
 
     // fill
-    if (e.has(COLOR)) {
-      p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
-    } else if (!e.has(COLOR)) {
-      p.fill = {value: e.fieldDef(COLOR).value};
+    if (model.has(COLOR)) {
+      p.fill = {scale: COLOR, field: model.fieldRef(COLOR)};
+    } else if (!model.has(COLOR)) {
+      p.fill = {value: model.fieldDef(COLOR).value};
     }
 
-    var opacity = e.fieldDef(COLOR).opacity  || style.opacity;
+    var opacity = model.fieldDef(COLOR).opacity  || style.opacity;
     if(opacity) p.opacity = {value: opacity};
 
     return p;
@@ -366,33 +366,33 @@ export function textBackground(model: Model, layout) {
   };
 }
 
-export function text(e: Model, layout, style) {
+export function text(model: Model, layout, style) {
   // TODO Use Vega's marks properties interface
   var p:any = {},
-    fieldDef = e.fieldDef(TEXT);
+    fieldDef = model.fieldDef(TEXT);
 
   // x
-  if (e.has(X)) {
-    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
-  } else if (!e.has(X)) {
-    if (e.has(TEXT) && e.fieldDef(TEXT).type === QUANTITATIVE) {
+  if (model.has(X)) {
+    p.x = {scale: X, field: model.fieldRef(X, {binSuffix: '_mid'})};
+  } else if (!model.has(X)) {
+    if (model.has(TEXT) && model.fieldDef(TEXT).type === QUANTITATIVE) {
       p.x = {value: layout.cellWidth-5};
     } else {
-      p.x = {value: e.bandWidth(X, layout.x.useSmallBand) / 2};
+      p.x = {value: model.bandWidth(X, layout.x.useSmallBand) / 2};
     }
   }
 
   // y
-  if (e.has(Y)) {
-    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
-  } else if (!e.has(Y)) {
-    p.y = {value: e.bandWidth(Y, layout.y.useSmallBand) / 2};
+  if (model.has(Y)) {
+    p.y = {scale: Y, field: model.fieldRef(Y, {binSuffix: '_mid'})};
+  } else if (!model.has(Y)) {
+    p.y = {value: model.bandWidth(Y, layout.y.useSmallBand) / 2};
   }
 
   // size
-  if (e.has(SIZE)) {
-    p.fontSize = {scale: SIZE, field: e.fieldRef(SIZE)};
-  } else if (!e.has(SIZE)) {
+  if (model.has(SIZE)) {
+    p.fontSize = {scale: SIZE, field: model.fieldRef(SIZE)};
+  } else if (!model.has(SIZE)) {
     p.fontSize = {value: fieldDef.font.size};
   }
 
@@ -400,20 +400,20 @@ export function text(e: Model, layout, style) {
   // color should be set to background
   p.fill = {value: fieldDef.color};
 
-  var opacity = e.fieldDef(COLOR).opacity  || style.opacity;
+  var opacity = model.fieldDef(COLOR).opacity  || style.opacity;
   if(opacity) p.opacity = {value: opacity};
 
   // text
-  if (e.has(TEXT)) {
-    if (e.fieldDef(TEXT).type === QUANTITATIVE) {
+  if (model.has(TEXT)) {
+    if (model.fieldDef(TEXT).type === QUANTITATIVE) {
       var numberFormat = fieldDef.format !== undefined ?
-                         fieldDef.format : e.numberFormat(TEXT);
+                         fieldDef.format : model.numberFormat(TEXT);
 
-      p.text = {template: '{{' + e.fieldRef(TEXT, {datum: true}) + ' | number:\'' +
+      p.text = {template: '{{' + model.fieldRef(TEXT, {datum: true}) + ' | number:\'' +
         numberFormat +'\'}}'};
       p.align = {value: fieldDef.align};
     } else {
-      p.text = {field: e.fieldRef(TEXT)};
+      p.text = {field: model.fieldRef(TEXT)};
     }
   } else {
     p.text = {value: fieldDef.placeholder};

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -50,85 +50,268 @@ export function compileMarks(model: Model, layout, style) {
 }
 
 export namespace properties {
-  export function bar(e: Model, layout, style) {
-    // TODO Use Vega's marks properties interface
-    var p:any = {};
+export function bar(e: Model, layout, style) {
+  // TODO Use Vega's marks properties interface
+  var p:any = {};
 
-    // x's and width
-    if (e.fieldDef(X).bin) {
-      p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_start'}), offset: 1};
-      p.x2 = {scale: X, field: e.fieldRef(X, {binSuffix: '_end'})};
-    } else if (e.isMeasure(X)) {
-      p.x = {scale: X, field: e.fieldRef(X)};
-      if (!e.has(Y) || e.isDimension(Y)) {
-        p.x2 = {value: 0};
-      }
-    } else {
-      if (e.has(X)) { // is ordinal
-         p.xc = {scale: X, field: e.fieldRef(X)};
-      } else {
-         p.x = {value: 0, offset: e.config('singleBarOffset')};
-      }
+  // x's and width
+  if (e.fieldDef(X).bin) {
+    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_start'}), offset: 1};
+    p.x2 = {scale: X, field: e.fieldRef(X, {binSuffix: '_end'})};
+  } else if (e.isMeasure(X)) {
+    p.x = {scale: X, field: e.fieldRef(X)};
+    if (!e.has(Y) || e.isDimension(Y)) {
+      p.x2 = {value: 0};
     }
-
-    // width
-    if (!p.x2) {
-      if (!e.has(X) || e.isOrdinalScale(X)) { // no X or X is ordinal
-        if (e.has(SIZE)) {
-          p.width = {scale: SIZE, field: e.fieldRef(SIZE)};
-        } else {
-          p.width = {
-            value: e.bandWidth(X, layout.x.useSmallBand),
-            offset: -1
-          };
-        }
-      } else { // X is Quant or Time Scale
-        p.width = {value: 2};
-      }
-    }
-
-    // y's & height
-    if (e.fieldDef(Y).bin) {
-      p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_start'})};
-      p.y2 = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_end'}), offset: 1};
-    } else if (e.isMeasure(Y)) {
-      p.y = {scale: Y, field: e.fieldRef(Y)};
-      p.y2 = {field: {group: 'height'}};
+  } else {
+    if (e.has(X)) { // is ordinal
+       p.xc = {scale: X, field: e.fieldRef(X)};
     } else {
-      if (e.has(Y)) { // is ordinal
-        p.yc = {scale: Y, field: e.fieldRef(Y)};
-      } else {
-        p.y2 = {
-          field: {group: 'height'},
-          offset: -e.config('singleBarOffset')
-        };
-      }
+       p.x = {value: 0, offset: e.config('singleBarOffset')};
+    }
+  }
 
+  // width
+  if (!p.x2) {
+    if (!e.has(X) || e.isOrdinalScale(X)) { // no X or X is ordinal
       if (e.has(SIZE)) {
-        p.height = {scale: SIZE, field: e.fieldRef(SIZE)};
+        p.width = {scale: SIZE, field: e.fieldRef(SIZE)};
       } else {
-        p.height = {
-          value: e.bandWidth(Y, layout.y.useSmallBand),
+        p.width = {
+          value: e.bandWidth(X, layout.x.useSmallBand),
           offset: -1
         };
       }
+    } else { // X is Quant or Time Scale
+      p.width = {value: 2};
     }
-
-    // fill
-    if (e.has(COLOR)) {
-      p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
-    } else {
-      p.fill = {value: e.fieldDef(COLOR).value};
-    }
-
-    // opacity
-    var opacity = e.fieldDef(COLOR).opacity;
-    if (opacity) p.opacity = {value: opacity};
-
-    return p;
   }
 
-  export function point(e: Model, layout, style) {
+  // y's & height
+  if (e.fieldDef(Y).bin) {
+    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_start'})};
+    p.y2 = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_end'}), offset: 1};
+  } else if (e.isMeasure(Y)) {
+    p.y = {scale: Y, field: e.fieldRef(Y)};
+    p.y2 = {field: {group: 'height'}};
+  } else {
+    if (e.has(Y)) { // is ordinal
+      p.yc = {scale: Y, field: e.fieldRef(Y)};
+    } else {
+      p.y2 = {
+        field: {group: 'height'},
+        offset: -e.config('singleBarOffset')
+      };
+    }
+
+    if (e.has(SIZE)) {
+      p.height = {scale: SIZE, field: e.fieldRef(SIZE)};
+    } else {
+      p.height = {
+        value: e.bandWidth(Y, layout.y.useSmallBand),
+        offset: -1
+      };
+    }
+  }
+
+  // fill
+  if (e.has(COLOR)) {
+    p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
+  } else {
+    p.fill = {value: e.fieldDef(COLOR).value};
+  }
+
+  // opacity
+  var opacity = e.fieldDef(COLOR).opacity;
+  if (opacity) p.opacity = {value: opacity};
+
+  return p;
+}
+
+export function point(e: Model, layout, style) {
+  // TODO Use Vega's marks properties interface
+  var p:any = {};
+
+  // x
+  if (e.has(X)) {
+    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
+  } else if (!e.has(X)) {
+    p.x = {value: e.bandWidth(X, layout.x.useSmallBand) / 2};
+  }
+
+  // y
+  if (e.has(Y)) {
+    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
+  } else if (!e.has(Y)) {
+    p.y = {value: e.bandWidth(Y, layout.y.useSmallBand) / 2};
+  }
+
+  // size
+  if (e.has(SIZE)) {
+    p.size = {scale: SIZE, field: e.fieldRef(SIZE)};
+  } else if (!e.has(SIZE)) {
+    p.size = {value: e.fieldDef(SIZE).value};
+  }
+
+  // shape
+  if (e.has(SHAPE)) {
+    p.shape = {scale: SHAPE, field: e.fieldRef(SHAPE)};
+  } else if (!e.has(SHAPE)) {
+    p.shape = {value: e.fieldDef(SHAPE).value};
+  }
+
+  // fill or stroke
+  if (e.fieldDef(SHAPE).filled) {
+    if (e.has(COLOR)) {
+      p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
+    } else if (!e.has(COLOR)) {
+      p.fill = {value: e.fieldDef(COLOR).value};
+    }
+  } else {
+    if (e.has(COLOR)) {
+      p.stroke = {scale: COLOR, field: e.fieldRef(COLOR)};
+    } else if (!e.has(COLOR)) {
+      p.stroke = {value: e.fieldDef(COLOR).value};
+    }
+    p.strokeWidth = {value: e.config('strokeWidth')};
+  }
+
+  // opacity
+  var opacity = e.fieldDef(COLOR).opacity || style.opacity;
+  if (opacity) p.opacity = {value: opacity};
+
+  return p;
+}
+
+export function line(e: Model,layout, style) {
+  // TODO Use Vega's marks properties interface
+  var p:any = {};
+
+  // x
+  if (e.has(X)) {
+    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
+  } else if (!e.has(X)) {
+    p.x = {value: 0};
+  }
+
+  // y
+  if (e.has(Y)) {
+    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
+  } else if (!e.has(Y)) {
+    p.y = {field: {group: 'height'}};
+  }
+
+  // stroke
+  if (e.has(COLOR)) {
+    p.stroke = {scale: COLOR, field: e.fieldRef(COLOR)};
+  } else if (!e.has(COLOR)) {
+    p.stroke = {value: e.fieldDef(COLOR).value};
+  }
+
+  var opacity = e.fieldDef(COLOR).opacity;
+  if (opacity) p.opacity = {value: opacity};
+
+  p.strokeWidth = {value: e.config('strokeWidth')};
+
+  return p;
+}
+
+// TODO(#694): optimize area's usage with bin
+export function area(e: Model, layout, style) {
+  // TODO Use Vega's marks properties interface
+  var p:any = {};
+
+  // x
+  if (e.isMeasure(X)) {
+    p.x = {scale: X, field: e.fieldRef(X)};
+    if (e.isDimension(Y)) {
+      p.x2 = {scale: X, value: 0};
+      p.orient = {value: 'horizontal'};
+    }
+  } else if (e.has(X)) {
+    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
+  } else {
+    p.x = {value: 0};
+  }
+
+  // y
+  if (e.isMeasure(Y)) {
+    p.y = {scale: Y, field: e.fieldRef(Y)};
+    p.y2 = {scale: Y, value: 0};
+  } else if (e.has(Y)) {
+    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
+  } else {
+    p.y = {field: {group: 'height'}};
+  }
+
+  // fill
+  if (e.has(COLOR)) {
+    p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
+  } else if (!e.has(COLOR)) {
+    p.fill = {value: e.fieldDef(COLOR).value};
+  }
+
+  var opacity = e.fieldDef(COLOR).opacity;
+  if (opacity) p.opacity = {value: opacity};
+
+  return p;
+}
+
+export function tick(e: Model, layout, style) {
+  // TODO Use Vega's marks properties interface
+  var p:any = {};
+
+  // x
+  if (e.has(X)) {
+    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
+    if (e.isDimension(X)) {
+      p.x.offset = -e.bandWidth(X, layout.x.useSmallBand) / 3;
+    }
+  } else if (!e.has(X)) {
+    p.x = {value: 0};
+  }
+
+  // y
+  if (e.has(Y)) {
+    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
+    if (e.isDimension(Y)) {
+      p.y.offset = -e.bandWidth(Y, layout.y.useSmallBand) / 3;
+    }
+  } else if (!e.has(Y)) {
+    p.y = {value: 0};
+  }
+
+  // width
+  if (!e.has(X) || e.isDimension(X)) {
+    // TODO(#694): optimize tick's width for bin
+    p.width = {value: e.bandWidth(X, layout.y.useSmallBand) / 1.5};
+  } else {
+    p.width = {value: 1};
+  }
+
+  // height
+  if (!e.has(Y) || e.isDimension(Y)) {
+    // TODO(#694): optimize tick's height for bin
+    p.height = {value: e.bandWidth(Y, layout.y.useSmallBand) / 1.5};
+  } else {
+    p.height = {value: 1};
+  }
+
+  // fill
+  if (e.has(COLOR)) {
+    p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
+  } else {
+    p.fill = {value: e.fieldDef(COLOR).value};
+  }
+
+  var opacity = e.fieldDef(COLOR).opacity  || style.opacity;
+  if(opacity) p.opacity = {value: opacity};
+
+  return p;
+}
+
+function filled_point_props(shape) {
+  return function(e: Model, layout, style) {
     // TODO Use Vega's marks properties interface
     var p:any = {};
 
@@ -149,100 +332,12 @@ export namespace properties {
     // size
     if (e.has(SIZE)) {
       p.size = {scale: SIZE, field: e.fieldRef(SIZE)};
-    } else if (!e.has(SIZE)) {
+    } else if (!e.has(X)) {
       p.size = {value: e.fieldDef(SIZE).value};
     }
 
     // shape
-    if (e.has(SHAPE)) {
-      p.shape = {scale: SHAPE, field: e.fieldRef(SHAPE)};
-    } else if (!e.has(SHAPE)) {
-      p.shape = {value: e.fieldDef(SHAPE).value};
-    }
-
-    // fill or stroke
-    if (e.fieldDef(SHAPE).filled) {
-      if (e.has(COLOR)) {
-        p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
-      } else if (!e.has(COLOR)) {
-        p.fill = {value: e.fieldDef(COLOR).value};
-      }
-    } else {
-      if (e.has(COLOR)) {
-        p.stroke = {scale: COLOR, field: e.fieldRef(COLOR)};
-      } else if (!e.has(COLOR)) {
-        p.stroke = {value: e.fieldDef(COLOR).value};
-      }
-      p.strokeWidth = {value: e.config('strokeWidth')};
-    }
-
-    // opacity
-    var opacity = e.fieldDef(COLOR).opacity || style.opacity;
-    if (opacity) p.opacity = {value: opacity};
-
-    return p;
-  }
-
-  export function line(e: Model,layout, style) {
-    // TODO Use Vega's marks properties interface
-    var p:any = {};
-
-    // x
-    if (e.has(X)) {
-      p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
-    } else if (!e.has(X)) {
-      p.x = {value: 0};
-    }
-
-    // y
-    if (e.has(Y)) {
-      p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
-    } else if (!e.has(Y)) {
-      p.y = {field: {group: 'height'}};
-    }
-
-    // stroke
-    if (e.has(COLOR)) {
-      p.stroke = {scale: COLOR, field: e.fieldRef(COLOR)};
-    } else if (!e.has(COLOR)) {
-      p.stroke = {value: e.fieldDef(COLOR).value};
-    }
-
-    var opacity = e.fieldDef(COLOR).opacity;
-    if (opacity) p.opacity = {value: opacity};
-
-    p.strokeWidth = {value: e.config('strokeWidth')};
-
-    return p;
-  }
-
-  // TODO(#694): optimize area's usage with bin
-  export function area(e: Model, layout, style) {
-    // TODO Use Vega's marks properties interface
-    var p:any = {};
-
-    // x
-    if (e.isMeasure(X)) {
-      p.x = {scale: X, field: e.fieldRef(X)};
-      if (e.isDimension(Y)) {
-        p.x2 = {scale: X, value: 0};
-        p.orient = {value: 'horizontal'};
-      }
-    } else if (e.has(X)) {
-      p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
-    } else {
-      p.x = {value: 0};
-    }
-
-    // y
-    if (e.isMeasure(Y)) {
-      p.y = {scale: Y, field: e.fieldRef(Y)};
-      p.y2 = {scale: Y, value: 0};
-    } else if (e.has(Y)) {
-      p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
-    } else {
-      p.y = {field: {group: 'height'}};
-    }
+    p.shape = {value: shape};
 
     // fill
     if (e.has(COLOR)) {
@@ -251,179 +346,84 @@ export namespace properties {
       p.fill = {value: e.fieldDef(COLOR).value};
     }
 
-    var opacity = e.fieldDef(COLOR).opacity;
-    if (opacity) p.opacity = {value: opacity};
-
-    return p;
-  }
-
-  export function tick(e: Model, layout, style) {
-    // TODO Use Vega's marks properties interface
-    var p:any = {};
-
-    // x
-    if (e.has(X)) {
-      p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
-      if (e.isDimension(X)) {
-        p.x.offset = -e.bandWidth(X, layout.x.useSmallBand) / 3;
-      }
-    } else if (!e.has(X)) {
-      p.x = {value: 0};
-    }
-
-    // y
-    if (e.has(Y)) {
-      p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
-      if (e.isDimension(Y)) {
-        p.y.offset = -e.bandWidth(Y, layout.y.useSmallBand) / 3;
-      }
-    } else if (!e.has(Y)) {
-      p.y = {value: 0};
-    }
-
-    // width
-    if (!e.has(X) || e.isDimension(X)) {
-      // TODO(#694): optimize tick's width for bin
-      p.width = {value: e.bandWidth(X, layout.y.useSmallBand) / 1.5};
-    } else {
-      p.width = {value: 1};
-    }
-
-    // height
-    if (!e.has(Y) || e.isDimension(Y)) {
-      // TODO(#694): optimize tick's height for bin
-      p.height = {value: e.bandWidth(Y, layout.y.useSmallBand) / 1.5};
-    } else {
-      p.height = {value: 1};
-    }
-
-    // fill
-    if (e.has(COLOR)) {
-      p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
-    } else {
-      p.fill = {value: e.fieldDef(COLOR).value};
-    }
-
     var opacity = e.fieldDef(COLOR).opacity  || style.opacity;
     if(opacity) p.opacity = {value: opacity};
 
     return p;
-  }
+  };
+}
 
-  function filled_point_props(shape) {
-    return function(e: Model, layout, style) {
-      // TODO Use Vega's marks properties interface
-      var p:any = {};
+export const circle = filled_point_props('circle');
+export const square = filled_point_props('square');
 
-      // x
-      if (e.has(X)) {
-        p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
-      } else if (!e.has(X)) {
-        p.x = {value: e.bandWidth(X, layout.x.useSmallBand) / 2};
-      }
+export function textBackground(model: Model, layout) {
+  return {
+    x: {value: 0},
+    y: {value: 0},
+    x2: {value: layout.cellWidth},
+    y2: {value: layout.cellHeight},
+    fill: {scale: COLOR, field: model.fieldRef(COLOR)}
+  };
+}
 
-      // y
-      if (e.has(Y)) {
-        p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
-      } else if (!e.has(Y)) {
-        p.y = {value: e.bandWidth(Y, layout.y.useSmallBand) / 2};
-      }
+export function text(e: Model, layout, style) {
+  // TODO Use Vega's marks properties interface
+  var p:any = {},
+    fieldDef = e.fieldDef(TEXT);
 
-      // size
-      if (e.has(SIZE)) {
-        p.size = {scale: SIZE, field: e.fieldRef(SIZE)};
-      } else if (!e.has(X)) {
-        p.size = {value: e.fieldDef(SIZE).value};
-      }
-
-      // shape
-      p.shape = {value: shape};
-
-      // fill
-      if (e.has(COLOR)) {
-        p.fill = {scale: COLOR, field: e.fieldRef(COLOR)};
-      } else if (!e.has(COLOR)) {
-        p.fill = {value: e.fieldDef(COLOR).value};
-      }
-
-      var opacity = e.fieldDef(COLOR).opacity  || style.opacity;
-      if(opacity) p.opacity = {value: opacity};
-
-      return p;
-    };
-  }
-
-  export const circle = filled_point_props('circle');
-  export const square = filled_point_props('square');
-
-  export function textBackground(model: Model, layout) {
-    return {
-      x: {value: 0},
-      y: {value: 0},
-      x2: {value: layout.cellWidth},
-      y2: {value: layout.cellHeight},
-      fill: {scale: COLOR, field: model.fieldRef(COLOR)}
-    };
-  }
-
-  export function text(e: Model, layout, style) {
-    // TODO Use Vega's marks properties interface
-    var p:any = {},
-      fieldDef = e.fieldDef(TEXT);
-
-    // x
-    if (e.has(X)) {
-      p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
-    } else if (!e.has(X)) {
-      if (e.has(TEXT) && e.fieldDef(TEXT).type === QUANTITATIVE) {
-        p.x = {value: layout.cellWidth-5};
-      } else {
-        p.x = {value: e.bandWidth(X, layout.x.useSmallBand) / 2};
-      }
-    }
-
-    // y
-    if (e.has(Y)) {
-      p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
-    } else if (!e.has(Y)) {
-      p.y = {value: e.bandWidth(Y, layout.y.useSmallBand) / 2};
-    }
-
-    // size
-    if (e.has(SIZE)) {
-      p.fontSize = {scale: SIZE, field: e.fieldRef(SIZE)};
-    } else if (!e.has(SIZE)) {
-      p.fontSize = {value: fieldDef.font.size};
-    }
-
-    // fill
-    // color should be set to background
-    p.fill = {value: fieldDef.color};
-
-    var opacity = e.fieldDef(COLOR).opacity  || style.opacity;
-    if(opacity) p.opacity = {value: opacity};
-
-    // text
-    if (e.has(TEXT)) {
-      if (e.fieldDef(TEXT).type === QUANTITATIVE) {
-        var numberFormat = fieldDef.format !== undefined ?
-                           fieldDef.format : e.numberFormat(TEXT);
-
-        p.text = {template: '{{' + e.fieldRef(TEXT, {datum: true}) + ' | number:\'' +
-          numberFormat +'\'}}'};
-        p.align = {value: fieldDef.align};
-      } else {
-        p.text = {field: e.fieldRef(TEXT)};
-      }
+  // x
+  if (e.has(X)) {
+    p.x = {scale: X, field: e.fieldRef(X, {binSuffix: '_mid'})};
+  } else if (!e.has(X)) {
+    if (e.has(TEXT) && e.fieldDef(TEXT).type === QUANTITATIVE) {
+      p.x = {value: layout.cellWidth-5};
     } else {
-      p.text = {value: fieldDef.placeholder};
+      p.x = {value: e.bandWidth(X, layout.x.useSmallBand) / 2};
     }
-
-    p.font = {value: fieldDef.font.family};
-    p.fontWeight = {value: fieldDef.font.weight};
-    p.fontStyle = {value: fieldDef.font.style};
-    p.baseline = {value: fieldDef.baseline};
-
-    return p;
   }
+
+  // y
+  if (e.has(Y)) {
+    p.y = {scale: Y, field: e.fieldRef(Y, {binSuffix: '_mid'})};
+  } else if (!e.has(Y)) {
+    p.y = {value: e.bandWidth(Y, layout.y.useSmallBand) / 2};
+  }
+
+  // size
+  if (e.has(SIZE)) {
+    p.fontSize = {scale: SIZE, field: e.fieldRef(SIZE)};
+  } else if (!e.has(SIZE)) {
+    p.fontSize = {value: fieldDef.font.size};
+  }
+
+  // fill
+  // color should be set to background
+  p.fill = {value: fieldDef.color};
+
+  var opacity = e.fieldDef(COLOR).opacity  || style.opacity;
+  if(opacity) p.opacity = {value: opacity};
+
+  // text
+  if (e.has(TEXT)) {
+    if (e.fieldDef(TEXT).type === QUANTITATIVE) {
+      var numberFormat = fieldDef.format !== undefined ?
+                         fieldDef.format : e.numberFormat(TEXT);
+
+      p.text = {template: '{{' + e.fieldRef(TEXT, {datum: true}) + ' | number:\'' +
+        numberFormat +'\'}}'};
+      p.align = {value: fieldDef.align};
+    } else {
+      p.text = {field: e.fieldRef(TEXT)};
+    }
+  } else {
+    p.text = {value: fieldDef.placeholder};
+  }
+
+  p.font = {value: fieldDef.font.family};
+  p.fontWeight = {value: fieldDef.font.weight};
+  p.fontStyle = {value: fieldDef.font.style};
+  p.baseline = {value: fieldDef.baseline};
+
+  return p;
+}
 }

--- a/src/marktype.ts
+++ b/src/marktype.ts
@@ -4,3 +4,7 @@ export const LINE = 'line';
 export const POINT = 'point';
 export const TEXT = 'text';
 export const TICK = 'tick';
+
+// TODO: decide if we want to keep them?
+export const CIRCLE = 'circle';
+export const SQUARE = 'square';

--- a/test/compiler/marks.test.ts
+++ b/test/compiler/marks.test.ts
@@ -16,7 +16,7 @@ describe('compile.marks', function() {
     describe('vertical, with log', function() {
       var f = fixtures.bars.log_ver,
           e = new Model(f),
-          def = marks.bar.prop(e, mockLayout, {});
+          def = marks.properties.bar(e, mockLayout, {});
       it('should end on axis', function() {
         expect(def.y2).to.eql({field: {group: 'height'}});
       });
@@ -28,7 +28,7 @@ describe('compile.marks', function() {
     describe('horizontal, with log', function() {
       var f = fixtures.bars.log_hor,
           e = new Model(f),
-          def = marks.bar.prop(e, mockLayout, {});
+          def = marks.properties.bar(e, mockLayout, {});
       it('should end on axis', function() {
         expect(def.x2).to.eql({value: 0});
       });
@@ -40,7 +40,7 @@ describe('compile.marks', function() {
     describe('1D, vertical', function() {
       var f = fixtures.bars['1d_ver'],
           e = new Model(f),
-          def = marks.bar.prop(e, mockLayout, {});
+          def = marks.properties.bar(e, mockLayout, {});
       it('should end on axis', function() {
         expect(def.y2).to.eql({field: {group: 'height'}});
       });
@@ -55,7 +55,7 @@ describe('compile.marks', function() {
     describe('1D, horizontal', function() {
       var f = fixtures.bars['1d_hor'],
           e = new Model(f),
-          def = marks.bar.prop(e, mockLayout, {});
+          def = marks.properties.bar(e, mockLayout, {});
       it('should end on axis', function() {
         expect(def.x2).to.eql({value: 0});
       });
@@ -75,7 +75,7 @@ describe('compile.marks', function() {
     describe('1D, horizontal', function() {
       var f = fixtures.points['1d_hor'],
           e = new Model(f),
-          def = marks.point.prop(e, mockLayout, {});
+          def = marks.properties.point(e, mockLayout, {});
       it('should be centered', function() {
         expect(def.y).to.eql({value: e.bandWidth(Y, mockLayout.y.useSmallBand) / 2});
       });
@@ -87,7 +87,7 @@ describe('compile.marks', function() {
     describe('1D, vertical', function() {
       var f = fixtures.points['1d_ver'],
           e = new Model(f),
-          def = marks.point.prop(e, mockLayout, {});
+          def = marks.properties.point(e, mockLayout, {});
       it('should be centered', function() {
         expect(def.x).to.eql({value: e.bandWidth(X, mockLayout.x.useSmallBand) / 2});
       });
@@ -99,7 +99,7 @@ describe('compile.marks', function() {
     describe('2D, x and y', function() {
       var f = fixtures.points['x,y'],
           e = new Model(f),
-          def = marks.point.prop(e, mockLayout, {});
+          def = marks.properties.point(e, mockLayout, {});
       it('should scale on x', function() {
         expect(def.x).to.eql({scale: X, field: 'year'});
       });
@@ -112,7 +112,7 @@ describe('compile.marks', function() {
       describe('x,y,size', function () {
         var f = fixtures.points['x,y,size'],
             e = new Model(f),
-            def = marks.point.prop(e, mockLayout, {});
+            def = marks.properties.point(e, mockLayout, {});
         it('should have scale for size', function () {
           expect(def.size).to.eql({scale: SIZE, field: 'count'});
         });
@@ -121,7 +121,7 @@ describe('compile.marks', function() {
       describe('x,y,color', function () {
         var f = fixtures.points['x,y,stroke'],
             e = new Model(f),
-            def = marks.point.prop(e, mockLayout, {});
+            def = marks.properties.point(e, mockLayout, {});
         it('should have scale for color', function () {
           expect(def.stroke).to.eql({scale: COLOR, field: 'yield'});
         });
@@ -130,7 +130,7 @@ describe('compile.marks', function() {
       describe('x,y,shape', function () {
         var f = fixtures.points['x,y,shape'],
             e = new Model(f),
-            def = marks.point.prop(e, mockLayout, {});
+            def = marks.properties.point(e, mockLayout, {});
         it('should have scale for shape', function () {
           expect(def.shape).to.eql({scale: SHAPE, field: 'bin_yield_start'});
         });
@@ -142,7 +142,7 @@ describe('compile.marks', function() {
     describe('2D, x and y', function() {
       var f = fixtures.lines['x,y'],
           e = new Model(f),
-          def = marks.line.prop(e, mockLayout, {});
+          def = marks.properties.line(e, mockLayout, {});
       it('should have scale for x', function() {
         expect(def.x).to.eql({scale: X, field: 'year'});
       });
@@ -155,7 +155,7 @@ describe('compile.marks', function() {
       describe('x,y,color', function () {
         var f = fixtures.lines['x,y,stroke'],
             e = new Model(f),
-            def = marks.line.prop(e, mockLayout, {});
+            def = marks.properties.line(e, mockLayout, {});
         it('should have scale for color', function () {
           expect(def.stroke).to.eql({scale: COLOR, field: 'Acceleration'});
         });
@@ -167,7 +167,7 @@ describe('compile.marks', function() {
     describe('2D, x and y', function() {
       var f = fixtures.area['x,y'],
           e = new Model(f),
-          def = marks.area.prop(e, mockLayout, {});
+          def = marks.properties.area(e, mockLayout, {});
       it('should have scale for x', function() {
         expect(def.x).to.eql({scale: X, field: 'Displacement'});
       });
@@ -180,7 +180,7 @@ describe('compile.marks', function() {
       describe('x,y,color', function () {
         var f = fixtures.area['x,y,stroke'],
             e = new Model(f),
-            def = marks.area.prop(e, mockLayout, {});
+            def = marks.properties.area(e, mockLayout, {});
         it('should have scale for color', function () {
           expect(def.fill).to.eql({scale: COLOR, field: 'Miles_per_Gallon'});
         });


### PR DESCRIPTION
- Make `marks.ts` far less confusing 
  - refactor the weird pattern on the top
  - `e` => `model`
- Use `update` instead of `enter` for root 
- Use `{group: "width|height"}` for cell if there is no facet
