### PR TITLE
refactor facet and compiler -- reduce side effects

### DIFF
--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -34,26 +34,28 @@ export function compile(spec, stats, theme?) {
 
   var layout = vlLayout(model, stats);
 
+  var rootGroup:any = {
+    name: 'root',
+    type: 'group',
+    properties: {
+      update: {
+        width: model.has(COLUMN) ?
+                 {value: layout.cellWidth} :
+                 {field: {group: 'width'}},
+        height: model.has(ROW) ?
+                {value: layout.cellHeight} :
+                {field: {group: 'height'}}
+      }
+    }
+  };
+
   // TODO: change type to become VgSpec
   var output:any = {
       width: layout.width,
       height: layout.height,
       padding: 'auto',
       data: compileData(model),
-      marks: [{
-        name: 'cell',
-        type: 'group',
-        properties: {
-          update: {
-            width: model.has(COLUMN) ?
-                     {value: layout.cellWidth} :
-                     {field: {group: 'width'}},
-            height: model.has(ROW) ?
-                    {value: layout.cellHeight} :
-                    {field: {group: 'height'}}
-          }
-        }
-      }]
+      marks: [rootGroup]
     };
 
   // global scales contains only time unit scales
@@ -61,17 +63,17 @@ export function compile(spec, stats, theme?) {
   if (timeScales.length > 0) {
     output.scales = timeScales;
   }
-  var group = output.marks[0];
+
 
   // marks
   var styleCfg = vlStyle(model, stats);
-  group.marks = compileMarks(model, layout, styleCfg);
+  rootGroup.marks = compileMarks(model, layout, styleCfg);
 
   var legends = compileLegends(model, styleCfg);
 
   // Small Multiples
   if (model.has(ROW) || model.has(COLUMN)) {
-    output = vlFacet(group, model, layout, output, stats);
+    output = vlFacet(rootGroup, model, layout, output, stats);
     if (legends.length > 0) {
       output.legends = legends;
     }
@@ -81,7 +83,7 @@ export function compile(spec, stats, theme?) {
         names.push(channel);
         return names;
       }, []);
-    group.scales = compileScales(scaleNames, model, layout, stats);
+    rootGroup.scales = compileScales(scaleNames, model, layout, stats);
 
     var axes = [];
     if (model.has(X)) {
@@ -91,11 +93,11 @@ export function compile(spec, stats, theme?) {
       axes.push(compileAxis(Y, model, layout, stats));
     }
     if (axes.length > 0) {
-      group.axes = axes;
+      rootGroup.axes = axes;
     }
 
     if (legends.length > 0) {
-      group.legends = legends;
+      rootGroup.legends = legends;
     }
   }
 

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -6,14 +6,15 @@ import {Model} from './Model';
 import * as vlTime from './time';
 import {compileAxis} from './axis';
 import {compileData} from './data';
+import {facetMixins} from './facet';
 import {compileLegends} from './legend';
 import {compileMarks} from './marks';
 import {compileScales} from './scale';
 
 // TODO: stop using default if we were to keep these files
-import vlFacet from './facet';
 import vlLayout from './layout';
 import vlStyle from './style';
+import * as util from '../util';
 
 import {stats as vlDataStats} from '../data';
 import {COLUMN, ROW, X, Y, Channel} from '../channel';
@@ -37,17 +38,47 @@ export function compile(spec, stats, theme?) {
   var rootGroup:any = {
     name: 'root',
     type: 'group',
+    // TODO: add from: {data: 'stats'}
     properties: {
       update: {
-        width: model.has(COLUMN) ?
-                 {value: layout.cellWidth} :
-                 {field: {group: 'width'}},
-        height: model.has(ROW) ?
-                {value: layout.cellHeight} :
-                {field: {group: 'height'}}
+        // TODO replace with signal or inline calculation
+        width: {value: layout.width},
+        height: {value: layout.height}
       }
     }
   };
+
+  // marks
+  var styleCfg = vlStyle(model, stats);
+  const marks = compileMarks(model, layout, styleCfg);
+
+  // Small Multiples
+  if (model.has(ROW) || model.has(COLUMN)) {
+    // put the marks inside a facet cell's group
+    util.extend(rootGroup, facetMixins(model, marks, layout, stats));
+  } else {
+    rootGroup.marks = marks.map(function(marks) {
+      marks.from = marks.from || {};
+      marks.from.data = model.dataTable();
+      return marks;
+    });
+    const scaleNames = model.map(function(_, channel: Channel){
+        return channel; // TODO model.scaleName(channel)
+      });
+    rootGroup.scales = compileScales(scaleNames, model, layout, stats);
+
+    var axes = (model.has(X) ? [compileAxis(X, model, layout, stats)] : [])
+      .concat(model.has(Y) ? [compileAxis(Y, model, layout, stats)] : []);
+    if (axes.length > 0) {
+      rootGroup.axes = axes;
+    }
+  }
+
+  // legends (similar for either facets or non-facets
+  var legends = compileLegends(model, styleCfg);
+  if (legends.length > 0) {
+    rootGroup.legends = legends;
+  }
 
   // TODO: change type to become VgSpec
   var output:any = {
@@ -58,47 +89,11 @@ export function compile(spec, stats, theme?) {
       marks: [rootGroup]
     };
 
+  // FIXME(domoritz): remove this
   // global scales contains only time unit scales
   var timeScales = vlTime.scales(model);
   if (timeScales.length > 0) {
     output.scales = timeScales;
-  }
-
-
-  // marks
-  var styleCfg = vlStyle(model, stats);
-  rootGroup.marks = compileMarks(model, layout, styleCfg);
-
-  var legends = compileLegends(model, styleCfg);
-
-  // Small Multiples
-  if (model.has(ROW) || model.has(COLUMN)) {
-    output = vlFacet(rootGroup, model, layout, output, stats);
-    if (legends.length > 0) {
-      output.legends = legends;
-    }
-  } else {
-    const scaleNames = model.reduce(
-      function(names: Channel[], fieldDef: FieldDef, channel: Channel){
-        names.push(channel);
-        return names;
-      }, []);
-    rootGroup.scales = compileScales(scaleNames, model, layout, stats);
-
-    var axes = [];
-    if (model.has(X)) {
-      axes.push(compileAxis(X, model, layout, stats));
-    }
-    if (model.has(Y)) {
-      axes.push(compileAxis(Y, model, layout, stats));
-    }
-    if (axes.length > 0) {
-      rootGroup.axes = axes;
-    }
-
-    if (legends.length > 0) {
-      rootGroup.legends = legends;
-    }
   }
 
   return {

--- a/src/compiler/facet.ts
+++ b/src/compiler/facet.ts
@@ -6,49 +6,42 @@ import {Model} from './Model';
 import {compileAxis} from './axis';
 import {compileScales} from './scale';
 
-export default function(group, model: Model, layout, output, stats) {
-  var update = group.properties.update;
-  var facetKeys = [], cellAxes = [], from;
+/**
+ * return mixins that contains marks, scales, and axes for the rootGroup
+ */
+export function facetMixins(model: Model, marks, layout, stats) {
+  let facetGroupProperties: any = {
+    width: model.has(COLUMN) ?
+             {value: layout.cellWidth} :
+             {field: {group: 'width'}},
+    height: model.has(ROW) ?
+            {value: layout.cellHeight} :
+            {field: {group: 'height'}},
+    fill: {value: model.config('cellBackgroundColor')}
+  };
 
-  var hasRow = model.has(ROW), hasCol = model.has(COLUMN);
-
-  update.fill = {value: model.config('cellBackgroundColor')};
-
-  //move "from" to cell level and add facet transform
-  group.from = {data: group.marks[0].from.data};
-
-  // Hack, this needs to be refactored
-  for (var i = 0; i < group.marks.length; i++) {
-    var mark = group.marks[i];
-    if (mark.from.transform) {
-      delete mark.from.data; //need to keep transform for subfacetting case
-    } else {
-      delete mark.from;
-    }
-  }
-
+  let rootMarks = [], rootAxes = [], facetKeys = [], cellAxes = [];
+  const hasRow = model.has(ROW), hasCol = model.has(COLUMN);
   if (hasRow) {
     if (!model.isDimension(ROW)) {
       // TODO: add error to model instead
       util.error('Row encoding should be ordinal.');
     }
-    update.y = {scale: ROW, field: model.fieldRef(ROW)};
-    update.height = {'value': layout.cellHeight}; // HACK
+    facetGroupProperties.y = {
+      scale: ROW,
+      field: model.fieldRef(ROW)
+    };
+    facetGroupProperties.height = {'value': layout.cellHeight}; // HACK
 
     facetKeys.push(model.fieldRef(ROW));
 
-    if (hasCol) {
-      from = util.duplicate(group.from);
-      from.transform = from.transform || [];
-      from.transform.unshift({type: 'facet', groupby: [model.fieldRef(COLUMN)]});
-    }
+    rootAxes.push(compileAxis(ROW, model, layout, stats));
 
     if (model.has(X)) {
-      // prepend a group for shared x-axes in the root group's marks
-      output.marks.unshift({
+      // If has X, prepend a group for shared x-axes in the root group's marks
+      let xAxesGroup: any = { // VgMarks
         name: 'x-axes',
         type: 'group',
-        from: from,
         properties: {
           update: {
             width: hasCol ? {'value': layout.cellWidth} : {field: {group: 'width'}},
@@ -57,12 +50,15 @@ export default function(group, model: Model, layout, output, stats) {
           }
         },
         axes: [compileAxis(X, model, layout, stats)]
-      });
+      };
+      if (hasCol) {
+        xAxesGroup.from = {
+          data: model.dataTable(),
+          transform: {type: 'facet', groupby: [model.fieldRef(COLUMN)]}
+        };
+      }
+      rootMarks.push(xAxesGroup);
     }
-
-
-    (output.axes = output.axes || []);
-    output.axes.push(compileAxis(ROW, model, layout, stats));
   } else { // doesn't have row
     if (model.has(X)) {
       //keep x axis in the cell
@@ -75,23 +71,21 @@ export default function(group, model: Model, layout, output, stats) {
       // TODO: add error to model instead
       util.error('Col encoding should be ordinal.');
     }
-    update.x = {scale: COLUMN, field: model.fieldRef(COLUMN)};
-    update.width = {'value': layout.cellWidth}; // HACK
+    facetGroupProperties.x = {
+      scale: COLUMN,
+      field: model.fieldRef(COLUMN)
+    };
+    facetGroupProperties.width = {'value': layout.cellWidth}; // HACK
 
     facetKeys.push(model.fieldRef(COLUMN));
 
-    if (hasRow) {
-      from = util.duplicate(group.from);
-      from.transform = from.transform || [];
-      from.transform.unshift({type: 'facet', groupby: [model.fieldRef(ROW)]});
-    }
+    rootAxes.push(compileAxis(COLUMN, model, layout, stats));
 
     if (model.has(Y)) {
-      // prepend a group for shared y-axes in the root group's marks
-      output.marks.unshift({
+      // If has Y, prepend a group for shared y-axes in the root group's marks
+      let yAxesGroup: any = { // VgMarks
         name: 'y-axes',
         type: 'group',
-        from: from,
         properties: {
           update: {
             width: {field: {group: 'width'}},
@@ -100,41 +94,48 @@ export default function(group, model: Model, layout, output, stats) {
           }
         },
         axes: [compileAxis(Y, model, layout, stats)]
-      });
+      };
 
+      if (hasRow) {
+        yAxesGroup.from = {
+          data: model.dataTable(),
+          transform: {type: 'facet', groupby: [model.fieldRef(ROW)]}
+        };
+      }
+      rootMarks.push(yAxesGroup);
     }
 
-    (output.axes = output.axes || []);
-    output.axes.push(compileAxis(COLUMN, model, layout, stats));
   } else { // doesn't have column
     if (model.has(Y)) {
       cellAxes.push(compileAxis(Y, model, layout, stats));
     }
   }
 
-  const scaleNames = model.reduce(
-    function(names: Channel[], fieldDef: FieldDef, channel: Channel){
-      names.push(channel);
-      return names;
-    }, []);
-
-  // assuming equal cellWidth here
-  // TODO: support heterogenous cellWidth (maybe by using multiple scales?)
-  output.scales = (output.scales || []).concat(compileScales(
-    scaleNames,
-    model,
-    layout,
-    stats,
-    true
-  )); // row/column scales + cell scales
-
+  let facetGroup: any = {
+    name: 'cell', // FIXME model.name() + cell
+    type: 'group',
+    from: {
+      data: model.dataTable(),
+      transform: [{type: 'facet', groupby: facetKeys}]
+    },
+    properties: {
+      update: facetGroupProperties
+    },
+    marks: marks
+  };
   if (cellAxes.length > 0) {
-    group.axes = cellAxes;
+    facetGroup.axes = cellAxes;
   }
+  rootMarks.push(facetGroup);
 
-  // add facet transform
-  var trans = (group.from.transform || (group.from.transform = []));
-  trans.unshift({type: 'facet', groupby: facetKeys});
+  const scaleNames = model.map(function(_, channel: Channel){
+    return channel; // TODO model.scaleName(channel)
+  });
 
-  return output;
+  return {
+    marks: rootMarks,
+    axes: rootAxes,
+    // assuming equal cellWidth here
+    scales: compileScales(scaleNames, model, layout, stats, true)
+  };
 }

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -54,7 +54,7 @@ export function compileMarks(model: Model, layout, style): any[] {
         name: marktype  + '-facet',
         type: 'group',
         from: {
-          data: model.dataTable(),
+
           transform: transform
         },
         properties: {
@@ -66,14 +66,12 @@ export function compileMarks(model: Model, layout, style): any[] {
         marks: [mainDef]
       }];
     } else {
-      mainDef.from.data = model.dataTable();
       return [mainDef];
     }
   } else { // other mark type
-    const from:any = {data: model.dataTable()}; // TODO: VgDataFrom
-    const mainDef = { // TODO add name
+    const mainDef: any = { // TODO: vgMarks
+      // TODO add name
       type: MARKTYPES_MAP[marktype],
-      from: from,
       properties: {
         update: properties[marktype](model, layout, style)
       }
@@ -83,14 +81,15 @@ export function compileMarks(model: Model, layout, style): any[] {
       // add background to 'text' marks if has color
       return [{
         type: 'rect',
-        from: from, // FIXME this is tricky for small multiples of text
         properties: {update: properties.textBackground(model, layout)}
       }, mainDef];
     }
 
     const stack = model.stack();
     if (marktype === BAR && stack) {
-      from.transform = [stackTransform(model)];
+      mainDef.from = {
+        transform: [stackTransform(model)]
+      };
     }
 
     // if (model.has(LABEL)) {

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -30,9 +30,10 @@ export function compileMarks(model: Model, layout, style): any[] {
       sortBy = '-' + model.fieldRef(sortField);
     }
 
-    let mainDef: any = {
+    let pathMarks: any = {
       type: MARKTYPES_MAP[marktype],
       from: {
+        // from.data might be added later for non-facet, single group line/area
         transform: [{type: 'sort', by: sortBy}]
       },
       properties: {
@@ -54,7 +55,7 @@ export function compileMarks(model: Model, layout, style): any[] {
         name: marktype  + '-facet',
         type: 'group',
         from: {
-
+          // from.data might be added later for non-facet charts
           transform: transform
         },
         properties: {
@@ -63,34 +64,35 @@ export function compileMarks(model: Model, layout, style): any[] {
             height: {field: {group: 'height'}}
           }
         },
-        marks: [mainDef]
+        marks: [pathMarks]
       }];
     } else {
-      return [mainDef];
+      return [pathMarks];
     }
   } else { // other mark type
-    const mainDef: any = { // TODO: vgMarks
+    let marks = []; // TODO: vgMarks
+    if (marktype === TEXTMARKS && model.has(COLOR)) {
+      // add background to 'text' marks if has color
+      marks.push({
+        type: 'rect',
+        properties: {update: properties.textBackground(model, layout)}
+      });
+    }
+
+    let mainDef: any = {
       // TODO add name
       type: MARKTYPES_MAP[marktype],
       properties: {
         update: properties[marktype](model, layout, style)
       }
     };
-
-    if (marktype === TEXTMARKS && model.has(COLOR)) {
-      // add background to 'text' marks if has color
-      return [{
-        type: 'rect',
-        properties: {update: properties.textBackground(model, layout)}
-      }, mainDef];
-    }
-
     const stack = model.stack();
     if (marktype === BAR && stack) {
       mainDef.from = {
         transform: [stackTransform(model)]
       };
     }
+    marks.push(mainDef);
 
     // if (model.has(LABEL)) {
     //   // TODO: add label by type here


### PR DESCRIPTION
 #276	

- introduce “root” group, which appears in all visualization.  This is a preparation for eliminating stats.
- only include “cell” group for small multiples 
- refactor facet
  - avoid creating shared axes groups when they are not necessary 