### PR TITLE
remove stats from axis

### DIFF
--- a/gallery/examples.js
+++ b/gallery/examples.js
@@ -91,16 +91,6 @@ var EXAMPLES = [
       'data': {'url': 'data/cars.json'}
     }
   },{
-    title: 'Scatter Plot with Ordinal on Top',
-    spec: {
-      'marktype': 'point',
-      'encoding': {
-        'x': {'field': 'MPAA_Rating','type': 'nominal'},
-        'y': {'field': 'Release_Date','type': 'nominal'}
-      },
-      'data': {'url': 'data/movies.json'}
-    }
-  },{
     title: 'Line Chart',
     description: 'Horse power over time',
     spec: {

--- a/src/compiler/axis.ts
+++ b/src/compiler/axis.ts
@@ -8,7 +8,7 @@ import * as time from './time';
 // https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#11-ambient-declarations
 declare var exports;
 
-export function compileAxis(channel: Channel, model: Model, layout, stats) {
+export function compileAxis(channel: Channel, model: Model, layout) {
   var isCol = channel === COLUMN,
     isRow = channel === ROW,
     type = isCol ? 'x' : isRow ? 'y': channel;
@@ -28,11 +28,11 @@ export function compileAxis(channel: Channel, model: Model, layout, stats) {
     'tickPadding', 'tickSize', 'tickSizeMajor', 'tickSizeMinor', 'tickSizeEnd',
     'values', 'subdivide'
   ].forEach(function(property) {
-    let method: (model: Model, channel: Channel, layout:any, stats:any, def:any)=>any;
+    let method: (model: Model, channel: Channel, layout:any, def:any)=>any;
 
     var value = (method = exports[property]) ?
                   // calling axis.format, axis.grid, ...
-                  method(model, channel, layout, stats, def) :
+                  method(model, channel, layout, def) :
                   model.fieldDef(channel).axis[property];
     if (value !== undefined) {
       def[property] = value;
@@ -92,7 +92,7 @@ export function grid(model: Model, channel: Channel) {
     (model.isTypes(channel, [QUANTITATIVE, TEMPORAL]) && !model.fieldDef(channel).bin);
 }
 
-export function layer(model: Model, channel: Channel, layout, stats, def) {
+export function layer(model: Model, channel: Channel, layout, def) {
   var layer = model.fieldDef(channel).axis.layer;
   if (layer !== undefined) {
     return layer;
@@ -116,15 +116,11 @@ export function offset(model: Model, channel: Channel, layout) {
   return undefined;
 }
 
-export function orient(model: Model, channel: Channel, layout, stats) {
+export function orient(model: Model, channel: Channel, layout) {
   var orient = model.fieldDef(channel).axis.orient;
   if (orient) {
     return orient;
   } else if (channel === COLUMN) {
-    return 'top';
-  } else if (channel === X && model.has(Y) && model.isOrdinalScale(Y) && model.cardinality(Y, stats) > 30) {
-    // FIXME remove this case and migrate this logic to vega-lite-ui
-    // x-axis for long y - put on top
     return 'top';
   }
   return undefined;

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -67,8 +67,8 @@ export function compile(spec, stats, theme?) {
       });
     rootGroup.scales = compileScales(scaleNames, model, layout, stats);
 
-    var axes = (model.has(X) ? [compileAxis(X, model, layout, stats)] : [])
-      .concat(model.has(Y) ? [compileAxis(Y, model, layout, stats)] : []);
+    var axes = (model.has(X) ? [compileAxis(X, model, layout)] : [])
+      .concat(model.has(Y) ? [compileAxis(Y, model, layout)] : []);
     if (axes.length > 0) {
       rootGroup.axes = axes;
     }

--- a/src/compiler/facet.ts
+++ b/src/compiler/facet.ts
@@ -35,7 +35,7 @@ export function facetMixins(model: Model, marks, layout, stats) {
 
     facetKeys.push(model.fieldRef(ROW));
 
-    rootAxes.push(compileAxis(ROW, model, layout, stats));
+    rootAxes.push(compileAxis(ROW, model, layout));
 
     if (model.has(X)) {
       // If has X, prepend a group for shared x-axes in the root group's marks
@@ -49,7 +49,7 @@ export function facetMixins(model: Model, marks, layout, stats) {
             x: hasCol ? {scale: COLUMN, field: model.fieldRef(COLUMN)} : {value: 0},
           }
         },
-        axes: [compileAxis(X, model, layout, stats)]
+        axes: [compileAxis(X, model, layout)]
       };
       if (hasCol) {
         xAxesGroup.from = {
@@ -62,7 +62,7 @@ export function facetMixins(model: Model, marks, layout, stats) {
   } else { // doesn't have row
     if (model.has(X)) {
       //keep x axis in the cell
-      cellAxes.push(compileAxis(X, model, layout, stats));
+      cellAxes.push(compileAxis(X, model, layout));
     }
   }
 
@@ -79,7 +79,7 @@ export function facetMixins(model: Model, marks, layout, stats) {
 
     facetKeys.push(model.fieldRef(COLUMN));
 
-    rootAxes.push(compileAxis(COLUMN, model, layout, stats));
+    rootAxes.push(compileAxis(COLUMN, model, layout));
 
     if (model.has(Y)) {
       // If has Y, prepend a group for shared y-axes in the root group's marks
@@ -93,7 +93,7 @@ export function facetMixins(model: Model, marks, layout, stats) {
             x: hasCol ? {scale: COLUMN, field: model.fieldRef(COLUMN)} : {value: 0},
           }
         },
-        axes: [compileAxis(Y, model, layout, stats)]
+        axes: [compileAxis(Y, model, layout)]
       };
 
       if (hasRow) {
@@ -107,7 +107,7 @@ export function facetMixins(model: Model, marks, layout, stats) {
 
   } else { // doesn't have column
     if (model.has(Y)) {
-      cellAxes.push(compileAxis(Y, model, layout, stats));
+      cellAxes.push(compileAxis(Y, model, layout));
     }
   }
 

--- a/test/compiler/axis.test.ts
+++ b/test/compiler/axis.test.ts
@@ -4,8 +4,7 @@ import * as axis from '../../src/compiler/axis';
 import {Model} from '../../src/compiler/Model';
 
 describe('Axis', function() {
-  var stats = {a: {distinct: 5}, b: {distinct: 32}},
-    layout = {
+  var layout = {
       cellWidth: 60,  // default characterWidth = 6
       cellHeight: 60
     };
@@ -30,7 +29,7 @@ describe('Axis', function() {
       y: {
         axisTitleOffset: 60
       }
-    }, stats);
+    });
 
     //FIXME decouple the test here
 
@@ -53,7 +52,7 @@ describe('Axis', function() {
           encoding: {
             x: {field: 'a', axis:{orient: 'bottom'}}
           }
-        }), 'x', {}, stats);
+        }), 'x', {});
       expect(orient).to.eql('bottom');
     });
 
@@ -62,7 +61,7 @@ describe('Axis', function() {
           encoding: {
             x: {field: 'a'}
           }
-        }), 'x', {}, stats);
+        }), 'x', {});
       expect(orient).to.eql(undefined);
     });
 
@@ -72,7 +71,7 @@ describe('Axis', function() {
             x: {field: 'a'},
             column: {field: 'a'}
           }
-        }), 'column', {}, stats);
+        }), 'column', {});
       expect(orient).to.eql('top');
     });
 
@@ -82,7 +81,7 @@ describe('Axis', function() {
             x: {field: 'a'},
             y: {field: 'b', type: 'ordinal'}
           }
-        }), 'x', {}, stats);
+        }), 'x', {});
       expect(orient).to.eql('top');
     });
   });

--- a/test/compiler/axis.test.ts
+++ b/test/compiler/axis.test.ts
@@ -74,16 +74,6 @@ describe('Axis', function() {
         }), 'column', {});
       expect(orient).to.eql('top');
     });
-
-    it('should return top for X with high cardinality, ordinal Y', function () {
-      var orient = axis.orient(new Model({
-          encoding: {
-            x: {field: 'a'},
-            y: {field: 'b', type: 'ordinal'}
-          }
-        }), 'x', {});
-      expect(orient).to.eql('top');
-    });
   });
 
   describe('title()', function () {


### PR DESCRIPTION
This removes logic for automatically putting x-axis on top if y has high cardinality.

We should move this logic to `vlplot.js` so it’s still applied in both voyager and polestar.
