### PR TITLE
Rename fieldRef => field

### DIFF
--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -125,13 +125,6 @@ export class Model {
     return vlFieldDef.fieldRef(this._spec.encoding[channel], opt);
   }
 
-  /*
-   * return key-value pairs of field name and list of fields of that field name
-   */
-  fields() {
-    return vlEncoding.fields(this._spec.encoding);
-  }
-
   fieldTitle(channel: Channel) {
     if (vlFieldDef.isCount(this._spec.encoding[channel])) {
       return vlFieldDef.COUNT_DISPLAYNAME;

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -14,7 +14,7 @@ import * as schema from '../schema/schema';
 import * as schemaUtil from '../schema/schemautil';
 import {StackProperties} from './stack';
 import {getFullName, NOMINAL, ORDINAL, TEMPORAL} from '../type';
-import * as util from '../util';
+import {duplicate} from '../util';
 import * as time from './time';
 
 /**
@@ -82,7 +82,7 @@ export class Model {
   }
 
   toSpec(excludeConfig?, excludeData?) {
-    var encoding = util.duplicate(this._spec.encoding),
+    var encoding = duplicate(this._spec.encoding),
       spec: any;
 
     spec = {
@@ -91,11 +91,11 @@ export class Model {
     };
 
     if (!excludeConfig) {
-      spec.config = util.duplicate(this._spec.config);
+      spec.config = duplicate(this._spec.config);
     }
 
     if (!excludeData) {
-      spec.data = util.duplicate(this._spec.data);
+      spec.data = duplicate(this._spec.data);
     }
 
     // remove defaults
@@ -190,7 +190,7 @@ export class Model {
     return vlEncoding.forEach(this._spec.encoding, f);
   }
 
-  // FIXME: remove this 
+  // FIXME: remove this
   isTypes(channel: Channel, type: Array<any>) {
     var fieldDef = this.fieldDef(channel);
     return fieldDef && vlFieldDef.isTypes(fieldDef, type);

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -137,7 +137,7 @@ export class Model {
   }
 
   // get "field" reference for vega
-  fieldRef(channel: Channel, opt?: FieldRefOption) {
+  field(channel: Channel, opt?: FieldRefOption) {
     opt = opt || {};
 
     const fieldDef = this.fieldDef(channel);

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -221,17 +221,6 @@ export class Model {
     return this.isAggregate() ? SUMMARY : SOURCE;
   }
 
-  // FIXME remove this
-  facets() {
-    var encoding = this;
-    return this.reduce(function(refs: string[], field: FieldDef, channel: Channel) {
-      if (!field.aggregate && (channel === ROW || channel === COLUMN)) {
-        refs.push(encoding.fieldRef(channel));
-      }
-      return refs;
-    }, []);
-  }
-
   data() {
     return this._spec.data;
   }

--- a/src/compiler/axis.ts
+++ b/src/compiler/axis.ts
@@ -1,6 +1,5 @@
 import {Model} from './Model';
-import {roundFloat} from '../util';
-import * as util from '../util';
+import {extend, roundFloat, truncate} from '../util';
 import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../type';
 import {COLUMN, ROW, X, Y, Channel} from '../channel';
 import * as time from './time';
@@ -177,7 +176,7 @@ export function title(model: Model, channel: Channel) {
     maxLength = layout.cellHeight / model.config('characterWidth');
   }
 
-  return maxLength ? util.truncate(fieldTitle, maxLength) : fieldTitle;
+  return maxLength ? truncate(fieldTitle, maxLength) : fieldTitle;
 }
 
 
@@ -198,7 +197,7 @@ namespace properties {
   export function axis(model: Model, channel: Channel, spec) {
     if (channel === ROW || channel === COLUMN) {
       // hide axis for facets
-      return util.extend({
+      return extend({
         opacity: {value: 0}
       }, spec || {});
     }
@@ -209,14 +208,14 @@ namespace properties {
     let fieldDef = model.fieldDef(channel);
     var timeUnit = fieldDef.timeUnit;
     if (fieldDef.type === TEMPORAL && timeUnit && (time.hasScale(timeUnit))) {
-      spec = util.extend({
+      spec = extend({
         text: {scale: 'time-' + timeUnit, field: 'data'}
       }, spec || {});
     }
 
     if (model.isTypes(channel, [NOMINAL, ORDINAL]) && fieldDef.axis.labelMaxLength) {
       // TODO replace this with Vega's labelMaxLength once it is introduced
-      spec = util.extend({
+      spec = extend({
         text: {
           template: '{{ datum.data | truncate:' + fieldDef.axis.labelMaxLength + '}}'
         }
@@ -227,7 +226,7 @@ namespace properties {
     switch (channel) {
       case X:
         if ((model.isDimension(X) || fieldDef.type === TEMPORAL)) {
-          spec = util.extend({
+          spec = extend({
             angle: {value: 270},
             align: {value: def.orient === 'top' ? 'left': 'right'},
             baseline: {value: 'middle'}
@@ -236,7 +235,7 @@ namespace properties {
         break;
       case ROW:
         if (def.orient === 'right') {
-          spec = util.extend({
+          spec = extend({
             angle: {value: 90},
             align: {value: 'center'},
             baseline: {value: 'bottom'}

--- a/src/compiler/axis.ts
+++ b/src/compiler/axis.ts
@@ -110,7 +110,7 @@ export function offset(model: Model, channel: Channel, def) {
   if ((channel === ROW && !model.has(Y)) ||
       (channel === COLUMN && !model.has(X))
     ) {
-    return model.config('cellGridOffset')
+    return model.config('cellGridOffset');
   }
   return undefined;
 }

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -10,7 +10,7 @@ import {compileLegends} from './legend';
 import {compileMarks} from './marks';
 import {compileScales} from './scale';
 import * as vlTime from './time';
-import * as util from '../util';
+import {extend} from '../util';
 
 import {LAYOUT} from '../data';
 import {COLUMN, ROW, X, Y, Channel} from '../channel';
@@ -43,7 +43,7 @@ export function compile(spec, theme?) {
   // Small Multiples
   if (model.has(ROW) || model.has(COLUMN)) {
     // put the marks inside a facet cell's group
-    util.extend(rootGroup, facetMixins(model, marks));
+    extend(rootGroup, facetMixins(model, marks));
   } else {
     rootGroup.marks = marks.map(function(marks) {
       marks.from = marks.from || {};

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -156,19 +156,13 @@ export namespace source {
    * @return {Array} An array that might contain a filter transform for filtering null value based on filterNul config
    */
   export function nullFilterTransform(model: Model) {
-    var filteredFields = util.reduce(model.fields(),
-      function(filteredFields, fieldList, fieldName) {
-        if (fieldName === '*') return filteredFields; //count
-
-        // TODO(#597) revise how filterNull is structured.
-        if ((model.config('filterNull').quantitative && fieldList.containsType[QUANTITATIVE]) ||
-            (model.config('filterNull').temporal && fieldList.containsType[TEMPORAL]) ||
-            (model.config('filterNull').ordinal && fieldList.containsType[ORDINAL]) ||
-            (model.config('filterNull').nominal && fieldList.containsType[NOMINAL])) {
-          filteredFields.push(fieldName);
-        }
-        return filteredFields;
-      }, []);
+    const filterNull = model.config('filterNull');
+    const filteredFields = util.keys(model.reduce(function(filteredFields, fieldDef: FieldDef) {
+      if (fieldDef.field && fieldDef.field !== '*' && filterNull[fieldDef.type]) {
+        filteredFields[fieldDef.field] = true;
+      }
+      return filteredFields;
+    }, {}));
 
     return filteredFields.length > 0 ?
       [{

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -347,7 +347,8 @@ export namespace stack {
   export function def(model: Model, stackProps: StackProperties):VgData {
     var groupbyChannel = stackProps.groupbyChannel;
     var fieldChannel = stackProps.fieldChannel;
-    var facets = model.facets();
+    var facetFields = (model.has(COLUMN) ? [model.fieldRef(COLUMN)] : [])
+                      .concat((model.has(ROW) ? [model.fieldRef(ROW)] : []))
 
     var stacked:VgData = {
       name: STACKED,
@@ -355,15 +356,15 @@ export namespace stack {
       transform: [{
         type: 'aggregate',
         // group by channel and other facets
-        groupby: [model.fieldRef(groupbyChannel)].concat(facets),
+        groupby: [model.fieldRef(groupbyChannel)].concat(facetFields),
         summarize: [{ops: ['sum'], field: model.fieldRef(fieldChannel)}]
       }]
     };
 
-    if (facets && facets.length > 0) {
+    if (facetFields && facetFields.length > 0) {
       stacked.transform.push({ //calculate max for each facet
         type: 'aggregate',
-        groupby: facets,
+        groupby: facetFields,
         summarize: [{
           ops: ['max'],
           // we want max of sum from above transform

--- a/src/compiler/facet.ts
+++ b/src/compiler/facet.ts
@@ -33,7 +33,7 @@ export function facetMixins(model: Model, marks) {
   let rootMarks = [], rootAxes = [], facetKeys = [], cellAxes = [];
   const hasRow = model.has(ROW), hasCol = model.has(COLUMN);
 
-  // TODO: add property to keep axes in cells even if row is encoded
+  // TODO(#90): add property to keep axes in cells even if row is encoded
   if (hasRow) {
     if (!model.isDimension(ROW)) {
       // TODO: add error to model instead
@@ -59,7 +59,7 @@ export function facetMixins(model: Model, marks) {
     }
   }
 
-  // TODO: add property to keep axes in cells even if column is encoded
+  // TODO(#90): add property to keep axes in cells even if column is encoded
   if (hasCol) {
     if (!model.isDimension(COLUMN)) {
       // TODO: add error to model instead

--- a/src/compiler/facet.ts
+++ b/src/compiler/facet.ts
@@ -41,10 +41,10 @@ export function facetMixins(model: Model, marks) {
     }
     facetGroupProperties.y = {
       scale: ROW,
-      field: model.fieldRef(ROW)
+      field: model.field(ROW)
     };
 
-    facetKeys.push(model.fieldRef(ROW));
+    facetKeys.push(model.field(ROW));
     rootAxes.push(compileAxis(ROW, model));
     if (model.has(X)) {
       // If has X, prepend a group for shared x-axes in the root group's marks
@@ -67,10 +67,10 @@ export function facetMixins(model: Model, marks) {
     }
     facetGroupProperties.x = {
       scale: COLUMN,
-      field: model.fieldRef(COLUMN)
+      field: model.field(COLUMN)
     };
 
-    facetKeys.push(model.fieldRef(COLUMN));
+    facetKeys.push(model.field(COLUMN));
     rootAxes.push(compileAxis(COLUMN, model));
 
     if (model.has(Y)) {
@@ -122,7 +122,7 @@ function getXAxesGroup(model: Model, cellWidth, hasCol: boolean) {
       update: {
         width: cellWidth,
         height: {field: {group: 'height'}},
-        x: hasCol ? {scale: COLUMN, field: model.fieldRef(COLUMN)} : {value: 0},
+        x: hasCol ? {scale: COLUMN, field: model.field(COLUMN)} : {value: 0},
         y: {value: - model.config('cellPadding') / 2}
       }
     },
@@ -132,7 +132,7 @@ function getXAxesGroup(model: Model, cellWidth, hasCol: boolean) {
     // FIXME facet is too expensive here - we only need to know unique columns
     xAxesGroup.from = {
       data: model.dataTable(),
-      transform: {type: 'facet', groupby: [model.fieldRef(COLUMN)]}
+      transform: {type: 'facet', groupby: [model.field(COLUMN)]}
     };
   }
   return xAxesGroup;
@@ -147,7 +147,7 @@ function getYAxesGroup(model: Model, cellHeight, hasRow: boolean) {
         width: {field: {group: 'width'}},
         height: cellHeight,
         x: {value: - model.config('cellPadding') / 2},
-        y: hasRow ? {scale: ROW, field: model.fieldRef(ROW)} : {value: 0}
+        y: hasRow ? {scale: ROW, field: model.field(ROW)} : {value: 0}
       }
     },
     axes: [compileAxis(Y, model)]
@@ -157,7 +157,7 @@ function getYAxesGroup(model: Model, cellHeight, hasRow: boolean) {
     // FIXME facet is too expensive here - we only need to know unique rows
     yAxesGroup.from = {
       data: model.dataTable(),
-      transform: {type: 'facet', groupby: [model.fieldRef(ROW)]}
+      transform: {type: 'facet', groupby: [model.field(ROW)]}
     };
   }
   return yAxesGroup;
@@ -171,13 +171,13 @@ function getRowRulesGroup(model: Model, cellHeight): any { // TODO: VgMarks
     type: 'rule',
     from: {
       data: 'summary',
-      transform: [{type: 'facet', groupby: [model.fieldRef(ROW)]}]
+      transform: [{type: 'facet', groupby: [model.field(ROW)]}]
     },
     properties: {
       update: {
         y: {
           scale: 'row',
-          field: model.fieldRef(ROW),
+          field: model.field(ROW),
           offset: (rowRulesOnTop ? -1 : 1) * offset
         },
         x: {value: 0, offset: -model.config('cellGridOffset')},
@@ -219,13 +219,13 @@ function getColumnRulesGroup(model: Model, cellWidth): any { // TODO: VgMarks
     type: 'rule',
     from: {
       data: 'summary',
-      transform: [{type: 'facet', groupby: [model.fieldRef(COLUMN)]}]
+      transform: [{type: 'facet', groupby: [model.field(COLUMN)]}]
     },
     properties: {
       update: {
         x: {
           scale: 'column',
-          field: model.fieldRef(COLUMN),
+          field: model.field(COLUMN),
           offset: (colRulesOnLeft ? -1 : 1) * offset
         },
         y: {value: 0, offset: -model.config('cellGridOffset')},

--- a/src/compiler/layout.ts
+++ b/src/compiler/layout.ts
@@ -1,5 +1,3 @@
-/// <reference path="../../typings/d3-format.d.ts"/>
-
 import {FieldDef} from '../schema/fielddef.schema';
 
 import {setter} from '../util';

--- a/src/compiler/layout.ts
+++ b/src/compiler/layout.ts
@@ -1,12 +1,10 @@
-import {FieldDef} from '../schema/fielddef.schema';
-
-import {setter} from '../util';
-import {COLUMN, ROW, X, Y, TEXT, Channel} from '../channel';
-import {LAYOUT} from '../data';
 import {Model} from './Model';
 import * as time from './time';
+
+import {FieldDef} from '../schema/fielddef.schema';
+import {COLUMN, ROW, X, Y, TEXT, Channel} from '../channel';
+import {LAYOUT} from '../data';
 import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../type';
-import {roundFloat} from '../util';
 
 interface DataRef {
   data?: string;

--- a/src/compiler/legend.ts
+++ b/src/compiler/legend.ts
@@ -1,4 +1,4 @@
-import * as util from '../util';
+import {extend, keys} from '../util';
 import {COLOR, SIZE, SHAPE, Channel} from '../channel';
 import {Model} from './Model';
 import * as time from './time';
@@ -70,7 +70,7 @@ namespace properties {
     var fieldDef = model.fieldDef(channel);
     var timeUnit = fieldDef.timeUnit;
     if (fieldDef.type === TEMPORAL && timeUnit && time.hasScale(timeUnit)) {
-      return util.extend({
+      return extend({
         text: {
           scale: 'time-'+ timeUnit
         }
@@ -126,8 +126,8 @@ namespace properties {
       symbols.opacity = {value: opacity};
     }
 
-    symbols = util.extend(symbols, spec || {});
+    symbols = extend(symbols, spec || {});
 
-    return util.keys(symbols).length > 0 ? symbols : undefined;
+    return keys(symbols).length > 0 ? symbols : undefined;
   }
 }

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -27,7 +27,7 @@ export function compileMarks(model: Model): any[] {
     let sortBy = marktype === LINE ? model.config('sortLineBy') : undefined;
     if (!sortBy) {
       const sortField = (model.isMeasure(X) && model.isDimension(Y)) ? Y : X;
-      sortBy = '-' + model.fieldRef(sortField);
+      sortBy = '-' + model.field(sortField);
     }
 
     let pathMarks: any = {
@@ -109,7 +109,7 @@ export function compileMarks(model: Model): any[] {
 function detailFields(model:Model): string[] {
   return [COLOR, DETAIL, SHAPE].reduce(function(details, channel) {
     if (model.has(channel) && !model.fieldDef(channel).aggregate) {
-      details.push(model.fieldRef(channel));
+      details.push(model.field(channel));
     }
     return details;
   }, []);
@@ -126,26 +126,26 @@ export function bar(model: Model) {
   if (stack && X === stack.fieldChannel) {
     p.x = {
       scale: X,
-      field: model.fieldRef(X) + '_start'
+      field: model.field(X) + '_start'
     };
     p.x2 = {
       scale: X,
-      field: model.fieldRef(X) + '_end'
+      field: model.field(X) + '_end'
     };
   } else if (model.fieldDef(X).bin) {
     p.x = {
       scale: X,
-      field: model.fieldRef(X, {binSuffix: '_start'}),
+      field: model.field(X, {binSuffix: '_start'}),
       offset: 1
     };
     p.x2 = {
       scale: X,
-      field: model.fieldRef(X, {binSuffix: '_end'})
+      field: model.field(X, {binSuffix: '_end'})
     };
   } else if (model.isMeasure(X)) {
     p.x = {
       scale: X,
-      field: model.fieldRef(X)
+      field: model.field(X)
     };
     if (!model.has(Y) || model.isDimension(Y)) {
       p.x2 = {value: 0};
@@ -154,7 +154,7 @@ export function bar(model: Model) {
     if (model.has(X)) { // is ordinal
        p.xc = {
          scale: X,
-         field: model.fieldRef(X)
+         field: model.field(X)
        };
     } else {
        p.x = {value: 0, offset: model.config('singleBarOffset')};
@@ -167,7 +167,7 @@ export function bar(model: Model) {
       if (model.has(SIZE)) {
         p.width = {
           scale: SIZE,
-          field: model.fieldRef(SIZE)
+          field: model.field(SIZE)
         };
       } else {
         p.width = {
@@ -184,33 +184,33 @@ export function bar(model: Model) {
   if (stack && Y === stack.fieldChannel) {
     p.y = {
       scale: Y,
-      field: model.fieldRef(Y) + '_start'
+      field: model.field(Y) + '_start'
     };
     p.y2 = {
       scale: Y,
-      field: model.fieldRef(Y) + '_end'
+      field: model.field(Y) + '_end'
     };
   } else if (model.fieldDef(Y).bin) {
     p.y = {
       scale: Y,
-      field: model.fieldRef(Y, {binSuffix: '_start'})
+      field: model.field(Y, {binSuffix: '_start'})
     };
     p.y2 = {
       scale: Y,
-      field: model.fieldRef(Y, {binSuffix: '_end'}),
+      field: model.field(Y, {binSuffix: '_end'}),
       offset: 1
     };
   } else if (model.isMeasure(Y)) {
     p.y = {
       scale: Y,
-      field: model.fieldRef(Y)
+      field: model.field(Y)
     };
     p.y2 = {field: {group: 'height'}};
   } else {
     if (model.has(Y)) { // is ordinal
       p.yc = {
         scale: Y,
-        field: model.fieldRef(Y)
+        field: model.field(Y)
       };
     } else {
       p.y2 = {
@@ -222,7 +222,7 @@ export function bar(model: Model) {
     if (model.has(SIZE)) {
       p.height = {
         scale: SIZE,
-        field: model.fieldRef(SIZE)
+        field: model.field(SIZE)
       };
     } else {
       p.height = {
@@ -236,7 +236,7 @@ export function bar(model: Model) {
   if (model.has(COLOR)) {
     p.fill = {
       scale: COLOR,
-      field: model.fieldRef(COLOR)
+      field: model.field(COLOR)
     };
   } else {
     p.fill = {value: model.fieldDef(COLOR).value};
@@ -257,7 +257,7 @@ export function point(model: Model) {
   if (model.has(X)) {
     p.x = {
       scale: X,
-      field: model.fieldRef(X, {binSuffix: '_mid'})
+      field: model.field(X, {binSuffix: '_mid'})
     };
   } else if (!model.has(X)) {
     p.x = {value: model.bandWidth(X) / 2};
@@ -267,7 +267,7 @@ export function point(model: Model) {
   if (model.has(Y)) {
     p.y = {
       scale: Y,
-      field: model.fieldRef(Y, {binSuffix: '_mid'})
+      field: model.field(Y, {binSuffix: '_mid'})
     };
   } else if (!model.has(Y)) {
     p.y = {value: model.bandWidth(Y) / 2};
@@ -277,7 +277,7 @@ export function point(model: Model) {
   if (model.has(SIZE)) {
     p.size = {
       scale: SIZE,
-      field: model.fieldRef(SIZE)
+      field: model.field(SIZE)
     };
   } else if (!model.has(SIZE)) {
     p.size = {value: model.fieldDef(SIZE).value};
@@ -287,7 +287,7 @@ export function point(model: Model) {
   if (model.has(SHAPE)) {
     p.shape = {
       scale: SHAPE,
-      field: model.fieldRef(SHAPE)
+      field: model.field(SHAPE)
     };
   } else if (!model.has(SHAPE)) {
     p.shape = {value: model.fieldDef(SHAPE).value};
@@ -298,7 +298,7 @@ export function point(model: Model) {
     if (model.has(COLOR)) {
       p.fill = {
         scale: COLOR,
-        field: model.fieldRef(COLOR)
+        field: model.field(COLOR)
       };
     } else if (!model.has(COLOR)) {
       p.fill = {value: model.fieldDef(COLOR).value};
@@ -307,7 +307,7 @@ export function point(model: Model) {
     if (model.has(COLOR)) {
       p.stroke = {
         scale: COLOR,
-        field: model.fieldRef(COLOR)
+        field: model.field(COLOR)
       };
     } else if (!model.has(COLOR)) {
       p.stroke = {value: model.fieldDef(COLOR).value};
@@ -332,7 +332,7 @@ export function line(model: Model) {
   if (model.has(X)) {
     p.x = {
       scale: X,
-      field: model.fieldRef(X, {binSuffix: '_mid'})
+      field: model.field(X, {binSuffix: '_mid'})
     };
   } else if (!model.has(X)) {
     p.x = {value: 0};
@@ -342,7 +342,7 @@ export function line(model: Model) {
   if (model.has(Y)) {
     p.y = {
       scale: Y,
-      field: model.fieldRef(Y, {binSuffix: '_mid'})
+      field: model.field(Y, {binSuffix: '_mid'})
     };
   } else if (!model.has(Y)) {
     p.y = {field: {group: 'height'}};
@@ -352,7 +352,7 @@ export function line(model: Model) {
   if (model.has(COLOR)) {
     p.stroke = {
       scale: COLOR,
-      field: model.fieldRef(COLOR)
+      field: model.field(COLOR)
     };
   } else if (!model.has(COLOR)) {
     p.stroke = {value: model.fieldDef(COLOR).value};
@@ -377,14 +377,14 @@ export function area(model: Model) {
   if (stack && X === stack.fieldChannel) {
     p.x = {
       scale: X,
-      field: model.fieldRef(X) + '_start'
+      field: model.field(X) + '_start'
     };
     p.x2 = {
       scale: X,
-      field: model.fieldRef(X) + '_end'
+      field: model.field(X) + '_end'
     };
   } else if (model.isMeasure(X)) {
-    p.x = {scale: X, field: model.fieldRef(X)};
+    p.x = {scale: X, field: model.field(X)};
     if (model.isDimension(Y)) {
       p.x2 = {
         scale: X,
@@ -395,7 +395,7 @@ export function area(model: Model) {
   } else if (model.has(X)) {
     p.x = {
       scale: X,
-      field: model.fieldRef(X, {binSuffix: '_mid'})
+      field: model.field(X, {binSuffix: '_mid'})
     };
   } else {
     p.x = {value: 0};
@@ -405,16 +405,16 @@ export function area(model: Model) {
   if (stack && Y === stack.fieldChannel) {
     p.y = {
       scale: Y,
-      field: model.fieldRef(Y) + '_start'
+      field: model.field(Y) + '_start'
     };
     p.y2 = {
       scale: Y,
-      field: model.fieldRef(Y) + '_end'
+      field: model.field(Y) + '_end'
     };
   } else if (model.isMeasure(Y)) {
     p.y = {
       scale: Y,
-      field: model.fieldRef(Y)
+      field: model.field(Y)
     };
     p.y2 = {
       scale: Y,
@@ -423,7 +423,7 @@ export function area(model: Model) {
   } else if (model.has(Y)) {
     p.y = {
       scale: Y,
-      field: model.fieldRef(Y, {binSuffix: '_mid'})
+      field: model.field(Y, {binSuffix: '_mid'})
     };
   } else {
     p.y = {field: {group: 'height'}};
@@ -433,7 +433,7 @@ export function area(model: Model) {
   if (model.has(COLOR)) {
     p.fill = {
       scale: COLOR,
-      field: model.fieldRef(COLOR)
+      field: model.field(COLOR)
     };
   } else if (!model.has(COLOR)) {
     p.fill = {value: model.fieldDef(COLOR).value};
@@ -455,7 +455,7 @@ export function tick(model: Model) {
   if (model.has(X)) {
     p.x = {
       scale: X,
-      field: model.fieldRef(X, {binSuffix: '_mid'})
+      field: model.field(X, {binSuffix: '_mid'})
     };
     if (model.isDimension(X)) {
       p.x.offset = -model.bandWidth(X) / 3;
@@ -468,7 +468,7 @@ export function tick(model: Model) {
   if (model.has(Y)) {
     p.y = {
       scale: Y,
-      field: model.fieldRef(Y, {binSuffix: '_mid'})
+      field: model.field(Y, {binSuffix: '_mid'})
     };
     if (model.isDimension(Y)) {
       p.y.offset = -model.bandWidth(Y) / 3;
@@ -497,7 +497,7 @@ export function tick(model: Model) {
   if (model.has(COLOR)) {
     p.fill = {
       scale: COLOR,
-      field: model.fieldRef(COLOR)
+      field: model.field(COLOR)
     };
   } else {
     p.fill = {value: model.fieldDef(COLOR).value};
@@ -520,7 +520,7 @@ function filled_point_props(shape) {
     if (model.has(X)) {
       p.x = {
         scale: X,
-        field: model.fieldRef(X, {binSuffix: '_mid'})
+        field: model.field(X, {binSuffix: '_mid'})
       };
     } else if (!model.has(X)) {
       p.x = {value: model.bandWidth(X) / 2};
@@ -530,7 +530,7 @@ function filled_point_props(shape) {
     if (model.has(Y)) {
       p.y = {
         scale: Y,
-        field: model.fieldRef(Y, {binSuffix: '_mid'})
+        field: model.field(Y, {binSuffix: '_mid'})
       };
     } else if (!model.has(Y)) {
       p.y = {value: model.bandWidth(Y) / 2};
@@ -540,7 +540,7 @@ function filled_point_props(shape) {
     if (model.has(SIZE)) {
       p.size = {
         scale: SIZE,
-        field: model.fieldRef(SIZE)
+        field: model.field(SIZE)
       };
     } else if (!model.has(X)) {
       p.size = {value: model.fieldDef(SIZE).value};
@@ -553,7 +553,7 @@ function filled_point_props(shape) {
     if (model.has(COLOR)) {
       p.fill = {
         scale: COLOR,
-        field: model.fieldRef(COLOR)
+        field: model.field(COLOR)
       };
     } else if (!model.has(COLOR)) {
       p.fill = {value: model.fieldDef(COLOR).value};
@@ -577,7 +577,7 @@ export function textBackground(model: Model) {
     y: {value: 0},
     width: {field: {group: 'width'}},
     height: {field: {group: 'height'}},
-    fill: {scale: COLOR, field: model.fieldRef(COLOR)}
+    fill: {scale: COLOR, field: model.field(COLOR)}
   };
 }
 
@@ -590,7 +590,7 @@ export function text(model: Model) {
   if (model.has(X)) {
     p.x = {
       scale: X,
-      field: model.fieldRef(X, {binSuffix: '_mid'})
+      field: model.field(X, {binSuffix: '_mid'})
     };
   } else if (!model.has(X)) {
     if (model.has(TEXT) && model.fieldDef(TEXT).type === QUANTITATIVE) {
@@ -604,7 +604,7 @@ export function text(model: Model) {
   if (model.has(Y)) {
     p.y = {
       scale: Y,
-      field: model.fieldRef(Y, {binSuffix: '_mid'})
+      field: model.field(Y, {binSuffix: '_mid'})
     };
   } else if (!model.has(Y)) {
     p.y = {value: model.bandWidth(Y) / 2};
@@ -614,7 +614,7 @@ export function text(model: Model) {
   if (model.has(SIZE)) {
     p.fontSize = {
       scale: SIZE,
-      field: model.fieldRef(SIZE)
+      field: model.field(SIZE)
     };
   } else if (!model.has(SIZE)) {
     p.fontSize = {value: fieldDef.font.size};
@@ -637,11 +637,11 @@ export function text(model: Model) {
       var numberFormat = fieldDef.format !== undefined ?
                          fieldDef.format : model.numberFormat(TEXT);
 
-      p.text = {template: '{{' + model.fieldRef(TEXT, {datum: true}) + ' | number:\'' +
+      p.text = {template: '{{' + model.field(TEXT, {datum: true}) + ' | number:\'' +
         numberFormat +'\'}}'};
       p.align = {value: fieldDef.align};
     } else {
-      p.text = {field: model.fieldRef(TEXT)};
+      p.text = {field: model.field(TEXT)};
     }
   } else {
     p.text = {value: fieldDef.placeholder};

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -78,7 +78,7 @@ export function domain(model: Model, channel:Channel, type) {
     const facet = model.has(ROW) || model.has(COLUMN);
     return {
       data: STACKED,
-      field: model.fieldRef(channel, {
+      field: model.field(channel, {
         // If faceted, scale is determined by the max of sum in each facet.
         prefn: (facet ? 'max_' : '') + 'sum_'
       })
@@ -91,7 +91,7 @@ export function domain(model: Model, channel:Channel, type) {
   if (useRawDomain) { // useRawDomain - only Q/T
     return {
       data: SOURCE,
-      field: model.fieldRef(channel, {noAggregate:true})
+      field: model.field(channel, {noAggregate:true})
     };
   } else if (fieldDef.bin) { // bin
 
@@ -99,11 +99,11 @@ export function domain(model: Model, channel:Channel, type) {
       data: model.dataTable(),
       field: type === 'ordinal' ?
         // ordinal scale only use bin start for now
-        model.fieldRef(channel, { binSuffix: '_start' }) :
+        model.field(channel, { binSuffix: '_start' }) :
         // need to merge both bin_start and bin_end for non-ordinal scale
         [
-          model.fieldRef(channel, { binSuffix: '_start' }),
-          model.fieldRef(channel, { binSuffix: '_end' })
+          model.field(channel, { binSuffix: '_start' }),
+          model.field(channel, { binSuffix: '_end' })
         ]
     };
   } else if (sort) { // have sort -- only for ordinal
@@ -111,13 +111,13 @@ export function domain(model: Model, channel:Channel, type) {
       // If sort by aggregation of a specified sort field, we need to use SOURCE table,
       // so we can aggregate values for the scale independently from the main aggregation.
       data: sort.op ? SOURCE : model.dataTable(),
-      field: model.fieldRef(channel),
+      field: model.field(channel),
       sort: sort
     };
   } else {
     return {
       data: model.dataTable(),
-      field: model.fieldRef(channel)
+      field: model.field(channel)
     };
   }
 }

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -1,7 +1,7 @@
 // https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#11-ambient-declarations
 declare var exports;
 
-import * as util from '../util';
+import {extend, isObject} from '../util';
 import {Model} from './Model';
 import {SHARED_DOMAIN_OPS} from '../aggregate';
 import {COLUMN, ROW, X, Y, SHAPE, SIZE, COLOR, TEXT, Channel} from '../channel';
@@ -17,7 +17,7 @@ export function compileScales(names: Array<string>, model: Model) {
     };
 
     scaleDef.domain = domain(model, channel, scaleDef.type);
-    util.extend(scaleDef, rangeMixins(model, channel, scaleDef.type));
+    extend(scaleDef, rangeMixins(model, channel, scaleDef.type));
 
     // Add optional properties
     [
@@ -129,7 +129,7 @@ export function domainSort(model: Model, channel: Channel, type):any {
   }
 
   // Sorted based on an aggregate calculation over a specified sort field (only for ordinal scale)
-  if (type === 'ordinal' && util.isObject(sort)) {
+  if (type === 'ordinal' && isObject(sort)) {
     return {
       op: sort.op,
       field: sort.field

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -1,11 +1,5 @@
-/// <reference path="../../typings/colorbrewer.d.ts"/>
-/// <reference path="../../typings/d3-color.d.ts"/>
-
 // https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#11-ambient-declarations
 declare var exports;
-
-import * as colorbrewer from 'colorbrewer';
-import {interpolateHsl} from 'd3-color';
 
 import * as util from '../util';
 import {Model} from './Model';

--- a/src/compiler/stack.ts
+++ b/src/compiler/stack.ts
@@ -1,6 +1,6 @@
 import {Model} from './Model';
 import {Channel} from '../channel';
-import * as util from '../util';
+import {isObject} from '../util';
 
 export interface StackProperties {
   groupbyChannel: Channel;
@@ -38,7 +38,7 @@ export function stackTransform(model: Model) {
                    '-' + model.fieldRef(stack.stackChannel) :
                  stack.config.sort === 'ascending' ?
                    model.fieldRef(stack.stackChannel) :
-                 util.isObject(stack.config.sort) ?
+                 isObject(stack.config.sort) ?
                    stack.config.sort :
                    '-' + model.fieldRef(stack.stackChannel); // default
 

--- a/src/compiler/stack.ts
+++ b/src/compiler/stack.ts
@@ -20,13 +20,13 @@ interface StackTransform {
 }
 
 // impute data for stacked area
-export function imputeTransform(model) {
+export function imputeTransform(model: Model) {
   const stack = model.stack();
   return {
     type: 'impute',
-    field: model.fieldRef(stack.fieldChannel),
-    groupby: [model.fieldRef(stack.stackChannel)],
-    orderby: [model.fieldRef(stack.groupbyChannel)],
+    field: model.field(stack.fieldChannel),
+    groupby: [model.field(stack.stackChannel)],
+    orderby: [model.field(stack.groupbyChannel)],
     method: 'value',
     value: 0
   };
@@ -35,20 +35,20 @@ export function imputeTransform(model) {
 export function stackTransform(model: Model) {
   const stack = model.stack();
   const sortby = stack.config.sort === 'descending' ?
-                   '-' + model.fieldRef(stack.stackChannel) :
+                   '-' + model.field(stack.stackChannel) :
                  stack.config.sort === 'ascending' ?
-                   model.fieldRef(stack.stackChannel) :
+                   model.field(stack.stackChannel) :
                  isObject(stack.config.sort) ?
                    stack.config.sort :
-                   '-' + model.fieldRef(stack.stackChannel); // default
+                   '-' + model.field(stack.stackChannel); // default
 
-  const valName = model.fieldRef(stack.fieldChannel);
+  const valName = model.field(stack.fieldChannel);
 
   // add stack transform to mark
   var transform: StackTransform = {
     type: 'stack',
-    groupby: [model.fieldRef(stack.groupbyChannel)],
-    field: model.fieldRef(stack.fieldChannel),
+    groupby: [model.field(stack.groupbyChannel)],
+    field: model.field(stack.fieldChannel),
     sortby: sortby,
     output: {
       start: valName + '_start',

--- a/src/compiler/time.ts
+++ b/src/compiler/time.ts
@@ -32,10 +32,10 @@ export function cardinality(fieldDef: FieldDef, stats, filterNull, type) {
   return null;
 }
 
-export function formula(timeUnit, fieldRef: string) {
+export function formula(timeUnit, field: string) {
   // TODO(kanitw): add formula to other time format
   var fn = 'utc' + timeUnit;
-  return fn + '(' + fieldRef + ')';
+  return fn + '(' + field + ')';
 }
 
 export function range(timeUnit, model: Model) {

--- a/src/compiler/time.ts
+++ b/src/compiler/time.ts
@@ -1,7 +1,3 @@
-/// <reference path="../../typings/d3-time-format.d.ts"/>
-
-import {utcFormat} from 'd3-time-format';
-
 import {Model} from './Model';
 import {FieldDef} from '../schema/fielddef.schema';
 import * as vlFieldDef from '../fielddef';
@@ -40,30 +36,6 @@ export function formula(timeUnit, fieldRef: string) {
   // TODO(kanitw): add formula to other time format
   var fn = 'utc' + timeUnit;
   return fn + '(' + fieldRef + ')';
-}
-
-export function maxLength(timeUnit, model: Model) {
-  switch (timeUnit) {
-    case 'seconds':
-    case 'minutes':
-    case 'hours':
-    case 'date':
-      return 2;
-    case 'month':
-    case 'day':
-      var rng = range(timeUnit, model);
-      if (rng) {
-        // return the longest name in the range
-        return Math.max.apply(null, rng.map(function(r) {return r.length;}));
-      }
-      return 2;
-    case 'year':
-      return 4; //'1998'
-  }
-  // TODO(#600) revise this
-  // no time unit
-  var timeFormat = model.config('timeFormat');
-  return utcFormat(timeFormat)(LONG_DATE).length;
 }
 
 export function range(timeUnit, model: Model) {

--- a/src/data.ts
+++ b/src/data.ts
@@ -20,6 +20,7 @@ export const types = {
   'string': NOMINAL
 };
 
+// TODO: remove this
 export function stats(data: Array<Array<any>>) {
   var summary = util.summary(data);
 

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,10 +1,7 @@
 // utility for encoding mapping
 import {Encoding} from './schema/encoding.schema';
 import {FieldDef} from './schema/fielddef.schema';
-
 import {Channel, CHANNELS} from './channel';
-import * as vlFieldDef from './fielddef';
-import * as util from './util';
 
 export function countRetinal(encoding: Encoding) {
   var count = 0;

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -57,21 +57,3 @@ export function reduce(encoding: Encoding,
   });
   return r;
 }
-
-// FIXME: revise this / consider if we should remove
-/**
- * return key-value pairs of field name and list of fields of that field name
- */
-export function fields(encoding: Encoding) {
-  return reduce(encoding, function (m, fieldDef: FieldDef) {
-    var fieldList = m[fieldDef.field] = m[fieldDef.field] || [];
-    var containsType = fieldList.containsType = fieldList.containsType || {};
-
-    if (fieldList.indexOf(fieldDef) === -1) {
-      fieldList.push(fieldDef);
-      // augment the array with containsType.Q / O / N / T
-      containsType[fieldDef.type] = true;
-    }
-    return m;
-  }, {});
-}

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -10,43 +10,6 @@ import * as time from './compiler/time';
 import {TIMEUNITS} from './timeunit';
 import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL, SHORT_TYPE, TYPE_FROM_SHORT_TYPE} from './type';
 
-export interface FieldRefOption {
-  /** exclude bin, aggregate, timeUnit */
-  nofn?: boolean;
-  /** exclude aggregation function */
-  noAggregate?: boolean;
-  /** include 'datum.' */
-  datum?: boolean;
-  /** replace fn with custom function prefix */
-  fn?: string;
-  /** prepend fn with custom function prefix */
-  prefn?: string;
-  /** append suffix to the field ref for bin (default='_start') */
-  binSuffix?: string;
-}
-
-export function fieldRef(fieldDef: FieldDef, opt?: FieldRefOption) {
-  opt = opt || {};
-
-  var f = (opt.datum ? 'datum.' : '') + (opt.prefn || ''),
-    field = fieldDef.field;
-
-  if (isCount(fieldDef)) {
-    return f + 'count';
-  } else if (opt.fn) {
-    return f + opt.fn + '_' + field;
-  } else if (!opt.nofn && fieldDef.bin) {
-    var binSuffix = opt.binSuffix || '_start';
-    return f + 'bin_' + field + binSuffix;
-  } else if (!opt.nofn && !opt.noAggregate && fieldDef.aggregate) {
-    return f + fieldDef.aggregate + '_' + field;
-  } else if (!opt.nofn && fieldDef.timeUnit) {
-    return f + fieldDef.timeUnit + '_' + field;
-  }  else {
-    return f + field;
-  }
-}
-
 export function isTypes(fieldDef: FieldDef, types: Array<String>) {
   for (var t = 0; t < types.length; t++) {
     if (fieldDef.type === types[t]) {

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -5,7 +5,7 @@ import {Bin} from './schema/bin.schema';
 
 import {MAXBINS_DEFAULT} from './bin';
 import {AGGREGATE_OPS} from './aggregate';
-import * as util from './util';
+import {getbins} from './util';
 import * as time from './compiler/time';
 import {TIMEUNITS} from './timeunit';
 import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL, SHORT_TYPE, TYPE_FROM_SHORT_TYPE} from './type';
@@ -92,7 +92,7 @@ export function cardinality(fieldDef: FieldDef, stats, filterNull = {}) {
     const bin = fieldDef.bin;
     const maxbins = (typeof bin === 'boolean') ? MAXBINS_DEFAULT : bin.maxbins;
 
-    var bins = util.getbins(stat, maxbins);
+    var bins = getbins(stat, maxbins);
     return (bins.stop - bins.start) / bins.step;
   }
   if (fieldDef.type === TEMPORAL) {

--- a/src/shorthand.ts
+++ b/src/shorthand.ts
@@ -7,7 +7,6 @@ import {Spec} from './schema/schema';
 import {AGGREGATE_OPS} from './aggregate';
 import {TIMEUNITS} from './timeunit';
 import {SHORT_TYPE, TYPE_FROM_SHORT_TYPE} from './type';
-import * as util from './util';
 import * as vlEncoding from './encoding';
 
 export const DELIM = '|';

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -1,7 +1,7 @@
 /* Utilities for a Vega-Lite specificiation */
 
 import * as vlEncoding from './encoding';
-import * as util from './util';
+import {duplicate} from './util';
 import {Model} from './compiler/Model';
 import {Spec} from './schema/schema';
 import {COLOR, DETAIL} from './channel';
@@ -29,7 +29,7 @@ export function isStack(spec: Spec): boolean {
 // TODO revise
 export function transpose(spec: Spec): Spec {
   var oldenc = spec.encoding,
-    encoding = util.duplicate(spec.encoding);
+    encoding = duplicate(spec.encoding);
   encoding.x = oldenc.y;
   encoding.y = oldenc.x;
   encoding.row = oldenc.column;

--- a/test/compiler/time.test.ts
+++ b/test/compiler/time.test.ts
@@ -19,24 +19,4 @@ describe('time', function() {
       return scale.name === 'time-'+ timeUnit;
     }).length).to.equal(1);
   });
-
-  describe('maxLength', function() {
-    it('should return max length of the month custom scale', function () {
-      expect(time.maxLength('month', new Model({marktype: 'point'})))
-        .to.eql(3);
-    });
-
-    it('should return max length of the day custom scale', function () {
-      expect(time.maxLength('day', new Model({marktype: 'point'})))
-        .to.eql(3);
-    });
-
-    it('should return max length of the month custom scale', function () {
-      expect(time.maxLength('month', new Model({
-        config: {
-          timeScaleLabelLength: 0
-        }
-      }))).to.eql(9);
-    });
-  });
 });

--- a/typings/datalib.d.ts
+++ b/typings/datalib.d.ts
@@ -3,7 +3,6 @@ declare module "datalib/src/util" {
   export function extend(a, b, c?);
   export function duplicate(a);
   export function isArray(a);
-  export function range(a, b?);
   export function vals(a);
   export function truncate(a:string, length: number);
   export function toMap(a);
@@ -11,6 +10,7 @@ declare module "datalib/src/util" {
 }
 
 declare module "datalib/src/generate" {
+  export function range(a, b?);
 }
 
 declare module "datalib/src/stats" {


### PR DESCRIPTION
Formerly the helper method for vega’s field is called `fieldRef` since `field` in Vega-Lite used to refer to what we currently call `fieldDef`.  Since now `field` in Vega-Lite refers to the same thing as Vega, there is no reason to name the method differently.  

Also moved field() from `fieldDef.ts` to `model.ts` since it’s internal only.  

Please merge #804 first !  (See [Branch Specific Diff](https://github.com/uwdata/vega-lite/compare/kw/refactor...kw/field))