### PR TITLE
Revise config 

### DIFF
--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -173,23 +173,6 @@ export class Model {
     }
   }
 
-  bandWidth(channel: Channel) {
-    if (this.fieldDef(channel).scale.bandWidth !== undefined) {
-      // explicit value
-      return this.fieldDef(channel).scale.bandWidth;
-    }
-    // If not specified, draw value from config.
-    return this.config('bandWidth');
-  }
-
-  padding(channel: Channel) {
-    if (this.fieldDef(channel).scale.padding !== undefined) {
-      // explicit value
-      return this.fieldDef(channel).scale.padding;
-    }
-    return channel === X || channel === Y ? this.config('padding') : undefined;
-  }
-
   // returns false if binning is disabled, otherwise an object with binning properties
   bin(channel: Channel): Bin | boolean {
     var bin = this._spec.encoding[channel].bin;

--- a/src/compiler/axis.ts
+++ b/src/compiler/axis.ts
@@ -109,7 +109,7 @@ export function offset(model: Model, channel: Channel, def) {
   if ((channel === ROW && !model.has(Y)) ||
       (channel === COLUMN && !model.has(X))
     ) {
-    return model.config('cellGridOffset');
+    return model.config('cell').gridOffset;
   }
   return undefined;
 }

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -68,10 +68,10 @@ export function compile(spec, theme?) {
     rootGroup.legends = legends;
   }
 
+  // FIXME replace FIT with appropriate mechanism once Vega has it
   const FIT = 1;
   // TODO: change type to become VgSpec
   var output = {
-      // FIXME replace 'singleWidth|Height' below with 'auto' once Vega has it.
       width: layout.width.field ? FIT : layout.width,
       height: layout.height.field ? FIT : layout.height,
       padding: 'auto',

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -68,13 +68,12 @@ export function compile(spec, theme?) {
     rootGroup.legends = legends;
   }
 
-
-
+  const FIT = 1;
   // TODO: change type to become VgSpec
   var output = {
       // FIXME replace 'singleWidth|Height' below with 'auto' once Vega has it.
-      width: layout.width.field ? model.config('singleWidth') : layout.width,
-      height: layout.height.field ? model.config('singleHeight') : layout.height,
+      width: layout.width.field ? FIT : layout.width,
+      height: layout.height.field ? FIT : layout.height,
       padding: 'auto',
       data: compileData(model),
       marks: [rootGroup]

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -204,7 +204,7 @@ export namespace layout {
       formulas.push({
         type: 'formula',
         field: 'cellWidth',
-        // (xCardinality + model.padding(X)) * model.fieldDef(X).scale.bandWidth
+        // (xCardinality + model.padding(X)) * xBandWidth
         expr: '(' + model.field(X, {datum: true, prefn: 'distinct_'}) + ' + ' +
               xScale.padding + ') * ' + xScale.bandWidth
       });
@@ -220,7 +220,7 @@ export namespace layout {
       formulas.push({
         type: 'formula',
         field: 'cellHeight',
-        // (yCardinality + model.padding(Y)) * model.fieldDef(Y).scale.bandWidth
+        // (yCardinality + model.padding(Y)) * yBandWidth
         expr: '(' + model.field(Y, {datum: true, prefn: 'distinct_'}) + ' + ' +
               yScale.padding + ') * ' + yScale.bandWidth
       });

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -223,7 +223,7 @@ export namespace layout {
       });
     }
 
-    const cellPadding = model.config('cellPadding');
+    const cellPadding = model.config('cell').padding;
     const layout = model.layout();
 
     if (model.has(COLUMN)) {

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -200,12 +200,13 @@ export namespace layout {
         field: model.field(X),
         ops: ['distinct']
       });
+      const xScale = model.fieldDef(X).scale;
       formulas.push({
         type: 'formula',
         field: 'cellWidth',
-        // (xCardinality + model.padding(X)) * model.bandWidth(X)
+        // (xCardinality + model.padding(X)) * model.fieldDef(X).scale.bandWidth
         expr: '(' + model.field(X, {datum: true, prefn: 'distinct_'}) + ' + ' +
-              model.padding(X) + ') * ' + model.bandWidth(X)
+              xScale.padding + ') * ' + xScale.bandWidth
       });
     }
 
@@ -214,12 +215,14 @@ export namespace layout {
         field: model.field(Y),
         ops: ['distinct']
       });
+
+      const yScale = model.fieldDef(Y).scale;
       formulas.push({
         type: 'formula',
         field: 'cellHeight',
-        // (yCardinality + model.padding(Y)) * model.bandWidth(Y)
+        // (yCardinality + model.padding(Y)) * model.fieldDef(Y).scale.bandWidth
         expr: '(' + model.field(Y, {datum: true, prefn: 'distinct_'}) + ' + ' +
-              model.padding(Y) + ') * ' + model.bandWidth(Y)
+              yScale.padding + ') * ' + yScale.bandWidth
       });
     }
 

--- a/src/compiler/facet.ts
+++ b/src/compiler/facet.ts
@@ -27,7 +27,7 @@ export function facetMixins(model: Model, marks) {
   let facetGroupProperties: any = {
     width: cellWidth,
     height: cellHeight,
-    fill: {value: model.config('cellBackgroundColor')}
+    fill: {value: model.config('cell').fill}
   };
 
   let rootMarks = [], rootAxes = [], facetKeys = [], cellAxes = [];
@@ -123,7 +123,7 @@ function getXAxesGroup(model: Model, cellWidth, hasCol: boolean) {
         width: cellWidth,
         height: {field: {group: 'height'}},
         x: hasCol ? {scale: COLUMN, field: model.field(COLUMN)} : {value: 0},
-        y: {value: - model.config('cellPadding') / 2}
+        y: {value: - model.config('cell').padding / 2}
       }
     },
     axes: [compileAxis(X, model)]
@@ -146,7 +146,7 @@ function getYAxesGroup(model: Model, cellHeight, hasRow: boolean) {
       update: {
         width: {field: {group: 'width'}},
         height: cellHeight,
-        x: {value: - model.config('cellPadding') / 2},
+        x: {value: - model.config('cell').padding / 2},
         y: hasRow ? {scale: ROW, field: model.field(ROW)} : {value: 0}
       }
     },
@@ -165,7 +165,7 @@ function getYAxesGroup(model: Model, cellHeight, hasRow: boolean) {
 
 function getRowRulesGroup(model: Model, cellHeight): any { // TODO: VgMarks
   const rowRulesOnTop = !model.has(X) || model.fieldDef(X).axis.orient !== 'top';
-  const offset = model.config('cellPadding') / 2 - 1;
+  const offset = model.config('cell').padding / 2 - 1;
   const rowRules = {
     name: 'row-rules',
     type: 'rule',
@@ -180,10 +180,10 @@ function getRowRulesGroup(model: Model, cellHeight): any { // TODO: VgMarks
           field: model.field(ROW),
           offset: (rowRulesOnTop ? -1 : 1) * offset
         },
-        x: {value: 0, offset: -model.config('cellGridOffset')},
-        x2: {field: {group: 'width'}, offset: model.config('cellGridOffset')},
-        stroke: { value: model.config('cellGridColor') },
-        strokeOpacity: { value: model.config('cellGridOpacity') }
+        x: {value: 0, offset: -model.config('cell').gridOffset},
+        x2: {field: {group: 'width'}, offset: model.config('cell').gridOffset},
+        stroke: { value: model.config('cell').gridColor },
+        strokeOpacity: { value: model.config('cell').gridOpacity }
       }
     }
   };
@@ -213,7 +213,7 @@ function getRowRulesGroup(model: Model, cellHeight): any { // TODO: VgMarks
 
 function getColumnRulesGroup(model: Model, cellWidth): any { // TODO: VgMarks
   const colRulesOnLeft = !model.has(Y) || model.fieldDef(Y).axis.orient === 'right';
-  const offset = model.config('cellPadding') / 2 - 1;
+  const offset = model.config('cell').padding / 2 - 1;
   const columnRules = {
     name: 'column-rules',
     type: 'rule',
@@ -228,10 +228,10 @@ function getColumnRulesGroup(model: Model, cellWidth): any { // TODO: VgMarks
           field: model.field(COLUMN),
           offset: (colRulesOnLeft ? -1 : 1) * offset
         },
-        y: {value: 0, offset: -model.config('cellGridOffset')},
-        y2: {field: {group: 'height'}, offset: model.config('cellGridOffset')},
-        stroke: { value: model.config('cellGridColor') },
-        strokeOpacity: { value: model.config('cellGridOpacity') }
+        y: {value: 0, offset: -model.config('cell').gridOffset},
+        y2: {field: {group: 'height'}, offset: model.config('cell').gridOffset},
+        stroke: { value: model.config('cell').gridColor },
+        strokeOpacity: { value: model.config('cell').gridOpacity }
       }
     }
   };

--- a/src/compiler/facet.ts
+++ b/src/compiler/facet.ts
@@ -29,6 +29,7 @@ export function facetMixins(model: Model, marks) {
     height: cellHeight
   };
 
+  // add configs that are the resulting group marks properties
   const cellConfig = model.config('cell');
   ['fill', 'fillOpacity', 'stroke', 'strokeWidth',
     'strokeOpacity', 'strokeDash', 'strokeDashOffset']

--- a/src/compiler/facet.ts
+++ b/src/compiler/facet.ts
@@ -26,9 +26,18 @@ export function facetMixins(model: Model, marks) {
 
   let facetGroupProperties: any = {
     width: cellWidth,
-    height: cellHeight,
-    fill: {value: model.config('cell').fill}
+    height: cellHeight
   };
+
+  const cellConfig = model.config('cell');
+  ['fill', 'fillOpacity', 'stroke', 'strokeWidth',
+    'strokeOpacity', 'strokeDash', 'strokeDashOffset']
+    .forEach(function(property) {
+      const value = cellConfig[property];
+      if (value !== undefined) {
+        facetGroupProperties[property] = value;
+      }
+    });
 
   let rootMarks = [], rootAxes = [], facetKeys = [], cellAxes = [];
   const hasRow = model.has(ROW), hasCol = model.has(COLUMN);

--- a/src/compiler/layout.ts
+++ b/src/compiler/layout.ts
@@ -33,7 +33,7 @@ function getCellWidth(model: Model): LayoutValue {
     if (model.isOrdinalScale(X)) { // calculate in data
       return {data: LAYOUT, field: 'cellWidth'};
     }
-    return model.config(model.isFacet() ? 'cellWidth' : 'singleWidth');
+    return model.config('cell').width;
   }
   if (model.marktype() === TEXT) {
     return model.config('textCellWidth');
@@ -53,7 +53,7 @@ function getCellHeight(model: Model): LayoutValue {
     if (model.isOrdinalScale(Y)) { // calculate in data
       return {data: LAYOUT, field: 'cellHeight'};
     } else {
-      return model.config(model.isFacet() ? 'cellHeight' : 'singleHeight');
+      return model.config('cell').height;
     }
   }
   return model.bandWidth(Y);

--- a/src/compiler/layout.ts
+++ b/src/compiler/layout.ts
@@ -38,7 +38,7 @@ function getCellWidth(model: Model): LayoutValue {
   if (model.marktype() === TEXT) {
     return model.config('textCellWidth');
   }
-  return model.bandWidth(X);
+  return model.fieldDef(X).scale.bandWidth;
 }
 
 function getWidth(model: Model, cellWidth: LayoutValue): LayoutValue {
@@ -56,7 +56,7 @@ function getCellHeight(model: Model): LayoutValue {
       return model.config('cell').height;
     }
   }
-  return model.bandWidth(Y);
+  return model.fieldDef(Y).scale.bandWidth;
 }
 
 function getHeight(model: Model, cellHeight: LayoutValue): LayoutValue {

--- a/src/compiler/legend.ts
+++ b/src/compiler/legend.ts
@@ -97,7 +97,7 @@ namespace properties {
         /* fall through */
       case 'point':
         // fill or stroke
-        if (model.fieldDef(SHAPE).filled) {
+        if (model.config('marks').filled) {
           if (model.has(COLOR) && channel === COLOR) {
             symbols.fill = {scale: COLOR, field: 'data'};
           } else {
@@ -121,7 +121,7 @@ namespace properties {
         break;
     }
 
-    var opacity = model.fieldDef(COLOR).opacity;
+    var opacity = model.config('marks').opacity;
     if (opacity) {
       symbols.opacity = {value: opacity};
     }

--- a/src/compiler/legend.ts
+++ b/src/compiler/legend.ts
@@ -111,7 +111,7 @@ namespace properties {
             symbols.stroke = {value: model.fieldDef(COLOR).value};
           }
           symbols.fill = {value: 'transparent'};
-          symbols.strokeWidth = {value: model.config('strokeWidth')};
+          symbols.strokeWidth = {value: model.config('marks').strokeWidth};
         }
 
         break;

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -243,7 +243,7 @@ export function bar(model: Model) {
   }
 
   // opacity
-  var opacity = model.fieldDef(COLOR).opacity;
+  var opacity = model.config('marks').opacity;
   if (opacity) p.opacity = {value: opacity};
 
   return p;
@@ -252,6 +252,7 @@ export function bar(model: Model) {
 export function point(model: Model) {
   // TODO Use Vega's marks properties interface
   var p:any = {};
+  const marksConfig = model.config('marks');
 
   // x
   if (model.has(X)) {
@@ -294,7 +295,7 @@ export function point(model: Model) {
   }
 
   // fill or stroke
-  if (model.fieldDef(SHAPE).filled) {
+  if (marksConfig.filled) {
     if (model.has(COLOR)) {
       p.fill = {
         scale: COLOR,
@@ -316,7 +317,7 @@ export function point(model: Model) {
   }
 
   // opacity
-  var opacity = model.fieldDef(COLOR).opacity;
+  var opacity = marksConfig.opacity;
   if (opacity) {
     p.opacity = {value: opacity};
   }
@@ -358,7 +359,7 @@ export function line(model: Model) {
     p.stroke = {value: model.fieldDef(COLOR).value};
   }
 
-  var opacity = model.fieldDef(COLOR).opacity;
+  var opacity = model.config('marks').opacity;
   if (opacity) p.opacity = {value: opacity};
 
   p.strokeWidth = {value: model.config('strokeWidth')};
@@ -439,7 +440,7 @@ export function area(model: Model) {
     p.fill = {value: model.fieldDef(COLOR).value};
   }
 
-  var opacity = model.fieldDef(COLOR).opacity;
+  var opacity = model.config('marks').opacity;
   if (opacity) {
     p.opacity = {value: opacity};
   }
@@ -503,7 +504,7 @@ export function tick(model: Model) {
     p.fill = {value: model.fieldDef(COLOR).value};
   }
 
-  var opacity = model.fieldDef(COLOR).opacity;
+  var opacity = model.config('marks').opacity;
   if (opacity) {
     p.opacity = {value: opacity};
   }
@@ -559,7 +560,7 @@ function filled_point_props(shape) {
       p.fill = {value: model.fieldDef(COLOR).value};
     }
 
-    var opacity = model.fieldDef(COLOR).opacity;
+    var opacity = model.config('marks').opacity;
     if (opacity) {
       p.opacity = {value: opacity};
     }
@@ -626,7 +627,7 @@ export function text(model: Model) {
   // TODO: consider if color should just map to fill instead?
 
 
-  var opacity = model.fieldDef(COLOR).opacity;
+  var opacity = model.config('marks').opacity;
 
   // default opacity in vega is 1 if we don't set it
   if (opacity) {

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -647,10 +647,15 @@ export function text(model: Model) {
     p.text = {value: fieldDef.placeholder};
   }
 
-  p.font = {value: fieldDef.font.family};
-  p.fontWeight = {value: fieldDef.font.weight};
-  p.fontStyle = {value: fieldDef.font.style};
-  p.baseline = {value: fieldDef.baseline};
+  const marksConfig = model.config('marks');
+  ['baseline', 'font', 'fontWeight', 'fontStyle']
+    .forEach(function(property) {
+      const value = marksConfig[property];
+      if (value !== undefined) {
+        p[property] = {value: value};
+      }
+
+    });
 
   return p;
 }

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -170,8 +170,9 @@ export function bar(model: Model) {
           field: model.field(SIZE)
         };
       } else {
+        // FIXME consider using band: true here
         p.width = {
-          value: model.bandWidth(X),
+          value: model.fieldDef(X).scale.bandWidth,
           offset: -1
         };
       }
@@ -225,8 +226,9 @@ export function bar(model: Model) {
         field: model.field(SIZE)
       };
     } else {
+      // FIXME: band:true?
       p.height = {
-        value: model.bandWidth(Y),
+        value: model.fieldDef(Y).scale.bandWidth,
         offset: -1
       };
     }
@@ -261,7 +263,7 @@ export function point(model: Model) {
       field: model.field(X, {binSuffix: '_mid'})
     };
   } else if (!model.has(X)) {
-    p.x = {value: model.bandWidth(X) / 2};
+    p.x = {value: model.fieldDef(X).scale.bandWidth / 2};
   }
 
   // y
@@ -271,7 +273,7 @@ export function point(model: Model) {
       field: model.field(Y, {binSuffix: '_mid'})
     };
   } else if (!model.has(Y)) {
-    p.y = {value: model.bandWidth(Y) / 2};
+    p.y = {value: model.fieldDef(Y).scale.bandWidth / 2};
   }
 
   // size
@@ -450,6 +452,7 @@ export function area(model: Model) {
 
 export function tick(model: Model) {
   // TODO Use Vega's marks properties interface
+  // FIXME are /3 , /1.5 divisions here correct?
   var p:any = {};
 
   // x
@@ -459,7 +462,7 @@ export function tick(model: Model) {
       field: model.field(X, {binSuffix: '_mid'})
     };
     if (model.isDimension(X)) {
-      p.x.offset = -model.bandWidth(X) / 3;
+      p.x.offset = -model.fieldDef(X).scale.bandWidth / 3;
     }
   } else if (!model.has(X)) {
     p.x = {value: 0};
@@ -472,7 +475,7 @@ export function tick(model: Model) {
       field: model.field(Y, {binSuffix: '_mid'})
     };
     if (model.isDimension(Y)) {
-      p.y.offset = -model.bandWidth(Y) / 3;
+      p.y.offset = -model.fieldDef(Y).scale.bandWidth / 3;
     }
   } else if (!model.has(Y)) {
     p.y = {value: 0};
@@ -481,7 +484,7 @@ export function tick(model: Model) {
   // width
   if (!model.has(X) || model.isDimension(X)) {
     // TODO(#694): optimize tick's width for bin
-    p.width = {value: model.bandWidth(X) / 1.5};
+    p.width = {value: model.fieldDef(X).scale.bandWidth / 1.5};
   } else {
     p.width = {value: 1};
   }
@@ -489,7 +492,7 @@ export function tick(model: Model) {
   // height
   if (!model.has(Y) || model.isDimension(Y)) {
     // TODO(#694): optimize tick's height for bin
-    p.height = {value: model.bandWidth(Y) / 1.5};
+    p.height = {value: model.fieldDef(Y).scale.bandWidth / 1.5};
   } else {
     p.height = {value: 1};
   }
@@ -524,7 +527,7 @@ function filled_point_props(shape) {
         field: model.field(X, {binSuffix: '_mid'})
       };
     } else if (!model.has(X)) {
-      p.x = {value: model.bandWidth(X) / 2};
+      p.x = {value: model.fieldDef(X).scale.bandWidth / 2};
     }
 
     // y
@@ -534,7 +537,7 @@ function filled_point_props(shape) {
         field: model.field(Y, {binSuffix: '_mid'})
       };
     } else if (!model.has(Y)) {
-      p.y = {value: model.bandWidth(Y) / 2};
+      p.y = {value: model.fieldDef(Y).scale.bandWidth / 2};
     }
 
     // size
@@ -599,7 +602,7 @@ export function text(model: Model) {
       // TODO: make this -5 offset a config
       p.x = {field: {group: 'width'}, offset: -5};
     } else {
-      p.x = {value: model.bandWidth(X) / 2};
+      p.x = {value: model.fieldDef(X).scale.bandWidth / 2};
     }
   }
 
@@ -610,7 +613,7 @@ export function text(model: Model) {
       field: model.field(Y, {binSuffix: '_mid'})
     };
   } else if (!model.has(Y)) {
-    p.y = {value: model.bandWidth(Y) / 2};
+    p.y = {value: model.fieldDef(Y).scale.bandWidth / 2};
   }
 
   // size

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -313,7 +313,7 @@ export function point(model: Model) {
     } else if (!model.has(COLOR)) {
       p.stroke = {value: model.fieldDef(COLOR).value};
     }
-    p.strokeWidth = {value: model.config('strokeWidth')};
+    p.strokeWidth = {value: model.config('marks').strokeWidth};
   }
 
   // opacity
@@ -362,7 +362,7 @@ export function line(model: Model) {
   var opacity = model.config('marks').opacity;
   if (opacity) p.opacity = {value: opacity};
 
-  p.strokeWidth = {value: model.config('strokeWidth')};
+  p.strokeWidth = {value: model.config('marks').strokeWidth};
 
   return p;
 }

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -583,8 +583,9 @@ export function textBackground(model: Model) {
 
 export function text(model: Model) {
   // TODO Use Vega's marks properties interface
-  var p:any = {},
-    fieldDef = model.fieldDef(TEXT);
+  let p:any = {};
+  const fieldDef = model.fieldDef(TEXT);
+  const marksConfig = model.config('marks');
 
   // x
   if (model.has(X)) {
@@ -594,6 +595,7 @@ export function text(model: Model) {
     };
   } else if (!model.has(X)) {
     if (model.has(TEXT) && model.fieldDef(TEXT).type === QUANTITATIVE) {
+      // TODO: make this -5 offset a config
       p.x = {field: {group: 'width'}, offset: -5};
     } else {
       p.x = {value: model.bandWidth(X) / 2};
@@ -617,12 +619,12 @@ export function text(model: Model) {
       field: model.field(SIZE)
     };
   } else if (!model.has(SIZE)) {
-    p.fontSize = {value: fieldDef.font.size};
+    p.fontSize = {value: fieldDef.fontSize};
   }
 
   // fill
-  // color should be set to background
-  p.fill = {value: fieldDef.color};
+  // TODO: consider if color should just map to fill instead?
+
 
   var opacity = model.fieldDef(COLOR).opacity;
 
@@ -634,21 +636,21 @@ export function text(model: Model) {
   // text
   if (model.has(TEXT)) {
     if (model.fieldDef(TEXT).type === QUANTITATIVE) {
-      var numberFormat = fieldDef.format !== undefined ?
-                         fieldDef.format : model.numberFormat(TEXT);
+      // TODO: revise this line
+      var numberFormat = marksConfig.format !== undefined ?
+                         marksConfig.format : model.numberFormat(TEXT);
 
-      p.text = {template: '{{' + model.field(TEXT, {datum: true}) + ' | number:\'' +
-        numberFormat +'\'}}'};
-      p.align = {value: fieldDef.align};
+      p.text = {template: '{{' + model.field(TEXT, {datum: true}) +
+               ' | number:\'' + numberFormat +'\'}}'};
     } else {
       p.text = {field: model.field(TEXT)};
     }
   } else {
-    p.text = {value: fieldDef.placeholder};
+    p.text = {value: fieldDef.value};
   }
 
-  const marksConfig = model.config('marks');
-  ['baseline', 'font', 'fontWeight', 'fontStyle']
+
+  ['align', 'baseline', 'fill', 'font', 'fontWeight', 'fontStyle']
     .forEach(function(property) {
       const value = marksConfig[property];
       if (value !== undefined) {

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -152,14 +152,8 @@ export function reverse(model: Model, channel: Channel) {
  */
 export function _useRawDomain (model: Model, channel: Channel) {
   const fieldDef = model.fieldDef(channel);
-  const scaleUseRawDomain = fieldDef.scale.useRawDomain;
 
-  // Determine if useRawDomain is enabled. If scale value is specified, use scale value.
-  // Otherwise, use config value.
-  var useRawDomainEnabled = scaleUseRawDomain !== undefined ?
-      scaleUseRawDomain : model.config('useRawDomain');
-
-  return  useRawDomainEnabled &&
+  return fieldDef.scale.useRawDomain && //  if useRawDomain is enabled
     // only applied to aggregate table
     fieldDef.aggregate &&
     // only activated if used with aggregate functions that produces values ranging in the domain of the source data

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -172,13 +172,8 @@ export function _useRawDomain (model: Model, channel: Channel) {
 }
 
 export function bandWidth(model: Model, channel: Channel, scaleType) {
-  switch (channel) {
-    case X: /* fall through */
-    case Y:
-      if (scaleType === 'ordinal') {
-        return model.bandWidth(channel);
-      }
-      break;
+  if (scaleType === 'ordinal') {
+    return model.fieldDef(channel).scale.bandWidth;
   }
   return undefined;
 }
@@ -226,7 +221,7 @@ export function outerPadding(model: Model, channel: Channel, scaleType) {
 export function padding(model: Model, channel: Channel, scaleType) {
   if (scaleType === 'ordinal') {
     // Both explicit and non-explicit values are handled by the helper method.
-    return model.padding(channel);
+    return model.fieldDef(channel).scale.padding;
   }
   return undefined;
 }
@@ -267,12 +262,17 @@ export function rangeMixins(model: Model, channel: Channel, scaleType): any {
       if (model.is('bar')) {
         // FIXME this is definitely incorrect
         // but let's fix it later since bar size is a bad encoding anyway
-        return {range: [3, Math.max(model.bandWidth(X), model.bandWidth(Y))]};
+        return {
+          range: [3, Math.max(
+            model.fieldDef(X).scale.bandWidth,
+            model.fieldDef(Y).scale.bandWidth
+          )]
+        };
       } else if (model.is(TEXT)) {
         return {range: [8, 40]};
       }
       // else -- point
-      var bandWidth = Math.min(model.bandWidth(X), model.bandWidth(Y)) - 1;
+      var bandWidth = Math.min(model.fieldDef(X).scale.bandWidth, model.fieldDef(Y).scale.bandWidth) - 1;
       return {range: [10, 0.8 * bandWidth*bandWidth]};
     case SHAPE:
       return {range: 'shapes'};

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -239,15 +239,6 @@ export var config = {
       type: 'string',
       default: '%Y-%m-%d',
       description: 'Date format for axis labels.'
-    },
-    useRawDomain: {
-      type: 'boolean',
-      default: false,
-      description: 'Use the source data range as scale domain instead of ' +
-                   'aggregated data for aggregate axis. ' +
-                   'This option does not work with sum or count aggregate' +
-                   'as they might have a substantially larger scale range.' +
-                   'By default, use value from config.useRawDomain.'
     }
   }
 };

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -161,12 +161,16 @@ export var config = {
         },
 
         // General Vega
-
         opacity: {
           type: 'number',
           default: undefined,  // auto
           minimum: 0,
           maximum: 1
+        },
+        strokeWidth: {
+          type: 'integer',
+          default: 2,
+          minimum: 0
         },
 
         // text-only
@@ -216,11 +220,6 @@ export var config = {
     },
 
     // marks
-    strokeWidth: {
-      type: 'integer',
-      default: 2,
-      minimum: 0
-    },
     singleBarOffset: {
       type: 'integer',
       default: 5,

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -44,32 +44,6 @@ export var config = {
       description: 'default scale padding ratio for ordinal x/y scales.'
     },
     // small multiples
-    cellPadding: {
-      type: 'integer',
-      default: 16,
-      description: 'default padding between facets.'
-    },
-    cellGridColor: {
-      type: 'string',
-      role: 'color',
-      default: '#000000'
-    },
-    cellGridOpacity: {
-      type: 'number',
-      minimum: 0,
-      maximum: 1,
-      default: 0.25
-    },
-    cellGridOffset: {
-      type: 'number',
-      default: 6 // equal to tickSize
-    },
-    cellBackgroundColor: {
-      type: 'string',
-      role: 'color',
-      default: 'rgba(0,0,0,0)'
-    },
-
     textCellWidth: {
       type: 'integer',
       default: 90,
@@ -122,6 +96,31 @@ export var config = {
           type: 'integer',
           default: 200
         },
+        padding: {
+          type: 'integer',
+          default: 16,
+          description: 'default padding between facets.'
+        },
+        gridColor: {
+          type: 'string',
+          role: 'color',
+          default: '#000000'
+        },
+        gridOpacity: {
+          type: 'number',
+          minimum: 0,
+          maximum: 1,
+          default: 0.25
+        },
+        gridOffset: {
+          type: 'number',
+          default: 6 // equal to tickSize
+        },
+        fill: {
+          type: 'string',
+          role: 'color',
+          default: 'rgba(0,0,0,0)'
+        }
       }
     },
 

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -208,7 +208,7 @@ export var config = {
       }
     },
 
-    // marks
+    // FIXME remove this 
     singleBarOffset: {
       type: 'integer',
       default: 5,
@@ -219,11 +219,13 @@ export var config = {
       type: 'integer',
       default: 6
     },
+    // FIXME(#497) handle this
     numberFormat: {
       type: 'string',
       default: 's',
       description: 'D3 Number format for axis labels and text tables.'
     },
+    // FIXME(#497) handle this
     timeFormat: {
       type: 'string',
       default: '%Y-%m-%d',

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -120,6 +120,27 @@ export var config = {
           type: 'string',
           role: 'color',
           default: 'rgba(0,0,0,0)'
+        },
+        fillOpacity: {
+          type: 'number',
+        },
+        stroke: {
+          type: 'string',
+          role: 'color',
+        },
+        strokeWidth: {
+          type: 'integer'
+        },
+        strokeOpacity: {
+          type: 'number'
+        },
+        strokeDash: {
+          type: 'array',
+          default: undefined
+        },
+        strokeDashOffset: {
+          type: 'integer',
+          description: 'The offset (in pixels) into which to begin drawing with the stroke dash array.'
         }
       }
     },

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -147,23 +147,54 @@ export var config = {
     marks: {
       type: 'object',
       properties: {
+        // text-only
+        align: {
+          type: 'string',
+          default: 'right',
+          enum: ['left', 'right', 'center'],
+          description: 'The horizontal alignment of the text. One of left, right, center.'
+        },
         baseline: {
           type: 'string',
-          default: 'middle'
+          default: 'middle',
+          enum: ['top', 'middle', 'bottom'],
+          description: 'The vertical alignment of the text. One of top, middle, bottom.'
+        },
+        // TODO dx, dy, radius, theta, angle
+        fill: {
+          type: 'string',
+          role: 'color',
+          default: '#000000'
         },
         font: {
           type: 'string',
-          default: undefined
+          default: undefined,
+          role: 'font',
+          description: 'The typeface to set the text in (e.g., Helvetica Neue).'
+        },
+        fontSize: {
+          type: 'integer',
+          default: undefined,
+          minimum: 0,
+          description: 'The font size, in pixels.'
         },
         fontStyle: {
           type: 'string',
           default: undefined,
-          enum: ['normal', 'italic']
+          enum: ['normal', 'italic'],
+          description: 'The font style (e.g., italic).'
         },
         fontWeight: {
           type: 'string',
           enum: ['normal', 'bold'],
-          default: undefined
+          default: undefined,
+          description: 'The font weight (e.g., bold).'
+        },
+        format: {
+          type: 'string',
+          default: '',  // auto
+          description: 'The formatting pattern for text value.'+
+                       'If not defined, this will be determined automatically'
         }
       }
     },

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -147,6 +147,28 @@ export var config = {
     marks: {
       type: 'object',
       properties: {
+        // Vega-Lite special
+        filled: {
+          type: 'boolean',
+          default: false,
+          description: 'Whether the shape\'s color should be used as fill color instead of stroke color.'
+        },
+        format: {
+          type: 'string',
+          default: '',  // auto
+          description: 'The formatting pattern for text value.'+
+                       'If not defined, this will be determined automatically'
+        },
+
+        // General Vega
+
+        opacity: {
+          type: 'number',
+          default: undefined,  // auto
+          minimum: 0,
+          maximum: 1
+        },
+
         // text-only
         align: {
           type: 'string',
@@ -189,12 +211,6 @@ export var config = {
           enum: ['normal', 'bold'],
           default: undefined,
           description: 'The font weight (e.g., bold).'
-        },
-        format: {
-          type: 'string',
-          default: '',  // auto
-          description: 'The formatting pattern for text value.'+
-                       'If not defined, this will be determined automatically'
         }
       }
     },

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -19,17 +19,6 @@ export var config = {
       },
       default: undefined
     },
-    gridColor: {
-      type: 'string',
-      role: 'color',
-      default: '#000000'
-    },
-    gridOpacity: {
-      type: 'number',
-      minimum: 0,
-      maximum: 1,
-      default: 0.08
-    },
 
     // filter null
     // TODO(#597) revise this config
@@ -51,7 +40,7 @@ export var config = {
       minimum: 0
     },
     singleWidth: {
-      // will be overwritten by bandWidth 
+      // will be overwritten by bandWidth
       type: 'integer',
       default: 200,
       minimum: 0

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -32,19 +32,6 @@ export var config = {
       }
     },
 
-    // single plot
-    singleHeight: {
-      // will be overwritten by bandWidth
-      type: 'integer',
-      default: 200,
-      minimum: 0
-    },
-    singleWidth: {
-      // will be overwritten by bandWidth
-      type: 'integer',
-      default: 200,
-      minimum: 0
-    },
     // band size
     bandWidth: {
       type: 'integer',
@@ -82,14 +69,7 @@ export var config = {
       role: 'color',
       default: 'rgba(0,0,0,0)'
     },
-    cellWidth: {
-      type: 'integer',
-      default: 150
-    },
-    cellHeight: {
-      type: 'integer',
-      default: 150
-    },
+
     textCellWidth: {
       type: 'integer',
       default: 90,
@@ -128,6 +108,20 @@ export var config = {
           // TODO(#620) refer to Vega spec once it doesn't throw error
           // enum: vgStackSchema.properties.offset.oneOf[0].enum
         }
+      }
+    },
+    // cell
+    cell: {
+      type: 'object',
+      properties: {
+        width: {
+          type: 'integer',
+          default: 200
+        },
+        height: {
+          type: 'integer',
+          default: 200
+        },
       }
     },
 

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -32,17 +32,6 @@ export var config = {
       }
     },
 
-    // band size
-    bandWidth: {
-      type: 'integer',
-      default: 21,
-      minimum: 0
-    },
-    padding: {
-      type: 'number',
-      default: 1,
-      description: 'default scale padding ratio for ordinal x/y scales.'
-    },
     // small multiples
     textCellWidth: {
       type: 'integer',

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -144,6 +144,29 @@ export var config = {
         }
       }
     },
+    marks: {
+      type: 'object',
+      properties: {
+        baseline: {
+          type: 'string',
+          default: 'middle'
+        },
+        font: {
+          type: 'string',
+          default: undefined
+        },
+        fontStyle: {
+          type: 'string',
+          default: undefined,
+          enum: ['normal', 'italic']
+        },
+        fontWeight: {
+          type: 'string',
+          enum: ['normal', 'bold'],
+          default: undefined
+        }
+      }
+    },
 
     // marks
     strokeWidth: {

--- a/src/schema/encoding.schema.ts
+++ b/src/schema/encoding.schema.ts
@@ -39,7 +39,6 @@ var x = merge(duplicate(typicalField), requiredNameType, {
   }
 });
 
-console.log('xAxis', x.properties.axis);
 var y = duplicate(x);
 
 var facet = merge(duplicate(onlyOrdinalField), requiredNameType, {

--- a/src/schema/encoding.schema.ts
+++ b/src/schema/encoding.schema.ts
@@ -127,10 +127,7 @@ var text = merge(duplicate(typicalField), {
       type: 'string',
       default: 'right'
     },
-    baseline: {
-      type: 'string',
-      default: 'middle'
-    },
+
     color: {
       type: 'string',
       role: 'color',
@@ -148,24 +145,10 @@ var text = merge(duplicate(typicalField), {
     font: {
       type: 'object',
       properties: {
-        weight: {
-          type: 'string',
-          enum: ['normal', 'bold'],
-          default: 'normal'
-        },
         size: {
           type: 'integer',
           default: 10,
           minimum: 0
-        },
-        family: {
-          type: 'string',
-          default: 'Helvetica Neue'
-        },
-        style: {
-          type: 'string',
-          default: 'normal',
-          enum: ['normal', 'italic']
         }
       }
     },

--- a/src/schema/encoding.schema.ts
+++ b/src/schema/encoding.schema.ts
@@ -121,43 +121,10 @@ var detail = merge(duplicate(onlyOrdinalField), {
 var text = merge(duplicate(typicalField), {
   properties: {
     sort: sort,
-
-    // TODO: consider if these properties should be under 'marks.'
-    align: {
-      type: 'string',
-      default: 'right'
-    },
-
-    color: {
-      type: 'string',
-      role: 'color',
-      default: '#000000'
-    },
-    margin: {
-      type: 'integer',
-      default: 4,
-      minimum: 0
-    },
-    placeholder: {
+    value: {
       type: 'string',
       default: 'Abc'
-    },
-    font: {
-      type: 'object',
-      properties: {
-        size: {
-          type: 'integer',
-          default: 10,
-          minimum: 0
-        }
-      }
-    },
-    format: {
-      type: 'string',
-      default: '',  // auto
-      description: 'The formatting pattern for text value.'+
-                   'If not defined, this will be determined automatically'
-    },
+    }
   }
 });
 

--- a/src/schema/encoding.schema.ts
+++ b/src/schema/encoding.schema.ts
@@ -67,12 +67,6 @@ var color = merge(duplicate(typicalField), {
       default: '#4682b4',
       description: 'Color to be used for marks.'
     },
-    opacity: {
-      type: 'number',
-      default: undefined,  // auto
-      minimum: 0,
-      maximum: 1
-    },
     scale: {
       type: 'object',
       properties: {
@@ -102,11 +96,6 @@ var shape = merge(duplicate(onlyOrdinalField), {
       enum: ['circle', 'square', 'cross', 'diamond', 'triangle-up', 'triangle-down'],
       default: 'circle',
       description: 'Mark to be used.'
-    },
-    filled: {
-      type: 'boolean',
-      default: false,
-      description: 'Whether the shape\'s color should be used as fill color instead of stroke color.'
     }
   }
 });

--- a/src/schema/encoding.schema.ts
+++ b/src/schema/encoding.schema.ts
@@ -28,10 +28,18 @@ var requiredNameType = {
 
 var x = merge(duplicate(typicalField), requiredNameType, {
   properties: {
-    axis: axis,
+    scale: {// replacing default values for just these two axis
+      properties: {
+        padding: {default: 1},
+        bandWidth: {default: 21}
+      }
+    },
+    axis: axis
     sort: sort
   }
 });
+
+console.log('xAxis', x.properties.axis);
 var y = duplicate(x);
 
 var facet = merge(duplicate(onlyOrdinalField), requiredNameType, {

--- a/src/schema/encoding.schema.ts
+++ b/src/schema/encoding.schema.ts
@@ -28,7 +28,7 @@ var requiredNameType = {
 
 var x = merge(duplicate(typicalField), requiredNameType, {
   properties: {
-    scale: {// replacing default values for just these two axis
+    scale: {// replacing default values for just these two axes
       properties: {
         padding: {default: 1},
         bandWidth: {default: 21}

--- a/src/schema/scale.schema.ts
+++ b/src/schema/scale.schema.ts
@@ -122,12 +122,11 @@ var typicalScaleMixin = {
     /* Vega-lite only Properties */
     useRawDomain: {
       type: 'boolean',
-      default: undefined,
+      default: false,
       description: 'Uses the source data range as scale domain instead of ' +
                    'aggregated data for aggregate axis. ' +
                    'This option does not work with sum or count aggregate' +
-                   'as they might have a substantially larger scale range.' +
-                   'By default, use value from config.useRawDomain.'
+                   'as they might have a substantially larger scale range.' 
     }
   }
 };

--- a/test/compiler/axis.test.ts
+++ b/test/compiler/axis.test.ts
@@ -109,7 +109,7 @@ describe('Axis', function() {
             x: {field: 'abcdefghijkl'}
           },
           config: {
-            singleWidth: 60
+            cell: {width: 60}
           }
         }), 'x');
       expect(title).to.eql('abcdefghi…');

--- a/test/compiler/marks.test.ts
+++ b/test/compiler/marks.test.ts
@@ -73,7 +73,7 @@ describe('compile.marks', function() {
           e = new Model(f),
           def = marks.properties.point(e);
       it('should be centered', function() {
-        expect(def.y).to.eql({value: e.bandWidth(Y) / 2});
+        expect(def.y).to.eql({value: e.fieldDef(Y).scale.bandWidth / 2});
       });
       it('should scale on x', function() {
         expect(def.x).to.eql({scale: X, field: 'year'});
@@ -85,7 +85,7 @@ describe('compile.marks', function() {
           e = new Model(f),
           def = marks.properties.point(e);
       it('should be centered', function() {
-        expect(def.x).to.eql({value: e.bandWidth(X) / 2});
+        expect(def.x).to.eql({value: e.fieldDef(X).scale.bandWidth / 2});
       });
       it('should scale on y', function() {
         expect(def.y).to.eql({scale: Y, field: 'year'});


### PR DESCRIPTION
Most important part of #666 for 0.9.0 — still left a few to be removed/added later.  

### Config 
- remove `single/cell Width/Height`, always use `cell.width|height`
- remove unused `gridColor`, `gridOpacity`
- remove `config.bandWidth|padding` and `model.bandWidth|padding()` and set different default values for different channels instead!
- remove config.useRawDomain

- group configs for a particular part
  - `config.cell`
    - move `cell` configs to be under `cell`:  `width`, `height`, `padding`, `gridColor`, `gridOpacity`, `gridOffset`
    - add group marks properties to `config.cell`: `fill`, `fillOpacity`, `stroke`, `strokeWidth`, `strokeOpacity`, strokeDash, strokeDashOffset`
  - `config.marks`
    - move `baseline`, `font`, `fontStyle`, `fontWeight` from `encoding.text` to `config.marks`
    -  `encoding.shape.filled` => `config.marks.filled`, `encoding.color.opacity` => `config.marks.opacity`
    - move all text properties from `encoding.text` to `config.marks` except renaming `encoding.text.placeholder` to `encoding.text.value`
    - `config.strokeWidth` => `config.marks.strokeWidth`


### output 
- set width and height to 1 if it's dynamically calculated