### PR TITLE
Simplify type checking

### DIFF
--- a/src/compiler/legend.ts
+++ b/src/compiler/legend.ts
@@ -3,7 +3,6 @@ import {COLOR, SIZE, SHAPE, Channel} from '../channel';
 import {Model} from './Model';
 import * as time from './time';
 import {TEMPORAL} from '../type';
-import {isLegend} from '../schema/legend.schema';
 
 export function compileLegends(model: Model) {
   var defs = [];
@@ -45,7 +44,7 @@ export function compileLegend(model: Model, channel: Channel, def) {
   });
 
   // 2) Add mark property definition groups
-  const props =  isLegend(legend) && legend.properties || {};
+  const props = (typeof legend !== 'boolean' && legend.properties) || {};
   ['title', 'labels', 'symbols', 'legend'].forEach(function(group) {
     let value = properties[group] ?
       properties[group](model, channel, props[group]) : // apply rule
@@ -63,7 +62,7 @@ export function title(model: Model, channel: Channel) {
   // https://github.com/Microsoft/TypeScript/issues/5842
   const legend: any = model.fieldDef(channel).legend;
 
-  if (isLegend(legend) && legend.title) {
+  if (typeof legend !== 'boolean' && legend.title) {
     return legend.title;
   }
 

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -1,14 +1,13 @@
 // https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#11-ambient-declarations
 declare var exports;
 
-import {extend, isObject} from '../util';
+import {extend} from '../util';
 import {Model} from './Model';
 import {SHARED_DOMAIN_OPS} from '../aggregate';
 import {COLUMN, ROW, X, Y, SHAPE, SIZE, COLOR, TEXT, Channel} from '../channel';
 import {SOURCE, STACKED, LAYOUT} from '../data';
 import * as time from './time';
 import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../type';
-import {isSort} from '../schema/sort.schema';
 
 export function compileScales(names: Array<string>, model: Model) {
   return names.reduce(function(a, channel: Channel) {
@@ -130,7 +129,7 @@ export function domainSort(model: Model, channel: Channel, type):any {
   }
 
   // Sorted based on an aggregate calculation over a specified sort field (only for ordinal scale)
-  if (type === 'ordinal' && isSort(sort)) {
+  if (type === 'ordinal' && typeof sort !== 'string') {
     return {
       op: sort.op,
       field: sort.field
@@ -141,7 +140,10 @@ export function domainSort(model: Model, channel: Channel, type):any {
 
 export function reverse(model: Model, channel: Channel) {
   var sort = model.fieldDef(channel).sort;
-  return sort && (sort === 'descending' || (isSort(sort) && sort.order === 'descending')) ? true : undefined;
+  return sort && (typeof sort === 'string' ?
+                    sort === 'descending' :
+                    sort.order === 'descending'
+                 ) ? true : undefined;
 }
 
 /**

--- a/src/schema/sort.schema.ts
+++ b/src/schema/sort.schema.ts
@@ -1,16 +1,11 @@
 import {AGGREGATE_OPS} from '../aggregate';
 import {ORDINAL, QUANTITATIVE} from '../type';
-import {toMap, isObject} from '../util';
+import {toMap} from '../util';
 
 export interface Sort {
   field: string;
   op: string;
   order?: string;
-}
-
-export function isSort(object: any): object is Sort {
-  // usually, the object is either Sort or boolean so we only do a simple check here
-  return isObject(object);
 }
 
 export var sort = {


### PR DESCRIPTION
If you can't type check the interface object, check if it's not the primitive and you can get away with it without introducing complex `isX` methods