### PR TITLE
scale documentation and minor refactor

### DIFF
--- a/docs/encoding.md
+++ b/docs/encoding.md
@@ -126,41 +126,46 @@ __In Roadmap__: Support for other values such as `year-month`, `year-month-day`,
 
 ### ▸ `scale`
 
-Vega-Lite's `scale` object supports the following Vega scale properties:
+Vega-Lite's `scale` definition supports the following properties<sup>1</sup>:
 
-- [Common Scale Properties](https://github.com/vega/vega/wiki/Scales#common-scale-properties)__<sup>1</sup>__:
-`type`__<sup>2</sup>__, `domain`, `range`, and `round`.
-
-- [Quantitative Scale Properties](https://github.com/vega/vega/wiki/Scales#quantitative-scale-properties):
-`clamp`, `exponent`, `nice`, and `zero`.
-
-- [Time Scale Properties](https://github.com/vega/vega/wiki/Scales#time-scale-properties):
-`clamp` and `nice`.
-
-- [Ordinal Scale Properties](https://github.com/vega/vega/wiki/Scales#ordinal-scale-properties):
-`bandWidth`, `padding` and `points`.
-
-See [Vega's documentation](https://github.com/vega/vega/wiki/Scales#common-scale-properties) for more information about these properties.
-
-<!-- TODO: add a table here instead of pointing to Vega-->
-
-Moreover, Vega-Lite has the following additional scale properties:
+#### Common Scale Properties
 
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
-| useRawDomain  | Boolean       | Use the raw data instead of summary data for scale domain (Only for aggregated field).  This property only works with aggregate functions that produce values ranging in the domain of the source data (`'mean'`, `'average'`, `'stdev'`, `'stdevp'`, `'median'`, `'q1'`, `'q3'`, `'min'`, `'max'`).  Otherwise, this property is ignored.  If the scale's `domain` is specified, this property is also ignored. |
+| type          | String        | The type of scale. This is only customizable for quantitative and temporal fields. <br/> For a quantitative field, the default value is `linear`. Other supported quantitative scale types  are `linear`, `log`, `pow`, `sqrt`, `quantile`, `quantize`, and `threshold`.  <br/> For a temporal field without time unit, the scale type should be `time` (default) or `utc` (for UTC time).  For temporal fields with time units, the scale type can also be `ordinal` (default for `hours`, `day`, `date`, `month`) or `linear` (default for `year`, `second`, `minute`). <br/> See [d3 scale documentation](https://github.com/mbostock/d3/wiki/Quantitative-Scales) for more information.|
+| domain        | Array  | By default, the field's scale draw domain values directly from the field's values.  Custom domain values can be specified.  For quantitative data, this can take the form of a two-element array with minimum and maximum values. For ordinal/categorical data, this may be an array of valid input values. |
+| range        | Array &#124; String  | For `x` and `y`, the range covers the chart's cell width and cell height respectively by default.  For `color`, the default range is `'category10'` for nominal fields, and a green ramp (`['#AFC6A3', '#09622A']`) for other types of fields.  <!-- TODO default for size size -->  For `shape`, the default is [Vega's `"shape"` preset](https://github.com/vega/vega/wiki/Scales#scale-range-literals).  For `row` and `column`, the default range is `width` and `height` respectively.  <br/> Custom domain values can be specified. For numeric values, the range can take the form of a two-element array with minimum and maximum values. For ordinal or quantized data, the range may by an array of desired output values, which are mapped to elements in the specified domain. [See Vega's documentation on range literals for more options](https://github.com/vega/vega/wiki/Scales#scale-range-literals). |
+| round         | Boolean       | If true, rounds numeric output values to integers. This can be helpful for snapping to the pixel grid.|
 
-<!-- TODO: document default behavior for each properties__ -->
+#### Ordinal Scale Properties
 
-__<sup>1</sup>__ `reverse` is excluded from Vega-Lite's `scale` to avoid conflicts with `sort` property.  Please use `sort='descending'` to get a `reverse=true`.
-
-__<sup>2</sup>__
-Vega-Lite automatically determines scale's `type` based on the field's data type.
-By default, scales of nominal and ordinal fields are ordinal scales.
-Scales of time fields are time scales if time unit conversion is not applied.
-Scales of quantitative fields are linear scales by default, but users can specify `type` property to use other types of quantitative scale.
+| Property      | Type          | Description    |
+| :------------ |:-------------:| :------------- |
+| bandWidth     | Number        | Width for each ordinal band.  <!--TODO need to write better explanation --> |
+| points        | Boolean       | If true (default), distributes the ordinal values over a quantitative range at uniformly spaced points. The spacing of the points can be adjusted using the _padding_ property. If false, the ordinal scale will construct evenly-spaced bands, rather than points.  |
+| padding       | Number        | Applies spacing among ordinal elements in the scale range. The actual effect depends on how the scale is configured. If the __points__ parameter is `true`, the padding value is interpreted as a multiple of the spacing between points. A reasonable value is 1.0, such that the first and last point will be offset from the minimum and maximum value by half the distance between points. Otherwise, padding is typically in the range [0, 1] and corresponds to the fraction of space in the range interval to allocate to padding. A value of 0.5 means that the range band width will be equal to the padding width. For more, see the [D3 ordinal scale documentation](https://github.com/mbostock/d3/wiki/Ordinal-Scales).|
 
 
+#### Time Scale Properties
+
+| Property      | Type          | Description    |
+| :------------ |:-------------:| :------------- |
+| clamp         | Boolean       | If true (default), values that exceed the data domain are clamped to either the minimum or maximum range value.|
+| nice          | String        | If specified, modifies the scale domain to use a more human-friendly value range. For `time` and `utc` scale types only, the nice value should be a string indicating the desired time interval; legal values are `"second"`, `"minute"`, `"hour"`, `"day"`, `"week"`, `"month"`, or `"year"`.|
+
+#### Quantitative Scale Properties
+
+| Property      | Type          | Description    |
+| :------------ |:-------------:| :------------- |
+| clamp         | Boolean       | If true (default), values that exceed the data domain are clamped to either the minimum or maximum range value.|
+| exponent      | Number        | Sets the exponent of the scale transformation. For `pow` scale types only, otherwise ignored.|
+| nice          | Boolean       | If true, modifies the scale domain to use a more human-friendly number range (e.g., 7 instead of 6.96).|
+| zero          | Boolean       | If true, ensures that a zero baseline value is included in the scale domain. This option is ignored for non-quantitative scales.  If unspecified, zero is true by default. |
+| useRawDomain<sup>1</sup>  | Boolean       | (For aggregate field only) If false (default), draw domain data the aggregate (`summary`) data table.  If true, use the raw data instead of summary data for scale domain.  This property only works with aggregate functions that produce values ranging in the domain of the source data (`'mean'`, `'average'`, `'stdev'`, `'stdevp'`, `'median'`, `'q1'`, `'q3'`, `'min'`, `'max'`).  Otherwise, this property is ignored.  If the scale's `domain` is specified, this property is also ignored. |
+
+<small>
+__<sup>1</sup>__ All Vega-Lite scale properties exist in Vega except `useRawDomain`, which is a special property in Vega-Lite.  Some Vega properties are excluded in Vega-Lite. For example,  `reverse` is excluded from Vega-Lite's `scale` to avoid conflicts with `sort` property.  Please use `sort` of a field definition to `'descending'` to get similar behavior to setting  `reverse` to `true` in Vega.  
+</small>
 ----
 
 ### ▸ `axis`
@@ -210,9 +215,3 @@ The `legend` property object supports the following [Vega legend properties](htt
 See [Vega documentation](https://github.com/vega/vega/wiki/Legends#legend-properties) for more information about each property.
 
 <!-- TODO: add a table here instead of pointing to Vega-->
-
-----
-
-## Channel Specific Properties
-
-_(More Detail Coming Soon)_

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -50,7 +50,7 @@ export function type(channel: Channel, model: Model) {
       let range = fieldDef.scale.range;
       return channel === COLOR && (typeof range !== 'string') ? 'linear' : 'ordinal';
     case TEMPORAL:
-      return fieldDef.timeUnit ? time.scale.type(fieldDef.timeUnit, channel) : 'time';
+      return time.scale.type(fieldDef.timeUnit, channel);
     case QUANTITATIVE:
       if (model.bin(channel)) {
         return channel === ROW || channel === COLUMN || channel === SHAPE ? 'ordinal' : 'linear';
@@ -255,8 +255,11 @@ export function rangeMixins(model: Model, channel: Channel, scaleType): any {
 
   switch (channel) {
     case X:
-      return { rangeMin: 0, rangeMax: model.layout().cellWidth};
+      // we can't use {range: "width"} here since we put scale in the root group
+      // not inside the cell, so scale is reusable for axes group
+      return {rangeMin: 0, rangeMax: model.layout().cellWidth};
     case Y:
+      // We can't use {range: "height"} here for the same reason
       if (scaleType === 'ordinal') {
         return {rangeMin: 0, rangeMax: model.layout().cellHeight};
       }

--- a/src/compiler/time.ts
+++ b/src/compiler/time.ts
@@ -52,27 +52,31 @@ export function range(timeUnit, model: Model) {
   return;
 }
 
-function isOrdinalFn(timeUnit) {
-  switch (timeUnit) {
-    case 'seconds':
-    case 'minutes':
-    case 'hours':
-    case 'day':
-    case 'date':
-    case 'month':
-      return true;
-  }
-  return false;
-}
-
 export namespace scale {
+  // FIXME move this to scale.type
   export function type(timeUnit, channel: Channel) {
     if (channel === COLOR) {
+      // FIXME if user specify scale.range as ordinal presets, then this should be ordinal
       return 'linear'; // time has order, so use interpolated ordinal color scale.
     }
+    if (channel === COLUMN || channel === ROW) {
+      return 'ordinal';
+    }
 
-    // FIXME revise this -- should 'year' be linear too?
-    return isOrdinalFn(timeUnit) || channel === COLUMN || channel === ROW ? 'ordinal' : 'linear';
+    switch (timeUnit) {
+      case 'hours':
+      case 'day':
+      case 'date':
+      case 'month':
+        return 'ordinal';
+      case 'year':
+      case 'second':
+      case 'minute':
+        return 'linear';
+    }
+    return 'time';
+
+
   }
 
   export function domain(timeUnit, channel?: Channel) {


### PR DESCRIPTION
I think we should extract “transformation”, “axis”, “scale” and “legend” as their own page in a later PR.  