### PR TITLE
Make `npm start` working sensible

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,21 @@ You can run `npm run build` to compile Vega-Lite and regenerate `vega-lite-schem
 
 During development, it can be convenient to rebuild automatically or run tests in the background.
 
-You can `npm run watch:dev` to start a watcher task that **lints and runs tests** when any `.ts` file changes.
+You can run `npm run start` to start a watcher task that shows the example gallery.
+Whenever any `.ts` file changes, the watcher:
+(1) re-compiles Vega-Lite
+(2) automatically refreshes the gallery with BrowserSync
+(3) lints and runs tests
+(4) regenerates the JSON schema (`vega-lite-schema.json`)
 
-You can use `npm run watch:build` to start a watcher task that **re-compiles Vega-Lite** when `.ts` files related to VL change.
+If you only want subset of these actions, you can use:
 
-The previous two commands run very fast but don't run all tasks that you may want. If you are okay to use a slow command, you can use `npm run watch:all` to start a watcher task that when any `.ts` file changes:
-- lints and runs tests
-- re-compiles Vega-Lite
-- regenerates `vega-lite-schema.json`
+- `npm run watch` to start a watcher task that do all of above except opening and syncing the gallery.
+
+- `npm run watch:test` to start a watcher task that **lints and runs tests** when any `.ts` file changes.
+
+- `npm run watch:build` to start a watcher task that **re-compiles Vega-Lite** when `.ts` files related to VL change.
+
 
 
 ### Developing Vega-Lite and Datalib

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
     "clean": "rm -f vega-lite.* vega-lite-schema.json & find src -name '*.js*' -type f -delete & find test -name '*.js*' -type f -delete",
     "deploy": "npm run clean && npm run lint && npm run test && scripts/deploy.sh",
     "lint": "tslint -c tslint.json src/*.ts test/*.ts src/**/*.ts test/**/*.ts",
-    "start": "npm run watch:build & browser-sync start --server --files 'vega-lite.js' --index 'gallery.html'",
+    "start": "npm run watch & browser-sync start --server --files 'vega-lite.js' --index 'gallery.html'",
     "schema": "tsc && node src/schema/schemagen.js > vega-lite-schema.json",
     "site": "bundle exec jekyll serve",
     "test": "tsc && mocha --recursive --require source-map-support/register",
     "watch:build": "watchify src/vl.ts -p tsify -v -d -s vl -o 'exorcist vega-lite.js.map > vega-lite.js'",
-    "watch:dev": "nodemon -e ts -x 'npm test && npm run lint'",
-    "watch:all": "nodemon -e ts -x 'npm test && npm run lint && npm run build'"
+    "watch:test": "nodemon -e ts -x 'npm test && npm run lint'",
+    "watch": "nodemon -e ts -x 'npm run build && npm test && npm run lint'"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION

- swap order of `npm run watch:all`, so that `npm start` can run `npm run watch` without being too slow. 
- rename dev=>test + update README.md.


