### PR TITLE
Hide the binned scatterplot again since Vega hasn't updated…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,6 @@
     "example/_diff/*"
   ],
   "dependencies": {
-    "datalib": "^1.5.7",
     "vega": "^2.4.1"
   }
 }

--- a/examples/vlexamples.json
+++ b/examples/vlexamples.json
@@ -22,7 +22,8 @@
     },
     {
       "name": "scatter_binned",
-      "title": "Binned Scatterplot"
+      "title": "Binned Scatterplot",
+      "hide": true 
     },
     {
       "name": "scatter_log",


### PR DESCRIPTION
- hide the binned scatterplot again since Vega hasn't released an update that uses datalib `1.5.7`.    
- remove datalib from bower dependency as datalib is embedded as vg.util