### PR TITLE
Remove `vega.d.ts` and  triple slash reference 

### DIFF
--- a/src/schema/schema.ts
+++ b/src/schema/schema.ts
@@ -1,7 +1,5 @@
 // Package of defining Vega-lite Specification's json schema
 
-/// <reference path="../../typings/vega.d.ts"/>
-
 import * as schemaUtil from './schemautil';
 import {mark} from './mark.schema';
 import {config, Config} from './config.schema';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -87,8 +87,7 @@
         "typings/chai.d.ts",
         "typings/datalib.d.ts",
         "typings/mocha.d.ts",
-        "typings/node.d.ts",
-        "typings/vega.d.ts"
+        "typings/node.d.ts"
     ],
     "atom": {
         "rewriteTsconfig": true

--- a/typings/vega.d.ts
+++ b/typings/vega.d.ts
@@ -1,3 +1,0 @@
-declare module "vega/src/transforms/Aggregate" {
-  export var VALID_OPS;
-}


### PR DESCRIPTION
so that we don't get "exported external package typings file cannot contain triple slash references" error when importing vega-lite into compass.