### PR TITLE
Add missing axis properties, rename shortTimeName => shortTimeLabel

### DIFF
--- a/docs/encoding.md
+++ b/docs/encoding.md
@@ -182,13 +182,21 @@ Vega-Lite's `axis` object supports the following [Vega axis properties](https://
 
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
+| format        | String        | The formatting pattern for axis labels. Vega uses [D3's format pattern](https://github.com/mbostock/d3/wiki/Formatting).|
+| grid          | Boolean       | A flag indicate if gridlines should be created in addition to ticks.  If `grid` is unspecified for X and Y, the default value is `true` for (1) quantitative fields that are not binned and (2) time fields.  Otherwise, the default value is `false`. |
+| layer         | String        | A string indicating if the axis (and any gridlines) should be placed above or below the data marks. One of `"front"` or `"back"` (default).|
+| offset        | Number | The offset, in pixels, by which to displace the axis from the edge of the enclosing group or data rectangle. |
 | orient        | String        | The orientation of the axis. One of `top` or `bottom` for `y` and `row` channels, and `left` or `right` for `x` and `column` channels.  By default, `x` axis is placed on the bottom, `y` axis is placed on the left, `column`'s x-axis is placed on the top, `row`'s y-axis is placed on the right. |
+| subdivide     | Number        | If provided, sets the number of minor ticks between major ticks (the value 9 results in decimal subdivision). Only applicable for axes visualizing quantitative scales.|
+| ticks         | Number        | A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are "nice" (multiples of 2, 5, 10) and lie within the underlying scale's range.  |
+| tickPadding   | Number        | The padding, in pixels, between ticks and text labels.|
+| tickSize      | Number        | The size, in pixels, of major, minor and end ticks.|
+| tickSizeMajor | Number        | The size, in pixels, of major ticks.|
+| tickSizeMinor | Number        | The size, in pixels, of minor ticks.|
+| tickSizeEnd   | Number        | The size, in pixels, of end ticks.|
 | title         | String        | A title for the axis.  If `title` is unspecified, the default value is produced from the field's name and transformation function applied e.g, "field_name", "SUM(field_name)", "BIN(field_name)", "YEAR(field_name)". |
 | titleOffset   | Number        | The offset (in pixels) from the axis at which to place the title.|
-| format        | String        | The formatting pattern for axis labels. Vega uses [D3's format pattern](https://github.com/mbostock/d3/wiki/Formatting).|
-| ticks         | Number        | A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are "nice" (multiples of 2, 5, 10) and lie within the underlying scale's range.  |
-| layer         | String        | A string indicating if the axis (and any gridlines) should be placed above or below the data marks. One of `"front"` or `"back"` (default).|
-| grid          | Boolean       | A flag indicate if gridlines should be created in addition to ticks.  If `grid` is unspecified for X and Y, the default value is `true` for (1) quantitative fields that are not binned and (2) time fields.  Otherwise, the default value is `false`. |
+| values        | Array         | Explicitly set the visible axis tick values.|
 | properties    | Object        | Optional mark property definitions for custom axis styling. The input object can include sub-objects for `ticks` (both major and minor), `majorTicks`, `minorTicks`, `labels` and `axis` (for the axis line).  These mark property definitions can make value references to their scale domain data via `data` property like so: `{field: "data"}`. This is a shorthand for `{field: {datum: "data"}}`. The template follows suite: `{template: "datum.data"}`. |
 
 

--- a/src/compiler/axis.ts
+++ b/src/compiler/axis.ts
@@ -179,7 +179,7 @@ namespace properties {
 
   export function labels(model: Model, channel: Channel, spec, def) {
     let fieldDef = model.fieldDef(channel);
-    var filterName = time.labelTemplate(fieldDef.timeUnit, fieldDef.axis.shortTimeNames);
+    var filterName = time.labelTemplate(fieldDef.timeUnit, fieldDef.axis.shortTimeLabels);
     if (fieldDef.type === TEMPORAL && filterName) {
       spec = extend({
         text: {template: '{{datum.data | ' + filterName + '}}'}

--- a/src/schema/axis.schema.ts
+++ b/src/schema/axis.schema.ts
@@ -8,8 +8,8 @@ export interface Axis {
   title?: string;
   tickSize?: number;
   offset?: number;
-  shortTimeNames?: boolean;
   // Vega-Lite only
+  shortTimeLabels?: boolean;
   labelMaxLength?: number;
   titleMaxLength?: number;
   titleOffset?: number;
@@ -74,7 +74,7 @@ export var axis = {
       default: undefined,  // auto
       description: 'A title offset value for the axis.'
     },
-    shortTimeNames: {
+    shortTimeLabels: {
       type: 'boolean',
       default: false,
       description: 'Whether month names and weekday names should be abbreviated.'

--- a/src/schema/axis.schema.ts
+++ b/src/schema/axis.schema.ts
@@ -3,17 +3,23 @@ export interface Axis {
   format?: string;
   grid?: boolean;
   layer?: string;
-  orient?: string;
-  ticks?: number;
-  title?: string;
-  tickSize?: number;
   offset?: number;
+  orient?: string;
+  subdivide?: number;
+  ticks?: number;
+  tickPadding?: number;
+  tickSize?: number;
+  tickSizeMajor?: number;
+  tickSizeMinor?: number;
+  tickSizeEnd?: number;
+  title?: string;
+  titleOffset?: number;
+  values?: number[];
+  properties?: any; // TODO: declare VgAxisProperties
   // Vega-Lite only
   shortTimeLabels?: boolean;
   labelMaxLength?: number;
   titleMaxLength?: number;
-  titleOffset?: number;
-  properties?: any; // TODO: declare VgAxisProperties
 }
 
 export var axis = {
@@ -38,11 +44,21 @@ export var axis = {
       default: undefined,
       description: 'A string indicating if the axis (and any gridlines) should be placed above or below the data marks.'
     },
+    offset: {
+      type: 'number',
+      default: undefined,
+      description: 'The offset, in pixels, by which to displace the axis from the edge of the enclosing group or data rectangle.'
+    },
     orient: {
       type: 'string',
       default: undefined,
       enum: ['top', 'right', 'left', 'bottom'],
       description: 'The orientation of the axis. One of top, bottom, left or right. The orientation can be used to further specialize the axis type (e.g., a y axis oriented for the right edge of the chart).'
+    },
+    subdivide: {
+      type: 'number',
+      default: undefined,
+      description: 'If provided, sets the number of minor ticks between major ticks (the value 9 results in decimal subdivision). Only applicable for axes visualizing quantitative scales.'
     },
     ticks: {
       type: 'integer',
@@ -50,11 +66,53 @@ export var axis = {
       minimum: 0,
       description: 'A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are "nice" (multiples of 2, 5, 10) and lie within the underlying scale\'s range.'
     },
-    /* Vega Axis Properties that are automatically populated by Vega-lite */
+    tickPadding: {
+      type: 'integer',
+      default: undefined,
+      description: 'The padding, in pixels, between ticks and text labels.'
+    },
+    tickSize: {
+      type: 'integer',
+      default: undefined,
+      minimum: 0,
+      description: 'The size, in pixels, of major, minor and end ticks.'
+    },
+    tickSizeMajor: {
+      type: 'integer',
+      default: undefined,
+      minimum: 0,
+      description: 'The size, in pixels, of major ticks.'
+    },
+    tickSizeMinor: {
+      type: 'integer',
+      default: undefined,
+      minimum: 0,
+      description: 'The size, in pixels, of minor ticks.'
+    },
+    tickSizeEnd: {
+      type: 'integer',
+      default: undefined,
+      minimum: 0,
+      description: 'The size, in pixels, of end ticks.'
+    },
     title: {
       type: 'string',
       default: undefined,
       description: 'A title for the axis. (Shows field name and its function by default.)'
+    },
+    titleOffset: {
+      type: 'integer',
+      default: undefined,  // auto
+      description: 'A title offset value for the axis.'
+    },
+    values: {
+      type: 'array',
+      default: undefined
+    },
+    properties: {
+      type: 'object',
+      default: undefined,
+      description: 'Optional mark property definitions for custom axis styling.'
     },
     /* Vega-lite only */
     labelMaxLength: {
@@ -63,26 +121,16 @@ export var axis = {
       minimum: 0,
       description: 'Truncate labels that are too long.'
     },
-    titleMaxLength: {
-      type: 'integer',
-      default: undefined,
-      minimum: 0,
-      description: 'Max length for axis title if the title is automatically generated from the field\'s description'
-    },
-    titleOffset: {
-      type: 'integer',
-      default: undefined,  // auto
-      description: 'A title offset value for the axis.'
-    },
     shortTimeLabels: {
       type: 'boolean',
       default: false,
       description: 'Whether month names and weekday names should be abbreviated.'
     },
-    properties: {
-      type: 'object',
+    titleMaxLength: {
+      type: 'integer',
       default: undefined,
-      description: 'Optional mark property definitions for custom axis styling.'
+      minimum: 0,
+      description: 'Max length for axis title if the title is automatically generated from the field\'s description'
     }
   }
 };


### PR DESCRIPTION
+ `shortTimeName` => `shortTimeLabel`
+ Adding `tickSizeMajor, tickSizeMinor, tickSizeEnd, values` to axis's schema and docs 
+ reorder values alphabetically

Fixes #796