### PR TITLE
Replace facet transform with aggregate for axes group

### DIFF
--- a/src/compiler/facet.ts
+++ b/src/compiler/facet.ts
@@ -132,7 +132,11 @@ function getXAxesGroup(model: Model, cellWidth, hasCol: boolean) { // TODO: VgMa
     hasCol ? {
       from: {
         data: model.dataTable(),
-        transform: [{type: 'facet', groupby: [model.field(COLUMN)]}]
+        transform: [{
+          type: 'aggregate',
+          groupby: [model.field(COLUMN)],
+          summarize: {'*': 'count'} // just a placeholder aggregation
+        }]
       }
     } : {},
     {
@@ -157,7 +161,11 @@ function getYAxesGroup(model: Model, cellHeight, hasRow: boolean) { // TODO: VgM
     hasRow ? {
       from: {
         data: model.dataTable(),
-        transform: [{type: 'facet', groupby: [model.field(ROW)]}]
+        transform: [{
+          type: 'aggregate',
+          groupby: [model.field(ROW)],
+          summarize: {'*': 'count'} // just a placeholder aggregation
+        }]
       }
     } : {},
     {


### PR DESCRIPTION
Do `aggregate` transform for x-axes group and y-axes group instead of `facet` because it should leave smaller memory footprint