### PR TITLE
make `config.marks.filled` applied to other applicable mark types

### DIFF
--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -248,29 +248,35 @@ export class Model {
     return vals && vals.length;
   }
 
-  public config(name: string) {
-    return this._spec.config[name];
+  public config(name: string, prop?: string) {
+    const value = prop ? this._spec.config[name][prop] : this._spec.config[name];
+
+    if (value === undefined) {
+      // rules for automatically determining default values
+      switch (name) {
+        case 'marks':
+          switch (prop) {
+            case 'filled':
+              // only point is not filled by default
+              return this.mark() !== POINT;
+            case 'opacity':
+              if (contains([POINT, TICK, CIRCLE, SQUARE], this.mark())) {
+                // point-based marks and bar
+                if (!this.isAggregate() || this.has(DETAIL)) {
+                  return 0.7;
+                }
+              }
+              break;
+          }
+          break;
+      }
+    }
+    return value;
   }
 
   /** returns scale name for a given channel */
   public scale(channel: Channel): string {
     const name = this.spec().name;
     return (name ? name + '-' : '') + channel;
-  }
-
-  // FIXME -- move this to marks.ts
-  public markOpacity(): number {
-    const opacity = this.config('marks').opacity;
-    if (opacity) {
-      return opacity;
-    } else {
-      if (contains([POINT, TICK, CIRCLE, SQUARE], this.mark())) {
-        // point-based marks and bar
-        if (!this.isAggregate() || this.has(DETAIL)) {
-          return 0.7;
-        }
-      }
-    }
-    return undefined;
   }
 }

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -248,6 +248,12 @@ export class Model {
     return vals && vals.length;
   }
 
+  /**
+   * @return Config value from the spec.  If a value is not specified,
+   * return default values.
+   * For example, `config('marks', 'filled')`` returns either true or false based
+   * on the spec's mark type.
+   */
   public config(name: string, prop?: string) {
     const value = prop ? this._spec.config[name][prop] : this._spec.config[name];
 

--- a/src/compiler/legend.ts
+++ b/src/compiler/legend.ts
@@ -124,7 +124,7 @@ namespace properties {
         break;
     }
 
-    var opacity = model.markOpacity();
+    var opacity = model.config('marks', 'opacity');
     if (opacity) { symbols.opacity = {value: opacity}; }
 
     symbols = extend(symbols, spec || {});

--- a/src/compiler/legend.ts
+++ b/src/compiler/legend.ts
@@ -100,7 +100,7 @@ namespace properties {
         /* fall through */
       case POINT:
         // fill or stroke
-        if (model.config('marks').filled) {
+        if (model.config('marks', 'filled')) {
           if (model.has(COLOR) && channel === COLOR) {
             symbols.fill = {scale: model.scale(COLOR), field: 'data'};
           } else {

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -122,6 +122,32 @@ export function compileMarks(model: Model): any[] {
   }
 }
 
+function colorMixins(model: Model, defaultFilled: boolean) {
+  let p: any = {};
+  const marksConfig = model.config('marks');
+  if (marksConfig.filled !== undefined ? marksConfig.filled : defaultFilled) {
+    if (model.has(COLOR)) {
+      p.fill = {
+        scale: model.scale(COLOR),
+        field: model.field(COLOR)
+      };
+    } else {
+      p.fill = { value: model.fieldDef(COLOR).value };
+    }
+  } else {
+    if (model.has(COLOR)) {
+      p.stroke = {
+        scale: model.scale(COLOR),
+        field: model.field(COLOR)
+      };
+    } else {
+      p.stroke = { value: model.fieldDef(COLOR).value };
+    }
+    p.strokeWidth = { value: model.config('marks').strokeWidth };
+  }
+  return p;
+}
+
 function applyMarksConfig(marksProperties, marksConfig, propsList) {
   propsList.forEach(function(property) {
     const value = marksConfig[property];
@@ -265,14 +291,7 @@ export namespace bar {
     }
 
     // fill
-    if (model.has(COLOR)) {
-      p.fill = {
-        scale: model.scale(COLOR),
-        field: model.field(COLOR)
-      };
-    } else {
-      p.fill = { value: model.fieldDef(COLOR).value };
-    }
+    extend(p, colorMixins(model, true));
 
     // opacity
     var opacity = model.markOpacity();
@@ -286,7 +305,6 @@ export namespace point {
   export function properties(model: Model) {
     // TODO Use Vega's marks properties interface
     var p: any = {};
-    const marksConfig = model.config('marks');
 
     // x
     if (model.has(X)) {
@@ -329,26 +347,7 @@ export namespace point {
     }
 
     // fill or stroke
-    if (marksConfig.filled) {
-      if (model.has(COLOR)) {
-        p.fill = {
-          scale: model.scale(COLOR),
-          field: model.field(COLOR)
-        };
-      } else {
-        p.fill = { value: model.fieldDef(COLOR).value };
-      }
-    } else {
-      if (model.has(COLOR)) {
-        p.stroke = {
-          scale: model.scale(COLOR),
-          field: model.field(COLOR)
-        };
-      } else {
-        p.stroke = { value: model.fieldDef(COLOR).value };
-      }
-      p.strokeWidth = { value: model.config('marks').strokeWidth };
-    }
+    extend(p, colorMixins(model, false));
 
     // opacity
     const opacity = model.markOpacity();
@@ -472,14 +471,7 @@ export namespace area {
     }
 
     // fill
-    if (model.has(COLOR)) {
-      p.fill = {
-        scale: model.scale(COLOR),
-        field: model.field(COLOR)
-      };
-    } else {
-      p.fill = { value: model.fieldDef(COLOR).value };
-    }
+    extend(p, colorMixins(model, true));
 
     // opacity
     var opacity = model.markOpacity();

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -122,10 +122,9 @@ export function compileMarks(model: Model): any[] {
   }
 }
 
-function colorMixins(model: Model, defaultFilled: boolean) {
+function colorMixins(model: Model) {
   let p: any = {};
-  const marksConfig = model.config('marks');
-  if (marksConfig.filled !== undefined ? marksConfig.filled : defaultFilled) {
+  if (model.config('marks', 'filled')) {
     if (model.has(COLOR)) {
       p.fill = {
         scale: model.scale(COLOR),
@@ -291,10 +290,10 @@ export namespace bar {
     }
 
     // fill
-    extend(p, colorMixins(model, true));
+    extend(p, colorMixins(model));
 
     // opacity
-    var opacity = model.markOpacity();
+    var opacity = model.config('marks', 'opacity');
     if (opacity) { p.opacity = { value: opacity }; };
 
     return p;
@@ -347,10 +346,10 @@ export namespace point {
     }
 
     // fill or stroke
-    extend(p, colorMixins(model, false));
+    extend(p, colorMixins(model));
 
     // opacity
-    const opacity = model.markOpacity();
+    const opacity = model.config('marks', 'opacity');
     if (opacity) { p.opacity = { value: opacity }; };
 
     return p;
@@ -393,7 +392,7 @@ export namespace line {
     }
 
     // opacity
-    var opacity = model.markOpacity();
+    var opacity = model.config('marks', 'opacity');
     if (opacity) { p.opacity = { value: opacity }; };
 
     p.strokeWidth = { value: model.config('marks').strokeWidth };
@@ -471,10 +470,10 @@ export namespace area {
     }
 
     // fill
-    extend(p, colorMixins(model, true));
+    extend(p, colorMixins(model));
 
     // opacity
-    var opacity = model.markOpacity();
+    var opacity = model.config('marks', 'opacity');
     if (opacity) { p.opacity = { value: opacity }; };
 
     applyMarksConfig(p, model.config('marks'), ['interpolate', 'tension']);
@@ -542,7 +541,7 @@ export namespace tick {
     }
 
     // opacity
-    var opacity = model.markOpacity();
+    var opacity = model.config('marks', 'opacity');
     if (opacity) { p.opacity = { value: opacity }; };
 
     return p;
@@ -598,7 +597,7 @@ function filled_point_props(shape) {
     }
 
     // opacity
-    var opacity = model.markOpacity();
+    var opacity = model.config('marks', 'opacity');
     if (opacity) { p.opacity = { value: opacity }; };
 
     return p;
@@ -669,7 +668,7 @@ export namespace text {
     // TODO: consider if color should just map to fill instead?
 
     // opacity
-    var opacity = model.markOpacity();
+    var opacity = model.config('marks', 'opacity');
     if (opacity) { p.opacity = { value: opacity }; };
 
     // text

--- a/src/schema/config.marks.schema.ts
+++ b/src/schema/config.marks.schema.ts
@@ -34,8 +34,10 @@ export const marksConfig = {
     // Vega-Lite special
     filled: {
       type: 'boolean',
-      default: false,
-      description: 'Whether the shape\'s color should be used as fill color instead of stroke color.  This is only applicable for "bar", "point", and "area"'
+      default: undefined,
+      description: 'Whether the shape\'s color should be used as fill color instead of stroke color. ' +
+        'This is only applicable for "bar", "point", and "area". ' +
+        'All marks except "point" marks are filled by default.'
     },
     format: {
       type: 'string',

--- a/src/schema/config.marks.schema.ts
+++ b/src/schema/config.marks.schema.ts
@@ -35,7 +35,7 @@ export const marksConfig = {
     filled: {
       type: 'boolean',
       default: false,
-      description: 'Whether the shape\'s color should be used as fill color instead of stroke color.'
+      description: 'Whether the shape\'s color should be used as fill color instead of stroke color.  This is only applicable for "bar", "point", and "area"'
     },
     format: {
       type: 'string',

--- a/test/compiler/marks.test.ts
+++ b/test/compiler/marks.test.ts
@@ -173,7 +173,7 @@ describe('compile.marks', function() {
 
     describe('3D', function() {
       describe('x,y,color', function () {
-        var f = fixtures.area['x,y,stroke'],
+        var f = fixtures.area['x,y,color'],
             e = new Model(f),
             def = marks.area.properties(e);
         it('should have scale for color', function () {

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -144,7 +144,7 @@ f.area['x,y'] = {
   'data': {'url': 'data/cars.json'}
 };
 
-f.area['x,y,stroke'] = {
+f.area['x,y,color'] = {
   'mark': 'area',
   'encoding': {
     'x': {'field': 'Displacement','type': 'quantitative'},


### PR DESCRIPTION
- make `config.marks.filled` applied to other applicable mark types (`bar` and `area`) 
- consolidate rules for determining default config values. 

fixes #812.