### PR TITLE
remove scale and sort from detail, add / reorganize config 

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -33,6 +33,15 @@ the size of one plot inside the trellis plots.
 | width         | Integer       | The width of the visualization for a single cell (200 pixels by default).  This property is used only when `x` uses non-ordinal scale.  When `x` uses ordinal scale, the width is determined by x-scale's `bandWidth`.  |
 | height        | Integer       | The height of the visualization for a single cell (200 pixels by default).  This property is used only when `y` uses non-ordinal scale.  When `y` uses ordinal scale, the height is determined by y-scale's `bandWidth`. |
 
+the following grid properties:
+
+| Property      | Type          | Description    |
+| :------------ |:-------------:| :------------- |
+| gridShow      | Boolean       | Whether to show facet rules.  (True by default)  |
+| gridColor     | Color         | Color of the rules between facets. |
+| gridOpacity   | Number        | Opacity of the rules between facets. |
+| gridOffset    | Number        | Offset for rules between facets.  |
+
 and the following fill and stroke properties:
 
 | Property      | Type          | Description    |

--- a/docs/config.md
+++ b/docs/config.md
@@ -56,6 +56,7 @@ and the following fill and stroke properties:
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
 | filled        | Boolean        | Whether the shape\'s color should be used as fill color instead of stroke color.  This is only applicable for `bar`, `point`, and `area`.  All marks except `point` marks are filled by default. |
+| sortBy        | Field &#124; Field[] | Data field(s) for sorting layer of marks.  The first mark will placed on the bottom.  `"-"` prefix can be added to each field to set descending order. |
 | sortLineBy    | Field &#124; Field[] | Data field(s) for sorting points in each group of line.  `"-"` prefix can be added to each field to set descending order.  |
 | opacity       | Number        | The overall opacity (value between [0,1]). |
 | strokeWidth   | Number        | The stroke width, in pixels. |

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,7 +12,7 @@ A Vega-Lite `config` object can have the following top-level properties:
 | :------------ |:-------------:| :------------- |
 | viewport      | Integer[]     | The width and height of the on-screen viewport, in pixels. If necessary, clipping and scrolling will be applied. |
 | background    | String        | CSS color property to use as background of visualization. Default is `"transparent"`. |
-| sortLineBy    | Number[]      | Data field to sort line by.  `"-"` prefix can be added to set descending order.  |
+
 
 <!-- TODO: consider adding width, height, viewport, filterNull, numberFormat, timeFormat  -->
 
@@ -56,6 +56,7 @@ and the following fill and stroke properties:
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
 | filled        | Boolean        | Whether the shape\'s color should be used as fill color instead of stroke color.  This is only applicable for `bar`, `point`, and `area`.  All marks except `point` marks are filled by default. |
+| sortLineBy    | Field &#124; Field[] | Data field(s) for sorting points in each group of line.  `"-"` prefix can be added to each field to set descending order.  |
 | opacity       | Number        | The overall opacity (value between [0,1]). |
 | strokeWidth   | Number        | The stroke width, in pixels. |
 | strokeDash    | Number[]      | An array of alternating stroke, space lengths for creating dashed or dotted lines.  |

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -1,4 +1,5 @@
 import {Spec} from '../schema/schema';
+import {Axis} from '../schema/axis.schema';
 import {FieldDef} from '../schema/fielddef.schema';
 
 import {COLUMN, ROW, X, Y, COLOR, DETAIL, Channel, supportMark} from '../channel';
@@ -252,6 +253,11 @@ export class Model {
     return this._spec.config.cell[name];
   }
 
+  public axisDef(channel: Channel): Axis {
+    const axis = this.fieldDef(channel).axis;
+    return typeof axis !== 'boolean' ? axis : {};
+  }
+
   /**
    * @return Mark config value from the spec, or a default value if unspecified.
    */
@@ -309,9 +315,10 @@ export class Model {
   public labelTemplate(channel: Channel): string {
     const fieldDef = this.fieldDef(channel);
     const legend = fieldDef.legend;
+    const axis = fieldDef.axis;
     const abbreviated = contains([ROW, COLUMN, X, Y], channel) ?
-      fieldDef.axis.shortTimeLabels :
-      typeof legend !== 'boolean' ? legend.shortTimeLabels : false;
+      (typeof axis !== 'boolean' ? axis.shortTimeLabels : false) :
+      (typeof legend !== 'boolean' ? legend.shortTimeLabels : false);
 
     var postfix = abbreviated ? '-abbrev' : '';
     switch (fieldDef.timeUnit) {

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -1,6 +1,7 @@
 import {Spec} from '../schema/schema';
-import {Axis} from '../schema/axis.schema';
+import {Axis, axis as axisSchema} from '../schema/axis.schema';
 import {FieldDef} from '../schema/fielddef.schema';
+import {instantiate} from '../schema/schemautil';
 
 import {COLUMN, ROW, X, Y, COLOR, DETAIL, Channel, supportMark} from '../channel';
 import {SOURCE, SUMMARY} from '../data';
@@ -59,6 +60,10 @@ export class Model {
       if (fieldDef.type) {
         // convert short type to full type
         fieldDef.type = getFullName(fieldDef.type);
+      }
+
+      if (fieldDef.axis === true) {
+        fieldDef.axis = instantiate(axisSchema);
       }
     }, this);
 

--- a/src/compiler/axis.ts
+++ b/src/compiler/axis.ts
@@ -38,7 +38,7 @@ export function compileAxis(channel: Channel, model: Model) {
   });
 
   // 2) Add mark property definition groups
-  var props = model.fieldDef(channel).axis.properties || {};
+  var props = model.axisDef(channel).properties || {};
 
   [
     'axis', 'labels',// have special rules
@@ -58,7 +58,7 @@ export function compileAxis(channel: Channel, model: Model) {
 
 export function format(model: Model, channel: Channel) {
   const fieldDef = model.fieldDef(channel);
-  var format = fieldDef.axis.format;
+  var format = model.axisDef(channel).format;
   if (format !== undefined)  {
     return format;
   }
@@ -78,7 +78,7 @@ export function format(model: Model, channel: Channel) {
 
 export function grid(model: Model, channel: Channel) {
   const fieldDef = model.fieldDef(channel);
-  var grid = fieldDef.axis.grid;
+  var grid = model.axisDef(channel).grid;
   if (grid !== undefined) {
     return grid;
   }
@@ -89,7 +89,7 @@ export function grid(model: Model, channel: Channel) {
 }
 
 export function layer(model: Model, channel: Channel, def) {
-  var layer = model.fieldDef(channel).axis.layer;
+  var layer = model.axisDef(channel).layer;
   if (layer !== undefined) {
     return layer;
   }
@@ -101,14 +101,14 @@ export function layer(model: Model, channel: Channel, def) {
 };
 
 export function orient(model: Model, channel: Channel) {
-  var orient = model.fieldDef(channel).axis.orient;
+  var orient = model.axisDef(channel).orient;
   if (orient) {
     return orient;
   } else if (channel === COLUMN) {
     // FIXME test and decide
     return 'top';
   } else if (channel === ROW) {
-    if (model.has(Y) && model.fieldDef(Y).axis.orient !== 'right') {
+    if (model.has(Y) && model.axisDef(Y).orient !== 'right') {
       return 'right';
     }
   }
@@ -116,7 +116,7 @@ export function orient(model: Model, channel: Channel) {
 }
 
 export function ticks(model: Model, channel: Channel) {
-  const ticks = model.fieldDef(channel).axis.ticks;
+  const ticks = model.axisDef(channel).ticks;
   if (ticks !== undefined) {
     return ticks;
   }
@@ -130,7 +130,7 @@ export function ticks(model: Model, channel: Channel) {
 }
 
 export function tickSize(model: Model, channel: Channel) {
-  const tickSize = model.fieldDef(channel).axis.tickSize;
+  const tickSize = model.axisDef(channel).tickSize;
   if (tickSize !== undefined) {
     return tickSize;
   }
@@ -142,9 +142,9 @@ export function tickSize(model: Model, channel: Channel) {
 
 
 export function title(model: Model, channel: Channel) {
-  var axisSpec = model.fieldDef(channel).axis;
-  if (axisSpec.title !== undefined) {
-    return axisSpec.title;
+  var axisDef = model.axisDef(channel);
+  if (axisDef.title !== undefined) {
+    return axisDef.title;
   }
 
   // if not defined, automatically determine axis title from field def
@@ -152,14 +152,14 @@ export function title(model: Model, channel: Channel) {
   const layout = model.layout();
 
   var maxLength;
-  if (axisSpec.titleMaxLength) {
-    maxLength = axisSpec.titleMaxLength;
+  if (axisDef.titleMaxLength) {
+    maxLength = axisDef.titleMaxLength;
   } else if (channel === X && typeof layout.cellWidth === 'number') {
     // Guess max length if we know cell size at compile time
-    maxLength = layout.cellWidth / model.fieldDef(X).axis.characterWidth;
+    maxLength = layout.cellWidth / model.axisDef(X).characterWidth;
   } else if (channel === Y && typeof layout.cellHeight === 'number') {
     // Guess max length if we know cell size at compile time
-    maxLength = layout.cellHeight / model.fieldDef(Y).axis.characterWidth;
+    maxLength = layout.cellHeight / model.axisDef(Y).characterWidth;
   }
   // FIXME: we should use template to truncate instead
   return maxLength ? truncate(fieldTitle, maxLength) : fieldTitle;
@@ -177,9 +177,10 @@ export namespace properties {
   }
 
   export function labels(model: Model, channel: Channel, spec, def) {
-    let fieldDef = model.fieldDef(channel);
+    const fieldDef = model.fieldDef(channel);
+    const axisDef = model.axisDef(channel);
 
-    if (!fieldDef.axis.labels) {
+    if (!axisDef.labels) {
       return extend({
         text: ''
       }, spec);
@@ -192,11 +193,11 @@ export namespace properties {
       }, spec || {});
     }
 
-    if (contains([NOMINAL, ORDINAL], fieldDef.type) && fieldDef.axis.labelMaxLength) {
+    if (contains([NOMINAL, ORDINAL], fieldDef.type) && axisDef.labelMaxLength) {
       // TODO replace this with Vega's labelMaxLength once it is introduced
       spec = extend({
         text: {
-          template: '{{ datum.data | truncate:' + fieldDef.axis.labelMaxLength + '}}'
+          template: '{{ datum.data | truncate:' + axisDef.labelMaxLength + '}}'
         }
       }, spec || {});
     }

--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -49,8 +49,8 @@ export function compile(spec, theme?) {
     rootGroup.marks = marks;
     rootGroup.scales = compileScales(model.channels(), model);
 
-    var axes = (model.has(X) ? [compileAxis(X, model)] : [])
-      .concat(model.has(Y) ? [compileAxis(Y, model)] : []);
+    var axes = (model.has(X) && model.fieldDef(X).axis ? [compileAxis(X, model)] : [])
+      .concat(model.has(Y) && model.fieldDef(Y).axis ? [compileAxis(Y, model)] : []);
     if (axes.length > 0) {
       rootGroup.axes = axes;
     }

--- a/src/compiler/facet.ts
+++ b/src/compiler/facet.ts
@@ -60,8 +60,9 @@ export function facetMixins(model: Model, marks) {
       // If has X, prepend a group for shared x-axes in the root group's marks
       rootMarks.push(getXAxesGroup(model, cellWidth, hasCol));
     }
-
-    rootMarks.push(getRowRulesGroup(model, cellHeight));
+    if (model.cellConfig('gridShow')) {
+      rootMarks.push(getRowRulesGroup(model, cellHeight));
+    }
   } else { // doesn't have row
     if (model.has(X)) { // keep x axis in the cell
       cellAxes.push(compileAxis(X, model));
@@ -87,8 +88,9 @@ export function facetMixins(model: Model, marks) {
       // If has Y, prepend a group for shared y-axes in the root group's marks
       rootMarks.push(getYAxesGroup(model, cellHeight, hasRow));
     }
-    // TODO: add properties to make rule optional
-    rootMarks.push(getColumnRulesGroup(model, cellWidth));
+    if (model.cellConfig('gridShow')) {
+      rootMarks.push(getColumnRulesGroup(model, cellWidth));
+    }
   } else { // doesn't have column
     if (model.has(Y)) { // keep y axis in the cell
       cellAxes.push(compileAxis(Y, model));

--- a/src/compiler/facet.ts
+++ b/src/compiler/facet.ts
@@ -204,7 +204,7 @@ function getRowRulesGroup(model: Model, cellHeight): any { // TODO: VgMarks
     }
   };
 
-  const rowRulesOnTop = !model.has(X) || model.fieldDef(X).axis.orient !== 'top';
+  const rowRulesOnTop = !model.has(X) || model.axisDef(X).orient !== 'top';
   if (rowRulesOnTop) { // on top - no need to add offset
     return rowRules;
   } // otherwise, need to offset all rules by cellHeight
@@ -254,7 +254,7 @@ function getColumnRulesGroup(model: Model, cellWidth): any { // TODO: VgMarks
     }
   };
 
-  const colRulesOnLeft = !model.has(Y) || model.fieldDef(Y).axis.orient === 'right';
+  const colRulesOnLeft = !model.has(Y) || model.axisDef(Y).orient === 'right';
   if (colRulesOnLeft) { // on left, no need to add global offset
     return columnRules;
   } // otherwise, need to offset all rules by cellWidth

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -18,7 +18,7 @@ export function compileMarks(model: Model): any[] {
 
     // For line and area, we sort values based on dimension by default
     // For line, a special config "sortLineBy" is allowed
-    let sortBy = mark === LINE ? model.config('sortLineBy') : undefined;
+    let sortBy = mark === LINE ? model.markConfig('sortLineBy') : undefined;
     if (!sortBy) {
       sortBy = '-' + model.field(model.markConfig('orient') === 'horizontal' ? Y : X);
     }

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -18,9 +18,9 @@ export function compileMarks(model: Model): any[] {
 
     // For line and area, we sort values based on dimension by default
     // For line, a special config "sortLineBy" is allowed
-    let sortBy = mark === LINE ? model.markConfig('sortLineBy') : undefined;
-    if (!sortBy) {
-      sortBy = '-' + model.field(model.markConfig('orient') === 'horizontal' ? Y : X);
+    let sortLineBy = mark === LINE ? model.markConfig('sortLineBy') : undefined;
+    if (!sortLineBy) {
+      sortLineBy = '-' + model.field(model.markConfig('orient') === 'horizontal' ? Y : X);
     }
 
     let pathMarks: any = extend(
@@ -34,7 +34,7 @@ export function compileMarks(model: Model): any[] {
           isFaceted || details.length > 0 ? {} : dataFrom,
 
           // sort transform
-          {transform: [{ type: 'sort', by: sortBy }]}
+          {transform: [{ type: 'sort', by: sortLineBy }]}
         ),
         properties: { update: exports[mark].properties(model) }
       }

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -4,41 +4,44 @@ declare var exports;
 import {contains, extend, range} from '../util';
 import {Model} from './Model';
 import {SHARED_DOMAIN_OPS} from '../aggregate';
-import {COLUMN, ROW, X, Y, SHAPE, SIZE, COLOR, TEXT, Channel} from '../channel';
+import {COLUMN, ROW, X, Y, SHAPE, SIZE, COLOR, TEXT, DETAIL, Channel} from '../channel';
 import {SOURCE, STACKED} from '../data';
 import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../type';
 import {BAR, TEXT as TEXT_MARK} from '../mark';
 
 export function compileScales(channels: Channel[], model: Model) {
-  return channels.map(function(channel: Channel) {
-    var scaleDef: any = {
-      name: model.scale(channel),
-      type: type(channel, model),
-    };
+  return channels.filter(function(channel: Channel) {
+      return channel !== DETAIL;
+    })
+    .map(function(channel: Channel) {
+      var scaleDef: any = {
+        name: model.scale(channel),
+        type: type(channel, model),
+      };
 
-    scaleDef.domain = domain(model, channel, scaleDef.type);
-    extend(scaleDef, rangeMixins(model, channel, scaleDef.type));
+      scaleDef.domain = domain(model, channel, scaleDef.type);
+      extend(scaleDef, rangeMixins(model, channel, scaleDef.type));
 
-    // Add optional properties
-    [
-      // general properties
-      'reverse', 'round',
-      // quantitative / time
-      'clamp', 'nice',
-      // quantitative
-      'exponent', 'zero',
-      // ordinal
-      'bandWidth', 'outerPadding', 'padding', 'points'
-    ].forEach(function(property) {
-      // TODO include fieldDef as part of the parameters
-      var value = exports[property](model, channel, scaleDef.type);
-      if (value !== undefined) {
-        scaleDef[property] = value;
-      }
+      // Add optional properties
+      [
+        // general properties
+        'reverse', 'round',
+        // quantitative / time
+        'clamp', 'nice',
+        // quantitative
+        'exponent', 'zero',
+        // ordinal
+        'bandWidth', 'outerPadding', 'padding', 'points'
+      ].forEach(function(property) {
+        // TODO include fieldDef as part of the parameters
+        var value = exports[property](model, channel, scaleDef.type);
+        if (value !== undefined) {
+          scaleDef[property] = value;
+        }
+      });
+
+      return scaleDef;
     });
-
-    return scaleDef;
-  });
 }
 
 export function type(channel: Channel, model: Model): string {

--- a/src/schema/config.cell.schema.ts
+++ b/src/schema/config.cell.schema.ts
@@ -3,6 +3,7 @@ export interface CellConfig {
   height?: number;
   padding?: number;
 
+  gridShow?: boolean;
   gridColor?: string;
   gridOpacity?: number;
   gridOffset?: number;
@@ -31,6 +32,10 @@ export const cellConfig = {
       type: 'integer',
       default: 16,
       description: 'default padding between facets.'
+    },
+    gridShow: {
+      type: 'boolean',
+      default: true
     },
     gridColor: {
       type: 'string',

--- a/src/schema/config.marks.schema.ts
+++ b/src/schema/config.marks.schema.ts
@@ -1,5 +1,6 @@
 export interface MarkConfig {
   filled?: boolean;
+  sortBy?: String | String[];
   sortLineBy?: String | String[];
 
   // General Vega
@@ -40,6 +41,14 @@ export const markConfig = {
       description: 'Whether the shape\'s color should be used as fill color instead of stroke color. ' +
         'This is only applicable for "bar", "point", and "area". ' +
         'All marks except "point" marks are filled by default.'
+    },
+    sortBy: {
+      default: undefined,
+      oneOf: [
+        {type: 'string'},
+        {type: 'array', items:{type:'string'}}
+      ],
+      description: 'Sort layer of marks by a given field or fields.'
     },
     sortLineBy: {
       default: undefined,

--- a/src/schema/config.marks.schema.ts
+++ b/src/schema/config.marks.schema.ts
@@ -1,5 +1,6 @@
 export interface MarkConfig {
   filled?: boolean;
+  sortLineBy?: String | String[];
 
   // General Vega
   opacity?: number;
@@ -39,6 +40,14 @@ export const markConfig = {
       description: 'Whether the shape\'s color should be used as fill color instead of stroke color. ' +
         'This is only applicable for "bar", "point", and "area". ' +
         'All marks except "point" marks are filled by default.'
+    },
+    sortLineBy: {
+      default: undefined,
+      oneOf: [
+        {type: 'string'},
+        {type: 'array', items:{type:'string'}}
+      ],
+      description: 'Sort layer of marks by a given field or fields.'
     },
     // General Vega
     // TODO consider removing as it is conflicting with color.value

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -8,9 +8,7 @@ export interface Config {
   height?: number;
   padding?: number|string;
   viewport?: number;
-
   background?: string;
-  sortLineBy?: string;
 
   cell?: CellConfig;
   mark?: MarkConfig;
@@ -54,12 +52,6 @@ export const config = {
       role: 'color',
       default: undefined,
       description: 'CSS color property to use as background of visualization. Default is `"transparent"`.'
-    },
-    sortLineBy: {
-      type: 'string',
-      default: undefined,
-      description: 'Data field to sort line by. ' +
-        '\'-\' prefix can be added to suggest descending order.'
     },
 
     // filter null

--- a/src/schema/encoding.schema.ts
+++ b/src/schema/encoding.schema.ts
@@ -3,7 +3,7 @@ import {duplicate} from '../util';
 
 
 import {axis} from './axis.schema';
-import {FieldDef, facetField, onlyOrdinalField, typicalField} from './fielddef.schema';
+import {FieldDef, fieldDef, facetField, onlyOrdinalField, typicalField} from './fielddef.schema';
 import {legend} from './legend.schema';
 import {sort} from './sort.schema';
 
@@ -95,11 +95,7 @@ var shape = merge(duplicate(onlyOrdinalField), {
   }
 });
 
-var detail = merge(duplicate(onlyOrdinalField), {
-  properties: {
-    sort: sort
-  }
-});
+var detail = duplicate(fieldDef);
 
 // we only put aggregated measure in pivot table
 var text = merge(duplicate(typicalField), {

--- a/src/schema/fielddef.schema.ts
+++ b/src/schema/fielddef.schema.ts
@@ -28,7 +28,7 @@ export interface FieldDef {
   sort?: Sort | string;
 
   // override vega components
-  axis?: Axis;
+  axis?: Axis | boolean;
   legend?: Legend | boolean;
   scale?: Scale;
 

--- a/test/compiler/axis.test.ts
+++ b/test/compiler/axis.test.ts
@@ -5,8 +5,29 @@ import {Model} from '../../src/compiler/Model';
 import {POINT, LINE} from '../../src/mark';
 import {X, COLUMN} from '../../src/channel';
 import {TEMPORAL, QUANTITATIVE, ORDINAL} from '../../src/type';
+import * as vl from '../../src/vl';
 
 describe('Axis', function() {
+  describe('=true', function() {
+    it('should produce default properties for axis', function() {
+      const spec1 = vl.compile({
+        mark: 'point',
+        encoding: {
+          x: {field: 'Horsepower', type: 'quantitative'},
+          y: {field: 'Miles_per_Gallon', type: 'quantitative'}
+        }
+      });
+      const spec2 = vl.compile({
+        mark: 'point',
+        encoding: {
+          x: {field: 'Horsepower', type: 'quantitative', axis: true},
+          y: {field: 'Miles_per_Gallon', type: 'quantitative', axis: true}
+        }
+      });
+      expect(spec1).to.eql(spec2);
+    });
+  });
+
   describe('(X) for Time Data', function() {
     var field = 'a',
       timeUnit = 'month',


### PR DESCRIPTION
Fixes #871, #901, #771

- remove scale and sort from detail	
- make sure we don’t produce a scale for detail in the output	
- add `config.mark.sortBy` and move `config.sortLineBy` to `config.mark.sortLine`.
- Add properties for hiding facet's rules/grid and docs for all `cell.facet/grid` properties (still need to determine how should we call these properties though) – addresses #896
- Allow hiding axis 