### PR TITLE
Support Multiple Detail

### DIFF
--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -76,15 +76,17 @@ export class Model {
     const spec = this.spec();
     const stackFields = [COLOR, DETAIL].reduce(function(fields, channel) {
       const channelEncoding = spec.encoding[channel];
-      if (isArray(channelEncoding)) {
-        channelEncoding.forEach(function(fieldDef) {
-          fields.push(fieldDef);
-        });
-      } else {
-        fields.push(channelEncoding);
+      if (this.has(channel)) {
+        if (isArray(channelEncoding)) {
+          channelEncoding.forEach(function(fieldDef) {
+            fields.push(fieldDef);
+          });
+        } else {
+          fields.push(channelEncoding);
+        }
       }
       return fields;
-    }, []);
+    }.bind(this), []);
 
     if (stackFields.length > 0 &&
       (this.is(BAR) || this.is(AREA)) &&

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -59,15 +59,16 @@ export class Model {
 
   private getStackProperties(): StackProperties {
     const spec = this.spec();
+    const model = this;
     const stackFields = [COLOR, DETAIL].reduce(function(fields, channel) {
       const channelEncoding = spec.encoding[channel];
-      if (this.has(channel)) {
+      if (model.has(channel)) {
         if (isArray(channelEncoding)) {
           channelEncoding.forEach(function(fieldDef) {
-            fields.push(fieldDef);
+            fields.push(vlFieldDef.field(fieldDef));
           });
         } else {
-          fields.push(channelEncoding);
+          fields.push(model.field(channel));
         }
       }
       return fields;

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -7,6 +7,7 @@ import {StackProperties} from './stack';
 import {autoMaxBins} from '../bin';
 import {Channel, X, Y, ROW, COLUMN} from '../channel';
 import {SOURCE, STACKED, LAYOUT, SUMMARY} from '../data';
+import {field} from '../fielddef';
 import {QUANTITATIVE, TEMPORAL} from '../type';
 import {type as scaleType} from './scale';
 
@@ -124,9 +125,9 @@ export namespace source {
       if (fieldDef.type === TEMPORAL && fieldDef.timeUnit) {
         transform.push({
           type: 'formula',
-          field: model.field(channel),
+          field: field(fieldDef),
           expr: 'utc' + fieldDef.timeUnit + '(' +
-                model.field(channel, {nofn: true, datum: true}) + ')'
+                field(fieldDef, {nofn: true, datum: true}) + ')'
         });
       }
       return transform;
@@ -141,9 +142,9 @@ export namespace source {
             type: 'bin',
             field: fieldDef.field,
             output: {
-              start: model.field(channel, {binSuffix: '_start'}),
-              mid: model.field(channel, {binSuffix: '_mid'}),
-              end: model.field(channel, {binSuffix: '_end'})
+              start: field(fieldDef, {binSuffix: '_start'}),
+              mid: field(fieldDef, {binSuffix: '_mid'}),
+              end: field(fieldDef, {binSuffix: '_end'})
             }
           },
           // if bin is an object, load parameter here!
@@ -159,10 +160,10 @@ export namespace source {
         if (scaleType(fieldDef, channel) === 'ordinal') {
           transform.push({
             type: 'formula',
-            field: model.field(channel, {binSuffix: '_range'}),
-            expr: model.field(channel, {datum: true, binSuffix: '_start'}) +
+            field: field(fieldDef, {binSuffix: '_range'}),
+            expr: field(fieldDef, {datum: true, binSuffix: '_start'}) +
                   '+ \'-\' +' +
-                  model.field(channel, {datum: true, binSuffix: '_end'})
+                  field(fieldDef, {datum: true, binSuffix: '_end'})
           });
         }
       }
@@ -327,7 +328,7 @@ export namespace summary {
 
     var hasAggregate = false;
 
-    model.forEach(function(fieldDef, channel: Channel) {
+    model.forEach(function(fieldDef: FieldDef, channel: Channel) {
       if (fieldDef.aggregate) {
         hasAggregate = true;
         if (fieldDef.aggregate === 'count') {
@@ -340,11 +341,11 @@ export namespace summary {
       } else {
         if (fieldDef.bin) {
           // TODO(#694) only add dimension for the required ones.
-          dims[model.field(channel, {binSuffix: '_start'})] = model.field(channel, {binSuffix: '_start'});
-          dims[model.field(channel, {binSuffix: '_mid'})] = model.field(channel, {binSuffix: '_mid'});
-          dims[model.field(channel, {binSuffix: '_end'})] = model.field(channel, {binSuffix: '_end'});
+          dims[field(fieldDef, {binSuffix: '_start'})] = field(fieldDef, {binSuffix: '_start'});
+          dims[field(fieldDef, {binSuffix: '_mid'})] = field(fieldDef, {binSuffix: '_mid'});
+          dims[field(fieldDef, {binSuffix: '_end'})] = field(fieldDef, {binSuffix: '_end'});
         } else {
-          dims[fieldDef.field] = model.field(channel);
+          dims[field(fieldDef)] = field(fieldDef);
         }
       }
     });

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -412,7 +412,8 @@ export namespace stack {
 
 export function filterNonPositiveForLog(dataTable, model: Model) {
   model.forEach(function(_, channel) {
-    if (model.fieldDef(channel).scale.type === 'log') {
+    const scale = model.fieldDef(channel).scale;
+    if (scale && scale.type === 'log') {
       dataTable.transform.push({
         type: 'filter',
         test: model.field(channel, {datum: true}) + ' > 0'

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -346,7 +346,6 @@ export namespace summary {
         } else {
           dims[fieldDef.field] = model.field(channel);
         }
-
       }
     });
 

--- a/src/compiler/stack.ts
+++ b/src/compiler/stack.ts
@@ -7,8 +7,10 @@ export interface StackProperties {
   groupbyChannel: Channel;
   /** Measure axis of the stack ('x' or 'y'). */
   fieldChannel: Channel;
-  /** Stack by channels of the stack ('color' or 'detail'). */
-  stackChannels: Channel[];
+
+  /** Stack by fields of the name (fields for 'color' or 'detail') */
+  stackFields: string[];
+
   /** Stack config for the stack transform. */
   config: any;
 }
@@ -29,7 +31,7 @@ export function imputeTransform(model: Model) {
   return {
     type: 'impute',
     field: model.field(stack.fieldChannel),
-    groupby: stack.stackChannels.map(function(c) { return model.field(c); }),
+    groupby: stack.stackFields,
     orderby: [model.field(stack.groupbyChannel)],
     method: 'value',
     value: 0
@@ -39,14 +41,12 @@ export function imputeTransform(model: Model) {
 export function stackTransform(model: Model) {
   const stack = model.stack();
   const sortby = stack.config.sort === 'ascending' ?
-                   stack.stackChannels.map(function(c) {
-                     return model.field(c);
-                   }) :
+                   stack.stackFields :
                  isArray(stack.config.sort) ?
                    stack.config.sort :
                    // descending, or default
-                   stack.stackChannels.map(function(c) {
-                     return '-' + model.field(c);
+                   stack.stackFields.map(function(field) {
+                     return '-' + field;
                    });
 
   const valName = model.field(stack.fieldChannel);

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,7 +1,7 @@
 // utility for encoding mapping
 import {Encoding} from './schema/encoding.schema';
 import {FieldDef} from './schema/fielddef.schema';
-import {Channel, CHANNELS, DETAIL} from './channel';
+import {Channel, CHANNELS} from './channel';
 import {isArray} from './util';
 
 export function countRetinal(encoding: Encoding) {

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,7 +1,8 @@
 // utility for encoding mapping
 import {Encoding} from './schema/encoding.schema';
 import {FieldDef} from './schema/fielddef.schema';
-import {Channel, CHANNELS} from './channel';
+import {Channel, CHANNELS, DETAIL} from './channel';
+import {isArray} from './util';
 
 export function countRetinal(encoding: Encoding) {
   var count = 0;
@@ -18,8 +19,11 @@ export function channels(encoding: Encoding) {
 }
 
 export function has(encoding: Encoding, channel: Channel): boolean {
-  var fieldDef: FieldDef = encoding && encoding[channel];
-  return fieldDef && !!fieldDef.field;
+  const channelEncoding = encoding && encoding[channel];
+  return channelEncoding && (
+    !!channelEncoding.field ||
+    (isArray(channelEncoding) && channelEncoding.length)
+  );
 }
 
 export function isAggregate(encoding: Encoding) {
@@ -33,9 +37,15 @@ export function isAggregate(encoding: Encoding) {
 
 export function fieldDefs(encoding: Encoding): FieldDef[] {
   var arr = [];
-  CHANNELS.forEach(function(k) {
-    if (has(encoding, k)) {
-      arr.push(encoding[k]);
+  CHANNELS.forEach(function(channel) {
+    if (has(encoding, channel)) {
+      if (isArray(encoding[channel])) {
+        encoding[channel].forEach(function(fieldDef) {
+          arr.push(fieldDef);
+        });
+      } else {
+        arr.push(encoding[channel]);
+      }
     }
   });
   return arr;
@@ -47,7 +57,13 @@ export function forEach(encoding: Encoding,
   var i = 0;
   CHANNELS.forEach(function(channel) {
     if (has(encoding, channel)) {
-      f.call(thisArg, encoding[channel], channel, i++);
+      if (isArray(encoding[channel])) {
+        encoding[channel].forEach(function(fieldDef) {
+            f.call(thisArg, fieldDef, channel, i++);
+        });
+      } else {
+        f.call(thisArg, encoding[channel], channel, i++);
+      }
     }
   });
 }
@@ -56,9 +72,15 @@ export function map(encoding: Encoding,
     f: (fd: FieldDef, c: Channel, e: Encoding) => any,
     thisArg?: any) {
   var arr = [];
-  CHANNELS.forEach(function(k) {
-    if (has(encoding, k)) {
-      arr.push(f.call(thisArg, encoding[k], k, encoding));
+  CHANNELS.forEach(function(channel) {
+    if (has(encoding, channel)) {
+      if (isArray(encoding[channel])) {
+        encoding[channel].forEach(function(fieldDef) {
+          arr.push(f.call(thisArg, fieldDef, channel, encoding));
+        });
+      } else {
+        arr.push(f.call(thisArg, encoding[channel], channel, encoding));
+      }
     }
   });
   return arr;
@@ -69,9 +91,15 @@ export function reduce(encoding: Encoding,
     init,
     thisArg?: any) {
   var r = init;
-  CHANNELS.forEach(function(k) {
-    if (has(encoding, k)) {
-      r = f.call(thisArg, r, encoding[k], k, encoding);
+  CHANNELS.forEach(function(channel) {
+    if (has(encoding, channel)) {
+      if (isArray(encoding[channel])) {
+        encoding[channel].forEach(function(fieldDef) {
+            r = f.call(thisArg, r, fieldDef, channel, encoding);
+        });
+      } else {
+        r = f.call(thisArg, r, encoding[channel], channel, encoding);
+      }
     }
   });
   return r;

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -5,6 +5,40 @@ import {contains, getbins} from './util';
 import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from './type';
 
 
+export interface FieldRefOption {
+  /** exclude bin, aggregate, timeUnit */
+  nofn?: boolean;
+  /** exclude aggregation function */
+  noAggregate?: boolean;
+  /** include 'datum.' */
+  datum?: boolean;
+  /** replace fn with custom function prefix */
+  fn?: string;
+  /** prepend fn with custom function prefix */
+  prefn?: string;
+  /** append suffix to the field ref for bin (default='_start') */
+  binSuffix?: string;
+}
+
+export function field(fieldDef: FieldDef, opt: FieldRefOption = {}) {
+  var f = (opt.datum ? 'datum.' : '') + (opt.prefn || ''),
+    field = fieldDef.field;
+
+  if (isCount(fieldDef)) {
+    return f + 'count';
+  } else if (opt.fn) {
+    return f + opt.fn + '_' + field;
+  } else if (!opt.nofn && fieldDef.bin) {
+    return f + 'bin_' + field + opt.binSuffix;
+  } else if (!opt.nofn && !opt.noAggregate && fieldDef.aggregate) {
+    return f + fieldDef.aggregate + '_' + field;
+  } else if (!opt.nofn && fieldDef.timeUnit) {
+    return f + fieldDef.timeUnit + '_' + field;
+  } else {
+    return f + field;
+  }
+}
+
 // TODO remove these "isDimension/isMeasure" stuff
 function _isFieldDimension(fieldDef: FieldDef) {
   return contains([NOMINAL, ORDINAL], fieldDef.type) || !!fieldDef.bin ||

--- a/src/schema/encoding.schema.ts
+++ b/src/schema/encoding.schema.ts
@@ -15,7 +15,7 @@ export interface Encoding {
   color?: FieldDef;
   size?: FieldDef;
   shape?: FieldDef;
-  detail?: FieldDef;
+  detail?: FieldDef | FieldDef[];
   text?: FieldDef;
   label?: FieldDef;
 }
@@ -95,7 +95,13 @@ var shape = merge(duplicate(onlyOrdinalField), {
   }
 });
 
-var detail = duplicate(fieldDef);
+var detail = {
+  default: undefined,
+  oneOf: [duplicate(fieldDef), {
+    type: 'array',
+    items: duplicate(fieldDef)
+  }]
+};
 
 // we only put aggregated measure in pivot table
 var text = merge(duplicate(typicalField), {

--- a/test/compiler/data.test.ts
+++ b/test/compiler/data.test.ts
@@ -244,4 +244,43 @@ describe('data.summary', function () {
       }]
     });
   });
+
+  it('should return correct aggregation for detail arrays', function() {
+    var encoding = new Model({
+        mark: POINT,
+        encoding: {
+          'y': {
+            'aggregate': 'mean',
+            'field': 'Acceleration',
+            'type': QUANTITATIVE
+          },
+          'x': {
+            'aggregate': 'mean',
+            'field': 'Displacement',
+            'type': QUANTITATIVE
+          },
+          'detail': [{
+            'field': 'Origin',
+            'type': ORDINAL
+          },{
+            'field': 'Cylinders',
+            'type': QUANTITATIVE
+          }]
+        }
+      });
+
+    var aggregated = summary.def(encoding);
+    expect(aggregated).to.eql({
+      'name': SUMMARY,
+      'source': 'source',
+      'transform': [{
+        'type': 'aggregate',
+        'groupby': ['Origin', 'Cylinders'],
+        'summarize': {
+          'Displacement': ['mean'],
+          'Acceleration': ['mean']
+        }
+      }]
+    });
+  });
 });


### PR DESCRIPTION
Fixed #864 

- bring back `vl.fieldDef.field()` so we can use it with detail array 
- replace `stackChannels` with `stackFields` in StackProperties (so we can have multiple fields for details)
- modify methods in `model.ts` to check if `encoding[channel]` is an array 
