### PR TITLE
Refactor Stack Test

### DIFF
--- a/src/compiler/compiler.ts
+++ b/src/compiler/compiler.ts
@@ -1,14 +1,12 @@
 /**
  * Module for compiling Vega-lite spec into Vega spec.
  */
-import {Spec} from '../schema/schema';
 import {Model} from './Model';
 
 import {compileAxis} from './axis';
 import {compileData} from './data';
 import {facetMixins} from './facet';
 import {compileLegends} from './legend';
-import {Layout} from './layout';
 import {compileMarks} from './marks';
 import {compileScales} from './scale';
 import {extend, keys} from '../util';
@@ -51,7 +49,7 @@ export function compile(spec, theme?) {
     }, {}) : {},
     {
       data: compileData(model),
-      marks: [compileRootGroup(spec, model, layout)]
+      marks: [compileRootGroup(model)]
     });
 
   return {
@@ -60,9 +58,10 @@ export function compile(spec, theme?) {
   };
 }
 
-function compileRootGroup(spec: Spec, model: Model, layout: Layout) {
-  const width = layout.width;
-  const height = layout.height;
+export function compileRootGroup(model: Model) {
+  const spec = model.spec();
+  const width = model.layout().width;
+  const height = model.layout().height;
 
   let rootGroup:any = extend({
       name: spec.name ? spec.name + '-root' : 'root',
@@ -105,4 +104,5 @@ function compileRootGroup(spec: Spec, model: Model, layout: Layout) {
   if (legends.length > 0) {
     rootGroup.legends = legends;
   }
+  return rootGroup;
 }

--- a/test/compiler/stack.test.ts
+++ b/test/compiler/stack.test.ts
@@ -1,7 +1,7 @@
 import {expect} from 'chai';
 
 import {stack} from '../fixtures';
-import {Model} from '../../src/compiler/model';
+import {Model} from '../../src/compiler/Model';
 import {compileData} from '../../src/compiler/data';
 import {compileRootGroup} from '../../src/compiler/compiler';
 import {SUMMARY} from '../../src/data';

--- a/test/compiler/stack.test.ts
+++ b/test/compiler/stack.test.ts
@@ -1,35 +1,19 @@
 import {expect} from 'chai';
 
 import {stack} from '../fixtures';
-import {compile} from '../../src/compiler/compiler';
+import {Model} from '../../src/compiler/model';
+import {compileData} from '../../src/compiler/data';
+import {compileRootGroup} from '../../src/compiler/compiler';
 import {SUMMARY} from '../../src/data';
-
-const stats = {
-  'Cost__Total_$': {
-    min: 0,
-    max: 100,
-    length: { max: 5}
-  },
-  'Cost__Other': {
-    min: 0,
-    max: 100,
-    length: { max: 5}
-  },
-  'Effect__Amount_of_damage': {
-    min: 0,
-    max: 100,
-    length: { max: 5}
-  }
-};
 
 describe('vl.compile.stack()', function () {
 
   describe('bin-x', function () {
-    it('should put stack on y', function () {
-      // FIXME don't run the whole compile
-      var vgSpec = compile(stack.binX, stats).spec;
+    const model = new Model(stack.binX);
+    const dataSpec = compileData(model);
+    it('should aggregate data correctly', function () {
 
-      var tableData = vgSpec.data.filter(function(data) {
+      var tableData = dataSpec.filter(function(data) {
         return data.name === SUMMARY;
       });
       expect(tableData.length).to.equal(1);
@@ -39,22 +23,34 @@ describe('vl.compile.stack()', function () {
       })[0];
       expect(tableAggrTransform.groupby.length).to.equal(4);
       expect(tableAggrTransform.groupby.indexOf('bin_Cost__Total_$_start')).to.gt(-1);
+    });
 
-      var stackedData = vgSpec.data.filter(function(data) {
+    it('should create stack summary data correctly', function() {
+      var stackedData = dataSpec.filter(function(data) {
         return data.name === 'stacked';
       });
       expect(stackedData.length).to.equal(1);
       var stackedAggrTransform = stackedData[0].transform[0];
       expect(stackedAggrTransform.groupby[0]).to.equal('bin_Cost__Total_$_start');
     });
+
+    it('should stack data correctly', function() {
+      const rootGroup = compileRootGroup(model);
+      const stackTransform = rootGroup.marks[0].from.transform[0];
+      expect(stackTransform.type).to.equal('stack');
+
+      expect(stackTransform.groupby).to.eql(['bin_Cost__Total_$_start']);
+      expect(stackTransform.field).to.eql('sum_Cost__Other');
+      expect(stackTransform.sortby).to.eql(['-Effect__Amount_of_damage']);
+    });
   });
 
   describe('bin-y', function () {
-    it('should put stack on x', function () {
-      // FIXME don't run the whole compile
-      var vgSpec = compile(stack.binY, stats).spec;
+    const model = new Model(stack.binY);
+    const dataSpec = compileData(model);
+    it('should aggregate data correctly', function () {
 
-      var tableData = vgSpec.data.filter(function(data) {
+      var tableData = dataSpec.filter(function(data) {
         return data.name === SUMMARY;
       });
       expect(tableData.length).to.equal(1);
@@ -64,14 +60,26 @@ describe('vl.compile.stack()', function () {
       })[0];
       expect(tableAggrTransform.groupby.length).to.equal(4);
       expect(tableAggrTransform.groupby.indexOf('bin_Cost__Total_$_start')).to.gt(-1);
+    });
 
-      var stackedData = vgSpec.data.filter(function(data) {
+    it('should create stack summary data correctly', function() {
+      var stackedData = dataSpec.filter(function(data) {
         return data.name === 'stacked';
       });
 
       expect(stackedData.length).to.equal(1);
       var stackedAggrTransform = stackedData[0].transform[0];
       expect(stackedAggrTransform.groupby[0]).to.equal('bin_Cost__Total_$_start');
+    });
+
+    it('should stack data correctly', function() {
+      const rootGroup = compileRootGroup(model);
+      const stackTransform = rootGroup.marks[0].from.transform[0];
+      expect(stackTransform.type).to.equal('stack');
+
+      expect(stackTransform.groupby).to.eql(['bin_Cost__Total_$_start']);
+      expect(stackTransform.field).to.eql('sum_Cost__Other');
+      expect(stackTransform.sortby).to.eql(['-Effect__Amount_of_damage']);
     });
   });
 });

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -37,7 +37,7 @@ export const stack = {
   binY: {
     'mark': BAR,
     'encoding': {
-      'x': {'type': QUANTITATIVE, 'field': 'Cost__Other', 'aggregate': 'mean'},
+      'x': {'type': QUANTITATIVE, 'field': 'Cost__Other', 'aggregate': 'sum'},
       'y': {'bin': true, 'type': QUANTITATIVE, 'field': 'Cost__Total_$'},
       'color': {'type': ORDINAL, 'field': 'Effect__Amount_of_damage'}
     }
@@ -45,7 +45,7 @@ export const stack = {
   binX: {
     'mark': BAR,
     'encoding': {
-      'y': {'type': QUANTITATIVE, 'field': 'Cost__Other', 'aggregate': 'mean'},
+      'y': {'type': QUANTITATIVE, 'field': 'Cost__Other', 'aggregate': 'sum'},
       'x': {'bin': true, 'type': QUANTITATIVE, 'field': 'Cost__Total_$'},
       'color': {'type': ORDINAL, 'field': 'Effect__Amount_of_damage'}
     }


### PR DESCRIPTION
- simplify and export `compileRootGroup`
- correctly write unit test for stack without calling the whole `compile` method