### PR TITLE
Refactor STACKED_SCALE (originally STACKED)

### DIFF
--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -6,7 +6,7 @@ import {StackProperties} from './stack';
 
 import {autoMaxBins} from '../bin';
 import {Channel, X, Y, ROW, COLUMN} from '../channel';
-import {SOURCE, STACKED, LAYOUT, SUMMARY} from '../data';
+import {SOURCE, STACKED_SCALE, LAYOUT, SUMMARY} from '../data';
 import {QUANTITATIVE, TEMPORAL} from '../type';
 import {type as scaleType} from './scale';
 
@@ -388,7 +388,7 @@ export namespace stack {
                       .concat((model.has(ROW) ? [model.field(ROW)] : []));
 
     var stacked:VgData = {
-      name: STACKED,
+      name: STACKED_SCALE,
       source: model.dataTable(),
       transform: [{
         type: 'aggregate',

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -398,17 +398,6 @@ export namespace stack {
       }]
     };
 
-    if (facetFields && facetFields.length > 0) {
-      stacked.transform.push({ // calculate max for each facet
-        type: 'aggregate',
-        groupby: facetFields,
-        summarize: [{
-          ops: ['max'],
-          // we want max of sum from above transform
-          field: model.field(fieldChannel, {prefn: 'sum_'})
-        }]
-      });
-    }
     return stacked;
   };
 }

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -7,7 +7,7 @@ import {contains, extend, range} from '../util';
 import {Model} from './Model';
 import {SHARED_DOMAIN_OPS} from '../aggregate';
 import {COLUMN, ROW, X, Y, SHAPE, SIZE, COLOR, TEXT, DETAIL, Channel} from '../channel';
-import {SOURCE, STACKED} from '../data';
+import {SOURCE, STACKED_SCALE} from '../data';
 import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../type';
 import {BAR, TEXT as TEXT_MARK} from '../mark';
 
@@ -124,7 +124,7 @@ export function domain(model: Model, channel:Channel, scaleType: string) {
   if (stack && channel === stack.fieldChannel) {
     const facet = model.has(ROW) || model.has(COLUMN);
     return {
-      data: STACKED,
+      data: STACKED_SCALE,
       field: model.field(channel, {
         // If faceted, scale is determined by the max of sum in each facet.
         prefn: (facet ? 'max_' : '') + 'sum_'

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -122,12 +122,11 @@ export function domain(model: Model, channel:Channel, scaleType: string) {
   // For stack, use STACKED data.
   var stack = model.stack();
   if (stack && channel === stack.fieldChannel) {
-    const facet = model.has(ROW) || model.has(COLUMN);
     return {
       data: STACKED_SCALE,
       field: model.field(channel, {
         // If faceted, scale is determined by the max of sum in each facet.
-        prefn: (facet ? 'max_' : '') + 'sum_'
+        prefn: 'sum_'
       })
     };
   }

--- a/src/data.ts
+++ b/src/data.ts
@@ -6,7 +6,7 @@ import {NOMINAL, QUANTITATIVE, TEMPORAL} from './type';
 
 export const SUMMARY = 'summary';
 export const SOURCE = 'source';
-export const STACKED = 'stacked';
+export const STACKED_SCALE = 'stacked_scale';
 export const LAYOUT = 'layout';
 
 /** Mapping from datalib's inferred type to Vega-lite's type */

--- a/test/compiler/scale.test.ts
+++ b/test/compiler/scale.test.ts
@@ -27,7 +27,7 @@ describe('vl.compile.scale', function() {
 
         expect(domain).to.eql({
           data: 'stacked_scale',
-          field: 'max_sum_sum_origin'
+          field: 'sum_sum_origin'
         });
       });
 
@@ -47,7 +47,7 @@ describe('vl.compile.scale', function() {
 
         expect(domain).to.eql({
           data: 'stacked_scale',
-          field: 'max_sum_sum_origin'
+          field: 'sum_sum_origin'
         });
       });
     });

--- a/test/compiler/scale.test.ts
+++ b/test/compiler/scale.test.ts
@@ -26,7 +26,7 @@ describe('vl.compile.scale', function() {
         }), Y, 'linear');
 
         expect(domain).to.eql({
-          data: 'stacked',
+          data: 'stacked_scale',
           field: 'max_sum_sum_origin'
         });
       });
@@ -46,7 +46,7 @@ describe('vl.compile.scale', function() {
         }), Y, 'linear');
 
         expect(domain).to.eql({
-          data: 'stacked',
+          data: 'stacked_scale',
           field: 'max_sum_sum_origin'
         });
       });

--- a/test/compiler/stack.test.ts
+++ b/test/compiler/stack.test.ts
@@ -27,7 +27,7 @@ describe('vl.compile.stack()', function () {
 
     it('should create stack summary data correctly', function() {
       var stackedData = dataSpec.filter(function(data) {
-        return data.name === 'stacked';
+        return data.name === 'stacked_scale';
       });
       expect(stackedData.length).to.equal(1);
       var stackedAggrTransform = stackedData[0].transform[0];
@@ -64,7 +64,7 @@ describe('vl.compile.stack()', function () {
 
     it('should create stack summary data correctly', function() {
       var stackedData = dataSpec.filter(function(data) {
-        return data.name === 'stacked';
+        return data.name === 'stacked_scale';
       });
 
       expect(stackedData.length).to.equal(1);


### PR DESCRIPTION
- Rename STACKED to STACKED_SCALE to avoid confusion since the data source sums data for scale while the actual stack layout is applied inline.

- Remove the unnecessary max calculation in STACKED_SCALE since scale would automatically calculate max anyway.  

@arvind @domoritz 