### PR TITLE
Refactor to avoid overloading the term spec / def.

### DIFF
--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -245,7 +245,7 @@ export class Model {
     return this._spec.config.cell[name];
   }
 
-  public axisDef(channel: Channel): Axis {
+  public axis(channel: Channel): Axis {
     const axis = this.fieldDef(channel).axis;
     return typeof axis !== 'boolean' ? axis : {};
   }

--- a/src/compiler/facet.ts
+++ b/src/compiler/facet.ts
@@ -203,7 +203,7 @@ function getRowGridGroup(model: Model, cellHeight): any { // TODO: VgMarks
     }
   };
 
-  const rowGridOnTop = !model.has(X) || model.axisDef(X).orient !== 'top';
+  const rowGridOnTop = !model.has(X) || model.axis(X).orient !== 'top';
   if (rowGridOnTop) { // on top - no need to add offset
     return rowGrid;
   } // otherwise, need to offset all grid by cellHeight
@@ -253,7 +253,7 @@ function getColumnGridGroup(model: Model, cellWidth): any { // TODO: VgMarks
     }
   };
 
-  const columnGridOnLeft = !model.has(Y) || model.axisDef(Y).orient === 'right';
+  const columnGridOnLeft = !model.has(Y) || model.axis(Y).orient === 'right';
   if (columnGridOnLeft) { // on left, no need to add global offset
     return columnGrid;
   } // otherwise, need to offset all grid by cellWidth

--- a/src/compiler/legend.ts
+++ b/src/compiler/legend.ts
@@ -72,7 +72,7 @@ export function title(fieldDef: FieldDef) {
 }
 
 namespace properties {
-  export function labels(fieldDef: FieldDef, spec, model: Model, channel: Channel) {
+  export function labels(fieldDef: FieldDef, labelsSpec, model: Model, channel: Channel) {
     const timeUnit = fieldDef.timeUnit;
     const labelTemplate = model.labelTemplate(channel);
     if (fieldDef.type === TEMPORAL && timeUnit && labelTemplate) {
@@ -80,12 +80,12 @@ namespace properties {
         text: {
           template: '{{datum.data | ' + labelTemplate + '}}'
         }
-      }, spec || {});
+      }, labelsSpec || {});
     }
-    return spec;
+    return labelsSpec;
   }
 
-  export function symbols(fieldDef: FieldDef, spec, model: Model, channel: Channel) {
+  export function symbols(fieldDef: FieldDef, symbolsSpec, model: Model, channel: Channel) {
     let symbols:any = {};
     const mark = model.mark();
 
@@ -141,7 +141,7 @@ namespace properties {
         break;
     }
 
-    symbols = extend(symbols, spec || {});
+    symbols = extend(symbols, symbolsSpec || {});
 
     return keys(symbols).length > 0 ? symbols : undefined;
   }


### PR DESCRIPTION
- `model.axisDef` => `model.axis()`
- spec always refers to input
- def generally refers to output except `fieldDef`, which is too late to change.

- part of #276