### PR TITLE
	simplify `scale.type`

### DIFF
--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -155,7 +155,7 @@ export class Model {
     const fieldDef = this.fieldDef(channel);
     if (fieldDef.bin) { // bin has default suffix that depends on scaleType
       opt = extend({
-        binSuffix: scaleType(fieldDef, channel, this) === 'ordinal' ? '_range' : '_start'
+        binSuffix: scaleType(fieldDef, channel, this.mark()) === 'ordinal' ? '_range' : '_start'
       }, opt);
     }
     return vlFieldDef.field(fieldDef, opt);
@@ -190,7 +190,7 @@ export class Model {
     const fieldDef = this.fieldDef(channel);
     return fieldDef && (
       contains([NOMINAL, ORDINAL], fieldDef.type) ||
-      ( fieldDef.type === TEMPORAL && scaleType(fieldDef, channel, this) === 'ordinal' )
+      ( fieldDef.type === TEMPORAL && scaleType(fieldDef, channel, this.mark()) === 'ordinal' )
       );
   }
 

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -164,7 +164,7 @@ export namespace source {
         }
 
         transform.push(binTrans);
-        if (scaleType(fieldDef, channel, model) === 'ordinal') {
+        if (scaleType(fieldDef, channel, model.mark()) === 'ordinal') {
           transform.push({
             type: 'formula',
             field: field(fieldDef, {binSuffix: '_range'}),

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -8,6 +8,7 @@ import {Model} from './Model';
 import {SHARED_DOMAIN_OPS} from '../aggregate';
 import {COLUMN, ROW, X, Y, SHAPE, SIZE, COLOR, TEXT, DETAIL, Channel} from '../channel';
 import {SOURCE, STACKED_SCALE} from '../data';
+import {isDimension} from '../fielddef';
 import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../type';
 import {BAR, TEXT as TEXT_MARK, TICK} from '../mark';
 
@@ -60,7 +61,7 @@ export function type(fieldDef: FieldDef, channel: Channel, model: Model): string
         // Also, if we support color ramp, this should be ordinal too.
         return 'linear'; // time has order, so use interpolated ordinal color scale.
       }
-      if (channel === COLUMN || channel === ROW) {
+      if (contains([ROW, COLUMN, SHAPE], channel)) {
         return 'ordinal';
       }
       if (fieldDef.scale.type !== undefined) {
@@ -76,12 +77,11 @@ export function type(fieldDef: FieldDef, channel: Channel, model: Model): string
         case 'year':
         case 'second':
         case 'minute':
-          // Returns ordinal if the channel is the dimension of BAR or TICK mark
+          // Returns ordinal if (1) the channel is X or Y, and
+          // (2) is the dimension of BAR or TICK mark.
           // Otherwise return linear.
-          const isHorizontal = model.markConfig('orient') === 'horizontal';
           return contains([BAR, TICK], model.mark()) &&
-            ((isHorizontal && channel === Y) || (!isHorizontal && channel === X))
-            ? 'ordinal' : 'linear';
+            isDimension(fieldDef) ? 'ordinal' : 'linear';
       }
       return 'time';
 

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -10,7 +10,7 @@ import {COLUMN, ROW, X, Y, SHAPE, SIZE, COLOR, TEXT, DETAIL, Channel} from '../c
 import {SOURCE, STACKED_SCALE} from '../data';
 import {isDimension} from '../fielddef';
 import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../type';
-import {BAR, TEXT as TEXT_MARK, TICK} from '../mark';
+import {Mark, BAR, TEXT as TEXT_MARK, TICK} from '../mark';
 
 export function compileScales(channels: Channel[], model: Model) {
   return channels.filter(function(channel: Channel) {
@@ -21,7 +21,7 @@ export function compileScales(channels: Channel[], model: Model) {
 
       var scaleDef: any = {
         name: model.scale(channel),
-        type: type(fieldDef, channel, model),
+        type: type(fieldDef, channel, model.mark()),
       };
 
       scaleDef.domain = domain(model, channel, scaleDef.type);
@@ -49,7 +49,7 @@ export function compileScales(channels: Channel[], model: Model) {
     });
 }
 
-export function type(fieldDef: FieldDef, channel: Channel, model: Model): string {
+export function type(fieldDef: FieldDef, channel: Channel, mark: Mark): string {
   switch (fieldDef.type) {
     case NOMINAL:
       return 'ordinal';
@@ -80,7 +80,7 @@ export function type(fieldDef: FieldDef, channel: Channel, model: Model): string
           // Returns ordinal if (1) the channel is X or Y, and
           // (2) is the dimension of BAR or TICK mark.
           // Otherwise return linear.
-          return contains([BAR, TICK], model.mark()) &&
+          return contains([BAR, TICK], mark) &&
             isDimension(fieldDef) ? 'ordinal' : 'linear';
       }
       return 'time';


### PR DESCRIPTION
- correctly check isDimension
- take `mark` as param instead of `model` in `scale.type`