### PR TITLE
`model.markConfig()` => `compileMarkConfig` & extract `compileStackProperties`

### DIFF
--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -6,12 +6,12 @@ import {instantiate} from '../schema/schemautil';
 import * as schema from '../schema/schema';
 import * as schemaUtil from '../schema/schemautil';
 
-import {COLUMN, ROW, X, Y, DETAIL, Channel, supportMark} from '../channel';
+import {COLUMN, ROW, X, Y, Channel, supportMark} from '../channel';
 import {SOURCE, SUMMARY} from '../data';
 import * as vlFieldDef from '../fielddef';
 import {FieldRefOption} from '../fielddef';
 import * as vlEncoding from '../encoding';
-import {POINT, TICK, CIRCLE, SQUARE, Mark} from '../mark';
+import {Mark} from '../mark';
 
 import {getFullName, NOMINAL, ORDINAL, TEMPORAL} from '../type';
 import {contains, duplicate, extend} from '../util';
@@ -197,46 +197,6 @@ export class Model {
   public axis(channel: Channel): Axis {
     const axis = this.fieldDef(channel).axis;
     return typeof axis !== 'boolean' ? axis : {};
-  }
-
-  /**
-   * @return Mark config value from the spec, or a default value if unspecified.
-   */
-  public markConfig(name: string) {
-    const value = this._spec.config.mark[name];
-    switch (name) {
-      case 'filled':
-        if (value === undefined) {
-          // only point is not filled by default
-          return this.mark() !== POINT;
-        }
-        return value;
-      case 'opacity':
-        if (value === undefined && contains([POINT, TICK, CIRCLE, SQUARE], this.mark())) {
-          // point-based marks and bar
-          if (!this.isAggregate() || this.has(DETAIL)) {
-            return 0.7;
-          }
-        }
-        return value;
-      case 'orient':
-        const stack = this.stack();
-        if (stack) {
-          // For stacked chart, explicitly specified orient property will be ignored.
-          return stack.groupbyChannel === Y ? 'horizontal' : undefined;
-        }
-        if (value === undefined) {
-          return this.isMeasure(X) && !this.isMeasure(Y) ?
-            // horizontal if X is measure and Y is dimension or unspecified
-            'horizontal' :
-            // vertical (undefined) otherwise.  This includes when
-            // - Y is measure and X is dimension or unspecified
-            // - both X and Y are measures or both are dimension
-            undefined;  //
-        }
-        return value;
-    }
-    return value;
   }
 
   /** returns scale name for a given channel */

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -156,13 +156,11 @@ export class Model {
   }
 
   public isDimension(channel: Channel) {
-    return this.has(channel) &&
-      vlFieldDef.isDimension(this.fieldDef(channel));
+    return vlFieldDef.isDimension(this.fieldDef(channel));
   }
 
   public isMeasure(channel: Channel) {
-    return this.has(channel) &&
-      vlFieldDef.isMeasure(this.fieldDef(channel));
+    return vlFieldDef.isMeasure(this.fieldDef(channel));
   }
 
   public isAggregate() {

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -143,12 +143,7 @@ export class Model {
   }
 
   public has(channel: Channel) {
-    // equivalent to calling vlenc.has(this._spec.encoding, channel)
-    const channelEncoding = this._spec.encoding[channel];
-    return channelEncoding && (
-      channelEncoding.field !== undefined ||
-      (isArray(channelEncoding) && channelEncoding.length > 0)
-    );
+    return vlEncoding.has(this._spec.encoding, channel);
   }
 
   public fieldDef(channel: Channel): FieldDef {

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -1,23 +1,25 @@
 import {Spec} from '../schema/schema';
 import {Axis, axis as axisSchema} from '../schema/axis.schema';
+import {Encoding} from '../schema/encoding.schema';
 import {FieldDef} from '../schema/fielddef.schema';
 import {instantiate} from '../schema/schemautil';
+import * as schema from '../schema/schema';
+import * as schemaUtil from '../schema/schemautil';
 
 import {COLUMN, ROW, X, Y, DETAIL, Channel, supportMark} from '../channel';
 import {SOURCE, SUMMARY} from '../data';
 import * as vlFieldDef from '../fielddef';
 import {FieldRefOption} from '../fielddef';
 import * as vlEncoding from '../encoding';
-import {compileLayout, Layout} from './layout';
 import {POINT, TICK, CIRCLE, SQUARE, Mark} from '../mark';
-import * as schema from '../schema/schema';
-import * as schemaUtil from '../schema/schemautil';
-import {compileStackProperties, StackProperties} from './stack';
-import {type as scaleType} from './scale';
+
 import {getFullName, NOMINAL, ORDINAL, TEMPORAL} from '../type';
 import {contains, duplicate, extend} from '../util';
-import {Encoding} from '../schema/encoding.schema';
 
+import {compileMarkConfig} from './config';
+import {compileLayout, Layout} from './layout';
+import {compileStackProperties, StackProperties} from './stack';
+import {type as scaleType} from './scale';
 
 /**
  * Internal model of Vega-Lite specification for the compiler.
@@ -53,8 +55,10 @@ export class Model {
     }, this);
 
     // calculate stack
-    this._stack = compileStackProperties(this.spec());
+    this._stack = compileStackProperties(this._spec);
+    this._spec.config.mark = compileMarkConfig(this._spec, this._stack);
     this._layout = compileLayout(this);
+
   }
 
   public layout(): Layout {

--- a/src/compiler/config.ts
+++ b/src/compiler/config.ts
@@ -7,7 +7,9 @@ import {isMeasure} from '../fielddef';
 import {POINT, TICK, CIRCLE, SQUARE} from '../mark';
 import {contains, extend} from '../util';
 
-
+/**
+ * Augment config.mark with rule-based default values.
+ */
 export function compileMarkConfig(spec: Spec, stack: StackProperties) {
    return extend(
      ['filled', 'opacity', 'orient'].reduce(function(cfg, property: string) {

--- a/src/compiler/config.ts
+++ b/src/compiler/config.ts
@@ -1,0 +1,50 @@
+import {Spec} from '../schema/schema';
+import {StackProperties} from './stack';
+
+import {X, Y, DETAIL} from '../channel';
+import {isAggregate, has} from '../encoding';
+import {isMeasure} from '../fielddef';
+import {POINT, TICK, CIRCLE, SQUARE} from '../mark';
+import {contains, extend} from '../util';
+
+
+export function compileMarkConfig(spec: Spec, stack: StackProperties) {
+   return extend(
+     ['filled', 'opacity', 'orient'].reduce(function(cfg, property: string) {
+       const value = spec.config.mark[property];
+       switch (property) {
+         case 'filled':
+           if (value === undefined) {
+             // only point is not filled by default
+             cfg[property] = spec.mark !== POINT;
+           }
+           break;
+         case 'opacity':
+           if (value === undefined && contains([POINT, TICK, CIRCLE, SQUARE], spec.mark)) {
+             // point-based marks and bar
+             if (!isAggregate(spec.encoding) || has(spec.encoding, DETAIL)) {
+               cfg[property] = 0.7;
+             }
+           }
+           break;
+         case 'orient':
+           if (stack) {
+             // For stacked chart, explicitly specified orient property will be ignored.
+             cfg[property] = stack.groupbyChannel === Y ? 'horizontal' : undefined;
+           }
+           if (value === undefined) {
+             cfg[property] = isMeasure(spec.encoding[X]) &&  !isMeasure(spec.encoding[Y]) ?
+               // horizontal if X is measure and Y is dimension or unspecified
+               'horizontal' :
+               // vertical (undefined) otherwise.  This includes when
+               // - Y is measure and X is dimension or unspecified
+               // - both X and Y are measures or both are dimension
+               undefined;  //
+           }
+           break;
+       }
+       return cfg;
+     }, {}),
+     spec.config.mark
+   );
+}

--- a/src/compiler/legend.ts
+++ b/src/compiler/legend.ts
@@ -108,7 +108,7 @@ namespace properties {
         /* fall through */
       case POINT:
         // fill or stroke
-        if (model.markConfig('filled')) { // filled
+        if (model.config().mark.filled) { // filled
           // set stroke to transparent by default unless there is a config for stroke
           symbols.stroke = {value: 'transparent'};
           applyMarkConfig(symbols, model, FILL_STROKE_CONFIG);

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -12,16 +12,16 @@ export function compileMarks(model: Model): any[] {
   const name = model.spec().name;
   const isFaceted = model.has(ROW) || model.has(COLUMN);
   const dataFrom = {data: model.dataTable()};
-  const sortBy = model.markConfig('sortBy');
+  const sortBy = model.config().mark.sortBy;
 
   if (mark === LINE || mark === AREA) {
     const details = detailFields(model);
 
     // For line and area, we sort values based on dimension by default
     // For line, a special config "sortLineBy" is allowed
-    let sortLineBy = mark === LINE ? model.markConfig('sortLineBy') : undefined;
+    let sortLineBy = mark === LINE ? model.config().mark.sortLineBy : undefined;
     if (!sortLineBy) {
-      sortLineBy = '-' + model.field(model.markConfig('orient') === 'horizontal' ? Y : X);
+      sortLineBy = '-' + model.field(model.config().mark.orient === 'horizontal' ? Y : X);
     }
 
     let pathMarks: any = extend(
@@ -153,7 +153,7 @@ export const FILL_STROKE_CONFIG = ['fill', 'fillOpacity',
 function applyColorAndOpacity(p, model: Model, colorMode?: ColorMode) {
   const filled = colorMode === ColorMode.ALWAYS_FILLED ? true :
     colorMode === ColorMode.ALWAYS_STROKED ? false :
-    model.markConfig('filled');
+    model.config().mark.filled;
 
   // Apply fill and stroke config first
   // so that `color.value` can override `fill` and `stroke` config
@@ -182,7 +182,7 @@ function applyColorAndOpacity(p, model: Model, colorMode?: ColorMode) {
 
 export function applyMarkConfig(marksProperties, model: Model, propsList: string[]) {
   propsList.forEach(function(property) {
-    const value = model.markConfig(property);
+    const value = model.config().mark[property];
     if (value !== undefined) {
       marksProperties[property] = { value: value };
     }
@@ -216,7 +216,7 @@ export namespace bar {
     // TODO Use Vega's marks properties interface
     let p: any = {};
 
-    const orient = model.markConfig('orient');
+    const orient = model.config().mark.orient;
 
     const stack = model.stack();
     // x, x2, and width -- we must specify two of these in all conditions
@@ -485,7 +485,7 @@ export namespace area {
     // TODO Use Vega's marks properties interface
     var p: any = {};
 
-    const orient = model.markConfig('orient');
+    const orient = model.config().mark.orient;
     if (orient !== undefined) {
       p.orient = { value: orient };
     }
@@ -604,7 +604,7 @@ export namespace tick {
       // TODO(#694): optimize tick's width for bin
       p.width = { value: model.fieldDef(X).scale.bandWidth / 1.5 };
     } else {
-      p.width = { value: model.markConfig('tickSize') };
+      p.width = { value: model.config().mark.tickSize };
     }
 
     // height
@@ -612,7 +612,7 @@ export namespace tick {
       // TODO(#694): optimize tick's height for bin
       p.height = { value: model.fieldDef(Y).scale.bandWidth / 1.5 };
     } else {
-      p.height = { value: model.markConfig('tickSize') };
+      p.height = { value: model.config().mark.tickSize };
     }
 
     applyColorAndOpacity(p, model, ColorMode.ALWAYS_FILLED);
@@ -754,13 +754,13 @@ export namespace text {
     // TODO: consider if color should just map to fill instead?
 
     // opacity
-    var opacity = model.markConfig('opacity');
+    var opacity = model.config().mark.opacity;
     if (opacity) { p.opacity = { value: opacity }; };
 
     // text
     if (model.has(TEXT)) {
       if (model.fieldDef(TEXT).type === QUANTITATIVE) {
-        const format = model.markConfig('format');
+        const format = model.config().mark.format;
         // TODO: revise this line
         var numberFormat = format !== undefined ? format : model.numberFormat(TEXT);
 

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -12,16 +12,17 @@ export function compileMarks(model: Model): any[] {
   const name = model.spec().name;
   const isFaceted = model.has(ROW) || model.has(COLUMN);
   const dataFrom = {data: model.dataTable()};
-  const sortBy = model.config().mark.sortBy;
+  const markConfig = model.config().mark;
+  const sortBy = markConfig.sortBy;
 
   if (mark === LINE || mark === AREA) {
     const details = detailFields(model);
 
     // For line and area, we sort values based on dimension by default
     // For line, a special config "sortLineBy" is allowed
-    let sortLineBy = mark === LINE ? model.config().mark.sortLineBy : undefined;
+    let sortLineBy = mark === LINE ? markConfig.sortLineBy : undefined;
     if (!sortLineBy) {
-      sortLineBy = '-' + model.field(model.config().mark.orient === 'horizontal' ? Y : X);
+      sortLineBy = '-' + model.field(markConfig.orient === 'horizontal' ? Y : X);
     }
 
     let pathMarks: any = extend(

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -319,7 +319,7 @@ export function rangeMixins(model: Model, channel: Channel, scaleType: string): 
     case SIZE:
       if (model.is(BAR)) {
         // TODO: determine bandSize for bin, which actually uses linear scale
-        const dimension = model.markConfig('orient') === 'horizontal' ? Y : X;
+        const dimension = model.config().mark.orient === 'horizontal' ? Y : X;
         return {range: [2, model.fieldDef(dimension).scale.bandWidth]};
       } else if (model.is(TEXT_MARK)) {
         return {range: [8, 40]};

--- a/src/compiler/stack.ts
+++ b/src/compiler/stack.ts
@@ -17,7 +17,7 @@ export interface StackProperties {
   /** Measure axis of the stack ('x' or 'y'). */
   fieldChannel: Channel;
 
-  /** Stack by fields of the name (fields for 'color' or 'detail') */
+  /** Stack-by field names (from 'color' and 'detail') */
   stackFields: string[];
 
   /** Stack config for the stack transform. */
@@ -34,23 +34,9 @@ interface StackTransform {
   output: any;
 }
 
+/** Compile stack properties from a given spec */
 export function compileStackProperties(spec: Spec) {
-  const stackFields = [COLOR, DETAIL].reduce(function(fields, channel) {
-    const channelEncoding = spec.encoding[channel];
-    if (has(spec.encoding, channel)) {
-      if (isArray(channelEncoding)) {
-        channelEncoding.forEach(function(fieldDef) {
-          fields.push(field(fieldDef));
-        });
-      } else {
-        const fieldDef: FieldDef = channelEncoding;
-        fields.push(field(fieldDef, {
-          binSuffix: scaleType(fieldDef, channel, spec.mark) === 'ordinal' ? '_range' : '_start'
-        }));
-      }
-    }
-    return fields;
-  }, []);
+  const stackFields = getStackFields(spec);
 
   if (stackFields.length > 0 &&
       contains([BAR, AREA], spec.mark) &&
@@ -77,6 +63,26 @@ export function compileStackProperties(spec: Spec) {
     }
   }
   return null;
+}
+
+/** Compile stack-by field names from (from 'color' and 'detail') */
+function getStackFields(spec: Spec) {
+  return [COLOR, DETAIL].reduce(function(fields, channel) {
+    const channelEncoding = spec.encoding[channel];
+    if (has(spec.encoding, channel)) {
+      if (isArray(channelEncoding)) {
+        channelEncoding.forEach(function(fieldDef) {
+          fields.push(field(fieldDef));
+        });
+      } else {
+        const fieldDef: FieldDef = channelEncoding;
+        fields.push(field(fieldDef, {
+          binSuffix: scaleType(fieldDef, channel, spec.mark) === 'ordinal' ? '_range' : '_start'
+        }));
+      }
+    }
+    return fields;
+  }, []);
 }
 
 // impute data for stacked area

--- a/src/compiler/stack.ts
+++ b/src/compiler/stack.ts
@@ -1,5 +1,6 @@
 import {Spec} from '../schema/schema';
 import {stackConfig as stackConfigSchema} from '../schema/config.stack.schema';
+import {FieldDef} from '../schema/fielddef.schema';
 import {instantiate} from '../schema/schemautil';
 import {Model} from './Model';
 import {Channel, X, Y, COLOR, DETAIL} from '../channel';
@@ -7,6 +8,8 @@ import {BAR, AREA} from '../mark';
 import {field, isMeasure} from '../fielddef';
 import {has, isAggregate} from '../encoding';
 import {isArray, contains} from '../util';
+
+import {type as scaleType} from './scale';
 
 export interface StackProperties {
   /** Dimension axis of the stack ('x' or 'y'). */
@@ -31,7 +34,7 @@ interface StackTransform {
   output: any;
 }
 
-export function compileStackProperties(spec: Spec, model: Model) {
+export function compileStackProperties(spec: Spec) {
   const stackFields = [COLOR, DETAIL].reduce(function(fields, channel) {
     const channelEncoding = spec.encoding[channel];
     if (has(spec.encoding, channel)) {
@@ -40,7 +43,10 @@ export function compileStackProperties(spec: Spec, model: Model) {
           fields.push(field(fieldDef));
         });
       } else {
-        fields.push(model.field(channel));
+        const fieldDef: FieldDef = channelEncoding;
+        fields.push(field(fieldDef, {
+          binSuffix: scaleType(fieldDef, channel, spec.mark) === 'ordinal' ? '_range' : '_start'
+        }));
       }
     }
     return fields;

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -21,8 +21,8 @@ export function channels(encoding: Encoding) {
 export function has(encoding: Encoding, channel: Channel): boolean {
   const channelEncoding = encoding && encoding[channel];
   return channelEncoding && (
-    !!channelEncoding.field ||
-    (isArray(channelEncoding) && channelEncoding.length)
+    channelEncoding.field !== undefined ||
+    (isArray(channelEncoding) && channelEncoding.length > 0)
   );
 }
 

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -39,18 +39,17 @@ export function field(fieldDef: FieldDef, opt: FieldRefOption = {}) {
   }
 }
 
-// TODO remove these "isDimension/isMeasure" stuff
 function _isFieldDimension(fieldDef: FieldDef) {
   return contains([NOMINAL, ORDINAL], fieldDef.type) || !!fieldDef.bin ||
     (fieldDef.type === TEMPORAL && !!fieldDef.timeUnit);
 }
 
 export function isDimension(fieldDef: FieldDef) {
-  return fieldDef && _isFieldDimension(fieldDef);
+  return fieldDef && fieldDef.field && _isFieldDimension(fieldDef);
 }
 
 export function isMeasure(fieldDef: FieldDef) {
-  return fieldDef && !_isFieldDimension(fieldDef);
+  return fieldDef && fieldDef.field && !_isFieldDimension(fieldDef);
 }
 
 export const COUNT_DISPLAYNAME = 'Number of Records';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
         "src/channel.ts",
         "src/compiler/axis.ts",
         "src/compiler/compiler.ts",
+        "src/compiler/config.ts",
         "src/compiler/data.ts",
         "src/compiler/facet.ts",
         "src/compiler/layout.ts",


### PR DESCRIPTION
- extract `compileStackProperties` to stack.ts
- add `compileMarkConfig` and remove `model.markConfig()`
- fix `fieldDef.isDimension|Measure` and use it entirely in `model`

Please merge #926 first!  

(See [Branch Specific Diff](https://github.com/uwdata/vega-lite/compare/kw/scale.type...kw/markConfig))