### PR TITLE
Refactor Tick and Bar Marks

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -100,7 +100,7 @@ and the following fill and stroke properties:
 
 | Property            | Type                | Description  |
 | :------------------ |:-------------------:| :------------|
-| tickSize            | Number              | Size of the tick mark. |
+| thickness           | Number              | Thickness of the tick mark. |
 
 
 ### Marks Config for Text Marks

--- a/docs/encoding.md
+++ b/docs/encoding.md
@@ -21,7 +21,7 @@ These channels are properties for the top-level `encoding` definition object.
 | row, column   | [FieldDef](#field-definition)| Description of a field that facets data into vertical and horizontal [trellis plots](https://en.wikipedia.org/wiki/Small_multiple) respectively. |
 | color | [FieldDef](#field-definition)| Description of a field mapped to color or a constant value for color.  The values are mapped to hue if the field is nominal, and mapped to saturation otherwise.  |
 | shape  | [FieldDef](#field-definition)| Description of a field mapped to shape encoding or a constant value for shape.   `shape` channel is only applicable for `point` marks.  |
-| size  | [FieldDef](#field-definition)| Description of a field mapped to size encoding or a constant value for size.  `size` channel is currently not applicable for `line` and `area`. |
+| size  | [FieldDef](#field-definition)| Description of a field mapped to size encoding or a constant value for size.  `size` channel is currently not applicable for `line` and `area`. If `size` is not mapped to a field, the default value is 10 for `text` mark, `bandWidth-1` for `bar` with ordinal dimension scale and 2 for `bar` with linear dimension scale, `2/3*bandWidth` for `tick`, and 30 for other marks. |
 | detail | [FieldDef](#field-definition)| Description of a field that serves as an additional dimension for aggregate views without mapping to a specific visual channel.  `detail` channel is  not applicable raw plots (plots without aggregation). |
 
 <!-- # Faceting

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -599,7 +599,7 @@ export namespace tick {
       // TODO(#694): optimize tick's width for bin
       p.width = { value: model.fieldDef(X).scale.bandWidth / 1.5 };
     } else {
-      p.width = { value: model.config().mark.tickSize };
+      p.width = { value: model.config().mark.thickness };
     }
 
     // height
@@ -607,7 +607,7 @@ export namespace tick {
       // TODO(#694): optimize tick's height for bin
       p.height = { value: model.fieldDef(Y).scale.bandWidth / 1.5 };
     } else {
-      p.height = { value: model.config().mark.tickSize };
+      p.height = { value: model.config().mark.thickness };
     }
 
     applyColorAndOpacity(p, model, ColorMode.ALWAYS_FILLED);

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -263,7 +263,7 @@ export namespace bar {
           scale: model.scale(X),
           field: model.field(X)
         };
-        p.width = size(model, X);
+        p.width = {value: size(model, X)};
       }
     } else if (model.fieldDef(X).bin) {
       if (model.has(SIZE) && orient !== 'horizontal') {

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -576,26 +576,20 @@ export namespace tick {
 
     // x
     if (model.has(X)) {
-      p.x = {
+      p.xc = {
         scale: model.scale(X),
         field: model.field(X, { binSuffix: '_mid' })
       };
-      if (model.isDimension(X)) {
-        p.x.offset = -model.fieldDef(X).scale.bandWidth / 3;
-      }
     } else {
       p.x = { value: 0 };
     }
 
     // y
     if (model.has(Y)) {
-      p.y = {
+      p.yc = {
         scale: model.scale(Y),
         field: model.field(Y, { binSuffix: '_mid' })
       };
-      if (model.isDimension(Y)) {
-        p.y.offset = -model.fieldDef(Y).scale.bandWidth / 3;
-      }
     } else {
       p.y = { value: 0 };
     }

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -133,8 +133,9 @@ export function compileMarks(model: Model): any[] {
 }
 
 export function size(model: Model, channel: Channel = SIZE) {
-  if (model.fieldDef(SIZE).value !== undefined) {
-    return model.fieldDef(SIZE).value;
+  const value = model.fieldDef(SIZE).value;
+  if (value !== undefined) {
+    return value;
   }
   switch (model.mark()) {
     case TEXTMARKS:
@@ -148,20 +149,7 @@ export function size(model: Model, channel: Channel = SIZE) {
         // otherwise, set to 2 by default
         2;
     case TICK:
-      // TICK's size is applied on either X or Y
-      if (
-          (!model.has(channel) || model.isDimension(channel)) &&
-          // Tick's bandWidth should only be applied to one side
-          // (X for vertical, Y for horizontal)
-          ((channel === X && model.config().mark.orient !== 'horizontal') ||
-          (channel === Y && model.config().mark.orient === 'horizontal'))
-        ) {
-
-        // TODO(#694): optimize tick's width for bin
-        return model.fieldDef(channel).scale.bandWidth / 1.5;
-      } else {
-        return model.config().mark.thickness;
-      }
+      return model.fieldDef(channel).scale.bandWidth / 1.5;
   }
   return 30;
 }
@@ -604,9 +592,13 @@ export namespace tick {
       p.y = { value: 0 };
     }
 
-    // width & height
-    p.width = { value: size(model, X) };
-    p.height = { value: size(model, Y) };
+    if (model.config().mark.orient === 'horizontal') {
+      p.width = { value: model.config().mark.thickness };
+      p.height = { value: size(model, Y) }; // TODO(#932) support size channel
+    } else {
+      p.width = { value: size(model, X) }; // TODO(#932) support size channel
+      p.height = { value: model.config().mark.thickness };
+    }
 
     applyColorAndOpacity(p, model, ColorMode.ALWAYS_FILLED);
     return p;

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -149,7 +149,14 @@ export function size(model: Model, channel: Channel = SIZE) {
         2;
     case TICK:
       // TICK's size is applied on either X or Y
-      if (!model.has(channel) || model.isDimension(channel)) {
+      if (
+          (!model.has(channel) || model.isDimension(channel)) &&
+          // Tick's bandWidth should only be applied to one side
+          // (X for vertical, Y for horizontal)
+          ((channel === X && model.config().mark.orient !== 'horizontal') ||
+          (channel === Y && model.config().mark.orient === 'horizontal'))
+        ) {
+
         // TODO(#694): optimize tick's width for bin
         return model.fieldDef(channel).scale.bandWidth / 1.5;
       } else {
@@ -575,7 +582,6 @@ export namespace tick {
   }
 
   export function properties(model: Model) {
-    // FIXME are /3 , /1.5 divisions here correct?
     var p: any = {};
 
     // x

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -581,7 +581,7 @@ export namespace tick {
         field: model.field(X, { binSuffix: '_mid' })
       };
     } else {
-      p.x = { value: 0 };
+      p.x = { value: 0, offset: 2 };
     }
 
     // y

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -1,6 +1,6 @@
 import {Model} from './Model';
 import {X, Y, COLOR, TEXT, SIZE, SHAPE, DETAIL, ROW, COLUMN, LABEL, Channel} from '../channel';
-import {AREA, LINE, BAR, TEXT as TEXTMARKS} from '../mark';
+import {AREA, LINE, BAR, TEXT as TEXTMARKS, TICK} from '../mark';
 import {imputeTransform, stackTransform} from './stack';
 import {QUANTITATIVE} from '../type';
 import {extend} from '../util';
@@ -147,6 +147,14 @@ export function size(model: Model, channel: Channel = SIZE) {
         model.fieldDef(channel).scale.bandWidth - 1 :
         // otherwise, set to 2 by default
         2;
+    case TICK:
+      // TICK's size is applied on either X or Y
+      if (!model.has(channel) || model.isDimension(channel)) {
+        // TODO(#694): optimize tick's width for bin
+        return model.fieldDef(channel).scale.bandWidth / 1.5;
+      } else {
+        return model.config().mark.thickness;
+      }
   }
   return 30;
 }
@@ -590,23 +598,9 @@ export namespace tick {
       p.y = { value: 0 };
     }
 
-    // width
-    if (!model.has(X) || model.isDimension(X)) {
-      // TODO(#694): optimize tick's width for bin
-      // TODO: call size()
-      p.width = { value: model.fieldDef(X).scale.bandWidth / 1.5 };
-    } else {
-      p.width = { value: model.config().mark.thickness };
-    }
-
-    // height
-    if (!model.has(Y) || model.isDimension(Y)) {
-      // TODO(#694): optimize tick's height for bin
-      // TODO: call size()
-      p.height = { value: model.fieldDef(Y).scale.bandWidth / 1.5 };
-    } else {
-      p.height = { value: model.config().mark.thickness };
-    }
+    // width & height
+    p.width = { value: size(model, X) };
+    p.height = { value: size(model, Y) };
 
     applyColorAndOpacity(p, model, ColorMode.ALWAYS_FILLED);
     return p;

--- a/src/schema/config.marks.schema.ts
+++ b/src/schema/config.marks.schema.ts
@@ -21,7 +21,7 @@ export interface MarkConfig {
   tension?: number;
 
   // Tick-only
-  tickSize?: number;
+  thickness?: number;
 
   // Text-only
   align?: string;
@@ -136,10 +136,10 @@ export const markConfig = {
     },
 
     // Tick-only
-    tickSize: {
+    thickness: {
       type: 'number',
       default: 1,
-      description: 'Size of the tick mark.'
+      description: 'Thickness of the tick mark.'
     },
 
     // text-only


### PR DESCRIPTION
- Use `xc` and `yc` for ticks so we don’t have to add offset
- add offset for vertical dot plot with tick
- `config.mark.tickSize` => `config.mark.thickness`
- make `size.value` works with `tick` and `bar` mark – fixes #931