### PR TITLE
Follow up refactor for #933

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -100,7 +100,7 @@ and the following fill and stroke properties:
 
 | Property            | Type                | Description  |
 | :------------------ |:-------------------:| :------------|
-| tickSize            | Number              | Size of the tick mark. |
+| thickness           | Number              | Thickness of the tick mark. |
 
 
 ### Marks Config for Text Marks

--- a/docs/encoding.md
+++ b/docs/encoding.md
@@ -21,7 +21,7 @@ These channels are properties for the top-level `encoding` definition object.
 | row, column   | [FieldDef](#field-definition)| Description of a field that facets data into vertical and horizontal [trellis plots](https://en.wikipedia.org/wiki/Small_multiple) respectively. |
 | color | [FieldDef](#field-definition)| Description of a field mapped to color or a constant value for color.  The values are mapped to hue if the field is nominal, and mapped to saturation otherwise.  |
 | shape  | [FieldDef](#field-definition)| Description of a field mapped to shape encoding or a constant value for shape.   `shape` channel is only applicable for `point` marks.  |
-| size  | [FieldDef](#field-definition)| Description of a field mapped to size encoding or a constant value for size.  `size` channel is currently not applicable for `line` and `area`. |
+| size  | [FieldDef](#field-definition)| Description of a field mapped to size encoding or a constant value for size.  `size` channel is currently not applicable for `line` and `area`. If `size` is not mapped to a field, the default value is 10 for `text` mark, `bandWidth-1` for `bar` with ordinal dimension scale and 2 for `bar` with linear dimension scale, `2/3*bandWidth` for `tick`, and 30 for other marks. |
 | detail | [FieldDef](#field-definition)| Description of a field that serves as an additional dimension for aggregate views without mapping to a specific visual channel.  `detail` channel is  not applicable raw plots (plots without aggregation). |
 
 <!-- # Faceting

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -6,12 +6,12 @@ import {instantiate} from '../schema/schemautil';
 import * as schema from '../schema/schema';
 import * as schemaUtil from '../schema/schemautil';
 
-import {COLUMN, ROW, X, Y, Channel, supportMark} from '../channel';
+import {COLUMN, ROW, X, Y, SIZE, Channel, supportMark} from '../channel';
 import {SOURCE, SUMMARY} from '../data';
 import * as vlFieldDef from '../fielddef';
 import {FieldRefOption} from '../fielddef';
 import * as vlEncoding from '../encoding';
-import {Mark} from '../mark';
+import {Mark, BAR, TICK, TEXT as TEXTMARK} from '../mark';
 
 import {getFullName, NOMINAL, ORDINAL, TEMPORAL} from '../type';
 import {contains, duplicate, extend} from '../util';
@@ -201,6 +201,28 @@ export class Model {
   public scale(channel: Channel): string {
     const name = this.spec().name;
     return (name ? name + '-' : '') + channel;
+  }
+
+  public sizeValue(channel: Channel = SIZE) {
+    const value = this.fieldDef(SIZE).value;
+    if (value !== undefined) {
+      return value;
+    }
+    switch (this.mark()) {
+      case TEXTMARK:
+        return 10; // font size 10 by default
+      case BAR:
+        // BAR's size is applied on either X or Y
+        return !this.has(channel) || this.isOrdinalScale(channel) ?
+          // For ordinal scale or single bar, we can use bandWidth - 1
+          // (-1 so that the border of the bar falls on exact pixel)
+          this.fieldDef(channel).scale.bandWidth - 1 :
+          // otherwise, set to 2 by default
+          2;
+      case TICK:
+        return this.fieldDef(channel).scale.bandWidth / 1.5;
+    }
+    return 30;
   }
 
   /** returns the template name used for axis labels for a time unit */

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -599,7 +599,7 @@ export namespace tick {
       // TODO(#694): optimize tick's width for bin
       p.width = { value: model.fieldDef(X).scale.bandWidth / 1.5 };
     } else {
-      p.width = { value: model.config().mark.tickSize };
+      p.width = { value: model.config().mark.thickness };
     }
 
     // height
@@ -607,7 +607,7 @@ export namespace tick {
       // TODO(#694): optimize tick's height for bin
       p.height = { value: model.fieldDef(Y).scale.bandWidth / 1.5 };
     } else {
-      p.height = { value: model.config().mark.tickSize };
+      p.height = { value: model.config().mark.thickness };
     }
 
     applyColorAndOpacity(p, model, ColorMode.ALWAYS_FILLED);

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -263,7 +263,7 @@ export namespace bar {
           scale: model.scale(X),
           field: model.field(X)
         };
-        p.width = size(model, X);
+        p.width = {value: size(model, X)};
       }
     } else if (model.fieldDef(X).bin) {
       if (model.has(SIZE) && orient !== 'horizontal') {

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -1,6 +1,6 @@
 import {Model} from './Model';
-import {X, Y, COLOR, TEXT, SIZE, SHAPE, DETAIL, ROW, COLUMN, LABEL, Channel} from '../channel';
-import {AREA, LINE, BAR, TEXT as TEXTMARKS, TICK} from '../mark';
+import {X, Y, COLOR, TEXT, SIZE, SHAPE, DETAIL, ROW, COLUMN, LABEL} from '../channel';
+import {AREA, LINE, TEXT as TEXTMARK} from '../mark';
 import {imputeTransform, stackTransform} from './stack';
 import {QUANTITATIVE} from '../type';
 import {extend} from '../util';
@@ -76,7 +76,7 @@ export function compileMarks(model: Model): any[] {
     }
   } else { // other mark type
     let marks = []; // TODO: vgMarks
-    if (mark === TEXTMARKS && model.has(COLOR)) {
+    if (mark === TEXTMARK && model.has(COLOR)) {
       // add background to 'text' marks if has color
       marks.push(extend(
         name ? { name: name + '-background' } : {},
@@ -130,28 +130,6 @@ export function compileMarks(model: Model): any[] {
 
     return marks;
   }
-}
-
-export function size(model: Model, channel: Channel = SIZE) {
-  const value = model.fieldDef(SIZE).value;
-  if (value !== undefined) {
-    return value;
-  }
-  switch (model.mark()) {
-    case TEXTMARKS:
-      return 10; // font size 10 by default
-    case BAR:
-      // BAR's size is applied on either X or Y
-      return !model.has(channel) || model.isOrdinalScale(channel) ?
-        // For ordinal scale or single bar, we can use bandWidth - 1
-        // (-1 so that the border of the bar falls on exact pixel)
-        model.fieldDef(channel).scale.bandWidth - 1 :
-        // otherwise, set to 2 by default
-        2;
-    case TICK:
-      return model.fieldDef(channel).scale.bandWidth / 1.5;
-  }
-  return 30;
 }
 
 enum ColorMode {
@@ -251,7 +229,7 @@ export namespace bar {
           scale: model.scale(X),
           field: model.field(X)
         };
-        p.width = {value: size(model, X)};
+        p.width = {value: model.sizeValue(X)};
       }
     } else if (model.fieldDef(X).bin) {
       if (model.has(SIZE) && orient !== 'horizontal') {
@@ -292,7 +270,7 @@ export namespace bar {
           field: model.field(SIZE)
         } : {
           // otherwise, use fixed size
-          value: size(model, X)
+          value: model.sizeValue(X)
         };
     }
 
@@ -318,7 +296,7 @@ export namespace bar {
           scale: model.scale(Y),
           field: model.field(Y)
         };
-        p.height = { value: size(model, Y) };
+        p.height = { value: model.sizeValue(Y) };
       }
     } else if (model.fieldDef(Y).bin) {
       if (model.has(SIZE) && orient === 'horizontal') {
@@ -363,7 +341,7 @@ export namespace bar {
           scale: model.scale(SIZE),
           field: model.field(SIZE)
         } : {
-          value: size(model, Y)
+          value: model.sizeValue(Y)
         };
     }
 
@@ -413,7 +391,7 @@ export namespace point {
         field: model.field(SIZE)
       };
     } else {
-      p.size = { value: size(model) };
+      p.size = { value: model.sizeValue() };
     }
 
     // shape
@@ -594,9 +572,9 @@ export namespace tick {
 
     if (model.config().mark.orient === 'horizontal') {
       p.width = { value: model.config().mark.thickness };
-      p.height = { value: size(model, Y) }; // TODO(#932) support size channel
+      p.height = { value: model.sizeValue(Y) }; // TODO(#932) support size channel
     } else {
-      p.width = { value: size(model, X) }; // TODO(#932) support size channel
+      p.width = { value: model.sizeValue(X) }; // TODO(#932) support size channel
       p.height = { value: model.config().mark.thickness };
     }
 
@@ -642,7 +620,7 @@ function filled_point_props(shape) {
         field: model.field(SIZE)
       };
     } else {
-      p.size = { value: size(model) };
+      p.size = { value: model.sizeValue() };
     }
 
     // shape
@@ -731,7 +709,7 @@ export namespace text {
         field: model.field(SIZE)
       };
     } else {
-      p.fontSize = { value: size(model) };
+      p.fontSize = { value: model.sizeValue() };
     }
 
     // FIXME applyColorAndOpacity

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -576,26 +576,20 @@ export namespace tick {
 
     // x
     if (model.has(X)) {
-      p.x = {
+      p.xc = {
         scale: model.scale(X),
         field: model.field(X, { binSuffix: '_mid' })
       };
-      if (model.isDimension(X)) {
-        p.x.offset = -model.fieldDef(X).scale.bandWidth / 3;
-      }
     } else {
       p.x = { value: 0 };
     }
 
     // y
     if (model.has(Y)) {
-      p.y = {
+      p.yc = {
         scale: model.scale(Y),
         field: model.field(Y, { binSuffix: '_mid' })
       };
-      if (model.isDimension(Y)) {
-        p.y.offset = -model.fieldDef(Y).scale.bandWidth / 3;
-      }
     } else {
       p.y = { value: 0 };
     }

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -133,8 +133,9 @@ export function compileMarks(model: Model): any[] {
 }
 
 export function size(model: Model, channel: Channel = SIZE) {
-  if (model.fieldDef(SIZE).value !== undefined) {
-    return model.fieldDef(SIZE).value;
+  const value = model.fieldDef(SIZE).value;
+  if (value !== undefined) {
+    return value;
   }
   switch (model.mark()) {
     case TEXTMARKS:
@@ -148,20 +149,7 @@ export function size(model: Model, channel: Channel = SIZE) {
         // otherwise, set to 2 by default
         2;
     case TICK:
-      // TICK's size is applied on either X or Y
-      if (
-          (!model.has(channel) || model.isDimension(channel)) &&
-          // Tick's bandWidth should only be applied to one side
-          // (X for vertical, Y for horizontal)
-          ((channel === X && model.config().mark.orient !== 'horizontal') ||
-          (channel === Y && model.config().mark.orient === 'horizontal'))
-        ) {
-
-        // TODO(#694): optimize tick's width for bin
-        return model.fieldDef(channel).scale.bandWidth / 1.5;
-      } else {
-        return model.config().mark.thickness;
-      }
+      return model.fieldDef(channel).scale.bandWidth / 1.5;
   }
   return 30;
 }
@@ -604,9 +592,13 @@ export namespace tick {
       p.y = { value: 0 };
     }
 
-    // width & height
-    p.width = { value: size(model, X) };
-    p.height = { value: size(model, Y) };
+    if (model.config().mark.orient === 'horizontal') {
+      p.width = { value: model.config().mark.thickness };
+      p.height = { value: size(model, Y) }; // TODO(#932) support size channel
+    } else {
+      p.width = { value: size(model, X) }; // TODO(#932) support size channel
+      p.height = { value: model.config().mark.thickness };
+    }
 
     applyColorAndOpacity(p, model, ColorMode.ALWAYS_FILLED);
     return p;

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -149,7 +149,14 @@ export function size(model: Model, channel: Channel = SIZE) {
         2;
     case TICK:
       // TICK's size is applied on either X or Y
-      if (!model.has(channel) || model.isDimension(channel)) {
+      if (
+          (!model.has(channel) || model.isDimension(channel)) &&
+          // Tick's bandWidth should only be applied to one side
+          // (X for vertical, Y for horizontal)
+          ((channel === X && model.config().mark.orient !== 'horizontal') ||
+          (channel === Y && model.config().mark.orient === 'horizontal'))
+        ) {
+
         // TODO(#694): optimize tick's width for bin
         return model.fieldDef(channel).scale.bandWidth / 1.5;
       } else {
@@ -575,7 +582,6 @@ export namespace tick {
   }
 
   export function properties(model: Model) {
-    // FIXME are /3 , /1.5 divisions here correct?
     var p: any = {};
 
     // x

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -581,7 +581,7 @@ export namespace tick {
         field: model.field(X, { binSuffix: '_mid' })
       };
     } else {
-      p.x = { value: 0 };
+      p.x = { value: 0, offset: 2 };
     }
 
     // y

--- a/src/compiler/marks.ts
+++ b/src/compiler/marks.ts
@@ -1,6 +1,6 @@
 import {Model} from './Model';
 import {X, Y, COLOR, TEXT, SIZE, SHAPE, DETAIL, ROW, COLUMN, LABEL, Channel} from '../channel';
-import {AREA, LINE, BAR, TEXT as TEXTMARKS} from '../mark';
+import {AREA, LINE, BAR, TEXT as TEXTMARKS, TICK} from '../mark';
 import {imputeTransform, stackTransform} from './stack';
 import {QUANTITATIVE} from '../type';
 import {extend} from '../util';
@@ -147,6 +147,14 @@ export function size(model: Model, channel: Channel = SIZE) {
         model.fieldDef(channel).scale.bandWidth - 1 :
         // otherwise, set to 2 by default
         2;
+    case TICK:
+      // TICK's size is applied on either X or Y
+      if (!model.has(channel) || model.isDimension(channel)) {
+        // TODO(#694): optimize tick's width for bin
+        return model.fieldDef(channel).scale.bandWidth / 1.5;
+      } else {
+        return model.config().mark.thickness;
+      }
   }
   return 30;
 }
@@ -590,23 +598,9 @@ export namespace tick {
       p.y = { value: 0 };
     }
 
-    // width
-    if (!model.has(X) || model.isDimension(X)) {
-      // TODO(#694): optimize tick's width for bin
-      // TODO: call size()
-      p.width = { value: model.fieldDef(X).scale.bandWidth / 1.5 };
-    } else {
-      p.width = { value: model.config().mark.thickness };
-    }
-
-    // height
-    if (!model.has(Y) || model.isDimension(Y)) {
-      // TODO(#694): optimize tick's height for bin
-      // TODO: call size()
-      p.height = { value: model.fieldDef(Y).scale.bandWidth / 1.5 };
-    } else {
-      p.height = { value: model.config().mark.thickness };
-    }
+    // width & height
+    p.width = { value: size(model, X) };
+    p.height = { value: size(model, Y) };
 
     applyColorAndOpacity(p, model, ColorMode.ALWAYS_FILLED);
     return p;

--- a/src/schema/config.marks.schema.ts
+++ b/src/schema/config.marks.schema.ts
@@ -21,7 +21,7 @@ export interface MarkConfig {
   tension?: number;
 
   // Tick-only
-  tickSize?: number;
+  thickness?: number;
 
   // Text-only
   align?: string;
@@ -136,10 +136,10 @@ export const markConfig = {
     },
 
     // Tick-only
-    tickSize: {
+    thickness: {
       type: 'number',
       default: 1,
-      description: 'Size of the tick mark.'
+      description: 'Thickness of the tick mark.'
     },
 
     // text-only


### PR DESCRIPTION
- `mark.size` => `model.sizeValue()`
- `TEXTMARKS` => `TEXTMARK`

Please merge #933 first!  

(See [Branch Specific Diff](https://github.com/uwdata/vega-lite/compare/kw/tick...kw/refactor))