### PR TITLE
More time units

### DIFF
--- a/examples/temp_histogram.json
+++ b/examples/temp_histogram.json
@@ -1,0 +1,17 @@
+{
+  "data": {"url": "data/seattle-temps.csv","formatType": "csv"},
+  "mark": "line",
+  "encoding": {
+    "x": {
+      "field": "date",
+      "type": "temporal",
+      "timeUnit": "month",
+      "axis": {"shortTimeLabels": true}
+    },
+    "y": {
+      "aggregate": "mean",
+      "field": "temp",
+      "type": "quantitative"
+    }
+  }
+}

--- a/examples/temp_histogram_bar.json
+++ b/examples/temp_histogram_bar.json
@@ -1,0 +1,18 @@
+{
+  "description": "Temperature in Seattle as a bar chart with yearmonth time unit.",
+  "data": {"url": "data/seattle-temps.csv","formatType": "csv"},
+  "mark": "bar",
+  "encoding": {
+    "x": {
+      "field": "date",
+      "type": "temporal",
+      "timeUnit": "yearmonth",
+      "axis": {"shortTimeLabels": true}
+    },
+    "y": {
+      "aggregate": "mean",
+      "field": "temp",
+      "type": "quantitative"
+    }
+  }
+}

--- a/examples/temp_histogram_bar.json
+++ b/examples/temp_histogram_bar.json
@@ -7,7 +7,9 @@
       "field": "date",
       "type": "temporal",
       "timeUnit": "yearmonth",
-      "format": "%B of %Y"
+      "axis": {
+        "format": "%B of %Y"
+      }
     },
     "y": {
       "aggregate": "mean",

--- a/examples/temp_histogram_bar.json
+++ b/examples/temp_histogram_bar.json
@@ -7,7 +7,7 @@
       "field": "date",
       "type": "temporal",
       "timeUnit": "yearmonth",
-      "axis": {"shortTimeLabels": true}
+      "format": "%B of %Y"
     },
     "y": {
       "aggregate": "mean",

--- a/examples/vlexamples.json
+++ b/examples/vlexamples.json
@@ -109,6 +109,11 @@
     {
       "name": "stacked_bar_1d",
       "title": "1D Stacked Bar Chart"
+    },
+    {
+      "name": "temp_histogram",
+      "title": "Temperature in seattle",
+      "showInEditor": true
     }
   ],
   "Trellis": [

--- a/examples/vlexamples.json
+++ b/examples/vlexamples.json
@@ -112,8 +112,12 @@
     },
     {
       "name": "temp_histogram",
-      "title": "Temperature in seattle",
+      "title": "Temperature in Seattle",
       "showInEditor": true
+    },
+    {
+      "name": "temp_histogram_bar",
+      "title": "Temperature in Seattle"
     }
   ],
   "Trellis": [

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -13,7 +13,7 @@ import {FieldRefOption} from '../fielddef';
 import * as vlEncoding from '../encoding';
 import {Mark, BAR, TICK, TEXT as TEXTMARK} from '../mark';
 
-import {getFullName, NOMINAL, ORDINAL, TEMPORAL} from '../type';
+import {getFullName, NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../type';
 import {contains, duplicate, extend} from '../util';
 
 import {compileMarkConfig} from './config';
@@ -226,7 +226,35 @@ export class Model {
     return 30;
   }
 
-  /** returns the tiem format used for axis labels for a time unit */
+  /** Add formatting to a mark definition. Used in axis and legend. */
+  public format(channel: Channel, format: string, def: any) {
+    const fieldDef = this.fieldDef(channel);
+
+    if (fieldDef.type === TEMPORAL) {
+      // explicitly set the fromat type so that vega uses the datetime formatter
+      def.formatType = 'time';
+    }
+
+    if (format !== undefined) {
+      def.format = format;
+    }
+
+    switch (fieldDef.type) {
+      case QUANTITATIVE:
+        def.format = this.numberFormat(channel);
+        break;
+      case TEMPORAL:
+        const f = this.timeFormat(channel);
+        if (f) {
+          def.format = f;
+        } else {
+          def.format = this.config().timeFormat;
+        }
+        break;
+    }
+  }
+
+  /** returns the time format used for axis labels for a time unit */
   public timeFormat(channel: Channel): string {
     const fieldDef = this.fieldDef(channel);
     const legend = fieldDef.legend;

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -237,6 +237,7 @@ export class Model {
 
     if (format !== undefined) {
       def.format = format;
+      return;
     }
 
     switch (fieldDef.type) {

--- a/src/compiler/Model.ts
+++ b/src/compiler/Model.ts
@@ -20,6 +20,7 @@ import {compileMarkConfig} from './config';
 import {compileLayout, Layout} from './layout';
 import {compileStackProperties, StackProperties} from './stack';
 import {type as scaleType} from './scale';
+import {format as timeFormatExpr} from './time';
 
 /**
  * Internal model of Vega-Lite specification for the compiler.
@@ -203,8 +204,8 @@ export class Model {
     return (name ? name + '-' : '') + channel;
   }
 
-  /** returns the template name used for axis labels for a time unit */
-  public labelTemplate(channel: Channel): string {
+  /** returns the time format used for axis labels for a time unit */
+  public timeFormat(channel: Channel): string {
     const fieldDef = this.fieldDef(channel);
     const legend = fieldDef.legend;
     const axis = fieldDef.axis;
@@ -212,14 +213,6 @@ export class Model {
       (typeof axis !== 'boolean' ? axis.shortTimeLabels : false) :
       (typeof legend !== 'boolean' ? legend.shortTimeLabels : false);
 
-    var postfix = abbreviated ? '-abbrev' : '';
-    switch (fieldDef.timeUnit) {
-      case 'day':
-        return 'day' + postfix;
-      case 'month':
-        return 'month' + postfix;
-    }
-    return null;
+    return timeFormatExpr(fieldDef.timeUnit, abbreviated);
   }
-
 }

--- a/src/compiler/axis.ts
+++ b/src/compiler/axis.ts
@@ -17,10 +17,13 @@ export function compileAxis(channel: Channel, model: Model) {
     scale: model.scale(channel)
   };
 
-  // 1. Add properties
+  // 1.1 Add properties with special rules
+  model.format(channel, model.axis(channel).format, def);
+
+  // 1.2. Add properties
   [
     // a) properties with special rules (so it has axis[property] methods) -- call rule functions
-    'format', 'grid', 'layer', 'orient', 'tickSize', 'ticks', 'title',
+    'grid', 'layer', 'orient', 'tickSize', 'ticks', 'title',
     // b) properties without rules, only produce default values in the schema, or explicit value if specified
     'offset', 'tickPadding', 'tickSize', 'tickSizeMajor', 'tickSizeMinor', 'tickSizeEnd',
     'titleOffset', 'values', 'subdivide'
@@ -40,7 +43,7 @@ export function compileAxis(channel: Channel, model: Model) {
   var props = model.axis(channel).properties || {};
 
   [
-    'axis', 'labels',// have special rules
+    'axis', 'labels', // have special rules
     'grid', 'title', 'ticks', 'majorTicks', 'minorTicks' // only default values
   ].forEach(function(group) {
     var value = properties[group] ?
@@ -53,24 +56,6 @@ export function compileAxis(channel: Channel, model: Model) {
   });
 
   return def;
-}
-
-export function format(model: Model, channel: Channel) {
-  const fieldDef = model.fieldDef(channel);
-  var format = model.axis(channel).format;
-  if (format !== undefined)  {
-    return format;
-  }
-
-  if (fieldDef.type === QUANTITATIVE) {
-    return model.numberFormat(channel);
-  } else if (fieldDef.type === TEMPORAL) {
-    const timeUnit = fieldDef.timeUnit;
-    if (!timeUnit) {
-      return model.config().timeFormat;
-    }
-  }
-  return undefined;
 }
 
 export function grid(model: Model, channel: Channel) {
@@ -183,13 +168,6 @@ export namespace properties {
       return extend({
         text: ''
       }, labelsSpec);
-    }
-
-    let format = model.timeFormat(channel);
-    if (fieldDef.type === TEMPORAL && format) {
-      labelsSpec = extend({
-        text: {template: '{{datum.data | time:\''+ format + '\'}}'}
-      }, labelsSpec || {});
     }
 
     if (contains([NOMINAL, ORDINAL], fieldDef.type) && axis.labelMaxLength) {

--- a/src/compiler/axis.ts
+++ b/src/compiler/axis.ts
@@ -68,8 +68,6 @@ export function format(model: Model, channel: Channel) {
     const timeUnit = fieldDef.timeUnit;
     if (!timeUnit) {
       return model.config().timeFormat;
-    } else if (timeUnit === 'year') {
-      return 'd';
     }
   }
   return undefined;
@@ -187,10 +185,10 @@ export namespace properties {
       }, labelsSpec);
     }
 
-    let filterName = model.labelTemplate(channel);
-    if (fieldDef.type === TEMPORAL && filterName) {
+    let format = model.timeFormat(channel);
+    if (fieldDef.type === TEMPORAL && format) {
       labelsSpec = extend({
-        text: {template: '{{datum.data | ' + filterName + '}}'}
+        text: {template: '{{datum.data | time:\''+ format + '\'}}'}
       }, labelsSpec || {});
     }
 

--- a/src/compiler/axis.ts
+++ b/src/compiler/axis.ts
@@ -1,6 +1,6 @@
 import {Model} from './Model';
 import {contains, extend, truncate} from '../util';
-import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../type';
+import {NOMINAL, ORDINAL, TEMPORAL} from '../type';
 import {COLUMN, ROW, X, Y, Channel} from '../channel';
 
 // https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#11-ambient-declarations

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -52,10 +52,7 @@ export function compileData(model: Model): VgData[] {
   }
 
   // Time domain tables
-
-  dates.defs(model).forEach(dateDef => {
-    def.push(dateDef);
-  });
+  dates.defs(model).forEach(dateDef => def.push(dateDef));
 
   return def;
 }

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -417,16 +417,14 @@ export namespace dates {
    * Add data source for with dates for all months, days, hours, ... as needed.
    */
   export function defs(model: Model) {
-    let defs = [];
-
     let alreadyAdded = {};
 
-    model.forEach(function(fieldDef, channel) {
+    var res = model.reduce(function(aggregator, fieldDef: FieldDef, channel: Channel) {
       if (fieldDef.timeUnit) {
         const domain = rawDomain(fieldDef.timeUnit, channel);
         if (domain && !alreadyAdded[fieldDef.timeUnit]) {
           alreadyAdded[fieldDef.timeUnit] = true;
-          defs.push({
+          aggregator.push({
             name: fieldDef.timeUnit,
             values: domain,
             transform: [{
@@ -437,9 +435,10 @@ export namespace dates {
           });
         }
       }
-    });
+      return aggregator;
+    }, []);
 
-    return defs;
+    return res;
   }
 }
 

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -19,12 +19,12 @@ const DEFAULT_NULL_FILTERS = {
 };
 
 /**
- * Create Vega's data array from a given encoding.
+ * Create Vega's data array from a given model.
  *
- * @param  encoding
+ * @param  model
  * @return Array of Vega data.
  *                 This always includes a "source" data table.
- *                 If the encoding contains aggregate value, this will also create
+ *                 If the model contains aggregate value, this will also create
  *                 aggregate table as well.
  */
 export function compileData(model: Model): VgData[] {

--- a/src/compiler/data.ts
+++ b/src/compiler/data.ts
@@ -424,7 +424,7 @@ export namespace dates {
 
     let alreadyAdded = {};
 
-    model.forEach((fieldDef, channel) => {
+    model.forEach(function(fieldDef, channel) {
       if (fieldDef.timeUnit) {
         const domain = rawDomain(fieldDef.timeUnit, channel);
         if (domain && !alreadyAdded[fieldDef.timeUnit]) {

--- a/src/compiler/legend.ts
+++ b/src/compiler/legend.ts
@@ -3,7 +3,6 @@ import {FieldDef} from '../schema/fielddef.schema';
 import {COLOR, SIZE, SHAPE, Channel} from '../channel';
 import {title as fieldTitle} from '../fielddef';
 import {AREA, BAR, TICK, TEXT, LINE, POINT, CIRCLE, SQUARE} from '../mark';
-import {TEMPORAL} from '../type';
 import {extend, keys} from '../util';
 import {Model} from './Model';
 import {applyMarkConfig, FILL_STROKE_CONFIG} from './marks';
@@ -38,9 +37,10 @@ export function compileLegend(model: Model, channel: Channel, def) {
 
   // 1.1 Add properties with special rules
   def.title = title(fieldDef);
+  model.format(channel, (typeof legend !== 'boolean' && legend.format) || undefined, def);
 
   // 1.2 Add properties without rules
-  ['orient', 'format', 'values'].forEach(function(property) {
+  ['orient', 'values'].forEach(function(property) {
     const value = legend[property];
     if (value !== undefined) {
       def[property] = value;
@@ -49,7 +49,7 @@ export function compileLegend(model: Model, channel: Channel, def) {
 
   // 2) Add mark property definition groups
   const props = (typeof legend !== 'boolean' && legend.properties) || {};
-  ['title', 'labels', 'symbols', 'legend'].forEach(function(group) {
+  ['title', 'symbols', 'legend'].forEach(function(group) {
     let value = properties[group] ?
       properties[group](fieldDef, props[group], model, channel) : // apply rule
       props[group]; // no rule -- just default values
@@ -72,19 +72,6 @@ export function title(fieldDef: FieldDef) {
 }
 
 namespace properties {
-  export function labels(fieldDef: FieldDef, labelsSpec, model: Model, channel: Channel) {
-    const timeUnit = fieldDef.timeUnit;
-    const format = model.timeFormat(channel);
-    if (fieldDef.type === TEMPORAL && timeUnit && format) {
-      return extend({
-        text: {
-          template: '{{datum.data | ' + format + '}}'
-        }
-      }, labelsSpec || {});
-    }
-    return labelsSpec;
-  }
-
   export function symbols(fieldDef: FieldDef, symbolsSpec, model: Model, channel: Channel) {
     let symbols:any = {};
     const mark = model.mark();

--- a/src/compiler/legend.ts
+++ b/src/compiler/legend.ts
@@ -74,11 +74,11 @@ export function title(fieldDef: FieldDef) {
 namespace properties {
   export function labels(fieldDef: FieldDef, labelsSpec, model: Model, channel: Channel) {
     const timeUnit = fieldDef.timeUnit;
-    const labelTemplate = model.labelTemplate(channel);
-    if (fieldDef.type === TEMPORAL && timeUnit && labelTemplate) {
+    const format = model.timeFormat(channel);
+    if (fieldDef.type === TEMPORAL && timeUnit && format) {
       return extend({
         text: {
-          template: '{{datum.data | ' + labelTemplate + '}}'
+          template: '{{datum.data | ' + format + '}}'
         }
       }, labelsSpec || {});
     }

--- a/src/compiler/scale.ts
+++ b/src/compiler/scale.ts
@@ -68,26 +68,27 @@ export function type(fieldDef: FieldDef, channel: Channel, mark: Mark): string {
       if (fieldDef.scale.type !== undefined) {
         return fieldDef.scale.type;
       }
-      switch (fieldDef.timeUnit) {
-        case 'hours':
-        case 'day':
-        case 'month':
-          return 'ordinal';
-        case 'date':
-        case 'year':
-        case 'second':
-        case 'minute':
-          // Returns ordinal if (1) the channel is X or Y, and
-          // (2) is the dimension of BAR or TICK mark.
-          // Otherwise return linear.
-          return contains([BAR, TICK], mark) &&
-            isDimension(fieldDef) ? 'ordinal' : 'time';
-      }
+
       if (fieldDef.timeUnit) {
-        // yearmonth, monthday, ...
-        return 'ordinal';
+        switch (fieldDef.timeUnit) {
+          case 'hours':
+          case 'day':
+          case 'month':
+            return 'ordinal';
+          case 'date':
+          case 'year':
+          case 'second':
+          case 'minute':
+            // Returns ordinal if (1) the channel is X or Y, and
+            // (2) is the dimension of BAR or TICK mark.
+            // Otherwise return linear.
+            return contains([BAR, TICK], mark) &&
+              isDimension(fieldDef) ? 'ordinal' : 'time';
+          default:
+            // yearmonth, monthday, ...
+            return 'ordinal';
+        }
       }
-      // no timeUnit
       return 'time';
 
     case QUANTITATIVE:

--- a/src/compiler/time.ts
+++ b/src/compiler/time.ts
@@ -69,6 +69,7 @@ export function parseExpression(timeUnit: string, fieldRef: string, onlyRef = fa
   if (timeUnit.indexOf('month') > -1) {
     out += get('month');
   } else {
+    // month starts at 0 in javascript
     out += '0, ';
   }
 

--- a/src/compiler/time.ts
+++ b/src/compiler/time.ts
@@ -1,11 +1,134 @@
+import {contains, range} from '../util';
+import {COLUMN, ROW, SHAPE, COLOR, Channel} from '../channel';
+
 /** returns the template name used for axis labels for a time unit */
-export function labelTemplate(timeUnit, abbreviated=false): string {
-  var postfix = abbreviated ? '-abbrev' : '';
-  switch (timeUnit) {
-    case 'day':
-      return 'day' + postfix;
-    case 'month':
-      return 'month' + postfix;
+export function format(timeUnit, abbreviated = false): string {
+  if (!timeUnit) {
+    return null;
   }
+
+  let dateComponents = [];
+
+  if (timeUnit.indexOf('year') > -1) {
+    dateComponents.push(abbreviated ? '%y' : '%Y');
+  }
+
+  if (timeUnit.indexOf('month') > -1) {
+    dateComponents.push(abbreviated ? '%b' : '%B');
+  }
+
+  if (timeUnit.indexOf('day') > -1) {
+    dateComponents.push(abbreviated ? '%a' : '%A');
+  } else if (timeUnit.indexOf('date') > -1) {
+    dateComponents.push('%d');
+  }
+
+  let timeComponents = [];
+
+  if (timeUnit.indexOf('hour') > -1) {
+    timeComponents.push('%H');
+  }
+  if (timeUnit.indexOf('minute') > -1) {
+    timeComponents.push('%M');
+  }
+  if (timeUnit.indexOf('second') > -1) {
+    timeComponents.push('%S');
+  }
+  if (timeUnit.indexOf('milliseconds') > -1) {
+    timeComponents.push('%L');
+  }
+
+  let out = [];
+  if (dateComponents.length > 0) {
+    out.push(dateComponents.join('-'));
+  }
+  if (timeComponents.length > 0) {
+    out.push(timeComponents.join(':'));
+  }
+
+  return out.length > 0 ? out.join(' ') : null;
+}
+
+export function parseExpression(timeUnit: string, fieldRef: string, onlyRef = false): string {
+  let out = 'time(datetime(';
+
+  function get(fun: string, addComma = true) {
+    if (onlyRef) {
+      return fieldRef + (addComma ? ', ' : '');
+    } else {
+      return fun + '(' + fieldRef + ')' + (addComma ? ', ' : '');
+    }
+  }
+
+  if (timeUnit.indexOf('year') > -1) {
+    out += get('year');
+  } else {
+    out += '2006, '; // January 1 2006 is a Sunday
+  }
+
+  if (timeUnit.indexOf('month') > -1) {
+    out += get('month');
+  } else {
+    out += '0, ';
+  }
+
+  // need to add 1 because days start at 1
+  if (timeUnit.indexOf('day') > -1) {
+    out += get('day', false) + '+1, ';
+  } else if (timeUnit.indexOf('date') > -1) {
+    out += get('date');
+  } else {
+    out += '1, ';
+  }
+
+  if (timeUnit.indexOf('hours') > -1) {
+    out += get('hours');
+  } else {
+    out += '0, ';
+  }
+
+  if (timeUnit.indexOf('minutes') > -1) {
+    out += get('minutes');
+  } else {
+    out += '0, ';
+  }
+
+  if (timeUnit.indexOf('seconds') > -1) {
+    out += get('seconds');
+  } else {
+    out += '0, ';
+  }
+
+  if (timeUnit.indexOf('milliseconds') > -1) {
+    out += get('milliseconds', false);
+  } else {
+    out += '0';
+  }
+
+  return out + '))';
+}
+
+/** Generate the complete raw domain. */
+export function rawDomain(timeUnit: string, channel: Channel) {
+  if (contains([ROW, COLUMN, SHAPE, COLOR], channel)) {
+    return null;
+  }
+
+  switch (timeUnit) {
+    case 'seconds':
+      return range(0, 60).map(v => { return { value: v }; });
+    case 'minutes':
+      return range(0, 60).map(v => { return { value: v }; });
+    case 'hours':
+      return range(0, 24).map(v => { return { value: v }; });
+    case 'day':
+      return range(0, 7).map(v => { return { value: v }; });
+    case 'date':
+      return range(1, 32).map(v => { return { value: v }; });
+    case 'month':
+      return range(0, 12).map(v => { return { value: v }; });
+
+  }
+
   return null;
 }

--- a/src/compiler/time.ts
+++ b/src/compiler/time.ts
@@ -4,7 +4,7 @@ import {COLUMN, ROW, SHAPE, COLOR, Channel} from '../channel';
 /** returns the template name used for axis labels for a time unit */
 export function format(timeUnit, abbreviated = false): string {
   if (!timeUnit) {
-    return null;
+    return undefined;
   }
 
   let dateComponents = [];
@@ -46,11 +46,11 @@ export function format(timeUnit, abbreviated = false): string {
     out.push(timeComponents.join(':'));
   }
 
-  return out.length > 0 ? out.join(' ') : null;
+  return out.length > 0 ? out.join(' ') : undefined;
 }
 
 export function parseExpression(timeUnit: string, fieldRef: string, onlyRef = false): string {
-  let out = 'time(datetime(';
+  let out = 'datetime(';
 
   function get(fun: string, addComma = true) {
     if (onlyRef) {
@@ -105,7 +105,7 @@ export function parseExpression(timeUnit: string, fieldRef: string, onlyRef = fa
     out += '0';
   }
 
-  return out + '))';
+  return out + ')';
 }
 
 /** Generate the complete raw domain. */

--- a/src/schema/axis.schema.ts
+++ b/src/schema/axis.schema.ts
@@ -31,10 +31,7 @@ export var axis = {
     format: {
       type: 'string',
       default: undefined,  // auto
-      description: 'The formatting pattern for axis labels. '+
-                   'If not undefined, this will be determined by ' +
-                   'the max value ' +
-                   'of the field.'
+      description: 'The formatting pattern for axis labels. If undefined, a good format is automatically determined. Vega-Lite uses D3\'s format pattern and automatically switches to datetime formatters.'
     },
     grid: {
       type: 'boolean',

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -76,7 +76,7 @@ export const config = {
     timeFormat: {
       type: 'string',
       default: '%Y-%m-%d',
-      description: 'Date format for axis labels.'
+      description: 'Default datetime format for axis and legend labels. The format can be set directly on the axis.'
     },
 
     // nested

--- a/src/timeunit.ts
+++ b/src/timeunit.ts
@@ -1,3 +1,4 @@
 export const TIMEUNITS = [
-  'year', 'month', 'day', 'date', 'hours', 'minutes', 'seconds'
+  'year', 'month', 'day', 'date', 'hours', 'minutes', 'seconds', 'milliseconds',
+  'yearmonth', 'yearmonthday', 'yearmonthdate', 'yearday', 'yeardate', 'yearmonthdayhours', 'yearmonthdayhoursminutes', 'hoursminutes', 'hoursminutesseconds', 'minutesseconds', 'secondsmilliseconds'
 ];

--- a/test/compiler/Model.test.ts
+++ b/test/compiler/Model.test.ts
@@ -27,7 +27,7 @@ describe('Model', function() {
         encoding: {
           x: {timeUnit: 'week', field:'a', type: TEMPORAL, axis: {shortTimeLabels: true}}
         }
-      }).timeFormat(X)).to.equal(null);
+      }).timeFormat(X)).to.equal(undefined);
     });
   });
 });

--- a/test/compiler/Model.test.ts
+++ b/test/compiler/Model.test.ts
@@ -13,36 +13,21 @@ describe('Model', function() {
         encoding: {
           x: {timeUnit: 'month', field:'a', type: TEMPORAL, axis: {shortTimeLabels: true}}
         }
-      }).labelTemplate(X)).to.equal('month-abbrev');
+      }).timeFormat(X)).to.equal('%b');
 
       expect(new Model({
         mark: POINT,
         encoding: {
           x: {timeUnit: 'month', field:'a', type: TEMPORAL}
         }
-      }).labelTemplate(X)).to.equal('month');
-
-      expect(new Model({
-        mark: POINT,
-        encoding: {
-          x: {timeUnit: 'day', field:'a', type: TEMPORAL, axis: {shortTimeLabels: true}}
-        }
-      }).labelTemplate(X)).to.equal('day-abbrev');
-
-      expect(new Model({
-        mark: POINT,
-        encoding: {
-          x: {timeUnit: 'day', field:'a', type: TEMPORAL}
-        }
-      }).labelTemplate(X)).to.equal('day');
+      }).timeFormat(X)).to.equal('%B');
 
       expect(new Model({
         mark: POINT,
         encoding: {
           x: {timeUnit: 'week', field:'a', type: TEMPORAL, axis: {shortTimeLabels: true}}
         }
-      }).labelTemplate(X)).to.equal(null);
+      }).timeFormat(X)).to.equal(null);
     });
   });
-
 });

--- a/test/compiler/axis.test.ts
+++ b/test/compiler/axis.test.ts
@@ -41,8 +41,8 @@ describe('Axis', function() {
 
     // FIXME decouple the test here
 
-    it('should use custom label', function() {
-      expect(_axis.properties.labels.text.template).to.equal('{{datum.data | time:\'%B\'}}');
+    it('should use custom format', function() {
+      expect(_axis.format).to.equal('%B');
     });
     it('should rotate label', function() {
       expect(_axis.properties.labels.angle.value).to.equal(270);

--- a/test/compiler/axis.test.ts
+++ b/test/compiler/axis.test.ts
@@ -42,7 +42,7 @@ describe('Axis', function() {
     // FIXME decouple the test here
 
     it('should use custom label', function() {
-      expect(_axis.properties.labels.text.template).to.equal('{{datum.data | month}}');
+      expect(_axis.properties.labels.text.template).to.equal('{{datum.data | time:\'%B\'}}');
     });
     it('should rotate label', function() {
       expect(_axis.properties.labels.angle.value).to.equal(270);

--- a/test/compiler/data.test.ts
+++ b/test/compiler/data.test.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 
-import {compileData, source, summary} from '../../src/compiler/data';
+import {compileData, source, summary, dates} from '../../src/compiler/data';
 import {SUMMARY} from '../../src/data';
 import {Model} from '../../src/compiler/Model';
 import {POINT} from '../../src/mark';
@@ -204,7 +204,7 @@ describe('data.source', function() {
         expect(transform[0]).to.eql({
           type: 'formula',
           field: 'year_a',
-          expr: 'utcyear(datum.a)'
+          expr: 'time(datetime(year(datum.a), 0, 1, 0, 0, 0, 0))'
         });
       });
     });
@@ -220,6 +220,54 @@ describe('data.source', function() {
   });
 });
 
+describe('data.dates', function() {
+  it('should add data source with raw domain data', function() {
+    var encoding = new Model({
+        mark: POINT,
+        encoding: {
+          'y': {
+            'aggregate': 'sum',
+            'field': 'Acceleration',
+            'type': QUANTITATIVE
+          },
+          'x': {
+            'field': 'date',
+            'type': TEMPORAL,
+            'timeUnit': 'day'
+          }
+        }
+      });
+
+    var defs = dates.defs(encoding);
+
+    expect(defs).to.eql([{
+      name: 'day',
+      transform: [
+        {
+          expr: 'time(datetime(2006, 0, datum.value+1, 0, 0, 0, 0))',
+          field: 'date',
+          type: 'formula'
+        }
+      ],
+      values: [{
+          value: 0
+        },{
+          value: 1
+        },{
+          value: 2
+        },{
+          value: 3
+        },{
+          value: 4
+        },{
+          value: 5
+        },{
+          value: 6
+        }
+      ]
+    }]);
+  });
+});
 
 describe('data.summary', function () {
   it('should return correct aggregation', function() {

--- a/test/compiler/data.test.ts
+++ b/test/compiler/data.test.ts
@@ -204,7 +204,7 @@ describe('data.source', function() {
         expect(transform[0]).to.eql({
           type: 'formula',
           field: 'year_a',
-          expr: 'time(datetime(year(datum.a), 0, 1, 0, 0, 0, 0))'
+          expr: 'datetime(year(datum.a), 0, 1, 0, 0, 0, 0)'
         });
       });
     });
@@ -244,7 +244,7 @@ describe('data.dates', function() {
       name: 'day',
       transform: [
         {
-          expr: 'time(datetime(2006, 0, datum.value+1, 0, 0, 0, 0))',
+          expr: 'datetime(2006, 0, datum.value+1, 0, 0, 0, 0)',
           field: 'date',
           type: 'formula'
         }

--- a/test/compiler/scale.test.ts
+++ b/test/compiler/scale.test.ts
@@ -178,8 +178,28 @@ describe('vl.compile.scale', function() {
             }
           }), Y, 'ordinal');
 
-          expect(domain).to.eql([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+          expect(domain).to.eql({ data: 'month', field: 'date' });
         });
+
+        it('should return the correct domain for yearmonth T',
+          function() {
+            var domain = vlscale.domain(new Model({
+              mark: POINT,
+              encoding: {
+                y: {
+                  field: 'origin',
+                  scale: {useRawDomain: true},
+                  type: TEMPORAL,
+                  timeUnit: 'yearmonth'
+                }
+              }
+            }), Y, 'ordinal');
+
+            expect(domain).to.eql({
+              data: 'source', field: 'yearmonth_origin',
+              sort: {field: 'yearmonth_origin', op: 'min'}
+            });
+          });
     });
 
     describe('for ordinal', function() {


### PR DESCRIPTION
Addresses parts of #145

* Adds additional time units such as `yearmonth`, `yearmonthday`, `hoursminutes`, ...
* Use timestamps internally for temporal data even if the data is being aggregated.
* When time unit is `month`, `day`, `hours`, `minutes`, or `seconds`, vl automatically adds missing points to the domain. Previously the domain was set directly. Now, vl creates a new data source. 
* Allow customization of time format.