### PR TITLE
Revise cell config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -38,7 +38,6 @@ the following grid properties:
 
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
-| gridShow      | Boolean       | Whether to show facet grid.  (True by default)  |
 | gridColor     | Color         | Color of the grid between facets. |
 | gridOpacity   | Number        | Opacity of the grid between facets. |
 | gridOffset    | Number        | Offset for grid between facets.  |

--- a/src/compile/Model.ts
+++ b/src/compile/Model.ts
@@ -52,6 +52,14 @@ export class Model {
       if (fieldDef.axis === true) {
         fieldDef.axis = instantiate(axisSchema);
       }
+
+      // set default padding for ROW and COLUMN
+      if (channel === ROW && fieldDef.scale.padding === undefined) {
+        fieldDef.scale.padding = this.has(Y) ? 16 : 0;
+      }
+      if (channel === COLUMN && fieldDef.scale.padding === undefined) {
+        fieldDef.scale.padding = this.has(X) ? 16 : 0;
+      }
     }, this);
 
     // calculate stack

--- a/src/compile/axis.ts
+++ b/src/compile/axis.ts
@@ -60,6 +60,11 @@ export function compileAxis(channel: Channel, model: Model) {
 
 export function grid(model: Model, channel: Channel) {
   const fieldDef = model.fieldDef(channel);
+  if (channel === ROW || channel === COLUMN) {
+    // never apply grid for ROW and COLUMN since we manually create rule-group for them
+    return undefined;
+  }
+
   var grid = model.axis(channel).grid;
   if (grid !== undefined) {
     return grid;

--- a/src/compile/data.ts
+++ b/src/compile/data.ts
@@ -263,7 +263,6 @@ export namespace layout {
       });
     }
 
-    const cellPadding = model.config().cell.padding;
     const layout = model.layout();
 
     if (model.has(COLUMN)) {
@@ -285,7 +284,7 @@ export namespace layout {
       formulas.push({
         type: 'formula',
         field: 'width',
-        expr: '(' + cellWidth + ' + ' + cellPadding + ')' + ' * ' + colCardinality
+        expr: '(' + cellWidth + ' + ' + colScale.padding + ')' + ' * ' + colCardinality
       });
     }
 
@@ -308,7 +307,7 @@ export namespace layout {
       formulas.push({
         type: 'formula',
         field: 'height',
-        expr: '(' + cellHeight + '+' + cellPadding + ')' + ' * ' + rowCardinality
+        expr: '(' + cellHeight + '+' + rowScale.padding + ')' + ' * ' + rowCardinality
       });
     }
 

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -51,7 +51,7 @@ export function facetMixins(model: Model, marks) {
     facetGroupProperties.y = {
       scale: model.scale(ROW),
       field: model.field(ROW),
-      offset: cellConfig.padding / 2
+      offset: model.fieldDef(ROW).scale.padding / 2
     };
 
     facetKeys.push(model.field(ROW));
@@ -79,7 +79,7 @@ export function facetMixins(model: Model, marks) {
     facetGroupProperties.x = {
       scale: model.scale(COLUMN),
       field: model.field(COLUMN),
-      offset: cellConfig.padding / 2
+      offset: model.fieldDef(COLUMN).scale.padding / 2
     };
 
     facetKeys.push(model.field(COLUMN));
@@ -222,11 +222,11 @@ function getRowGridGroup(model: Model, cellHeight): any { // TODO: VgMarks
         y: cellHeight.value ? {
             // If cellHeight contains value, just use it.
             value: cellHeight,
-            offset: cellConfig.padding
+            offset: model.fieldDef(ROW).scale.padding
           } : {
             // Otherwise, need to get it from layout data in the root group
             field: {parent: 'cellHeight'},
-            offset: cellConfig.padding
+            offset: model.fieldDef(ROW).scale.padding
           },
         // include width so it can be referred inside row-grid
         width: {field: {group: 'width'}}
@@ -274,11 +274,11 @@ function getColumnGridGroup(model: Model, cellWidth): any { // TODO: VgMarks
         x: cellWidth.value ? {
              // If cellWidth contains value, just use it.
              value: cellWidth,
-             offset: cellConfig.padding
+             offset: model.fieldDef(COLUMN).scale.padding
            } : {
              // Otherwise, need to get it from layout data in the root group
              field: {parent: 'cellWidth'},
-             offset: cellConfig.padding
+             offset: model.fieldDef(COLUMN).scale.padding
            },
         // include height so it can be referred inside column-grid
         height: {field: {group: 'height'}}

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -60,7 +60,8 @@ export function facetMixins(model: Model, marks) {
       // If has X, prepend a group for shared x-axes in the root group's marks
       rootMarks.push(getXAxesGroup(model, cellWidth, hasCol));
     }
-    if (cellConfig.gridShow) {
+    const rowAxis = model.fieldDef(ROW).axis;
+    if (typeof rowAxis === 'boolean' || rowAxis.grid !== false) {
       rootMarks.push(getRowGridGroup(model, cellHeight));
     }
   } else { // doesn't have row
@@ -88,7 +89,9 @@ export function facetMixins(model: Model, marks) {
       // If has Y, prepend a group for shared y-axes in the root group's marks
       rootMarks.push(getYAxesGroup(model, cellHeight, hasRow));
     }
-    if (cellConfig.gridShow) {
+
+    const colAxis = model.fieldDef(COLUMN).axis;
+    if (typeof colAxis === 'boolean' || colAxis.grid !== false) {
       rootMarks.push(getColumnGridGroup(model, cellWidth));
     }
   } else { // doesn't have column

--- a/src/compile/mark-area.ts
+++ b/src/compile/mark-area.ts
@@ -7,7 +7,6 @@ export namespace area {
     return 'area';
   }
 
-  // TODO(#694): optimize area's usage with bin
   export function properties(model: Model) {
     // TODO Use Vega's marks properties interface
     var p: any = {};

--- a/src/compile/scale.ts
+++ b/src/compile/scale.ts
@@ -286,8 +286,7 @@ export function outerPadding(model: Model, channel: Channel, scaleType: string) 
 }
 
 export function padding(model: Model, channel: Channel, scaleType: string) {
-  if (scaleType === 'ordinal') {
-    // Both explicit and non-explicit values are handled by the helper method.
+  if (scaleType === 'ordinal' && channel !== ROW && channel !== COLUMN) {
     return model.fieldDef(channel).scale.padding;
   }
   return undefined;

--- a/src/schema/config.cell.schema.ts
+++ b/src/schema/config.cell.schema.ts
@@ -33,10 +33,6 @@ export const cellConfig = {
       default: 16,
       description: 'default padding between facets.'
     },
-    gridShow: {
-      type: 'boolean',
-      default: true
-    },
     gridColor: {
       type: 'string',
       role: 'color',

--- a/src/schema/config.cell.schema.ts
+++ b/src/schema/config.cell.schema.ts
@@ -1,7 +1,6 @@
 export interface CellConfig {
   width?: number;
   height?: number;
-  padding?: number;
 
   gridShow?: boolean;
   gridColor?: string;
@@ -27,11 +26,6 @@ export const cellConfig = {
     height: {
       type: 'integer',
       default: 200
-    },
-    padding: {
-      type: 'integer',
-      default: 16,
-      description: 'default padding between facets.'
     },
     gridColor: {
       type: 'string',

--- a/src/schema/config.cell.schema.ts
+++ b/src/schema/config.cell.schema.ts
@@ -2,7 +2,6 @@ export interface CellConfig {
   width?: number;
   height?: number;
 
-  gridShow?: boolean;
   gridColor?: string;
   gridOpacity?: number;
   gridOffset?: number;


### PR DESCRIPTION
- Apply `axis.grid` of `row` and `column` to our customized grid built by a rule mark group instead of passing it to the row’s scale. Also remove the redundant `config.cell.gridShow`.  Fixes #943
- Apply `scale.padding` of `row` and `column` to our cell padding layout calculation & remove the redundant `config.cell.padding`. Fixes #917
- Set ROW and COLUMN’s padding to 0 if Y and X are not mapped respectively. Fixes #822

