### PR TITLE
By default, don’t pass a number format to vega.

### DIFF
--- a/examples/trellis_scatter.json
+++ b/examples/trellis_scatter.json
@@ -5,5 +5,8 @@
     "x": {"field": "Worldwide_Gross","type": "quantitative"},
     "y": {"field": "US_DVD_Sales","type": "quantitative"},
     "column": {"field": "MPAA_Rating","type": "ordinal"}
+  },
+  "config": {
+    "numberFormat": "s"
   }
 }

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -64,8 +64,8 @@ export const config = {
     // FIXME(#497) remove these
     numberFormat: {
       type: 'string',
-      default: 's',
-      description: 'D3 Number format for axis labels and text tables.'
+      default: undefined,
+      description: 'D3 Number format for axis labels and text tables. For example s for SI units.'
     },
     // FIXME(#497) handle this
     textCellWidth: {

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -61,22 +61,22 @@ export const config = {
       description: 'Filter null values from the data. If set to true, all rows with null values are filtered. If false, no rows are filtered. Set the property to undefined to filter only quantitative and temporal fields.'
     },
 
-    // FIXME(#497) remove these
+    // formats
     numberFormat: {
       type: 'string',
       default: undefined,
       description: 'D3 Number format for axis labels and text tables. For example s for SI units.'
     },
-    // FIXME(#497) handle this
-    textCellWidth: {
-      type: 'integer',
-      default: 90,
-      minimum: 0
-    },
     timeFormat: {
       type: 'string',
       default: '%Y-%m-%d',
       description: 'Default datetime format for axis and legend labels. The format can be set directly on the axis.'
+    },
+
+    textCellWidth: {
+      type: 'integer',
+      default: 90,
+      minimum: 0
     },
 
     // nested

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -65,12 +65,12 @@ export const config = {
     numberFormat: {
       type: 'string',
       default: undefined,
-      description: 'D3 Number format for axis labels and text tables. For example s for SI units.'
+      description: 'D3 Number format for axis labels and text tables. For example "s" for SI units.'
     },
     timeFormat: {
       type: 'string',
       default: '%Y-%m-%d',
-      description: 'Default datetime format for axis and legend labels. The format can be set directly on the axis.'
+      description: 'Default datetime format for axis and legend labels. The format can be set directly on each axis and legend.'
     },
 
     textCellWidth: {

--- a/test/compile/Model.test.ts
+++ b/test/compile/Model.test.ts
@@ -62,10 +62,10 @@ describe('Model', function() {
           x: {field:'a', type: "quantitative"}
         },
         config: {
-          numberFormat: 'foo'
+          numberFormat: 'd'
         }
       }).format(X, undefined), {
-        format: 'foo'
+        format: 'd'
       });
     });
 

--- a/test/compile/Model.test.ts
+++ b/test/compile/Model.test.ts
@@ -60,9 +60,12 @@ describe('Model', function() {
         mark: "point",
         encoding: {
           x: {field:'a', type: "quantitative"}
+        },
+        config: {
+          numberFormat: 'foo'
         }
       }).format(X, undefined), {
-        format: 's'
+        format: 'foo'
       });
     });
 


### PR DESCRIPTION
With this change, by default we don't see the legend label issues from #497. 