### PR TITLE
Make `detail.sort` the way to sort mark layer order + Correct the schema 

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -4,6 +4,7 @@
  */
 
 import {Mark} from './mark';
+import {contains} from './util';
 
 export enum Channel {
   X = 'x' as any,
@@ -127,4 +128,8 @@ export function getSupportedRole(channel: Channel): SupportedRole {
       };
   }
   throw new Error('Invalid encoding channel' + channel);
+}
+
+export function hasScale(channel: Channel) {
+  return !contains([DETAIL, PATH, TEXT, LABEL], channel);
 }

--- a/src/compile/scale.ts
+++ b/src/compile/scale.ts
@@ -6,7 +6,7 @@ import {FieldDef} from '../schema/fielddef.schema';
 import {contains, extend} from '../util';
 import {Model} from './Model';
 import {SHARED_DOMAIN_OPS} from '../aggregate';
-import {COLUMN, ROW, X, Y, SHAPE, SIZE, COLOR, PATH, TEXT, DETAIL, Channel} from '../channel';
+import {COLUMN, ROW, X, Y, SHAPE, SIZE, COLOR, TEXT, hasScale, Channel} from '../channel';
 import {SOURCE, STACKED_SCALE} from '../data';
 import {isDimension} from '../fielddef';
 import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../type';
@@ -14,9 +14,7 @@ import {Mark, BAR, TEXT as TEXT_MARK, TICK} from '../mark';
 import {rawDomain} from './time';
 
 export function compileScales(channels: Channel[], model: Model) {
-  return channels.filter(function(channel: Channel) {
-      return channel !== DETAIL && channel !== PATH;
-    })
+  return channels.filter(hasScale)
     .map(function(channel: Channel) {
       const fieldDef = model.fieldDef(channel);
 
@@ -51,8 +49,9 @@ export function compileScales(channels: Channel[], model: Model) {
 }
 
 export function type(fieldDef: FieldDef, channel: Channel, mark: Mark): string {
-  if (channel === DETAIL || channel === PATH) {
-    return null; // no scale for DETAIL and PATH
+  if (!hasScale(channel)) {
+    // There is no scale for these channels
+    return null;
   }
 
   switch (fieldDef.type) {

--- a/src/schema/config.marks.schema.ts
+++ b/src/schema/config.marks.schema.ts
@@ -1,6 +1,5 @@
 export interface MarkConfig {
   filled?: boolean;
-  sortBy?: String | String[];
 
   // General Vega
   opacity?: number;
@@ -50,14 +49,6 @@ export const markConfig = {
       description: 'Whether the shape\'s color should be used as fill color instead of stroke color. ' +
         'This is only applicable for "bar", "point", and "area". ' +
         'All marks except "point" marks are filled by default.'
-    },
-    sortBy: {
-      default: undefined,
-      oneOf: [
-        {type: 'string'},
-        {type: 'array', items:{type:'string'}}
-      ],
-      description: 'Sort layer of marks by a given field or fields.'
     },
     // General Vega
     fill: {

--- a/src/schema/encoding.schema.ts
+++ b/src/schema/encoding.schema.ts
@@ -1,11 +1,8 @@
 import {mergeDeep} from './schemautil';
 import {duplicate} from '../util';
-
-
-import {axis} from './axis.schema';
-import {FieldDef, fieldDef, facetField, onlyOrdinalField, typicalField} from './fielddef.schema';
+import {FieldDef, facetField, onlyOrdinalField, positionalField, textField, typicalField} from './fielddef.schema';
+import {typicalScale} from './scale.schema';
 import {legend} from './legend.schema';
-import {sort} from './sort.schema';
 
 export interface Encoding {
   x?: FieldDef;
@@ -21,29 +18,16 @@ export interface Encoding {
   label?: FieldDef;
 }
 
-var x = mergeDeep(duplicate(typicalField), {
-  required: ['field', 'type'], // TODO: remove if possible
-  properties: {
-    scale: {// replacing default values for just these two axes
-      properties: {
-        padding: {default: 1},
-        bandWidth: {default: 21}
-      }
-    },
-    axis: axis,
-    sort: sort
-  }
-});
-
-var y = duplicate(x);
+var x = duplicate(positionalField);
+var y = duplicate(positionalField);
 
 var row = mergeDeep(duplicate(facetField));
 var column = mergeDeep(duplicate(facetField));
 
 var size = mergeDeep(duplicate(typicalField), {
   properties: {
+    scale: duplicate(typicalScale),
     legend: legend,
-    sort: sort,
     value: {
       type: 'integer',
       default: undefined,
@@ -55,15 +39,7 @@ var size = mergeDeep(duplicate(typicalField), {
 
 var color = mergeDeep(duplicate(typicalField), {
   properties: {
-    legend: legend,
-    sort: sort,
-    value: {
-      type: 'string',
-      role: 'color',
-      default: '#4682b4',
-      description: 'Color to be used for marks.'
-    },
-    scale: {
+    scale: mergeDeep(duplicate(typicalScale), {
       type: 'object',
       properties: {
         quantitativeRange: {
@@ -79,6 +55,13 @@ var color = mergeDeep(duplicate(typicalField), {
           }
         }
       }
+    }),
+    legend: legend,
+    value: {
+      type: 'string',
+      role: 'color',
+      default: '#4682b4',
+      description: 'Color to be used for marks.'
     }
   }
 });
@@ -86,7 +69,6 @@ var color = mergeDeep(duplicate(typicalField), {
 var shape = mergeDeep(duplicate(onlyOrdinalField), {
   properties: {
     legend: legend,
-    sort: sort,
     value: {
       type: 'string',
       enum: ['circle', 'square', 'cross', 'diamond', 'triangle-up', 'triangle-down'],
@@ -98,24 +80,23 @@ var shape = mergeDeep(duplicate(onlyOrdinalField), {
 
 var path = {
   default: undefined,
-  oneOf: [duplicate(fieldDef), {
+  oneOf: [duplicate(typicalField), {
     type: 'array',
-    items: duplicate(fieldDef)
+    items: duplicate(typicalField)
   }]
 };
 
 var detail = {
   default: undefined,
-  oneOf: [duplicate(fieldDef), {
+  oneOf: [duplicate(typicalField), {
     type: 'array',
-    items: duplicate(fieldDef)
+    items: duplicate(typicalField)
   }]
 };
 
 // we only put aggregated measure in pivot table
-var text = mergeDeep(duplicate(typicalField), {
+var text = mergeDeep(duplicate(textField), {
   properties: {
-    sort: sort,
     value: {
       type: 'string',
       default: 'Abc'
@@ -123,11 +104,7 @@ var text = mergeDeep(duplicate(typicalField), {
   }
 });
 
-var label = mergeDeep(duplicate(typicalField), {
-  properies: {
-    sort: sort
-  }
-});
+var label = duplicate(textField);
 
 export var encoding = {
   type: 'object',

--- a/src/schema/fielddef.schema.ts
+++ b/src/schema/fielddef.schema.ts
@@ -71,13 +71,34 @@ export var aggregate = {
 
 export var typicalField = mergeDeep(duplicate(fieldDef), {
   properties: {
-    aggregate: aggregate,
-    scale: typicalScale
+    sort: sort,
+    aggregate: aggregate
+  }
+});
+
+export var positionalField = mergeDeep(duplicate(typicalField), {
+  required: ['field', 'type'], // TODO: remove if possible
+  properties: {
+    scale: mergeDeep(duplicate(typicalScale), {
+      // replacing default values for just these two axes
+      properties: {
+        padding: {default: 1},
+        bandWidth: {default: 21}
+      }
+    }),
+    axis: axis
+  }
+});
+
+export var textField = mergeDeep(duplicate(fieldDef), {
+  properties: {
+    aggregate: aggregate
   }
 });
 
 export var onlyOrdinalField = mergeDeep(duplicate(fieldDef), {
   properties: {
+    sort: sort,
     scale: ordinalOnlyScale
   }
 });
@@ -85,7 +106,7 @@ export var onlyOrdinalField = mergeDeep(duplicate(fieldDef), {
 export var facetField = mergeDeep(duplicate(onlyOrdinalField), {
   required: ['field', 'type'],
   properties: {
-    axis: axis,
-    sort: sort
+    sort: sort,
+    axis: axis
   }
 });


### PR DESCRIPTION
- Make `detail.sort` the way to sort mark layer order  (documentation will follow later)  part of #993
- Correct the schema
  - `path` and `detail` should have `sort`
  - `text` (and future `label`) should not have sort
  - consolidate positionalField

(More schema refactor will follow this PR) 