### PR TITLE
Replace value with config since value should be in the data domain rather than visual domain

### DIFF
--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -154,6 +154,15 @@ vg.embed('#scatter_filled', {
 </script>
 <div id="scatter_filled"></div>
 
+
+### Marks Configuration for Bar
+<div id="orient"></div>
+
+| Property      | Type          | Description    |
+| :------------ |:-------------:| :------------- |
+| barWidth      | Number        | The width of the bars.  If unspecified, the default width for bars on an ordinal scale is  `bandWidth-1`, which provides 1 pixel offset between bars.  If the dimension has linear scale, the bar's default size will be `2` instead.   |
+
+
 ### Marks Configuration for Bar, Line, and Area Marks
 <div id="orient"></div>
 
@@ -240,6 +249,20 @@ vg.embed('#line_interpolate', {
 </script>
 <div id="line_interpolate"></div>
 
+### Marks Configuration for Point Mark
+
+| Property            | Type                | Description  |
+| :------------------ |:-------------------:| :------------|
+| shape               | Number              | The symbol shape to use. One of `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"` |
+
+
+### Marks Configuration for Point, Circle, and Square Marks
+
+| Property            | Type                | Description  |
+| :------------------ |:-------------------:| :------------|
+| size                | Number              | The pixel area each the point (30 by default). For example: in the case of circles, the radius is determined in part by the square root of the size value. |
+
+
 
 ### Marks Configuration for Tick Marks
 
@@ -247,6 +270,7 @@ vg.embed('#line_interpolate', {
 
 | Property            | Type                | Description  |
 | :------------------ |:-------------------:| :------------|
+| tickWidth           | Number        | The width of the ticks.  If unspecified, the default value is `2/3*bandWidth`. This will provide offset between band equals to the width of the tick. |
 | thickness           | Number              | Thickness of the tick mark. |
 
 __TODO: Example - make tick mark thicker__
@@ -265,6 +289,7 @@ __TODO: Example - make tick mark thicker__
 | theta               | Number  | Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating "north".|
 | angle               | Number  | The rotation angle of the text, in degrees.|
 | font                | String  | The typeface to set the text in (e.g., `Helvetica Neue`).|
+| fontSize            | Number  | The font size, in pixels.  The default value is 10. |
 | fontWeight          | String  | The font weight (e.g., `bold`).|
 | fontStyle           | String  | The font style (e.g., `italic`).|
 | format              | String  | The formatting pattern for text value.  If not defined, this will be determined automatically|

--- a/site/docs/encoding.md
+++ b/site/docs/encoding.md
@@ -17,16 +17,16 @@ These channels are properties for the top-level `encoding` definition object.
 
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
-| x, y          | [FieldDef](#field-definition)| `x` and `y` channels map data fields to x and y coordinates (or to width and height for `bar` and `area` marks). |
-| color | [FieldDef](#field-definition)| `color` channel maps a field to color. For a nominal field, the field value is mapped to `hue` by default.  For other fields, the field value is mapped to saturation by default.  For constant value, color names and hex color value can be provided.  |
-| shape  | [FieldDef](#field-definition)| `shape` channel maps a field to the symbol's shape.  Possible values are: `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`.  (Only applicable for `point` marks.)  |
-| size  | [FieldDef](#field-definition)| Description of a field or a constant value mapped to size. If `size` is not mapped to a field, default value will be provided based on mark type.    <br/> • For `text`, this property determines the font size. The default value is `10`.     <br/> • For `bar` and `tick`, this property determines the width of the mark.  For `bar`, the default size is set to `bandWidth-1` to provide 1 pixel offset between bars.  If the dimension has linear scale, the bar's default size will be `2` instead.  For `tick`, the default value is `2/3*bandWidth`. This will provide offset between band equals to the width of the tick. <br/> • For `point`, `square` and `circle`, this property determines the pixel area of the mark.  The default value is `30`. |
-| detail | [FieldDef](#field-definition)| Description of a field or fields for (a) adding extra level of detail for aggregate views without mapping to a specific visual channel or (2) determining layer or stack order. |
-| path   | [FieldDef](#field-definition)| Description of a field or fields that determines order of data points in line mark.  For more information, please look at [line mark](mark.html#line). |
-| row, column   | [FieldDef](#field-definition)| Description of a field that facets data into vertical and horizontal [trellis plots](https://en.wikipedia.org/wiki/Small_multiple). |
+| x, y          | [FieldDef](#field-definition)| Mapping data fields to x and y coordinates (or to width and height for `bar` and `area` marks). |
+| color         | [FieldDef](#field-definition)| Mapping a field to color.  This channel automatically maps the assigned field to fill or stroke color based on mark type. (Fill color for `area`, `bar`, `tick`, `text` and filled point, circle, and square.,  Stroke color for `line` and unfilled point, circle, and square.)  |
+| shape  | [FieldDef](#field-definition)| Mapping a field to the symbol's shape. |
+| size  | [FieldDef](#field-definition)| Mapping a field to size of the mark.  This channel automatically maps the assigned field to different visual properties based on mark type.   <br/>     • For `point`, `square` and `circle`, this channel determines the symbol size, or pixel area of the mark.  <br/> • For `bar` and `tick`, this channel determines the bar and tick width respectively.  <br/>      • For `text`, this channel determines the font size of the text. |
+| detail | [FieldDef[]](#field-definition)| Mapping fields as (a) additional levels of detail for aggregate views without mapping to a specific visual channel or (2) determining layer or stack order. |
+| path   | [FieldDef[]](#field-definition)| Mapping a field or fields for sorting the order of data points in line mark.  For more information, please look at [line mark](mark.html#line). |
+| row, column   | [FieldDef](#field-definition)| Faceting the visualization into into vertical and horizontal [trellis plots](https://en.wikipedia.org/wiki/Small_multiple) with a given field. |
 
 <!-- TODO: Need to expand on "(or to width or height for `bar` and `area` marks)." for x,y -->
-<!-- TODO: describe more about color's behavior -- possibly link to the scale page -->
+<!-- TODO: describe more about color's behavior -- For a nominal field, the field value is mapped to `hue` by default.  For other fields, the field value is mapped to saturation by default.-- possibly link to the scale page -->
 
 <a id="mark-channel"></a>
 

--- a/src/compile/Model.ts
+++ b/src/compile/Model.ts
@@ -227,14 +227,13 @@ export class Model {
   }
 
   public sizeValue(channel: Channel = SIZE) {
-    const value = this.fieldDef(SIZE).value;
-    if (value !== undefined) {
-      return value;
-    }
     switch (this.mark()) {
       case TEXTMARK:
-        return 10; // font size 10 by default
+        return this.config().mark.fontSize; // font size 10 by default
       case BAR:
+        if (this.config().mark.barWidth) {
+          return this.config().mark.barWidth;
+        }
         // BAR's size is applied on either X or Y
         return !this.has(channel) || this.isOrdinalScale(channel) ?
           // For ordinal scale or single bar, we can use bandWidth - 1
@@ -243,8 +242,11 @@ export class Model {
           // otherwise, set to 2 by default
           2;
       case TICK:
+        if (this.config().mark.tickWidth) {
+          return this.config().mark.tickWidth;
+        }
         return this.fieldDef(channel).scale.bandWidth / 1.5;
     }
-    return 30;
+    return this.config().mark.size;
   }
 }

--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -117,7 +117,7 @@ namespace properties {
           if (model.has(COLOR) && channel === COLOR) {
             symbols.fill = {scale: model.scaleName(COLOR), field: 'data'};
           } else {
-            symbols.fill = {value: model.fieldDef(COLOR).value};
+            symbols.fill = {value: model.config().mark.color};
           }
         } else { // stroked
           // set fill to transparent by default unless there is a config for stroke
@@ -127,7 +127,7 @@ namespace properties {
           if (model.has(COLOR) && channel === COLOR) {
             symbols.stroke = {scale: model.scaleName(COLOR), field: 'data'};
           } else {
-            symbols.stroke = {value: model.fieldDef(COLOR).value};
+            symbols.stroke = {value: model.config().mark.color};
           }
         }
 

--- a/src/compile/mark-point.ts
+++ b/src/compile/mark-point.ts
@@ -50,7 +50,7 @@ export namespace point {
         field: model.field(SHAPE)
       };
     } else {
-      p.shape = { value: model.fieldDef(SHAPE).value };
+      p.shape = { value: model.config().mark.shape };
     }
 
     applyColorAndOpacity(p, model,

--- a/src/compile/util.ts
+++ b/src/compile/util.ts
@@ -23,10 +23,6 @@ export function applyColorAndOpacity(p, model: Model, colorMode: ColorMode = Col
         colorMode === ColorMode.FILLED_BY_DEFAULT ? true :
           false; // ColorMode.STROKED_BY_DEFAULT
 
-  // Apply fill and stroke config first
-  // so that `color.value` can override `fill` and `stroke` config
-  applyMarkConfig(p, model, FILL_STROKE_CONFIG);
-
   if (filled) {
     if (model.has(COLOR)) {
       p.fill = {
@@ -34,7 +30,7 @@ export function applyColorAndOpacity(p, model: Model, colorMode: ColorMode = Col
         field: model.field(COLOR)
       };
     } else {
-      p.fill = { value: model.fieldDef(COLOR).value };
+      p.fill = { value: model.config().mark.color };
     }
   } else {
     if (model.has(COLOR)) {
@@ -43,9 +39,13 @@ export function applyColorAndOpacity(p, model: Model, colorMode: ColorMode = Col
         field: model.field(COLOR)
       };
     } else {
-      p.stroke = { value: model.fieldDef(COLOR).value };
+      p.stroke = { value: model.config().mark.color };
     }
   }
+
+  // Apply fill and stroke config later
+  // `fill` and `stroke` config can override `color` config
+  applyMarkConfig(p, model, FILL_STROKE_CONFIG);
 }
 
 export function applyMarkConfig(marksProperties, model: Model, propsList: string[]) {

--- a/src/schema/config.marks.schema.ts
+++ b/src/schema/config.marks.schema.ts
@@ -1,9 +1,12 @@
 export interface MarkConfig {
+  // Vega-Lite Specific
   filled?: boolean;
+  color?: string;
+  barWidth?: number;
+  tickWidth?: number;
 
   // General Vega
   opacity?: number;
-
   strokeWidth?: number;
   strokeDash?: number[];
   strokeDashOffset?: number[];
@@ -12,11 +15,16 @@ export interface MarkConfig {
   stroke?: string;
   strokeOpacity?: number;
 
+
   // Bar / area
   orient?: string;
   // Line / area
   interpolate?: string;
   tension?: number;
+
+  // Point / Square / Circle
+  shape?: string;
+  size?: number;
 
   // Tick-only
   thickness?: number;
@@ -30,6 +38,7 @@ export interface MarkConfig {
   radius?: number;
   theta?: number;
   font?: string;
+  fontSize?: number;
   fontStyle?: string;
   fontWeight?: string;
   // Vega-Lite only for text only
@@ -49,6 +58,23 @@ export const markConfig = {
       description: 'Whether the shape\'s color should be used as fill color instead of stroke color. ' +
         'This is only applicable for "bar", "point", and "area". ' +
         'All marks except "point" marks are filled by default.'
+    },
+    color: {
+      type: 'string',
+      role: 'color',
+      default: '#4682b4',
+      description: 'Default color.'
+    },
+    barWidth: {
+      type: 'number',
+      default: undefined,
+      description: 'The width of the bars.  If unspecified, the default width is  `bandWidth-1`, which provides 1 pixel offset between bars.'
+    },
+    tickWidth: {
+      type: 'string',
+      role: 'color',
+      default: undefined,
+      description: 'The width of the ticks.'
     },
     // General Vega
     fill: {
@@ -120,6 +146,20 @@ export const markConfig = {
       description: 'Depending on the interpolation type, sets the tension parameter.'
     },
 
+    // point
+    shape: {
+      type: 'number',
+      enum: ['circle', 'square', 'cross', 'diamond', 'triangle-up', 'triangle-down'],
+      default: undefined,
+      description: 'The symbol shape to use. One of circle (default), square, cross, diamond, triangle-up, or triangle-down.'
+    },
+    // point / circle / square
+    size: {
+      type: 'number',
+      default: 30,
+      description: 'The pixel area each the point. For example: in the case of circles, the radius is determined in part by the square root of the size value.'
+    },
+
     // Tick-only
     thickness: {
       type: 'number',
@@ -160,6 +200,11 @@ export const markConfig = {
       default: undefined,
       role: 'font',
       description: 'The typeface to set the text in (e.g., Helvetica Neue).'
+    },
+    fontSize: {
+      type: 'number',
+      default: 10,
+      description: 'The font size, in pixels.'
     },
     // fontSize excluded as we use size.value
     fontStyle: {

--- a/src/schema/encoding.schema.ts
+++ b/src/schema/encoding.schema.ts
@@ -56,25 +56,13 @@ var color = mergeDeep(duplicate(typicalField), {
         }
       }
     }),
-    legend: legend,
-    value: {
-      type: 'string',
-      role: 'color',
-      default: '#4682b4',
-      description: 'Color to be used for marks.'
-    }
+    legend: legend
   }
 });
 
 var shape = mergeDeep(duplicate(onlyOrdinalField), {
   properties: {
-    legend: legend,
-    value: {
-      type: 'string',
-      enum: ['circle', 'square', 'cross', 'diamond', 'triangle-up', 'triangle-down'],
-      default: 'circle',
-      description: 'Mark to be used.'
-    }
+    legend: legend
   }
 });
 
@@ -94,7 +82,6 @@ var detail = {
   }]
 };
 
-// we only put aggregated measure in pivot table
 var text = mergeDeep(duplicate(textField), {
   properties: {
     value: {

--- a/test/compile/mark-point.test.ts
+++ b/test/compile/mark-point.test.ts
@@ -128,8 +128,8 @@ describe('Mark: Square', function() {
   it('should be filled by default', function() {
     const model = parseModel({
       "mark": "square",
-      "encoding": {
-        "color": {"value": "blue"}
+      "config": {
+        "mark": {"color": "blue"}
       }
     });
     const props = square.properties(model);
@@ -140,11 +140,9 @@ describe('Mark: Square', function() {
   it('should support config.mark.filled:false', function() {
     const model = parseModel({
       "mark": "square",
-      "encoding": {
-        "color" : {"value" : "blue"}
-      },
       "config" : {
         "mark" : {
+          "color": "blue",
           "filled" : false
         }
       }
@@ -159,48 +157,31 @@ describe('Mark: Square', function() {
 
 describe('Mark: Circle', function() {
   it('should return the correct mark type', function() {
-
-    const model = parseModel({
-      "mark": "circle",
-      "encoding": {
-        "color": {"value": "blue"}
-      }
-    });
     assert.equal(circle.markType(), 'symbol');
   });
 
-  it('should have correct shape', function() {
-    const model = parseModel({
-      "mark": "circle",
-      "encoding": {
-        "color": {"value": "blue"}
-      }
-    });
-    const props = circle.properties(model);
+  const model = parseModel({
+    "mark": "circle",
+    "config": {
+      "mark": {"color": "blue"}
+    }
+  });
+  const props = circle.properties(model);
 
+  it('should have correct shape', function() {
     assert.equal(props.shape.value, 'circle');
   });
 
   it('should be filled by default', function() {
-    const model = parseModel({
-      "mark": "circle",
-      "encoding": {
-        "color": {"value": "blue"}
-      }
-    });
-    const props = circle.properties(model);
-
     assert.equal(props.fill.value, 'blue');
   });
 
   it('should support config.mark.filled:false', function() {
     const model = parseModel({
-      "mark": "cirlce",
-      "encoding": {
-        "color" : {"value" : "blue"}
-      },
+      "mark": "circle",
       "config" : {
         "mark" : {
+          "color": "blue",
           "filled" : false
         }
       }


### PR DESCRIPTION
- Migrate
  - `color.value` => `config.mark.color`
  - `size.value` => `config.mark.size|barWidth|tickWidth|fontSize`
  - `shape.value` => `config.mark.shape`

part of #1029

@domoritz  I also rebase!  (Now that I realize that github works fine with rebase if we force push -- I re-read about it one more time and will try to give it a shot!) 