### PR TITLE
Bring back `encoding.<channel>.value`

### DIFF
--- a/site/docs/encoding.md
+++ b/site/docs/encoding.md
@@ -69,7 +69,7 @@ Here is a list of properties for the field definition object:
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
 | field         | String        | Name of the field from which to pull a data value.    |
-| value         | String &#124; Number | A constant value. |
+| value         | String &#124; Number | A constant value in visual domain. |
 | type          | String        | Data type of the field.  This property accepts both a full type name (`"quantitative"`, `"temporal"`, `"ordinal"`,  and `"nominal"`), or an initial character of the type name (`"Q"`, `"T"`, `"O"`, `"N"`).  This property is case insensitive.|
 
 {:#types}

--- a/src/compile/Model.ts
+++ b/src/compile/Model.ts
@@ -227,6 +227,10 @@ export class Model {
   }
 
   public sizeValue(channel: Channel = SIZE) {
+    const value = this.fieldDef(SIZE).value;
+    if (value !== undefined) {
+       return value;
+    }
     switch (this.mark()) {
       case TEXTMARK:
         return this.config().mark.fontSize; // font size 10 by default

--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -116,6 +116,8 @@ namespace properties {
 
           if (model.has(COLOR) && channel === COLOR) {
             symbols.fill = {scale: model.scaleName(COLOR), field: 'data'};
+          } else if (model.fieldDef(COLOR).value) {
+            symbols.fill = {value: model.fieldDef(COLOR).value};
           } else {
             symbols.fill = {value: model.config().mark.color};
           }
@@ -126,6 +128,8 @@ namespace properties {
 
           if (model.has(COLOR) && channel === COLOR) {
             symbols.stroke = {scale: model.scaleName(COLOR), field: 'data'};
+          } else if (model.fieldDef(COLOR).value) {
+            symbols.stroke = {value: model.fieldDef(COLOR).value};
           } else {
             symbols.stroke = {value: model.config().mark.color};
           }

--- a/src/compile/mark-point.ts
+++ b/src/compile/mark-point.ts
@@ -49,6 +49,8 @@ export namespace point {
         scale: model.scaleName(SHAPE),
         field: model.field(SHAPE)
       };
+    } else if (model.fieldDef(SHAPE).value) {
+      p.shape = { value: model.fieldDef(SHAPE).value };
     } else {
       p.shape = { value: model.config().mark.shape };
     }

--- a/src/compile/util.ts
+++ b/src/compile/util.ts
@@ -29,6 +29,8 @@ export function applyColorAndOpacity(p, model: Model, colorMode: ColorMode = Col
         scale: model.scaleName(COLOR),
         field: model.field(COLOR)
       };
+    } else if (model.fieldDef(COLOR).value) {
+      p.fill = { value: model.fieldDef(COLOR).value };
     } else {
       p.fill = { value: model.config().mark.color };
     }
@@ -38,6 +40,8 @@ export function applyColorAndOpacity(p, model: Model, colorMode: ColorMode = Col
         scale: model.scaleName(COLOR),
         field: model.field(COLOR)
       };
+    } else if (model.fieldDef(COLOR).value) {
+      p.stroke = { value: model.fieldDef(COLOR).value };
     } else {
       p.stroke = { value: model.config().mark.color };
     }

--- a/src/schema/fielddef.schema.ts
+++ b/src/schema/fielddef.schema.ts
@@ -56,6 +56,9 @@ const fieldDef = {
     field: {
       type: 'string'
     },
+    value: {
+      type: ['string', 'number']
+    },
     type: {
       type: 'string',
       enum: [NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL]

--- a/test/compile/mark-point.test.ts
+++ b/test/compile/mark-point.test.ts
@@ -106,6 +106,20 @@ describe('Mark: Point', function() {
       assert.deepEqual(props.shape, {scale: SHAPE, field: 'bin_yield_range'});
     });
   });
+
+  describe('with constant color, shape, and size', function() {
+    const model = parseModel(pointXY({
+      "shape": {"value": "circle"},
+      "color": {"value": "red"},
+      "size": {"value": 23}
+    }));
+    const props = point.properties(model);
+    it('should correct shape, color and size', function () {
+      assert.deepEqual(props.shape, {value: "circle"});
+      assert.deepEqual(props.stroke, {value: "red"});
+      assert.deepEqual(props.size, {value: 23});
+    });
+  });
 });
 
 describe('Mark: Square', function() {


### PR DESCRIPTION
I add separate case for value instead of using `||` with config because in the future, value might refer to parent.  

Fixes  #1029.  (For `datum`, I'm adding #1051 for doing later with composition) 