### PR TITLE
Flexible x-scale's `bandWidth` for text on ordinal + remove `config.textCellWidth`

### DIFF
--- a/src/compile/Model.ts
+++ b/src/compile/Model.ts
@@ -58,6 +58,18 @@ export class Model {
         fieldDef.legend = instantiate(legendSchema);
       }
 
+      // set default bandWidth for X and Y
+      if (channel === X && fieldDef.scale.bandWidth === undefined) {
+        // This should be zero for the sake of text table.
+        fieldDef.scale.bandWidth = this.isOrdinalScale(X) && this.mark() === 'text' ?
+          90 : // TODO: config.scale.textBandWidth
+          21; // TODO: config.scale.bandWidth
+      }
+      if (channel === Y && fieldDef.scale.bandWidth === undefined) {
+        // This should be zero for the sake of text table.
+        fieldDef.scale.bandWidth = 21;
+      }
+
       // set default padding for ROW and COLUMN
       if (channel === ROW && fieldDef.scale.padding === undefined) {
         // This should be zero for the sake of text table.

--- a/src/compile/layout.ts
+++ b/src/compile/layout.ts
@@ -41,9 +41,9 @@ function getCellWidth(model: Model): LayoutValue {
     return model.config().cell.width;
   }
   if (model.mark() === TEXT_MARK) {
-    return model.config().textCellWidth;
+    return 90; // TODO: config.scale.textBandWidth
   }
-  return model.fieldDef(X).scale.bandWidth;
+  return 21; // TODO: config.scale.bandWidth
 }
 
 function getWidth(model: Model, cellWidth: LayoutValue): LayoutValue {
@@ -61,7 +61,7 @@ function getCellHeight(model: Model): LayoutValue {
       return model.config().cell.height;
     }
   }
-  return model.fieldDef(Y).scale.bandWidth;
+  return 21 /* config.scale.bandWidth */;
 }
 
 function getHeight(model: Model, cellHeight: LayoutValue): LayoutValue {

--- a/src/compile/mark-point.ts
+++ b/src/compile/mark-point.ts
@@ -18,7 +18,7 @@ export namespace point {
         field: model.field(X, { binSuffix: '_mid' })
       };
     } else {
-      p.x = { value: model.fieldDef(X).scale.bandWidth / 2 };
+      p.x = { value: 21 /* config.scale.bandWidth */ / 2 };
     }
 
     // y
@@ -28,7 +28,7 @@ export namespace point {
         field: model.field(Y, { binSuffix: '_mid' })
       };
     } else {
-      p.y = { value: model.fieldDef(Y).scale.bandWidth / 2 };
+      p.y = { value: 21 /* config.scale.bandWidth */ / 2 };
     }
 
     // size

--- a/src/compile/mark-text.ts
+++ b/src/compile/mark-text.ts
@@ -30,13 +30,12 @@ export namespace text {
         scale: model.scaleName(X),
         field: model.field(X, { binSuffix: '_mid' })
       };
-    } else {
+    } else { // TODO: support x.value, x.datum
       if (model.has(TEXT) && model.fieldDef(TEXT).type === QUANTITATIVE) {
         p.x = { field: { group: 'width' }, offset: -5 };
       } else {
-        p.x = { value: model.fieldDef(X).scale.bandWidth / 2 };
+        p.x = { value: 90 / 2 }; // TODO: config.scale.textBandWidth
       }
-      // TODO: support x.value
     }
 
     // y
@@ -46,8 +45,7 @@ export namespace text {
         field: model.field(Y, { binSuffix: '_mid' })
       };
     } else {
-      p.y = { value: model.fieldDef(Y).scale.bandWidth / 2 };
-      // TODO: support x.value
+      p.y = { value: 21 / 2 }; // TODO: config.scale.bandWidth
     }
 
     // size

--- a/src/compile/mark-tick.ts
+++ b/src/compile/mark-tick.ts
@@ -17,7 +17,7 @@ export namespace tick {
         field: model.field(X, { binSuffix: '_mid' })
       };
     } else {
-      p.xc = { value: model.fieldDef(X).scale.bandWidth / 2 };
+      p.xc = { value: 21 /* config.scale.bandWidth */ / 2 };
     }
 
     // y
@@ -27,7 +27,7 @@ export namespace tick {
         field: model.field(Y, { binSuffix: '_mid' })
       };
     } else {
-      p.yc = { value: model.fieldDef(Y).scale.bandWidth / 2 };
+      p.yc = { value: 21 /* config.scale.bandWidth */ / 2 };
     }
 
     if (model.config().mark.orient === 'horizontal') {

--- a/src/compile/scale.ts
+++ b/src/compile/scale.ts
@@ -337,7 +337,10 @@ export function rangeMixins(model: Model, channel: Channel, scaleType: string): 
 
       const bandWidth = xIsMeasure !== yIsMeasure ?
         model.fieldDef(xIsMeasure ? Y : X).scale.bandWidth :
-        Math.min(model.fieldDef(X).scale.bandWidth, model.fieldDef(Y).scale.bandWidth);
+        Math.min(
+          model.fieldDef(X).scale.bandWidth || 21 /* config.scale.bandWidth */,
+          model.fieldDef(Y).scale.bandWidth || 21 /* config.scale.bandWidth */
+        );
 
       return {range: [10, (bandWidth - 2) * (bandWidth - 2)]};
     case SHAPE:

--- a/src/schema/config.schema.ts
+++ b/src/schema/config.schema.ts
@@ -10,15 +10,13 @@ export interface Config {
   viewport?: number;
   background?: string;
 
+  numberFormat?: string;
+  timeFormat?: string;
+
   cell?: CellConfig;
   mark?: MarkConfig;
   scene?: SceneConfig;
   stack?: StackConfig;
-
-  // TODO: revise
-  textCellWidth?: any;
-  numberFormat?: string;
-  timeFormat?: string;
 }
 
 export const config = {
@@ -63,12 +61,6 @@ export const config = {
       type: 'string',
       default: '%Y-%m-%d',
       description: 'Default datetime format for axis and legend labels. The format can be set directly on each axis and legend.'
-    },
-
-    textCellWidth: {
-      type: 'integer',
-      default: 90,
-      minimum: 0
     },
 
     // nested

--- a/src/schema/fielddef.schema.ts
+++ b/src/schema/fielddef.schema.ts
@@ -83,8 +83,7 @@ export const positionFieldDef = mergeDeep(duplicate(fieldDefWithScale), {
     scale: {
       // replacing default values for just these two axes
       properties: {
-        padding: {default: 1},
-        bandWidth: {default: 21}
+        padding: {default: 1}
       }
     },
     axis: axis

--- a/test/compile/mark-point.test.ts
+++ b/test/compile/mark-point.test.ts
@@ -36,7 +36,7 @@ describe('Mark: Point', function() {
     const props = point.properties(model);
 
     it('should be centered on y', function() {
-      assert.deepEqual(props.y, {value: model.fieldDef(Y).scale.bandWidth / 2});
+      assert.deepEqual(props.y, {value: 21 / 2});
     });
 
     it('should scale on x', function() {
@@ -54,7 +54,7 @@ describe('Mark: Point', function() {
     const props = point.properties(model);
 
     it('should be centered on x', function() {
-      assert.deepEqual(props.x, {value: model.fieldDef(X).scale.bandWidth / 2});
+      assert.deepEqual(props.x, {value: 21 / 2});
     });
 
     it('should scale on y', function() {


### PR DESCRIPTION
- Make `x`'s `bandWidth` 90 if `mark` = `text` and `x` is ordinal scale by default  (otherwise `bandWidth` = `21` for `x` and `y`)
- Do not refer to x&y's `bandWidth` when it doesn't exist.  (And add TODO refer to the future `config.scale.bandWidth` / `config.scale.textBandWidth`)
- Remove `config.textCellWidth`, which is out of place

Fix #724