### PR TITLE
Fix incorrect assignment of layout as a data source (Issue #992)

### DIFF
--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -71,7 +71,6 @@ export function compileRootGroup(model: Model) {
     },
     spec.description ? {description: spec.description} : {},
     {
-      from: {data: LAYOUT},
       properties: {
         update: {
           width: typeof width !== 'number' ?
@@ -83,6 +82,13 @@ export function compileRootGroup(model: Model) {
         }
       }
     });
+
+  // only add reference to layout if needed
+  if (typeof width !== 'number' || typeof height !== 'number') {
+    rootGroup = extend(rootGroup, {
+      from: {data: LAYOUT}
+    });
+  }
 
   const marks = compileMark(model);
 

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -1,0 +1,56 @@
+/* tslint:disable:quotemark */
+
+import {assert} from 'chai';
+import {parseModel} from '../util';
+import * as compile from '../../src/compile/compile';
+
+describe('Compile', function() {
+
+  describe('compileRootGroup()', function() {
+
+    describe('non-ordinal', function() {
+      const model = parseModel({
+        "description": "A scatterplot showing horsepower and miles per gallons.",
+        "data": {"url": "data/cars.json"},
+        "mark": "point",
+        "encoding": {
+          "x": {"field": "Horsepower","type": "quantitative"},
+          "y": {"field": "Miles_per_Gallon","type": "quantitative"},
+        }
+      });
+
+      const rootGroup = compile.compileRootGroup(model);
+
+      it('should not refer to layout data', function() {
+        assert.notDeepEqual(rootGroup.from, {"data": "layout"});
+      });
+
+    });
+
+    describe('ordinal', function() {
+      const model = parseModel({
+        "description": "A simple bar chart with embedded data.",
+        "data": {
+          "values": [
+            {"a": "A","b": 28}, {"a": "B","b": 55}, {"a": "C","b": 43},
+            {"a": "D","b": 91}, {"a": "E","b": 81}, {"a": "F","b": 53},
+            {"a": "G","b": 19}, {"a": "H","b": 87}, {"a": "I","b": 52}
+          ]
+        },
+        "mark": "bar",
+        "encoding": {
+          "x": {"field": "a", "type": "ordinal"},
+          "y": {"field": "b", "type": "quantitative"}
+        }
+      });
+
+      const rootGroup = compile.compileRootGroup(model);
+
+      it('should refer to layout data', function() {
+        assert.deepEqual(rootGroup.from, {"data": "layout"});
+      });
+
+    });
+
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -83,7 +83,7 @@
     "src/validate.ts",
     "src/vl.ts",
     "test/compile/axis.test.ts",
-    "test/compile/compiler.test.ts",
+    "test/compile/compile.test.ts",
     "test/compile/data.test.ts",
     "test/compile/legend.test.ts",
     "test/compile/mark-area.test.ts",


### PR DESCRIPTION
Fixes bug in #992 where non-ordinal marks are incorrectly set to use layout as a data source in the root group