### PR TITLE
Facet Styling

### DIFF
--- a/src/compile/axis.ts
+++ b/src/compile/axis.ts
@@ -65,9 +65,9 @@ export function compileAxis(channel: Channel, model: Model) {
   // 1.2. Add properties
   [
     // a) properties with special rules (so it has axis[property] methods) -- call rule functions
-    'grid', 'layer', 'orient', 'tickSize', 'ticks', 'title',
+    'grid', 'layer', 'offset', 'orient', 'tickSize', 'ticks', 'title',
     // b) properties without rules, only produce default values in the schema, or explicit value if specified
-    'offset', 'tickPadding', 'tickSize', 'tickSizeMajor', 'tickSizeMinor', 'tickSizeEnd',
+    'tickPadding', 'tickSize', 'tickSizeMajor', 'tickSizeMinor', 'tickSizeEnd',
     'titleOffset', 'values', 'subdivide'
   ].forEach(function(property) {
     let method: (model: Model, channel: Channel, def:any)=>any;
@@ -98,6 +98,11 @@ export function compileAxis(channel: Channel, model: Model) {
   });
 
   return def;
+}
+
+export function offset(model: Model, channel: Channel) {
+  return (channel === Y || channel === X) ||
+    (model.has(COLUMN) && model.has(ROW)) ? 8 : undefined;
 }
 
 // TODO: we need to refactor this method after we take care of config refactoring

--- a/src/compile/axis.ts
+++ b/src/compile/axis.ts
@@ -33,7 +33,7 @@ export function compileInnerAxis(channel: Channel, model: Model) {
     }
   };
 
-  ['layer', 'values', 'subdivide'].forEach(function(property) {
+  ['layer', 'ticks', 'values', 'subdivide'].forEach(function(property) {
     let method: (model: Model, channel: Channel, def:any)=>any;
 
     const value = (method = exports[property]) ?
@@ -101,8 +101,8 @@ export function compileAxis(channel: Channel, model: Model) {
 }
 
 export function offset(model: Model, channel: Channel) {
-  return (channel === Y || channel === X) ||
-    (model.has(COLUMN) && model.has(ROW)) ? 8 : undefined;
+  return (channel === Y || channel === X) &&
+    (model.has(COLUMN) || model.has(ROW)) ? 8 : undefined;
 }
 
 // TODO: we need to refactor this method after we take care of config refactoring
@@ -128,8 +128,7 @@ export function grid(model: Model, channel: Channel) {
   return gridShow(model, channel) && (
     // TODO refactor this cleanly -- essentially the condition below is whether
     // the axis is a shared / union axis.
-    (channel === Y && !model.has(COLUMN)) ||
-    (channel === X && !model.has(ROW))
+    (channel === Y || channel === X) && !(model.has(COLUMN) || model.has(ROW))
   );
 }
 

--- a/src/compile/data.ts
+++ b/src/compile/data.ts
@@ -325,7 +325,7 @@ export namespace layout {
       formulas.push({
         type: 'formula',
         field: 'height',
-        expr: '(' + cellHeight + '+' + rowScale.padding + ')' + ' * ' + rowCardinality
+        expr: '(' + cellHeight + ' + ' + rowScale.padding + ')' + ' * ' + rowCardinality
       });
     }
 

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -69,7 +69,8 @@ export function facetMixins(model: Model, marks) {
         }
       } else {
         // Otherwise, manually draw grids between cells
-        rootMarks.push(getRowGridGroup(model, cellHeight));
+        // Note: this is a weird syntax for pushing multiple items
+        rootMarks.push.apply(rootMarks, getRowGridGroups(model, cellHeight));
       }
     }
   } else { // doesn't have row
@@ -107,7 +108,8 @@ export function facetMixins(model: Model, marks) {
         }
       } else {
         // Otherwise, manually draw grids between cells
-        rootMarks.push(getColumnGridGroup(model, cellWidth));
+        // Note: this is a weird syntax for pushing multiple items
+        rootMarks.push.apply(rootMarks, getColumnGridGroups(model, cellWidth));
       }
     }
   } else { // doesn't have column
@@ -206,7 +208,7 @@ function getYAxesGroup(model: Model, cellHeight, hasRow: boolean) { // TODO: VgM
   );
 }
 
-function getRowGridGroup(model: Model, cellHeight): any { // TODO: VgMarks
+function getRowGridGroups(model: Model, cellHeight): any { // TODO: VgMarks
   const name = model.spec().name;
   const cellConfig = model.config().cell;
 
@@ -226,39 +228,29 @@ function getRowGridGroup(model: Model, cellHeight): any { // TODO: VgMarks
         x: {value: 0, offset: -cellConfig.gridOffset },
         x2: {field: {group: 'width'}, offset: cellConfig.gridOffset },
         stroke: { value: cellConfig.gridColor },
-        strokeOpacity: { value: cellConfig.gridOpacity }
+        strokeOpacity: { value: cellConfig.gridOpacity },
+        strokeWidth: {value: 0.5}
       }
     }
   };
 
-  const rowGridOnTop = !model.has(X) || model.axis(X).orient !== 'top';
-  if (rowGridOnTop) { // on top - no need to add offset
-    return rowGrid;
-  } // otherwise, need to offset all grid by cellHeight
-  return {
-    name: (name ? name + '-' : '') + 'row-grid-group',
-    type: 'group',
+  return [rowGrid, {
+    name: (name ? name + '-' : '') + 'row-grid-end',
+    type: 'rule',
     properties: {
       update: {
-        // add group offset = `cellHeight + padding` to avoid clashing with axis
-        y: cellHeight.value ? {
-            // If cellHeight contains value, just use it.
-            value: cellHeight,
-            offset: model.fieldDef(ROW).scale.padding
-          } : {
-            // Otherwise, need to get it from layout data in the root group
-            field: {parent: 'cellHeight'},
-            offset: model.fieldDef(ROW).scale.padding
-          },
-        // include width so it can be referred inside row-grid
-        width: {field: {group: 'width'}}
+        y: { field: {group: 'height'}},
+        x: {value: 0, offset: -cellConfig.gridOffset },
+        x2: {field: {group: 'width'}, offset: cellConfig.gridOffset },
+        stroke: { value: cellConfig.gridColor },
+        strokeOpacity: { value: cellConfig.gridOpacity },
+        strokeWidth: {value: 0.5}
       }
-    },
-    marks: [rowGrid]
-  };
+    }
+  }];
 }
 
-function getColumnGridGroup(model: Model, cellWidth): any { // TODO: VgMarks
+function getColumnGridGroups(model: Model, cellWidth): any { // TODO: VgMarks
   const name = model.spec().name;
   const cellConfig = model.config().cell;
 
@@ -278,34 +270,24 @@ function getColumnGridGroup(model: Model, cellWidth): any { // TODO: VgMarks
         y: {value: 0, offset: -cellConfig.gridOffset},
         y2: {field: {group: 'height'}, offset: cellConfig.gridOffset },
         stroke: { value: cellConfig.gridColor },
-        strokeOpacity: { value: cellConfig.gridOpacity }
+        strokeOpacity: { value: cellConfig.gridOpacity },
+        strokeWidth: {value: 0.5}
       }
     }
   };
 
-  const columnGridOnLeft = !model.has(Y) || model.axis(Y).orient === 'right';
-  if (columnGridOnLeft) { // on left, no need to add global offset
-    return columnGrid;
-  } // otherwise, need to offset all grid by cellWidth
-  return {
-    name: (name ? name + '-' : '') + 'column-grid-group',
-    type: 'group',
+  return [columnGrid,  {
+    name: (name ? name + '-' : '') + 'column-grid-end',
+    type: 'rule',
     properties: {
       update: {
-        // Add group offset = `cellWidth + padding` to avoid clashing with axis
-        x: cellWidth.value ? {
-             // If cellWidth contains value, just use it.
-             value: cellWidth,
-             offset: model.fieldDef(COLUMN).scale.padding
-           } : {
-             // Otherwise, need to get it from layout data in the root group
-             field: {parent: 'cellWidth'},
-             offset: model.fieldDef(COLUMN).scale.padding
-           },
-        // include height so it can be referred inside column-grid
-        height: {field: {group: 'height'}}
+        x: { field: {group: 'width'}},
+        y: {value: 0, offset: -cellConfig.gridOffset},
+        y2: {field: {group: 'height'}, offset: cellConfig.gridOffset },
+        stroke: { value: cellConfig.gridColor },
+        strokeOpacity: { value: cellConfig.gridOpacity },
+        strokeWidth: {value: 0.5}
       }
-    },
-    marks: [columnGrid]
-  };
+    }
+  }];
 }

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -3,7 +3,7 @@ import {extend} from '../util';
 import {COLUMN, ROW, X, Y} from '../channel';
 import {Model} from './Model';
 
-import {compileAxis} from './axis';
+import {compileAxis, compileGridOnlyAxis, gridShow} from './axis';
 import {compileScales} from './scale';
 
 /**
@@ -62,7 +62,15 @@ export function facetMixins(model: Model, marks) {
     }
     const rowAxis = model.fieldDef(ROW).axis;
     if (typeof rowAxis === 'boolean' || rowAxis.grid !== false) {
-      rootMarks.push(getRowGridGroup(model, cellHeight));
+      if (model.has(X)) {
+        if (gridShow(model, X)) {
+          // If has X and a grid show be shown, add grid-only x-axis to the cell
+          cellAxes.push(compileGridOnlyAxis(X, model));
+        }
+      } else {
+        // Otherwise, manually draw grids between cells
+        rootMarks.push(getRowGridGroup(model, cellHeight));
+      }
     }
   } else { // doesn't have row
     if (model.has(X) && model.fieldDef(X).axis) { // keep x axis in the cell
@@ -92,7 +100,15 @@ export function facetMixins(model: Model, marks) {
 
     const colAxis = model.fieldDef(COLUMN).axis;
     if (typeof colAxis === 'boolean' || colAxis.grid !== false) {
-      rootMarks.push(getColumnGridGroup(model, cellWidth));
+      if (model.has(Y)) {
+        if (gridShow(model, Y)) {
+          // If has Y and a grid show be shown, add grid-only y-axis to the cell
+          cellAxes.push(compileGridOnlyAxis(Y, model));
+        }
+      } else {
+        // Otherwise, manually draw grids between cells
+        rootMarks.push(getColumnGridGroup(model, cellWidth));
+      }
     }
   } else { // doesn't have column
     if (model.has(Y) && model.fieldDef(Y).axis) { // keep y axis in the cell

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -87,8 +87,7 @@ export function facetMixins(model: Model, marks) {
     }
     facetGroupProperties.x = {
       scale: model.scaleName(COLUMN),
-      field: model.field(COLUMN),
-      offset: model.fieldDef(COLUMN).scale.padding / 2
+      field: model.field(COLUMN)
     };
 
     facetKeys.push(model.field(COLUMN));

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -3,7 +3,7 @@ import {extend} from '../util';
 import {COLUMN, ROW, X, Y} from '../channel';
 import {Model} from './Model';
 
-import {compileAxis, compileGridOnlyAxis, gridShow} from './axis';
+import {compileAxis, compileInnerAxis, gridShow} from './axis';
 import {compileScales} from './scale';
 
 /**
@@ -65,7 +65,7 @@ export function facetMixins(model: Model, marks) {
       if (model.has(X)) {
         if (gridShow(model, X)) {
           // If has X and a grid show be shown, add grid-only x-axis to the cell
-          cellAxes.push(compileGridOnlyAxis(X, model));
+          cellAxes.push(compileInnerAxis(X, model));
         }
       } else {
         // Otherwise, manually draw grids between cells
@@ -104,7 +104,7 @@ export function facetMixins(model: Model, marks) {
       if (model.has(Y)) {
         if (gridShow(model, Y)) {
           // If has Y and a grid show be shown, add grid-only y-axis to the cell
-          cellAxes.push(compileGridOnlyAxis(Y, model));
+          cellAxes.push(compileInnerAxis(Y, model));
         }
       } else {
         // Otherwise, manually draw grids between cells

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -15,13 +15,13 @@ export function facetMixins(model: Model, marks) {
   const cellWidth: any = !model.has(COLUMN) ?
       {field: {group: 'width'}} :     // cellWidth = width -- just use group's
     typeof layout.cellWidth !== 'number' ?
-      {scale: model.scaleName(COLUMN), band: true} : // bandSize of the scale
+      {field: {parent: 'cellWidth'}} : // bandSize of the scale
       {value: layout.cellWidth};      // static value
 
   const cellHeight: any = !model.has(ROW) ?
       {field: {group: 'height'}} :  // cellHeight = height -- just use group's
     typeof layout.cellHeight !== 'number' ?
-      {scale: model.scaleName(ROW), band: true} :  // bandSize of the scale
+      {field: {parent: 'cellHeight'}} :  // bandSize of the scale
       {value: layout.cellHeight};   // static value
 
   let facetGroupProperties: any = {

--- a/src/schema/config.cell.schema.ts
+++ b/src/schema/config.cell.schema.ts
@@ -46,9 +46,11 @@ export const cellConfig = {
     stroke: {
       type: 'string',
       role: 'color',
+      default: '#ccc'
     },
     strokeWidth: {
-      type: 'integer'
+      type: 'integer',
+      default: 1
     },
     strokeOpacity: {
       type: 'number'


### PR DESCRIPTION
- Drawing grid for facet inside each cell and draw border around each cell.  Fix #920 
![vega_editor](https://cloud.githubusercontent.com/assets/111269/12997554/531fa18a-d0ef-11e5-89de-ee5690ee5ccf.png)

- Add extra rule mark to the manually drawn grid to close the table when faceting without inner x/y axis. Fix #803
![vega_editor](https://cloud.githubusercontent.com/assets/111269/12997990/53e9f83c-d0f3-11e5-8acc-b4e620c9b2a7.png)

- always add offset to facet's axis
- Don't use band of row/column scales to make sure the border of the cell works correctly