### PR TITLE
Refactor: add `model.scale()`  and always use it rather than fieldDef

### DIFF
--- a/src/compile/data.ts
+++ b/src/compile/data.ts
@@ -146,6 +146,7 @@ export namespace source {
   export function binTransform(model: Model) {
     return model.reduce(function(transform, fieldDef: FieldDef, channel: Channel) {
       const bin = model.fieldDef(channel).bin;
+      const scale = model.scale(channel);
       if (bin) {
         let binTrans = extend({
             type: 'bin',
@@ -167,7 +168,7 @@ export namespace source {
 
         transform.push(binTrans);
         // color ramp has type linear or time
-        if (scaleType(fieldDef, channel, model.mark()) === 'ordinal' || channel === COLOR) {
+        if (scaleType(scale, fieldDef, channel, model.mark()) === 'ordinal' || channel === COLOR) {
           transform.push({
             type: 'formula',
             field: field(fieldDef, {binSuffix: '_range'}),
@@ -244,7 +245,7 @@ export namespace layout {
 
     // TODO: handle "fit" mode
     if (model.has(X) && model.isOrdinalScale(X)) {
-      const xScale = model.fieldDef(X).scale;
+      const xScale = model.scale(X);
       const xHasDomain = xScale.domain instanceof Array;
       if (!xHasDomain) {
         summarize.push({
@@ -262,7 +263,7 @@ export namespace layout {
     }
 
     if (model.has(Y) && model.isOrdinalScale(Y)) {
-      const yScale = model.fieldDef(Y).scale;
+      const yScale = model.scale(Y);
       const yHasDomain = yScale.domain instanceof Array;
 
       if (!yHasDomain) {
@@ -288,7 +289,7 @@ export namespace layout {
       const cellWidth = typeof layoutCellWidth !== 'number' ?
                         'datum.' + layoutCellWidth.field :
                         layoutCellWidth;
-      const colScale = model.fieldDef(COLUMN).scale;
+      const colScale = model.scale(COLUMN);
       const colHasDomain = colScale.domain instanceof Array;
       if (!colHasDomain) {
         summarize.push({
@@ -311,7 +312,7 @@ export namespace layout {
       const cellHeight = typeof layoutCellHeight !== 'number' ?
                         'datum.' + layoutCellHeight.field :
                         layoutCellHeight;
-      const rowScale = model.fieldDef(ROW).scale;
+      const rowScale = model.scale(ROW);
       const rowHasDomain = rowScale.domain instanceof Array;
       if (!rowHasDomain) {
         summarize.push({
@@ -373,7 +374,8 @@ export namespace summary {
           dims[field(fieldDef, {binSuffix: '_mid'})] = field(fieldDef, {binSuffix: '_mid'});
           dims[field(fieldDef, {binSuffix: '_end'})] = field(fieldDef, {binSuffix: '_end'});
 
-          if (scaleType(fieldDef, channel, model.mark()) === 'ordinal') {
+          const scale = model.scale(channel);
+          if (scaleType(scale, fieldDef, channel, model.mark()) === 'ordinal') {
             // also produce bin_range if the binned field use ordinal scale
             dims[field(fieldDef, {binSuffix: '_range'})] = field(fieldDef, {binSuffix: '_range'});
           }
@@ -464,7 +466,7 @@ export namespace dates {
 
 export function filterNonPositiveForLog(dataTable, model: Model) {
   model.forEach(function(_, channel) {
-    const scale = model.fieldDef(channel).scale;
+    const scale = model.scale(channel);
     if (scale && scale.type === 'log') {
       dataTable.transform.push({
         type: 'filter',

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -50,7 +50,7 @@ function getCellWidth(model: Model) {
         // Need to offset the padding because width calculation need to overshoot
         // by the padding size to allow padding to be integer (can't rely on
         // ordinal scale's padding since it is fraction.)
-        offset: model.has(COLUMN) ? -model.fieldDef(COLUMN).scale.padding : undefined
+        offset: model.has(COLUMN) ? -model.scale(COLUMN).padding : undefined
       } :
     typeof layout.cellWidth !== 'number' ?
       {field: {parent: 'cellWidth'}} : // bandSize of the scale
@@ -65,7 +65,7 @@ function getCellHeight(model: Model) {
         // Need to offset the padding because height calculation need to overshoot
         // by the padding size to allow padding to be integer (can't rely on
         // ordinal scale's padding since it is fraction.)
-        offset: model.has(ROW) ? -model.fieldDef(ROW).scale.padding : undefined
+        offset: model.has(ROW) ? -model.scale(ROW).padding : undefined
       } :
     typeof layout.cellHeight !== 'number' ?
       {field: {parent: 'cellHeight'}} :  // bandSize of the scale
@@ -198,7 +198,7 @@ function getXAxesGroup(model: Model, cellWidth) { // TODO: VgMarks
             // Need to offset the padding because height calculation need to overshoot
             // by the padding size to allow padding to be integer (can't rely on
             // ordinal scale's padding since it is fraction.)
-            offset: model.has(ROW) ? -model.fieldDef(ROW).scale.padding : undefined
+            offset: model.has(ROW) ? -model.scale(ROW).padding : undefined
           },
           x: hasCol ? {scale: model.scaleName(COLUMN), field: model.field(COLUMN)} : {value: 0}
         }
@@ -236,7 +236,7 @@ function getYAxesGroup(model: Model, cellHeight) { // TODO: VgMarks
             // Need to offset the padding because width calculation need to overshoot
             // by the padding size to allow padding to be integer (can't rely on
             // ordinal scale's padding since it is fraction.)
-            offset: model.has(COLUMN) ? -model.fieldDef(COLUMN).scale.padding : undefined
+            offset: model.has(COLUMN) ? -model.scale(COLUMN).padding : undefined
           },
           height: cellHeight,
           y: hasRow ? {scale: model.scaleName(ROW), field: model.field(ROW)} : {value: 0}

--- a/src/compile/stack.ts
+++ b/src/compile/stack.ts
@@ -76,7 +76,7 @@ function getStackFields(spec: Spec) {
       } else {
         const fieldDef: FieldDef = channelEncoding;
         fields.push(field(fieldDef, {
-          binSuffix: scaleType(fieldDef, channel, spec.mark) === 'ordinal' ? '_range' : '_start'
+          binSuffix: scaleType(fieldDef.scale, fieldDef, channel, spec.mark) === 'ordinal' ? '_range' : '_start'
         }));
       }
     }

--- a/test/compile/scale.test.ts
+++ b/test/compile/scale.test.ts
@@ -21,7 +21,8 @@ describe('Scale', function() {
         }
       });
       const fieldDef = model.fieldDef(Y);
-      assert.deepEqual(vlscale.type(fieldDef, Y, model.mark()), 'time');
+      const scale = model.scale(Y);
+      assert.deepEqual(vlscale.type(scale, fieldDef, Y, model.mark()), 'time');
     });
 
     it('should return ordinal for month', function() {
@@ -35,7 +36,8 @@ describe('Scale', function() {
         }
       });
       const fieldDef = model.fieldDef(Y);
-      assert.deepEqual(vlscale.type(fieldDef, Y, model.mark()), 'ordinal');
+      const scale = model.scale(Y);
+      assert.deepEqual(vlscale.type(scale, fieldDef, Y, model.mark()), 'ordinal');
     });
 
     it('should return ordinal for row', function() {
@@ -49,13 +51,14 @@ describe('Scale', function() {
         }
       });
       const fieldDef = model.fieldDef(ROW);
-      assert.deepEqual(vlscale.type(fieldDef, ROW, model.mark()), 'ordinal');
+      const scale = model.scale(ROW);
+      assert.deepEqual(vlscale.type(scale, fieldDef, ROW, model.mark()), 'ordinal');
     });
   });
 
   describe('domain()', function() {
     it('should return domain for stack', function() {
-      const domain = vlscale.domain(parseModel({
+      const model = parseModel({
         mark: "bar",
         encoding: {
           y: {
@@ -66,7 +69,9 @@ describe('Scale', function() {
           color: {field: 'color', type: "ordinal"},
           row: {field: 'row'}
         }
-      }), Y, 'linear');
+      });
+
+      const domain = vlscale.domain(model.scale(Y), model, Y, 'linear');
 
       assert.deepEqual(domain, {
         data: 'stacked_scale',
@@ -77,7 +82,7 @@ describe('Scale', function() {
     describe('for quantitative', function() {
       it('should return the right domain for binned Q',
         function() {
-          const domain = vlscale.domain(parseModel({
+          const model = parseModel({
             mark: "point",
             encoding: {
               y: {
@@ -87,7 +92,8 @@ describe('Scale', function() {
                 type: "quantitative"
               }
             }
-          }), Y, 'ordinal');
+          });
+          const domain = vlscale.domain(model.scale(Y), model, Y, 'ordinal');
 
           assert.deepEqual(domain, {
             data: SOURCE,
@@ -101,7 +107,7 @@ describe('Scale', function() {
 
       it('should return the raw domain if useRawDomain is true for non-bin, non-sum Q',
         function() {
-          const domain = vlscale.domain(parseModel({
+          const model = parseModel({
             mark: "point",
             encoding: {
               y: {
@@ -111,14 +117,15 @@ describe('Scale', function() {
                 type: "quantitative"
               }
             }
-          }), Y, 'linear');
+          });
+          const domain = vlscale.domain(model.scale(Y), model, Y, 'linear');
 
           assert.deepEqual(domain.data, SOURCE);
         });
 
       it('should return the aggregate domain for sum Q',
         function() {
-          const domain = vlscale.domain(parseModel({
+          const model = parseModel({
             mark: "point",
             encoding: {
               y: {
@@ -128,14 +135,15 @@ describe('Scale', function() {
                 type: "quantitative"
               }
             }
-          }), Y, 'linear');
+          });
+          const domain = vlscale.domain(model.scale(Y), model, Y, 'linear');
 
           assert.deepEqual(domain.data, SUMMARY);
         });
 
 
       it('should return the aggregated domain if useRawDomain is false', function() {
-          const domain = vlscale.domain(parseModel({
+          const model = parseModel({
             mark: "point",
             encoding: {
               y: {
@@ -145,7 +153,8 @@ describe('Scale', function() {
                 type: "quantitative"
               }
             }
-          }), Y, 'linear');
+          });
+          const domain = vlscale.domain(model.scale(Y), model, Y, 'linear');
 
           assert.deepEqual(domain.data, SUMMARY);
         });
@@ -154,7 +163,7 @@ describe('Scale', function() {
     describe('for time', function() {
       it('should return the raw domain if useRawDomain is true for raw T',
         function() {
-          const domain = vlscale.domain(parseModel({
+          const model = parseModel({
             mark: "point",
             encoding: {
               y: {
@@ -163,14 +172,15 @@ describe('Scale', function() {
                 type: "temporal"
               }
             }
-          }), Y, 'time');
+          });
+          const domain = vlscale.domain(model.scale(Y), model, Y, 'time');
 
           assert.deepEqual(domain.data, SOURCE);
         });
 
       it('should return the raw domain if useRawDomain is true for year T',
         function() {
-          const domain = vlscale.domain(parseModel({
+          const model = parseModel({
             mark: "point",
             encoding: {
               y: {
@@ -180,7 +190,8 @@ describe('Scale', function() {
                 timeUnit: 'year'
               }
             }
-          }), Y, 'ordinal');
+          });
+          const domain = vlscale.domain(model.scale(Y), model, Y, 'ordinal');
 
           assert.deepEqual(domain.data, SOURCE);
           assert.operator(domain.field.indexOf('year'), '>', -1);
@@ -188,7 +199,7 @@ describe('Scale', function() {
 
       it('should return the correct domain for month T',
         function() {
-          const domain = vlscale.domain(parseModel({
+          const model = parseModel({
             mark: "point",
             encoding: {
               y: {
@@ -198,14 +209,15 @@ describe('Scale', function() {
                 timeUnit: 'month'
               }
             }
-          }), Y, 'ordinal');
+          });
+          const domain = vlscale.domain(model.scale(Y), model, Y, 'ordinal');
 
           assert.deepEqual(domain, { data: 'month', field: 'date' });
         });
 
         it('should return the correct domain for yearmonth T',
           function() {
-            const domain = vlscale.domain(parseModel({
+            const model = parseModel({
               mark: "point",
               encoding: {
                 y: {
@@ -215,7 +227,8 @@ describe('Scale', function() {
                   timeUnit: 'yearmonth'
                 }
               }
-            }), Y, 'ordinal');
+            });
+            const domain = vlscale.domain(model.scale(Y), model, Y, 'ordinal');
 
             assert.deepEqual(domain, {
               data: 'source', field: 'yearmonth_origin',
@@ -227,14 +240,14 @@ describe('Scale', function() {
     describe('for ordinal', function() {
       it('should return correct domain with the provided sort property', function() {
         const sortDef = {op: 'min', field:'Acceleration'};
-        const encoding = parseModel({
+        const model = parseModel({
             mark: "point",
             encoding: {
               y: { field: 'origin', type: "ordinal", sort: sortDef}
             }
           });
 
-        assert.deepEqual(vlscale.domain(encoding, Y, 'ordinal'), {
+        assert.deepEqual(vlscale.domain(model.scale(Y), model, Y, 'ordinal'), {
             data: "source",
             field: 'origin',
             sort: sortDef
@@ -242,14 +255,14 @@ describe('Scale', function() {
       });
 
       it('should return correct domain without sort if sort is not provided', function() {
-        const encoding = parseModel({
+        const model = parseModel({
             mark: "point",
             encoding: {
               y: { field: 'origin', type: "ordinal"}
             }
           });
 
-        assert.deepEqual(vlscale.domain(encoding, Y, 'ordinal'), {
+        assert.deepEqual(vlscale.domain(model.scale(Y), model, Y, 'ordinal'), {
             data: "source",
             field: 'origin',
             sort: true


### PR DESCRIPTION
- add `model.scale()`
- always refer to scale via `model.scale()` rather than via fieldDef

This is a refactor for 
(1) preparing to split scale's from encoding in the model  (for composition)
(2) enable declaration of different channelDefs -- some of them do not have scales. 

I have run x-compile and x-diff to see that all output from the examples still remain the same.  