### PR TITLE
Add interfaces for different types of channelDefs + Refactor 

### DIFF
--- a/src/compile/Model.ts
+++ b/src/compile/Model.ts
@@ -228,6 +228,10 @@ export class Model {
     return this._spec.config;
   }
 
+  public sort(channel: Channel) {
+    return this._spec.encoding[channel].sort;
+  }
+
   public scale(channel: Channel): Scale {
     return this.fieldDef(channel).scale;
   }

--- a/src/compile/data.ts
+++ b/src/compile/data.ts
@@ -146,6 +146,7 @@ export namespace source {
   export function binTransform(model: Model) {
     return model.reduce(function(transform, fieldDef: FieldDef, channel: Channel) {
       const bin = model.fieldDef(channel).bin;
+      const scale = model.scale(channel);
       if (bin) {
         let binTrans = extend({
             type: 'bin',
@@ -167,7 +168,7 @@ export namespace source {
 
         transform.push(binTrans);
         // color ramp has type linear or time
-        if (scaleType(fieldDef, channel, model.mark()) === 'ordinal' || channel === COLOR) {
+        if (scaleType(scale, fieldDef, channel, model.mark()) === 'ordinal' || channel === COLOR) {
           transform.push({
             type: 'formula',
             field: field(fieldDef, {binSuffix: '_range'}),
@@ -244,7 +245,7 @@ export namespace layout {
 
     // TODO: handle "fit" mode
     if (model.has(X) && model.isOrdinalScale(X)) {
-      const xScale = model.fieldDef(X).scale;
+      const xScale = model.scale(X);
       const xHasDomain = xScale.domain instanceof Array;
       if (!xHasDomain) {
         summarize.push({
@@ -262,7 +263,7 @@ export namespace layout {
     }
 
     if (model.has(Y) && model.isOrdinalScale(Y)) {
-      const yScale = model.fieldDef(Y).scale;
+      const yScale = model.scale(Y);
       const yHasDomain = yScale.domain instanceof Array;
 
       if (!yHasDomain) {
@@ -288,7 +289,7 @@ export namespace layout {
       const cellWidth = typeof layoutCellWidth !== 'number' ?
                         'datum.' + layoutCellWidth.field :
                         layoutCellWidth;
-      const colScale = model.fieldDef(COLUMN).scale;
+      const colScale = model.scale(COLUMN);
       const colHasDomain = colScale.domain instanceof Array;
       if (!colHasDomain) {
         summarize.push({
@@ -311,7 +312,7 @@ export namespace layout {
       const cellHeight = typeof layoutCellHeight !== 'number' ?
                         'datum.' + layoutCellHeight.field :
                         layoutCellHeight;
-      const rowScale = model.fieldDef(ROW).scale;
+      const rowScale = model.scale(ROW);
       const rowHasDomain = rowScale.domain instanceof Array;
       if (!rowHasDomain) {
         summarize.push({
@@ -373,7 +374,8 @@ export namespace summary {
           dims[field(fieldDef, {binSuffix: '_mid'})] = field(fieldDef, {binSuffix: '_mid'});
           dims[field(fieldDef, {binSuffix: '_end'})] = field(fieldDef, {binSuffix: '_end'});
 
-          if (scaleType(fieldDef, channel, model.mark()) === 'ordinal') {
+          const scale = model.scale(channel);
+          if (scaleType(scale, fieldDef, channel, model.mark()) === 'ordinal') {
             // also produce bin_range if the binned field use ordinal scale
             dims[field(fieldDef, {binSuffix: '_range'})] = field(fieldDef, {binSuffix: '_range'});
           }
@@ -464,7 +466,7 @@ export namespace dates {
 
 export function filterNonPositiveForLog(dataTable, model: Model) {
   model.forEach(function(_, channel) {
-    const scale = model.fieldDef(channel).scale;
+    const scale = model.scale(channel);
     if (scale && scale.type === 'log') {
       dataTable.transform.push({
         type: 'filter',

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -50,7 +50,7 @@ function getCellWidth(model: Model) {
         // Need to offset the padding because width calculation need to overshoot
         // by the padding size to allow padding to be integer (can't rely on
         // ordinal scale's padding since it is fraction.)
-        offset: model.has(COLUMN) ? -model.fieldDef(COLUMN).scale.padding : undefined
+        offset: model.has(COLUMN) ? -model.scale(COLUMN).padding : undefined
       } :
     typeof layout.cellWidth !== 'number' ?
       {field: {parent: 'cellWidth'}} : // bandSize of the scale
@@ -65,7 +65,7 @@ function getCellHeight(model: Model) {
         // Need to offset the padding because height calculation need to overshoot
         // by the padding size to allow padding to be integer (can't rely on
         // ordinal scale's padding since it is fraction.)
-        offset: model.has(ROW) ? -model.fieldDef(ROW).scale.padding : undefined
+        offset: model.has(ROW) ? -model.scale(ROW).padding : undefined
       } :
     typeof layout.cellHeight !== 'number' ?
       {field: {parent: 'cellHeight'}} :  // bandSize of the scale
@@ -198,7 +198,7 @@ function getXAxesGroup(model: Model, cellWidth) { // TODO: VgMarks
             // Need to offset the padding because height calculation need to overshoot
             // by the padding size to allow padding to be integer (can't rely on
             // ordinal scale's padding since it is fraction.)
-            offset: model.has(ROW) ? -model.fieldDef(ROW).scale.padding : undefined
+            offset: model.has(ROW) ? -model.scale(ROW).padding : undefined
           },
           x: hasCol ? {scale: model.scaleName(COLUMN), field: model.field(COLUMN)} : {value: 0}
         }
@@ -236,7 +236,7 @@ function getYAxesGroup(model: Model, cellHeight) { // TODO: VgMarks
             // Need to offset the padding because width calculation need to overshoot
             // by the padding size to allow padding to be integer (can't rely on
             // ordinal scale's padding since it is fraction.)
-            offset: model.has(COLUMN) ? -model.fieldDef(COLUMN).scale.padding : undefined
+            offset: model.has(COLUMN) ? -model.scale(COLUMN).padding : undefined
           },
           height: cellHeight,
           y: hasRow ? {scale: model.scaleName(ROW), field: model.field(ROW)} : {value: 0}

--- a/src/compile/scale.ts
+++ b/src/compile/scale.ts
@@ -28,6 +28,7 @@ export function compileScales(channels: Channel[], model: Model) {
     .reduce(function(scales: any[], channel: Channel) {
       const fieldDef = model.fieldDef(channel);
       const scale = model.scale(channel);
+      const sort = model.sort(channel);
 
       var scaleDef: any = {
         name: model.scaleName(channel),
@@ -37,10 +38,14 @@ export function compileScales(channels: Channel[], model: Model) {
       scaleDef.domain = domain(scale, model, channel, scaleDef.type);
       extend(scaleDef, rangeMixins(scale, model, channel, scaleDef.type));
 
+      if (sort && (typeof sort === 'string' ? sort : sort.order) === 'descending') {
+        scaleDef.reverse = true;
+      }
+
       // Add optional properties
       [
         // general properties
-        'reverse', 'round',
+        'round',
         // quantitative / time
         'clamp', 'nice',
         // quantitative
@@ -242,7 +247,7 @@ export function domainSort(model: Model, channel: Channel, scaleType: string): a
     return undefined;
   }
 
-  var sort = model.fieldDef(channel).sort;
+  var sort = model.sort(channel);
   if (sort === 'ascending' || sort === 'descending') {
     return true;
   }
@@ -257,13 +262,6 @@ export function domainSort(model: Model, channel: Channel, scaleType: string): a
   return undefined;
 }
 
-export function reverse(scale: Scale, fieldDef: FieldDef, channel: Channel) {
-  var sort = fieldDef.sort;
-  return sort && (typeof sort === 'string' ?
-                    sort === 'descending' :
-                    sort.order === 'descending'
-                 ) ? true : undefined;
-}
 
 /**
  * Determine if useRawDomain should be activated for this scale.

--- a/src/compile/stack.ts
+++ b/src/compile/stack.ts
@@ -76,7 +76,7 @@ function getStackFields(spec: Spec) {
       } else {
         const fieldDef: FieldDef = channelEncoding;
         fields.push(field(fieldDef, {
-          binSuffix: scaleType(fieldDef, channel, spec.mark) === 'ordinal' ? '_range' : '_start'
+          binSuffix: scaleType(fieldDef.scale, fieldDef, channel, spec.mark) === 'ordinal' ? '_range' : '_start'
         }));
       }
     }

--- a/src/compile/util.ts
+++ b/src/compile/util.ts
@@ -1,5 +1,5 @@
 import {Model} from './Model';
-import {FieldDef} from '../schema/fielddef.schema';
+import {FieldDef, OrderChannelDef} from '../schema/fielddef.schema';
 import {COLUMN, ROW, X, Y, SIZE, COLOR, SHAPE, TEXT, LABEL, Channel} from '../channel';
 import {field} from '../fielddef';
 import {QUANTITATIVE, ORDINAL, TEMPORAL} from '../type';
@@ -132,8 +132,8 @@ function isAbbreviated(model: Model, channel: Channel, fieldDef: FieldDef) {
 
 
 /** Return field reference with potential "-" prefix for descending sort */
-export function sortField(fieldDef: FieldDef) {
-  return (fieldDef.sort === 'descending' ? '-' : '') + field(fieldDef);
+export function sortField(orderChannelDef: OrderChannelDef) {
+  return (orderChannelDef.sort === 'descending' ? '-' : '') + field(orderChannelDef);
 }
 
 /**

--- a/src/schema/encoding.schema.ts
+++ b/src/schema/encoding.schema.ts
@@ -1,35 +1,39 @@
-import {FieldDef, detailFieldDefs, facetFieldDef, orderFieldDefs, positionFieldDef, shapeFieldDef, sizeFieldDef, textFieldDef, colorFieldDef} from './fielddef.schema';
+import {detailChannelDefs, textChannelDef, FieldDef} from './fielddef.schema';
+import {positionChannelDef, PositionChannelDef} from './fielddef.schema';
+import {facetChannelDef, FacetChannelDef} from './fielddef.schema';
+import {channelDefWithLegend, shapeChannelDef, ChannelDefWithLegend} from './fielddef.schema';
+import {orderChannelDefs, OrderChannelDef} from './fielddef.schema';
 
 export interface Encoding {
-  x?: FieldDef;
-  y?: FieldDef;
-  row?: FieldDef;
-  column?: FieldDef;
-  color?: FieldDef;
-  size?: FieldDef;
-  shape?: FieldDef;
+  x?: PositionChannelDef;
+  y?: PositionChannelDef;
+  row?: FacetChannelDef;
+  column?: FacetChannelDef;
+  color?: ChannelDefWithLegend;
+  size?: ChannelDefWithLegend;
+  shape?: ChannelDefWithLegend; // TODO: maybe distinguish ordinal-only
   detail?: FieldDef | FieldDef[];
   text?: FieldDef;
   label?: FieldDef;
 
-  path?: FieldDef | FieldDef[];
-  order?: FieldDef | FieldDef[];
+  path?: OrderChannelDef | OrderChannelDef[];
+  order?: OrderChannelDef | OrderChannelDef[];
 }
 
 export const encoding = {
   type: 'object',
   properties: {
-    x: positionFieldDef,
-    y: positionFieldDef,
-    row: facetFieldDef,
-    column: facetFieldDef,
-    size: sizeFieldDef,
-    color: colorFieldDef,
-    shape: shapeFieldDef,
-    text: textFieldDef,
-    detail: detailFieldDefs,
-    label: textFieldDef,
-    path: orderFieldDefs,
-    order: orderFieldDefs
+    x: positionChannelDef,
+    y: positionChannelDef,
+    row: facetChannelDef,
+    column: facetChannelDef,
+    size: channelDefWithLegend,
+    color: channelDefWithLegend,
+    shape: shapeChannelDef,
+    text: textChannelDef,
+    detail: detailChannelDefs,
+    label: textChannelDef,
+    path: orderChannelDefs,
+    order: orderChannelDefs
   }
 };

--- a/src/schema/fielddef.schema.ts
+++ b/src/schema/fielddef.schema.ts
@@ -73,14 +73,24 @@ const fieldDef = {
   }
 };
 
-const fieldDefWithScale = mergeDeep(duplicate(fieldDef), {
+export interface ChannelDefWithScale extends FieldDef {
+  scale?: Scale;
+  sort?: Sort;
+}
+
+const channelDefWithScale = mergeDeep(duplicate(fieldDef), {
   properties: {
     scale: typicalScale,
     sort: sort
   }
 });
 
-export const positionFieldDef = mergeDeep(duplicate(fieldDefWithScale), {
+
+export interface PositionChannelDef extends ChannelDefWithScale {
+  axis?: Axis;
+}
+
+export const positionChannelDef = mergeDeep(duplicate(channelDefWithScale), {
   required: ['field', 'type'], // TODO: remove if possible
   properties: {
     scale: {
@@ -94,17 +104,18 @@ export const positionFieldDef = mergeDeep(duplicate(fieldDefWithScale), {
   }
 });
 
-export const colorFieldDef = mergeDeep(duplicate(fieldDefWithScale), {
+export interface ChannelDefWithLegend extends ChannelDefWithScale {
+  legend?: Legend;
+}
+
+export const channelDefWithLegend = mergeDeep(duplicate(channelDefWithScale), {
   properties: {
     legend: legend
   }
 });
 
-export const sizeFieldDef = colorFieldDef;
-
 // Detail
-
-export const detailFieldDefs = {
+export const detailChannelDefs = {
   default: undefined,
   oneOf: [duplicate(fieldDef), {
     type: 'array',
@@ -114,47 +125,53 @@ export const detailFieldDefs = {
 
 // Order Path have no scale
 
-const orderFieldDef = mergeDeep(duplicate(fieldDef), {
+export interface OrderChannelDef extends FieldDef {
+  sort?: Sort;
+}
+
+const orderChannelDef = mergeDeep(duplicate(fieldDef), {
   properties: {
     sort: sortEnum
   }
 });
 
-export const orderFieldDefs = {
+export const orderChannelDefs = {
   default: undefined,
-  oneOf: [duplicate(orderFieldDef), {
+  oneOf: [duplicate(orderChannelDef), {
     type: 'array',
-    items: duplicate(orderFieldDef)
+    items: duplicate(orderChannelDef)
   }]
 };
 
 // Text has default value = `Abc`
-
-export const textFieldDef = mergeDeep(duplicate(fieldDef), {
+export const textChannelDef = mergeDeep(duplicate(fieldDef), {
   properties: {
     value: {
       type: 'string',
-      default: 'Abc'
+      default: 'Abc' // TODO: move this default into config!
     }
   }
 });
 
 // Shape / Row / Column only supports ordinal scale
 
-const fieldDefWithOrdinalScale = mergeDeep(duplicate(fieldDef), {
+const ordinalChannelDef = mergeDeep(duplicate(fieldDef), {
   properties: {
     scale: ordinalOnlyScale,
     sort: sort
   }
 });
 
-export const shapeFieldDef =  mergeDeep(duplicate(fieldDefWithOrdinalScale), {
+export const shapeChannelDef =  mergeDeep(duplicate(ordinalChannelDef), {
   properties: {
     legend: legend
   }
 });
 
-export const facetFieldDef = mergeDeep(duplicate(fieldDefWithOrdinalScale), {
+// TODO: consider if we want to distinguish ordinalOnlyScale from scale
+export type FacetChannelDef = PositionChannelDef;
+
+export const facetChannelDef = mergeDeep(duplicate(ordinalChannelDef), {
   required: ['field', 'type'],
   properties: {
     axis: axis

--- a/src/schema/fielddef.schema.ts
+++ b/src/schema/fielddef.schema.ts
@@ -25,9 +25,8 @@ export interface FieldDef {
   bin?: boolean | Bin;
 
   aggregate?: string;
-  sort?: SortField | SortEnum;
 
-  // override vega components
+  // TODO: remove these one by one
   axis?: Axis | boolean;
   legend?: Legend | boolean;
   scale?: Scale;

--- a/src/schema/fielddef.schema.ts
+++ b/src/schema/fielddef.schema.ts
@@ -2,7 +2,7 @@ import {axis, Axis} from './axis.schema';
 import {bin, Bin} from './bin.schema';
 import {legend, Legend} from './legend.schema';
 import {typicalScale, ordinalOnlyScale, Scale} from './scale.schema';
-import {sort, sortEnum, Sort} from './sort.schema';
+import {sortEnum, sort, SortField, SortEnum} from './sort.schema';
 
 import {AGGREGATE_OPS} from '../aggregate';
 import {toMap, duplicate} from '../util';
@@ -25,7 +25,7 @@ export interface FieldDef {
   bin?: boolean | Bin;
 
   aggregate?: string;
-  sort?: Sort | string;
+  sort?: SortField | SortEnum;
 
   // override vega components
   axis?: Axis | boolean;
@@ -75,7 +75,7 @@ const fieldDef = {
 
 export interface ChannelDefWithScale extends FieldDef {
   scale?: Scale;
-  sort?: Sort;
+  sort?: SortField | SortEnum;
 }
 
 const channelDefWithScale = mergeDeep(duplicate(fieldDef), {
@@ -126,7 +126,7 @@ export const detailChannelDefs = {
 // Order Path have no scale
 
 export interface OrderChannelDef extends FieldDef {
-  sort?: Sort;
+  sort?: SortEnum;
 }
 
 const orderChannelDef = mergeDeep(duplicate(fieldDef), {

--- a/src/schema/sort.schema.ts
+++ b/src/schema/sort.schema.ts
@@ -2,7 +2,9 @@ import {AGGREGATE_OPS} from '../aggregate';
 import {ORDINAL, QUANTITATIVE} from '../type';
 import {toMap} from '../util';
 
-export interface Sort {
+export type SortEnum = string; // TODO: string literal "ascending", "descending", "none"
+
+export interface SortField {
   field: string;
   op: string;
   order?: string;
@@ -11,7 +13,27 @@ export interface Sort {
 export const sortEnum = {
   default: 'ascending',
   type: 'string',
-  enum: ['ascending', 'descending', 'unsorted']
+  enum: ['ascending', 'descending', 'none']
+};
+
+const sortField = { // sort by aggregation of another field
+  type: 'object',
+  required: ['field', 'op'],
+  properties: {
+    field: {
+      type: 'string',
+      description: 'The field name to aggregate over.'
+    },
+    op: {
+      type: 'string',
+      enum: AGGREGATE_OPS,
+      description: 'The field name to aggregate over.'
+    },
+    order: {
+      type: 'string',
+      enum: ['ascending', 'descending']
+    }
+  }
 };
 
 export var sort = {
@@ -19,24 +41,6 @@ export var sort = {
   supportedTypes: toMap([QUANTITATIVE, ORDINAL]),
   oneOf: [
     sortEnum,
-    { // sort by aggregation of another field
-      type: 'object',
-      required: ['field', 'op'],
-      properties: {
-        field: {
-          type: 'string',
-          description: 'The field name to aggregate over.'
-        },
-        op: {
-          type: 'string',
-          enum: AGGREGATE_OPS,
-          description: 'The field name to aggregate over.'
-        },
-        order: {
-          type: 'string',
-          enum: ['ascending', 'descending']
-        }
-      }
-    }
+    sortField
   ]
 };

--- a/test/compile/scale.test.ts
+++ b/test/compile/scale.test.ts
@@ -21,7 +21,8 @@ describe('Scale', function() {
         }
       });
       const fieldDef = model.fieldDef(Y);
-      assert.deepEqual(vlscale.type(fieldDef, Y, model.mark()), 'time');
+      const scale = model.scale(Y);
+      assert.deepEqual(vlscale.type(scale, fieldDef, Y, model.mark()), 'time');
     });
 
     it('should return ordinal for month', function() {
@@ -35,7 +36,8 @@ describe('Scale', function() {
         }
       });
       const fieldDef = model.fieldDef(Y);
-      assert.deepEqual(vlscale.type(fieldDef, Y, model.mark()), 'ordinal');
+      const scale = model.scale(Y);
+      assert.deepEqual(vlscale.type(scale, fieldDef, Y, model.mark()), 'ordinal');
     });
 
     it('should return ordinal for row', function() {
@@ -49,13 +51,14 @@ describe('Scale', function() {
         }
       });
       const fieldDef = model.fieldDef(ROW);
-      assert.deepEqual(vlscale.type(fieldDef, ROW, model.mark()), 'ordinal');
+      const scale = model.scale(ROW);
+      assert.deepEqual(vlscale.type(scale, fieldDef, ROW, model.mark()), 'ordinal');
     });
   });
 
   describe('domain()', function() {
     it('should return domain for stack', function() {
-      const domain = vlscale.domain(parseModel({
+      const model = parseModel({
         mark: "bar",
         encoding: {
           y: {
@@ -66,7 +69,9 @@ describe('Scale', function() {
           color: {field: 'color', type: "ordinal"},
           row: {field: 'row'}
         }
-      }), Y, 'linear');
+      });
+
+      const domain = vlscale.domain(model.scale(Y), model, Y, 'linear');
 
       assert.deepEqual(domain, {
         data: 'stacked_scale',
@@ -77,7 +82,7 @@ describe('Scale', function() {
     describe('for quantitative', function() {
       it('should return the right domain for binned Q',
         function() {
-          const domain = vlscale.domain(parseModel({
+          const model = parseModel({
             mark: "point",
             encoding: {
               y: {
@@ -87,7 +92,8 @@ describe('Scale', function() {
                 type: "quantitative"
               }
             }
-          }), Y, 'ordinal');
+          });
+          const domain = vlscale.domain(model.scale(Y), model, Y, 'ordinal');
 
           assert.deepEqual(domain, {
             data: SOURCE,
@@ -101,7 +107,7 @@ describe('Scale', function() {
 
       it('should return the raw domain if useRawDomain is true for non-bin, non-sum Q',
         function() {
-          const domain = vlscale.domain(parseModel({
+          const model = parseModel({
             mark: "point",
             encoding: {
               y: {
@@ -111,14 +117,15 @@ describe('Scale', function() {
                 type: "quantitative"
               }
             }
-          }), Y, 'linear');
+          });
+          const domain = vlscale.domain(model.scale(Y), model, Y, 'linear');
 
           assert.deepEqual(domain.data, SOURCE);
         });
 
       it('should return the aggregate domain for sum Q',
         function() {
-          const domain = vlscale.domain(parseModel({
+          const model = parseModel({
             mark: "point",
             encoding: {
               y: {
@@ -128,14 +135,15 @@ describe('Scale', function() {
                 type: "quantitative"
               }
             }
-          }), Y, 'linear');
+          });
+          const domain = vlscale.domain(model.scale(Y), model, Y, 'linear');
 
           assert.deepEqual(domain.data, SUMMARY);
         });
 
 
       it('should return the aggregated domain if useRawDomain is false', function() {
-          const domain = vlscale.domain(parseModel({
+          const model = parseModel({
             mark: "point",
             encoding: {
               y: {
@@ -145,7 +153,8 @@ describe('Scale', function() {
                 type: "quantitative"
               }
             }
-          }), Y, 'linear');
+          });
+          const domain = vlscale.domain(model.scale(Y), model, Y, 'linear');
 
           assert.deepEqual(domain.data, SUMMARY);
         });
@@ -154,7 +163,7 @@ describe('Scale', function() {
     describe('for time', function() {
       it('should return the raw domain if useRawDomain is true for raw T',
         function() {
-          const domain = vlscale.domain(parseModel({
+          const model = parseModel({
             mark: "point",
             encoding: {
               y: {
@@ -163,14 +172,15 @@ describe('Scale', function() {
                 type: "temporal"
               }
             }
-          }), Y, 'time');
+          });
+          const domain = vlscale.domain(model.scale(Y), model, Y, 'time');
 
           assert.deepEqual(domain.data, SOURCE);
         });
 
       it('should return the raw domain if useRawDomain is true for year T',
         function() {
-          const domain = vlscale.domain(parseModel({
+          const model = parseModel({
             mark: "point",
             encoding: {
               y: {
@@ -180,7 +190,8 @@ describe('Scale', function() {
                 timeUnit: 'year'
               }
             }
-          }), Y, 'ordinal');
+          });
+          const domain = vlscale.domain(model.scale(Y), model, Y, 'ordinal');
 
           assert.deepEqual(domain.data, SOURCE);
           assert.operator(domain.field.indexOf('year'), '>', -1);
@@ -188,7 +199,7 @@ describe('Scale', function() {
 
       it('should return the correct domain for month T',
         function() {
-          const domain = vlscale.domain(parseModel({
+          const model = parseModel({
             mark: "point",
             encoding: {
               y: {
@@ -198,14 +209,15 @@ describe('Scale', function() {
                 timeUnit: 'month'
               }
             }
-          }), Y, 'ordinal');
+          });
+          const domain = vlscale.domain(model.scale(Y), model, Y, 'ordinal');
 
           assert.deepEqual(domain, { data: 'month', field: 'date' });
         });
 
         it('should return the correct domain for yearmonth T',
           function() {
-            const domain = vlscale.domain(parseModel({
+            const model = parseModel({
               mark: "point",
               encoding: {
                 y: {
@@ -215,7 +227,8 @@ describe('Scale', function() {
                   timeUnit: 'yearmonth'
                 }
               }
-            }), Y, 'ordinal');
+            });
+            const domain = vlscale.domain(model.scale(Y), model, Y, 'ordinal');
 
             assert.deepEqual(domain, {
               data: 'source', field: 'yearmonth_origin',
@@ -227,14 +240,14 @@ describe('Scale', function() {
     describe('for ordinal', function() {
       it('should return correct domain with the provided sort property', function() {
         const sortDef = {op: 'min', field:'Acceleration'};
-        const encoding = parseModel({
+        const model = parseModel({
             mark: "point",
             encoding: {
               y: { field: 'origin', type: "ordinal", sort: sortDef}
             }
           });
 
-        assert.deepEqual(vlscale.domain(encoding, Y, 'ordinal'), {
+        assert.deepEqual(vlscale.domain(model.scale(Y), model, Y, 'ordinal'), {
             data: "source",
             field: 'origin',
             sort: sortDef
@@ -242,14 +255,14 @@ describe('Scale', function() {
       });
 
       it('should return correct domain without sort if sort is not provided', function() {
-        const encoding = parseModel({
+        const model = parseModel({
             mark: "point",
             encoding: {
               y: { field: 'origin', type: "ordinal"}
             }
           });
 
-        assert.deepEqual(vlscale.domain(encoding, Y, 'ordinal'), {
+        assert.deepEqual(vlscale.domain(model.scale(Y), model, Y, 'ordinal'), {
             data: "source",
             field: 'origin',
             sort: true


### PR DESCRIPTION
- Add interfaces for different types of channelDefs 
- Refactor sort typings.
- Refer to sort via `model.sort()` and remove it from FieldDef
- remove `legend` from FieldDef, add `config.legend` and initialize it correctly

Please merge #1106 first!  

(See [Branch Specific Diff](https://github.com/uwdata/vega-lite/compare/kw/scale...kw/channelDef))