### PR TITLE
Correct Color Field/Value/Config precedence + Refactor

### DIFF
--- a/src/compile/config.ts
+++ b/src/compile/config.ts
@@ -4,7 +4,7 @@ import {StackProperties} from './stack';
 import {X, Y, DETAIL} from '../channel';
 import {isAggregate, has} from '../encoding';
 import {isMeasure} from '../fielddef';
-import {POINT, TICK, CIRCLE, SQUARE} from '../mark';
+import {POINT, LINE, TICK, CIRCLE, SQUARE} from '../mark';
 import {contains, extend} from '../util';
 
 /**
@@ -17,8 +17,8 @@ export function compileMarkConfig(spec: Spec, stack: StackProperties) {
        switch (property) {
          case 'filled':
            if (value === undefined) {
-             // only point is not filled by default
-             cfg[property] = spec.mark !== POINT;
+             // Point and line are not filled by default
+             cfg[property] = spec.mark !== POINT && spec.mark !== LINE;
            }
            break;
          case 'opacity':

--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -117,25 +117,31 @@ namespace properties {
         break;
     }
 
-    // do not set fill or stroke properties from config because the value from the scale should have precedence
-    applyMarkConfig(symbols, model, without(FILL_STROKE_CONFIG, ['fill', 'stroke']));
+    const filled = model.config().mark.filled;
 
-    if (model.config().mark.filled) {
+    if (filled) {
       symbols.strokeWidth = { value: 0 };
     }
 
+    applyMarkConfig(symbols, model,
+      // Do not set fill (when filled) or stroke (when unfilled) property from config
+      // because the value from the scale should have precedence
+      without(FILL_STROKE_CONFIG, [ filled ? 'fill' : 'stroke'])
+    );
+
     let value;
-    if (model.has(COLOR) && channel === COLOR && useColorLegendScale(fieldDef)) {
-      value = { scale: model.scaleName(COLOR), field: 'data' };
+    if (model.has(COLOR) && channel === COLOR) {
+      if (useColorLegendScale(fieldDef)) {
+        // for color legend scale, we need to override
+        value = { scale: model.scaleName(COLOR), field: 'data' };
+      }
     } else if (model.fieldDef(COLOR).value) {
       value = { value: model.fieldDef(COLOR).value };
-    } else if (channel !== COLOR) {
-      value = { value: model.config().mark.color };
     }
 
     if (value !== undefined) {
       // apply the value
-      if (model.config().mark.filled) {
+      if (filled) {
         symbols.fill = value;
       } else {
         symbols.stroke = value;

--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -146,6 +146,10 @@ namespace properties {
       } else {
         symbols.stroke = value;
       }
+    } else {
+      // apply color config if there is no fill / stroke config
+      symbols[filled ? 'fill' : 'stroke'] = symbols[filled ? 'fill' : 'stroke'] ||
+        {value: model.config().mark.color};
     }
 
     symbols = extend(symbols, symbolsSpec || {});

--- a/src/compile/mark-line.ts
+++ b/src/compile/mark-line.ts
@@ -1,6 +1,6 @@
 import {Model} from './Model';
 import {X, Y} from '../channel';
-import {applyColorAndOpacity, applyMarkConfig, ColorMode} from './util';
+import {applyColorAndOpacity, applyMarkConfig} from './util';
 
 
 export namespace line {
@@ -32,7 +32,7 @@ export namespace line {
       p.y = { field: { group: 'height' } };
     }
 
-    applyColorAndOpacity(p, model, ColorMode.ALWAYS_STROKED);
+    applyColorAndOpacity(p, model);
     applyMarkConfig(p, model, ['interpolate', 'tension']);
     return p;
   }

--- a/src/compile/mark-point.ts
+++ b/src/compile/mark-point.ts
@@ -1,6 +1,6 @@
 import {Model} from './Model';
 import {X, Y, SHAPE, SIZE} from '../channel';
-import {applyColorAndOpacity, ColorMode} from './util';
+import {applyColorAndOpacity} from './util';
 
 export namespace point {
   export function markType() {
@@ -55,10 +55,7 @@ export namespace point {
       p.shape = { value: model.config().mark.shape };
     }
 
-    applyColorAndOpacity(p, model,
-      // square and circle are filled by default, but point is stroked by default.
-      fixedShape ? ColorMode.FILLED_BY_DEFAULT : ColorMode.STROKED_BY_DEFAULT
-    );
+    applyColorAndOpacity(p, model);
     return p;
   }
 

--- a/src/compile/mark-tick.ts
+++ b/src/compile/mark-tick.ts
@@ -1,6 +1,6 @@
 import {Model} from './Model';
 import {X, Y, SIZE} from '../channel';
-import {applyColorAndOpacity, ColorMode} from './util';
+import {applyColorAndOpacity} from './util';
 
 export namespace tick {
   export function markType() {
@@ -48,7 +48,7 @@ export namespace tick {
       p.height = { value: model.config().mark.thickness };
     }
 
-    applyColorAndOpacity(p, model, ColorMode.ALWAYS_FILLED);
+    applyColorAndOpacity(p, model);
     return p;
   }
 

--- a/src/compile/util.ts
+++ b/src/compile/util.ts
@@ -6,24 +6,12 @@ import {QUANTITATIVE, ORDINAL, TEMPORAL} from '../type';
 import {format as timeFormatExpr} from './time';
 import {contains} from '../util';
 
-export enum ColorMode {
-  ALWAYS_FILLED,
-  ALWAYS_STROKED,
-  FILLED_BY_DEFAULT,
-  STROKED_BY_DEFAULT
-}
-
 export const FILL_STROKE_CONFIG = ['fill', 'fillOpacity',
   'stroke', 'strokeWidth', 'strokeDash', 'strokeDashOffset', 'strokeOpacity',
   'opacity'];
 
-export function applyColorAndOpacity(p, model: Model, colorMode: ColorMode = ColorMode.STROKED_BY_DEFAULT) {
-  const filled = colorMode === ColorMode.ALWAYS_FILLED ? true :
-    colorMode === ColorMode.ALWAYS_STROKED ? false :
-      model.config().mark.filled !== undefined ? model.config().mark.filled :
-        colorMode === ColorMode.FILLED_BY_DEFAULT ? true :
-          false; // ColorMode.STROKED_BY_DEFAULT
-
+export function applyColorAndOpacity(p, model: Model) {
+  const filled = model.config().mark.filled;
   const fieldDef = model.fieldDef(COLOR);
   if (filled) {
     if (model.has(COLOR)) {

--- a/src/compile/util.ts
+++ b/src/compile/util.ts
@@ -13,33 +13,32 @@ export const FILL_STROKE_CONFIG = ['fill', 'fillOpacity',
 export function applyColorAndOpacity(p, model: Model) {
   const filled = model.config().mark.filled;
   const fieldDef = model.fieldDef(COLOR);
-  if (filled) {
-    if (model.has(COLOR)) {
-      p.fill = {
-        scale: model.scaleName(COLOR),
-        field: model.field(COLOR, fieldDef.type === ORDINAL ? {prefn: 'rank_'} : {})
-      };
-    } else if (fieldDef.value) {
-      p.fill = { value: fieldDef.value };
-    } else {
-      p.fill = { value: model.config().mark.color };
-    }
-  } else {
-    if (model.has(COLOR)) {
-      p.stroke = {
-        scale: model.scaleName(COLOR),
-        field: model.field(COLOR, fieldDef.type === ORDINAL ? {prefn: 'rank_'} : {})
-      };
-    } else if (fieldDef.value) {
-      p.stroke = { value: fieldDef.value };
-    } else {
-      p.stroke = { value: model.config().mark.color };
-    }
+
+  // Apply fill stroke config first so that color field / value can override
+  // fill / stroke
+  applyMarkConfig(p, model, FILL_STROKE_CONFIG);
+
+  let value;
+  if (model.has(COLOR)) {
+    value = {
+      scale: model.scaleName(COLOR),
+      field: model.field(COLOR, fieldDef.type === ORDINAL ? {prefn: 'rank_'} : {})
+    };
+  } else if (fieldDef.value) {
+    value = { value: fieldDef.value };
   }
 
-  // Apply fill and stroke config later
-  // `fill` and `stroke` config can override `color` config
-  applyMarkConfig(p, model, FILL_STROKE_CONFIG);
+  if (value !== undefined) {
+    if (filled) {
+      p.fill = value;
+    } else {
+      p.stroke = value;
+    }
+  } else {
+    // apply color config if there is no fill / stroke config
+    p[filled ? 'fill' : 'stroke'] = p[filled ? 'fill' : 'stroke'] ||
+      {value: model.config().mark.color};
+  }
 }
 
 export function applyMarkConfig(marksProperties, model: Model, propsList: string[]) {

--- a/test/compile/mark-point.test.ts
+++ b/test/compile/mark-point.test.ts
@@ -120,6 +120,34 @@ describe('Mark: Point', function() {
       assert.deepEqual(props.size, {value: 23});
     });
   });
+
+  describe('with configs', function() {
+    it('should apply stroke config over color config', function() {
+      const model = parseModel({
+        "mark": "point",
+        "encoding": {
+          "x": {"field": "Horsepower","type": "quantitative"},
+          "y": {"field": "Miles_per_Gallon","type": "quantitative"}
+        },
+        "config": {"mark": {"color":"red", "stroke": "blue"}}
+      });
+      const props = point.properties(model);
+      assert.deepEqual(props.stroke, {value: "blue"});
+    });
+
+    it('should apply color config', function() {
+      const model = parseModel({
+        "mark": "point",
+        "encoding": {
+          "x": {"field": "Horsepower","type": "quantitative"},
+          "y": {"field": "Miles_per_Gallon","type": "quantitative"}
+        },
+        "config": {"mark": {"color":"red"}}
+      });
+      const props = point.properties(model);
+      assert.deepEqual(props.stroke, {value: "red"});
+    });
+  });
 });
 
 describe('Mark: Square', function() {
@@ -142,8 +170,8 @@ describe('Mark: Square', function() {
   it('should be filled by default', function() {
     const model = parseModel({
       "mark": "square",
-      "config": {
-        "mark": {"color": "blue"}
+      "encoding": {
+        "color": {"value": "blue"}
       }
     });
     const props = square.properties(model);
@@ -154,9 +182,11 @@ describe('Mark: Square', function() {
   it('should support config.mark.filled:false', function() {
     const model = parseModel({
       "mark": "square",
+      "encoding": {
+        "color": {"value": "blue"}
+      },
       "config" : {
         "mark" : {
-          "color": "blue",
           "filled" : false
         }
       }
@@ -176,8 +206,8 @@ describe('Mark: Circle', function() {
 
   const model = parseModel({
     "mark": "circle",
-    "config": {
-      "mark": {"color": "blue"}
+    "encoding": {
+      "color": {"value": "blue"}
     }
   });
   const props = circle.properties(model);
@@ -193,9 +223,11 @@ describe('Mark: Circle', function() {
   it('should support config.mark.filled:false', function() {
     const model = parseModel({
       "mark": "circle",
+      "encoding": {
+        "color": {"value": "blue"}
+      },
       "config" : {
         "mark" : {
-          "color": "blue",
           "filled" : false
         }
       }


### PR DESCRIPTION
My further fix for your #1113.  Please merge this into #1113 and feel free to merge #1113 to master. 

-  Correct Color Field/Value/Config precedence -- fixes #1114
The precedence is now: color field > color value > fill/stroke config > color config

- eliminate the complicated COLOR_MODE

- Only exclude either fill or stroke config for legend + refactor