### PR TITLE
Default to 'json' type if data format is not set

### DIFF
--- a/src/compile/data.ts
+++ b/src/compile/data.ts
@@ -83,7 +83,7 @@ export namespace source {
       // Set data's format.parse if needed
     var parse = formatParse(model);
     if (parse) {
-      source.format = source.format || {};
+      source.format = source.format || {type: 'json'};
       source.format.parse = parse;
     }
 


### PR DESCRIPTION
Whenever setting vega data, ensure that the data.type is set to something (otherwise is introduces ambiguity into the resulting vega spec, since data's oneOf will match multiple schemas when 'type' is unset).