### PR TITLE
Quick-fixes to docs (sidebar)

### DIFF
--- a/_layouts/docs.html
+++ b/_layouts/docs.html
@@ -29,7 +29,7 @@ sidebar:
     url: legend
 - text: Config
   url: config
-- text:
+- break: true
 - text: Customizing Size
   url: size
 - text: Faceting

--- a/_layouts/page_submenu.html
+++ b/_layouts/page_submenu.html
@@ -25,6 +25,9 @@ layout: plain
   <aside class="page-sidebar">
     <ul class="sidebar-nav">
       {% for link in page.sidebar %}
+      {% if link.break %}
+      <br>
+      {% else %}
       <li class="sidebar-nav-item"><a {% if (url == link.url) %}class="active"{% endif %}
           href="{{site.baseurl}}{{page.base}}{% if link.url != 'index' %}{{link.url}}.html{% endif %}" title="{{link.title}}">{{link.text}}
       </a></li>
@@ -36,6 +39,7 @@ layout: plain
         </a></li>
         {% endfor %}
       </ul>
+      {% endif %}
       {% endif %}
       {% endfor %}
     </nav>

--- a/site/static/main.css
+++ b/site/static/main.css
@@ -218,9 +218,10 @@ nav a:hover {
 
 .sidebar-nav-item {
   display: block;
-  padding: 0.5em 0;
 }
 .sidebar-nav-item a {
+  display: block;
+  padding: 0.5em 0;
   color: #666;
 }
 .sidebar-nav-item a.active {


### PR DESCRIPTION
- Increased click area
- added `break` instead of empty sidebar item
