### PR TITLE
Name root group mark as "rootCell"

### DIFF
--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -48,7 +48,7 @@ export function compileRootGroup(model: Model) {
   const spec = model.spec();
 
   let rootGroup:any = extend({
-      name: spec.name ? spec.name + '-root' : 'root',
+      name: spec.name ? spec.name + '-rootCell' : 'rootCell',
       type: 'group',
     },
     spec.description ? {description: spec.description} : {},


### PR DESCRIPTION
`root` is a reserved name corresponding to the actual root item of the Vega scenegraph (i.e., the element you can style with the `scene` property). This is relevant when we need to reference the `rootGroup` Vega-Lite adds during event handling via `eventGroup`.