### PR TITLE
Remove orient property from vega spec

### DIFF
--- a/src/compile/mark/area.ts
+++ b/src/compile/mark/area.ts
@@ -13,10 +13,6 @@ export namespace area {
     let p: any = {};
 
     const orient = model.config().mark.orient;
-    if (orient !== undefined) {
-      p.orient = { value: orient };
-    }
-
     const stack = model.stack();
     const xFieldDef = model.encoding().x;
     // x


### PR DESCRIPTION
The "orient" mark property no longer exists in the Vega schema (https://github.com/vega/vega/issues/539), so do not generate it. This fixes the last failing example in https://github.com/vega/vega-lite/issues/1156.