### PR TITLE
Include command-line tools with package

### DIFF
--- a/bin/vl2vg
+++ b/bin/vl2vg
@@ -9,7 +9,7 @@ var helpText =
 
 // import required libraries
 var fs = require('fs'),
-    vl = require('../vega-lite.js');
+    vl = require('vega-lite');
 
 // arguments
 var args = require('yargs')

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
   ],
   "description": "Vega-lite provides a higher-level grammar for visual analysis, comparable to ggplot or Tableau, that generates complete Vega specifications.",
   "main": "src/vl.js",
+  "bin": {
+    "vl2png": "./bin/vl2png",
+    "vl2svg": "./bin/vl2svg",
+    "vl2vg": "./bin/vl2vg"
+  },
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
I was trying to use Vega-Lite locally after an `npm install -g vega-lite`; this should make that possible. See also #1125 and #34.

Perhaps these tools should be documented? Let me know if you'd like me to add something to the docs.