### PR TITLE
Make vl2svg and vl2png scripts actually work when installed

### DIFF
--- a/bin/vl2png
+++ b/bin/vl2png
@@ -5,4 +5,4 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # only passes the first argument to vl2vg
-$DIR/vl2vg $1 | $DIR/../node_modules/vega/bin/vg2png '/dev/stdin' ${@:2}
+$DIR/vl2vg $1 | vg2png '/dev/stdin' ${@:2}

--- a/bin/vl2svg
+++ b/bin/vl2svg
@@ -5,4 +5,4 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # only passes the first argument to vl2vg
-$DIR/vl2vg $1 | $DIR/../node_modules/vega/bin/vg2svg '/dev/stdin' ${@:2}
+$DIR/vl2vg $1 | vg2svg '/dev/stdin' ${@:2}

--- a/bin/vl2vg
+++ b/bin/vl2vg
@@ -9,7 +9,7 @@ var helpText =
 
 // import required libraries
 var fs = require('fs'),
-    vl = require('../vega-lite.js');
+    vl = require('vega-lite');
 
 // arguments
 var args = require('yargs')

--- a/scripts/generate-images.sh
+++ b/scripts/generate-images.sh
@@ -5,5 +5,9 @@ set -e
 
 mkdir -p examples/images
 
+# Put `vega-lite.js` on the Node search path so the `vl2svg` script can
+# require it without needing it to be installed globally.
+export NODE_PATH=.
+
 echo "Generating SVGs..."
 ls examples/specs/*.json | parallel --eta --halt 1 "bin/vl2svg {} examples/images/{/.}.svg"


### PR DESCRIPTION
A follow-up to #1188, where the goal is to get usable CLI tools after running `npm install -g vega-lite`.

This fixes two search-path issues that made `vl2svg` and `vl2png` work only when run from the Vega-Lite source directory. As suggested by @domoritz, I tried to avoid breaking any scripts that clearly *want* to run from inside the source directory, without a global install. Namely, `npm run build:images` still works.

Please let me know if I broke anything else!