### PR TITLE
Correct type for stacked bar horizontal order example

### DIFF
--- a/examples/specs/stacked_bar_h_order.json
+++ b/examples/specs/stacked_bar_h_order.json
@@ -5,6 +5,6 @@
     "x": {"aggregate": "sum", "field": "yield", "type": "quantitative"},
     "y": {"field": "variety", "type": "nominal"},
     "color": {"field": "site", "type": "nominal"},
-    "order": {"aggregate": "sum", "field": "yield", "type": "nominal"}
+    "order": {"aggregate": "sum", "field": "yield", "type": "quantitative"}
   }
 }


### PR DESCRIPTION
I was reading the docs and thought the `type` of `yield sum` should be `quantitative` instead of `nominal` in the `stacked bar horizontal order` example.