### PR TITLE
Create LineInterpolation with valid interpolation options

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -27,11 +27,7 @@ export const defaultCellConfig: CellConfig = {
   height: 200
 };
 
-export const defaultFacetCellConfig: CellConfig = {
-  stroke: '#ccc',
-  strokeWidth: 1
-};
-
+int
 export interface FacetConfig {
   scale?: FacetScaleConfig;
   axis?: AxisConfig;
@@ -95,6 +91,19 @@ export enum StackOffset {
     CENTER = 'center' as any,
     NORMALIZE = 'normalize' as any,
     NONE = 'none' as any,
+}
+
+export enum LineInterpolation {
+    LINEAR = 'linear' as any,
+    BUNDLE = 'bundle' as any,
+    MONOTONE = 'monotone' as any,
+    STEP_BEFORE = 'step-before' as any,
+    STEP_AFTER = 'step-after' as any,
+    BASIS = 'basis' as any,
+    BASIS_OPEN = 'basis-open' as any,
+    BASIS_CLOSED = 'basis-closed' as any,
+    CARDINAL = 'cardinal' as any,
+    CARDINAL_OPEN = 'cardinal-open' as any,
 }
 
 export interface MarkConfig {
@@ -179,7 +188,7 @@ export interface MarkConfig {
   /**
    * The line interpolation method to use. One of linear, step-before, step-after, basis, basis-open, cardinal, cardinal-open, monotone.
    */
-  interpolate?: string;
+  interpolate?: LineInterpolation;
   /**
    * Depending on the interpolation type, sets the tension parameter.
    */

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,7 +27,11 @@ export const defaultCellConfig: CellConfig = {
   height: 200
 };
 
-int
+export const defaultFacetCellConfig: CellConfig = {
+  stroke: '#ccc',
+  strokeWidth: 1
+};
+ 
 export interface FacetConfig {
   scale?: FacetScaleConfig;
   axis?: AxisConfig;

--- a/src/config.ts
+++ b/src/config.ts
@@ -94,16 +94,32 @@ export enum StackOffset {
 }
 
 export enum LineInterpolation {
+    /** piecewise linear segments, as in a polyline */
     LINEAR = 'linear' as any,
-    BUNDLE = 'bundle' as any,
-    MONOTONE = 'monotone' as any,
+    /** close the linear segments to form a polygon */
+    LINEAR_CLOSED = 'linear-closed' as any,
+    /** alternate between horizontal and vertical segments, as in a step function */
+    STEP = 'step' as any,
+    /** alternate between vertical and horizontal segments, as in a step function */
     STEP_BEFORE = 'step-before' as any,
+    /** alternate between horizontal and vertical segments, as in a step function */
     STEP_AFTER = 'step-after' as any,
+    /** a B-spline, with control point duplication on the ends */
     BASIS = 'basis' as any,
+    /** an open B-spline; may not intersect the start or end */
     BASIS_OPEN = 'basis-open' as any,
+    /** a closed B-spline, as in a loop */
     BASIS_CLOSED = 'basis-closed' as any,
+    /** a Cardinal spline, with control point duplication on the ends */
     CARDINAL = 'cardinal' as any,
+    /** an open Cardinal spline; may not intersect the start or end, but will intersect other control points */
     CARDINAL_OPEN = 'cardinal-open' as any,
+    /** a closed Cardinal spline, as in a loop */
+    CARDINAL_CLOSED = 'cardinal-closed' as any,
+    /** equivalent to basis, except the tension parameter is used to straighten the spline */
+    BUNDLE = 'bundle' as any,
+    /** cubic interpolation that preserves monotonicity in y */
+    MONOTONE = 'monotone' as any,
 }
 
 export interface MarkConfig {

--- a/src/config.ts
+++ b/src/config.ts
@@ -177,7 +177,7 @@ export interface MarkConfig {
 
   // ---------- Interpolation: Line / area ----------
   /**
-   * The line interpolation method to use. One of linear, step-before, step-after, basis, basis-open, basis-closed, bundle, cardinal, cardinal-open, cardinal-closed, monotone.
+   * The line interpolation method to use. One of linear, step-before, step-after, basis, basis-open, cardinal, cardinal-open, monotone.
    */
   interpolate?: string;
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,7 +31,7 @@ export const defaultFacetCellConfig: CellConfig = {
   stroke: '#ccc',
   strokeWidth: 1
 };
- 
+
 export interface FacetConfig {
   scale?: FacetScaleConfig;
   axis?: AxisConfig;


### PR DESCRIPTION
The interpolate values of "basis-closed", "bundle", and "cardinal-closed" are not valid in the vega spec (despite being valid D3 interpolations).

Should interpolate be an enum? I can implement that if you like.