### PR TITLE
Make strokeDashOffset a number

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -156,7 +156,7 @@ export interface MarkConfig {
   /**
    * The offset (in pixels) into which to begin drawing with the stroke dash array.
    */
-  strokeDashOffset?: number[];
+  strokeDashOffset?: number;
 
   // ---------- Stacking: Bar & Area ----------
   stacked?: StackOffset;


### PR DESCRIPTION
Vega's strokeDashOffset is a number (or signal), not an array of numbers.