### PR TITLE
refactor scale

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -39,6 +39,7 @@ export const CHANNELS = [X, Y, ROW, COLUMN, SIZE, SHAPE, COLOR, PATH, ORDER, TEX
 export const UNIT_CHANNELS = without(CHANNELS, [ROW, COLUMN]);
 export const UNIT_SCALE_CHANNELS = without(UNIT_CHANNELS, [PATH, ORDER, DETAIL, TEXT, LABEL]);
 export const NONSPATIAL_CHANNELS = without(UNIT_CHANNELS, [X, Y]);
+export const NONSPATIAL_SCALE_CHANNELS = without(UNIT_SCALE_CHANNELS, [X, Y]);
 
 export interface SupportedMark {
   point?: boolean;

--- a/src/compile/scale.ts
+++ b/src/compile/scale.ts
@@ -7,7 +7,7 @@ import {StackOffset} from '../config';
 import {SOURCE, STACKED_SCALE} from '../data';
 import {FieldDef, field, isMeasure} from '../fielddef';
 import {Mark, BAR, TEXT as TEXT_MARK} from '../mark';
-import {Scale, ScaleType} from '../scale';
+import {Scale, ScaleType, NiceTime} from '../scale';
 import {TimeUnit} from '../timeunit';
 import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../type';
 import {contains, extend, Dict} from '../util';
@@ -42,13 +42,13 @@ export function parseScaleComponent(model: Model): Dict<ScaleComponent[]> {
         // Add additional scales needed to support ordinal legends (list of values)
         // for color ramp.
         if (channel === COLOR && model.legend(COLOR) && (fieldDef.type === ORDINAL || fieldDef.bin || fieldDef.timeUnit)) {
-          scales.push(colorLegendScale(model, fieldDef));
+          scales.push(parseColorLegendScale(model, fieldDef));
           if (fieldDef.bin) {
-            scales.push(binColorLegendLabel(model, fieldDef));
+            scales.push(parseBinColorLegendLabel(model, fieldDef));
           }
         }
 
-        scales.push(mainScale(model, fieldDef, channel));
+        scales.push(parseMainScale(model, fieldDef, channel));
         scale[channel] = scales;
       }
       return scale;
@@ -58,7 +58,7 @@ export function parseScaleComponent(model: Model): Dict<ScaleComponent[]> {
 /**
  * Return the main scale for each channel.  (Only color can have multiple scales.)
  */
-function mainScale(model: Model, fieldDef: FieldDef, channel: Channel) {
+function parseMainScale(model: Model, fieldDef: FieldDef, channel: Channel) {
   const scale = model.scale(channel);
   const sort = model.sort(channel);
 
@@ -67,8 +67,8 @@ function mainScale(model: Model, fieldDef: FieldDef, channel: Channel) {
     type: scale.type,
   };
 
-  scaleDef.domain = domain(scale, model, channel, scaleDef.type);
-  extend(scaleDef, rangeMixins(scale, model, channel, scaleDef.type));
+  scaleDef.domain = domain(scale, model, channel);
+  extend(scaleDef, rangeMixins(scale, model, channel));
 
   if (sort && (typeof sort === 'string' ? sort : sort.order) === 'descending') {
     scaleDef.reverse = true;
@@ -85,7 +85,7 @@ function mainScale(model: Model, fieldDef: FieldDef, channel: Channel) {
     // ordinal
     'padding', 'points'
   ].forEach(function(property) {
-    const value = exports[property](scale[property], scaleDef.type, channel, fieldDef);
+    const value = exports[property](scale, channel, fieldDef, model);
     if (value !== undefined) {
       scaleDef[property] = value;
     }
@@ -100,7 +100,7 @@ function mainScale(model: Model, fieldDef: FieldDef, channel: Channel) {
  *  - For a field with bin or timeUnit, provide an identity ordinal scale
  *    (mapping the field values to themselves)
  */
-function colorLegendScale(model: Model, fieldDef: FieldDef) {
+function parseColorLegendScale(model: Model, fieldDef: FieldDef) {
   return {
     name: model.scaleName(COLOR_LEGEND),
     type: 'ordinal',
@@ -116,7 +116,7 @@ function colorLegendScale(model: Model, fieldDef: FieldDef) {
 /**
  *  Return an additional scale for bin labels because we need to map bin_start to bin_range in legends
  */
-function binColorLegendLabel(model: Model, fieldDef: FieldDef) {
+function parseBinColorLegendLabel(model: Model, fieldDef: FieldDef) {
   return {
     name: model.scaleName(COLOR_LEGEND_LABEL),
     type: 'ordinal',
@@ -188,7 +188,7 @@ export function scaleType(scale: Scale, fieldDef: FieldDef, channel: Channel, ma
   return null;
 }
 
-export function domain(scale: Scale, model: Model, channel:Channel, scaleType: ScaleType): any {
+export function domain(scale: Scale, model: Model, channel:Channel): any {
   const fieldDef = model.fieldDef(channel);
 
   if (scale.domain) { // explicit value
@@ -227,8 +227,8 @@ export function domain(scale: Scale, model: Model, channel:Channel, scaleType: S
     };
   }
 
-  const includeRawDomain = _includeRawDomain(scale, model, channel, scaleType),
-  sort = domainSort(model, channel, scaleType);
+  const includeRawDomain = _includeRawDomain(scale, model, channel),
+  sort = domainSort(model, channel, scale.type);
 
   if (includeRawDomain) { // includeRawDomain - only Q/T
     return {
@@ -236,7 +236,7 @@ export function domain(scale: Scale, model: Model, channel:Channel, scaleType: S
       field: model.field(channel, {noAggregate: true})
     };
   } else if (fieldDef.bin) { // bin
-    return scaleType === ScaleType.ORDINAL ? {
+    return scale.type === ScaleType.ORDINAL ? {
       // ordinal bin scale takes domain from bin_range, ordered by bin_start
       data: model.dataTable(),
       field: model.field(channel, { binSuffix: '_range' }),
@@ -302,7 +302,7 @@ export function domainSort(model: Model, channel: Channel, scaleType: ScaleType)
  * 2. Aggregation function is not `count` or `sum`
  * 3. The scale is quantitative or time scale.
  */
-function _includeRawDomain (scale: Scale, model: Model, channel: Channel, scaleType: ScaleType) {
+function _includeRawDomain (scale: Scale, model: Model, channel: Channel) {
   const fieldDef = model.fieldDef(channel);
 
   return scale.includeRawDomain && //  if includeRawDomain is enabled
@@ -317,18 +317,18 @@ function _includeRawDomain (scale: Scale, model: Model, channel: Channel, scaleT
       // domain values from the summary table.
       (fieldDef.type === QUANTITATIVE && !fieldDef.bin) ||
       // T uses non-ordinal scale when there's no unit or when the unit is not ordinal.
-      (fieldDef.type === TEMPORAL && contains([ScaleType.TIME, ScaleType.UTC], scaleType))
+      (fieldDef.type === TEMPORAL && contains([ScaleType.TIME, ScaleType.UTC], scale.type))
     );
 }
 
 
-export function rangeMixins(scale: Scale, model: Model, channel: Channel, scaleType: ScaleType): any {
+export function rangeMixins(scale: Scale, model: Model, channel: Channel): any {
   // TODO: need to add rule for quantile, quantize, threshold scale
 
   const fieldDef = model.fieldDef(channel),
   scaleConfig = model.config().scale;
 
-  if (scaleType === ScaleType.ORDINAL && scale.bandSize && contains([X, Y], channel)) {
+  if (scale.type === ScaleType.ORDINAL && scale.bandSize && contains([X, Y], channel)) {
     return {bandSize: scale.bandSize};
   }
 
@@ -398,31 +398,31 @@ export function rangeMixins(scale: Scale, model: Model, channel: Channel, scaleT
   return {};
 }
 
-export function clamp(prop: boolean, scaleType: ScaleType) {
+export function clamp(scale: Scale) {
   // Only works for scale with both continuous domain continuous range
   // (Doesn't work for quantize, quantile, threshold, ordinal)
   if (contains([ScaleType.LINEAR, ScaleType.POW, ScaleType.SQRT,
-        ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scaleType)) {
-    return prop;
+        ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.type)) {
+    return scale.clamp;
   }
   return undefined;
 }
 
-export function exponent(prop: number, scaleType: ScaleType) {
-  if (scaleType === ScaleType.POW) {
-    return prop;
+export function exponent(scale: Scale) {
+  if (scale.type === ScaleType.POW) {
+    return scale.exponent;
   }
   return undefined;
 }
 
-export function nice(prop: boolean|string, scaleType: ScaleType, channel: Channel, fieldDef: FieldDef) {
+export function nice(scale: Scale, channel: Channel, fieldDef: FieldDef): boolean | NiceTime {
   if (contains([ScaleType.LINEAR, ScaleType.POW, ScaleType.SQRT, ScaleType.LOG,
-        ScaleType.TIME, ScaleType.UTC, ScaleType.QUANTIZE], scaleType)) {
-    if (prop !== undefined) {
-      return prop;
+        ScaleType.TIME, ScaleType.UTC, ScaleType.QUANTIZE], scale.type)) {
+    if (scale.nice !== undefined) {
+      return scale.nice;
     }
-    if (contains([ScaleType.TIME, ScaleType.UTC], scaleType)) {
-      return smallestUnit(fieldDef.timeUnit);
+    if (contains([ScaleType.TIME, ScaleType.UTC], scale.type)) {
+      return smallestUnit(fieldDef.timeUnit) as any;
     }
     return contains([X, Y], channel); // return true for quantitative X/Y
   }
@@ -430,7 +430,7 @@ export function nice(prop: boolean|string, scaleType: ScaleType, channel: Channe
 }
 
 
-export function padding(prop: number, scaleType: ScaleType, channel: Channel) {
+export function padding(scale: Scale, channel: Channel) {
   /* Padding is only allowed for X and Y.
    *
    * Basically it doesn't make sense to add padding for color and size.
@@ -439,14 +439,14 @@ export function padding(prop: number, scaleType: ScaleType, channel: Channel) {
    * is a ratio ([0, 1]) and it causes the padding to be decimals.
    * Therefore, we manually calculate padding in the layout by ourselves.
    */
-  if (scaleType === ScaleType.ORDINAL && contains([X, Y], channel)) {
-    return prop;
+  if (scale.type === ScaleType.ORDINAL && contains([X, Y], channel)) {
+    return scale.padding;
   }
   return undefined;
 }
 
-export function points(__, scaleType: ScaleType, channel: Channel) {
-  if (scaleType === ScaleType.ORDINAL && contains([X, Y], channel)) {
+export function points(scale: Scale, channel: Channel, __, model: Model) {
+  if (scale.type === ScaleType.ORDINAL && contains([X, Y], channel)) {
     // We always use ordinal point scale for x and y.
     // Thus `points` isn't included in the scale's schema.
     return true;
@@ -454,19 +454,19 @@ export function points(__, scaleType: ScaleType, channel: Channel) {
   return undefined;
 }
 
-export function round(prop: boolean, scaleType: ScaleType, channel: Channel) {
-  if (contains([X, Y, ROW, COLUMN, SIZE], channel) && prop !== undefined) {
-    return prop;
+export function round(scale: Scale, channel: Channel) {
+  if (contains([X, Y, ROW, COLUMN, SIZE], channel) && scale.round !== undefined) {
+    return scale.round;
   }
 
   return undefined;
 }
 
-export function zero(prop: boolean, scaleType: ScaleType, channel: Channel, fieldDef: FieldDef) {
+export function zero(scale: Scale, channel: Channel, fieldDef: FieldDef) {
   // only applicable for non-ordinal scale
-  if (!contains([ScaleType.TIME, ScaleType.UTC, ScaleType.ORDINAL], scaleType)) {
-    if (prop !== undefined) {
-      return prop;
+  if (!contains([ScaleType.TIME, ScaleType.UTC, ScaleType.ORDINAL], scale.type)) {
+    if (scale.zero !== undefined) {
+      return scale.zero;
     }
     // By default, return true only for non-binned, quantitative x-scale or y-scale.
     return !fieldDef.bin && contains([X, Y], channel);

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -1,6 +1,6 @@
 import {AggregateOp} from '../aggregate';
 import {AxisProperties} from '../axis';
-import {COLUMN, ROW, X, Y, COLOR, SHAPE, SIZE, TEXT, PATH, ORDER, Channel, UNIT_CHANNELS, supportMark} from '../channel';
+import {COLUMN, ROW, X, Y, TEXT, PATH, ORDER, Channel, UNIT_CHANNELS,  UNIT_SCALE_CHANNELS, NONSPATIAL_SCALE_CHANNELS, supportMark} from '../channel';
 import {defaultConfig, Config, CellConfig} from '../config';
 import {SOURCE, SUMMARY} from '../data';
 import {Encoding} from '../encoding';
@@ -83,7 +83,7 @@ export class UnitModel extends Model {
   }
 
   private _initScale(mark: Mark, encoding: Encoding, config: Config): Dict<Scale> {
-    return [X, Y, COLOR, SHAPE, SIZE].reduce(function(_scale, channel) {
+    return UNIT_SCALE_CHANNELS.reduce(function(_scale, channel) {
       if (vlEncoding.has(encoding, channel)) {
         const scaleSpec = encoding[channel].scale || {};
         const channelDef = encoding[channel];
@@ -120,7 +120,7 @@ export class UnitModel extends Model {
   }
 
   private _initLegend(encoding: Encoding, config: Config): Dict<LegendProperties> {
-    return [COLOR, SHAPE, SIZE].reduce(function(_legend, channel) {
+    return NONSPATIAL_SCALE_CHANNELS.reduce(function(_legend, channel) {
       if (vlEncoding.has(encoding, channel)) {
         const legendSpec = encoding[channel].legend;
         if (legendSpec !== false) {

--- a/test/compile/scale.test.ts
+++ b/test/compile/scale.test.ts
@@ -75,7 +75,7 @@ describe('Scale', function() {
         }
       });
 
-      const domain = vlscale.domain(model.scale(Y), model, Y, ScaleType.LINEAR);
+      const domain = vlscale.domain(model.scale(Y), model, Y);
 
       assert.deepEqual(domain, {
         data: 'stacked_scale',
@@ -97,15 +97,14 @@ describe('Scale', function() {
               }
             }
           });
-          const domain = vlscale.domain(model.scale(Y), model, Y, ScaleType.ORDINAL);
+          const domain = vlscale.domain(model.scale(Y), model, Y);
 
           assert.deepEqual(domain, {
             data: SOURCE,
-            field: 'bin_origin_range',
-            sort: {
-              field: 'bin_origin_start',
-              op: 'min'
-            }
+            field: [
+              'bin_origin_start',
+              'bin_origin_end'
+            ]
           });
         });
 
@@ -122,7 +121,7 @@ describe('Scale', function() {
               }
             }
           });
-          const domain = vlscale.domain(model.scale(Y), model, Y, ScaleType.LINEAR);
+          const domain = vlscale.domain(model.scale(Y), model, Y);
 
           assert.deepEqual(domain.data, SOURCE);
         });
@@ -140,7 +139,7 @@ describe('Scale', function() {
               }
             }
           });
-          const domain = vlscale.domain(model.scale(Y), model, Y, ScaleType.LINEAR);
+          const domain = vlscale.domain(model.scale(Y), model, Y);
 
           assert.deepEqual(domain.data, SUMMARY);
         });
@@ -158,7 +157,7 @@ describe('Scale', function() {
               }
             }
           });
-          const domain = vlscale.domain(model.scale(Y), model, Y, ScaleType.LINEAR);
+          const domain = vlscale.domain(model.scale(Y), model, Y);
 
           assert.deepEqual(domain.data, SUMMARY);
         });
@@ -177,7 +176,7 @@ describe('Scale', function() {
               }
             }
           });
-          const domain = vlscale.domain(model.scale(Y), model, Y, ScaleType.TIME);
+          const domain = vlscale.domain(model.scale(Y), model, Y);
 
           assert.deepEqual(domain.data, SOURCE);
         });
@@ -195,7 +194,7 @@ describe('Scale', function() {
               }
             }
           });
-          const domain = vlscale.domain(model.scale(Y), model, Y, ScaleType.ORDINAL);
+          const domain = vlscale.domain(model.scale(Y), model, Y);
 
           assert.deepEqual(domain.data, SOURCE);
           assert.operator(domain.field.indexOf('year'), '>', -1);
@@ -214,7 +213,7 @@ describe('Scale', function() {
               }
             }
           });
-          const domain = vlscale.domain(model.scale(Y), model, Y, ScaleType.ORDINAL);
+          const domain = vlscale.domain(model.scale(Y), model, Y);
 
           assert.deepEqual(domain, { data: 'month', field: 'date' });
         });
@@ -232,7 +231,7 @@ describe('Scale', function() {
                 }
               }
             });
-            const domain = vlscale.domain(model.scale(Y), model, Y, ScaleType.ORDINAL);
+            const domain = vlscale.domain(model.scale(Y), model, Y);
 
             assert.deepEqual(domain, {
               data: 'source', field: 'yearmonth_origin',
@@ -251,7 +250,7 @@ describe('Scale', function() {
             }
           });
 
-        assert.deepEqual(vlscale.domain(model.scale(Y), model, Y, ScaleType.ORDINAL), {
+        assert.deepEqual(vlscale.domain(model.scale(Y), model, Y), {
             data: "source",
             field: 'origin',
             sort: sortDef
@@ -266,7 +265,7 @@ describe('Scale', function() {
             }
           });
 
-        assert.deepEqual(vlscale.domain(model.scale(Y), model, Y, ScaleType.ORDINAL), {
+        assert.deepEqual(vlscale.domain(model.scale(Y), model, Y), {
             data: "source",
             field: 'origin',
             sort: true


### PR DESCRIPTION
- refactor scale,  remove scaleType as a parameter since we already pass `scale` around.  
- fix incorrect test for bin scale 
- correct `parseMainScale`, `parse...`

(A step toward #1214 – but let's review this separately first)