### PR TITLE
Export config

### DIFF
--- a/src/vl.ts
+++ b/src/vl.ts
@@ -1,5 +1,6 @@
 import * as vlBin from './bin';
 import * as vlChannel from './channel';
+import * as vlConfig from './config';
 import * as vlData from './data';
 import * as vlEncoding from './encoding';
 import * as vlFieldDef from './fielddef';
@@ -14,6 +15,7 @@ import * as vlUtil from './util';
 export const bin = vlBin;
 export const channel = vlChannel;
 export const compile = vlCompile.compile;
+export const config = vlConfig;
 export const data = vlData;
 export const encoding = vlEncoding;
 export const fieldDef = vlFieldDef;


### PR DESCRIPTION
An external tool would like to be able to access default spec config via `vl.config.defaultConfig`