### PR TITLE
Add row/column to the encoding docs

### DIFF
--- a/site/docs/encoding.md
+++ b/site/docs/encoding.md
@@ -21,7 +21,7 @@ An integral part of the data visualization process is encoding data with visual 
     "size": ...,
     "shape": ...,
     "text": ...,
-    "detail": ...,
+    "detail": ...
   },
   ...
 }

--- a/site/docs/encoding.md
+++ b/site/docs/encoding.md
@@ -15,11 +15,13 @@ An integral part of the data visualization process is encoding data with visual 
   "encoding": {     // Encoding
     "x": ...,
     "y": ...,
+    "column": ...,
+    "row": ...,
     "color": ...,
     "size": ...,
     "shape": ...,
     "text": ...,
-    "detail": ...
+    "detail": ...,
   },
   ...
 }
@@ -41,7 +43,8 @@ Mark properties channels map data fields directly to visual properties of the ma
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
 | x, y          | [ChannelDef](#def)| X and Y coordinates for `point`, `circle`, `square`, `line`, `text`, and `tick`. (or to width and height for `bar` and `area` marks). |
-| color         | [ChannelDef](#def)| Color of the marks – either fill or stroke color based on mark type. (By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /   stroke color for `line` and `point`.) (See [scale range](scale.html#range) for more detail about color palettes.)  |
+| column, row  | [ChannelDef](#def)| `row` and `column` are special encoding channels for [faceting](#facet). |
+| color        | [ChannelDef](#def)| Color of the marks – either fill or stroke color based on mark type. (By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /   stroke color for `line` and `point`.) (See [scale range](scale.html#range) for more detail about color palettes.)  |
 | shape  | [ChannelDef](#def)| The symbol's shape (only for `point` marks).  The supported values are `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`. |
 | size  | [ChannelDef](#def)| Size of the mark.  <br/>     • For `point`, `square` and `circle` – the symbol size, or pixel area of the mark.  <br/> • For `bar` and `tick` – the bar and tick's size.  <br/>      • For `text` – the text's font size. <br/>      • Size is currently unsupported for `line` and `area`.|
 | text  | [ChannelDef](#def)| Text of the `text` mark. |

--- a/site/docs/encoding.md
+++ b/site/docs/encoding.md
@@ -13,10 +13,10 @@ An integral part of the data visualization process is encoding data with visual 
   "data": ... ,
   "mark": ... ,
   "encoding": {     // Encoding
-    "x": ...,
-    "y": ...,
     "column": ...,
     "row": ...,
+    "x": ...,
+    "y": ...,
     "color": ...,
     "size": ...,
     "shape": ...,
@@ -43,11 +43,12 @@ Mark properties channels map data fields directly to visual properties of the ma
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
 | x, y          | [ChannelDef](#def)| X and Y coordinates for `point`, `circle`, `square`, `line`, `text`, and `tick`. (or to width and height for `bar` and `area` marks). |
-| column, row  | [ChannelDef](#def)| `row` and `column` are special encoding channels for [faceting](#facet). |
-| color        | [ChannelDef](#def)| Color of the marks – either fill or stroke color based on mark type. (By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /   stroke color for `line` and `point`.) (See [scale range](scale.html#range) for more detail about color palettes.)  |
+| color         | [ChannelDef](#def)| Color of the marks – either fill or stroke color based on mark type. (By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /   stroke color for `line` and `point`.) (See [scale range](scale.html#range) for more detail about color palettes.)  |
 | shape  | [ChannelDef](#def)| The symbol's shape (only for `point` marks).  The supported values are `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`. |
 | size  | [ChannelDef](#def)| Size of the mark.  <br/>     • For `point`, `square` and `circle` – the symbol size, or pixel area of the mark.  <br/> • For `bar` and `tick` – the bar and tick's size.  <br/>      • For `text` – the text's font size. <br/>      • Size is currently unsupported for `line` and `area`.|
 | text  | [ChannelDef](#def)| Text of the `text` mark. |
+| column, row  | [ChannelDef](#def)| `row` and `column` are special encoding channels for [faceting](#facet). |
+
 
 ### Additional Level of Detail Channel
 


### PR DESCRIPTION
At least we should have a reference to not confuse people about why we did not put it there. This can be reverted once we have composition.