### PR TITLE
Flip x and y axes for the scatter_binned example

### DIFF
--- a/examples/specs/scatter_binned.json
+++ b/examples/specs/scatter_binned.json
@@ -4,12 +4,12 @@
   "encoding": {
     "x": {
       "bin": {"maxbins": 10},
-      "field": "IMDB_Rating",
+      "field": "Rotten_Tomatoes_Rating",
       "type": "quantitative"
     },
     "y": {
-      "bin": {"maxbins": 10},
-      "field": "Rotten_Tomatoes_Rating",
+      "bin": {"maxbins": 10},  
+      "field": "IMDB_Rating",
       "type": "quantitative"
     },
     "size": {


### PR DESCRIPTION
**What**: Put Rotten Tomatoes ratings on the x axis and IMDB ratings on the y axis.

**Why**: From Jeff's class yesterday, Rotten Tomatoes ratings are more uniform while IMDB ratings are more like normal distribution. Putting Rotten Tomatoes ratings on the x axis makes it easier to examine correlations.

Before:
![before](https://cloud.githubusercontent.com/assets/822034/14390457/f31f304e-fd6b-11e5-81cb-b3760c238008.png)

After:
![after](https://cloud.githubusercontent.com/assets/822034/14390466/fdbc7782-fd6b-11e5-91e2-f2f85d0fcce5.png)