### PR TITLE
Disable default strokeDash for legend

### DIFF
--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -30,7 +30,8 @@ export function buildModel(spec: Spec, parent: Model, parentGivenName: string): 
 }
 
 // TODO: figure if we really need opacity in both
-export const STROKE_CONFIG = ['stroke', 'strokeWidth', 'strokeOpacity', 'opacity'];
+export const STROKE_CONFIG = ['stroke', 'strokeWidth',
+  'strokeDash', 'strokeDashOffset', 'strokeOpacity', 'opacity'];
 
 export const FILL_CONFIG = ['fill', 'fillOpacity',
   'opacity'];

--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -30,8 +30,7 @@ export function buildModel(spec: Spec, parent: Model, parentGivenName: string): 
 }
 
 // TODO: figure if we really need opacity in both
-export const STROKE_CONFIG = ['stroke', 'strokeWidth',
-  'strokeDash', 'strokeDashOffset', 'strokeOpacity', 'opacity'];
+export const STROKE_CONFIG = ['stroke', 'strokeWidth', 'strokeOpacity', 'opacity'];
 
 export const FILL_CONFIG = ['fill', 'fillOpacity',
   'opacity'];

--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -142,15 +142,15 @@ export namespace properties {
     }
 
     const filled = model.config().mark.filled;
-    
-    
+
+
     let config = channel === COLOR ?
         /* For color's legend, do not set fill (when filled) or stroke (when unfilled) property from config because the the legend's `fill` or `stroke` scale should have precedence */
         without(FILL_STROKE_CONFIG, [ filled ? 'fill' : 'stroke', 'strokeDash', 'strokeDashOffset']) :
         /* For other legend, no need to omit. */
          without(FILL_STROKE_CONFIG, ['strokeDash', 'strokeDashOffset']);
-         
-    config = without(config, ['strokeDash', 'strokeDashOffset'])
+
+    config = without(config, ['strokeDash', 'strokeDashOffset']);
 
     applyMarkConfig(symbols, model, config);
 

--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -146,9 +146,9 @@ export namespace properties {
     applyMarkConfig(symbols, model,
       channel === COLOR ?
         /* For color's legend, do not set fill (when filled) or stroke (when unfilled) property from config because the the legend's `fill` or `stroke` scale should have precedence */
-        without(FILL_STROKE_CONFIG, [ filled ? 'fill' : 'stroke']) :
+        without(FILL_STROKE_CONFIG, [ filled ? 'fill' : 'stroke', 'strokeDash', 'strokeDashOffset']) :
         /* For other legend, no need to omit. */
-        FILL_STROKE_CONFIG
+         without(FILL_STROKE_CONFIG, ['strokeDash', 'strokeDashOffset'])
     );
 
     if (filled) {

--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -142,14 +142,17 @@ export namespace properties {
     }
 
     const filled = model.config().mark.filled;
-
-    applyMarkConfig(symbols, model,
-      channel === COLOR ?
+    
+    
+    let config = channel === COLOR ?
         /* For color's legend, do not set fill (when filled) or stroke (when unfilled) property from config because the the legend's `fill` or `stroke` scale should have precedence */
         without(FILL_STROKE_CONFIG, [ filled ? 'fill' : 'stroke', 'strokeDash', 'strokeDashOffset']) :
         /* For other legend, no need to omit. */
-         without(FILL_STROKE_CONFIG, ['strokeDash', 'strokeDashOffset'])
-    );
+         without(FILL_STROKE_CONFIG, ['strokeDash', 'strokeDashOffset']);
+         
+    config = without(config, ['strokeDash', 'strokeDashOffset'])
+
+    applyMarkConfig(symbols, model, config);
 
     if (filled) {
       symbols.strokeWidth = { value: 0 };

--- a/test/compile/legend.test.ts
+++ b/test/compile/legend.test.ts
@@ -82,7 +82,7 @@ describe('Legend', function() {
         assert.deepEqual(symbol.strokeWidth.value, 2);
     });
 
-    it('should not have strokeDash and strokeDashOffset for any mark', function() {
+    it('should not have strokeDash and strokeDashOffset', function() {
       const symbol = legend.properties.symbols({field: 'a'}, {}, parseUnitModel({
           mark: "point",
           encoding: {

--- a/test/compile/legend.test.ts
+++ b/test/compile/legend.test.ts
@@ -82,6 +82,18 @@ describe('Legend', function() {
         assert.deepEqual(symbol.strokeWidth.value, 2);
     });
 
+    it('should not have strokeDash and strokeDashOffset for any mark', function() {
+      const symbol = legend.properties.symbols({field: 'a'}, {}, parseUnitModel({
+          mark: "point",
+          encoding: {
+            x: {field: "a", type: "nominal"},
+            color: {field: "a", type: "nominal"}
+          }
+        }), COLOR);
+        assert.isUndefined(symbol.strokeDash);
+        assert.isUndefined(symbol.strokeDashOffset);
+    });
+
     it('should return specific color value', function() {
       const symbol = legend.properties.symbols({field: 'a'}, {}, parseUnitModel({
           mark: "point",


### PR DESCRIPTION
Fix #1314 
Now legend won't take `strokeDash` and `strokeDashOffset` from config for all marks.

the following spec create the correct legend symbol now.
```
{
  "data": {"url": "data/stocks.csv", "formatType":"csv"},
  "mark": "line",
  "encoding": {
    "x": {"field": "date", "type": "temporal"},
    "y": {"field": "price", "type": "quantitative"},
    "color": {"field": "symbol", "type": "nominal"}
  },
  "config": {
    "mark": {
      "strokeWidth": 1,
      "strokeDash": [ 24, 20 ] ,
      "strokeDashOffset": 24
    }
  }
}
```
![vega](https://cloud.githubusercontent.com/assets/11696585/15169971/fdba99b4-16f5-11e6-8ede-7dc39da554eb.png)
