### PR TITLE
fix bug tick orient inverted

### DIFF
--- a/src/compile/config.ts
+++ b/src/compile/config.ts
@@ -34,9 +34,17 @@ export function initMarkConfig(mark: Mark, encoding: Encoding, config: Config) {
 
            // When unambiguous, do not allow overriding
            if (xIsMeasure && !yIsMeasure) {
-             cfg[property] = 'vertical'; // implicitly vertical
+             if (mark === TICK) {
+               cfg[property] = 'vertical'; // implicitly vertical
+             } else {
+               cfg[property] = 'horizontal'; // implicitly horizontal
+             }
            } else if (!xIsMeasure && yIsMeasure) {
-             cfg[property] = undefined; // implicitly vertical
+             if (mark === TICK) {
+               cfg[property] = 'horizontal';
+             } else {
+               cfg[property] = 'vertical';
+             }
            }
 
            // In ambiguous cases (QxQ or OxO) use specified value

--- a/src/compile/config.ts
+++ b/src/compile/config.ts
@@ -34,7 +34,7 @@ export function initMarkConfig(mark: Mark, encoding: Encoding, config: Config) {
 
            // When unambiguous, do not allow overriding
            if (xIsMeasure && !yIsMeasure) {
-             cfg[property] = 'horizontal'; // implicitly vertical
+             cfg[property] = 'vertical'; // implicitly vertical
            } else if (!xIsMeasure && yIsMeasure) {
              cfg[property] = undefined; // implicitly vertical
            }

--- a/test/compile/mark/bar.test.ts
+++ b/test/compile/mark/bar.test.ts
@@ -35,7 +35,7 @@ describe('Mark: Bar', function() {
     });
   });
 
-  describe('vertical, with log', function() {
+  describe('horizontal, with log', function() {
     const model = parseUnitModel({
       "mark": "bar",
       "encoding": {
@@ -47,12 +47,12 @@ describe('Mark: Bar', function() {
 
     const props = bar.properties(model);
 
-    it('should have y offset', function() {
-      assert.deepEqual(props.y2.offset, 1);
+    it('should end on axis', function() {
+      assert.deepEqual(props.x2, {scale: 'x', value: 0});
     });
 
-    it('should have no height', function(){
-      assert.isUndefined(props.height);
+    it('should have no width', function(){
+      assert.isUndefined(props.width);
     });
   });
 
@@ -85,8 +85,12 @@ describe('Mark: Bar', function() {
       });
     const props = bar.properties(model);
 
-    it('should have y-offset', function() {
-      assert.deepEqual(props.y2.offset, -1);
+    it('should end on axis', function() {
+      assert.deepEqual(props.x2, {scale: 'x', value: 0});
+    });
+
+    it('should have no width', function(){
+      assert.isUndefined(props.width);
     });
 
     it('should have y-offset', function(){

--- a/test/compile/mark/bar.test.ts
+++ b/test/compile/mark/bar.test.ts
@@ -42,7 +42,12 @@ describe('Mark: Bar', function() {
         "y": {"bin": true, "type": "quantitative", "field": "IMDB_Rating"},
         "x": {"scale": {"type": 'log'}, "type": "quantitative", "field": 'US_Gross', "aggregate": "mean"}
       },
-      "data": {"url": 'data/movies.json'}
+      "data": {"url": 'data/movies.json'},
+      "config": {
+        "mark": {
+          "orient": "horizontal"
+        }
+      }
     });
 
     const props = bar.properties(model);
@@ -81,7 +86,12 @@ describe('Mark: Bar', function() {
     const model = parseUnitModel({
         "mark": "bar",
         "encoding": {"x": {"type": "quantitative", "field": 'US_Gross', "aggregate": 'sum'}},
-        "data": {"url": 'data/movies.json'}
+        "data": {"url": 'data/movies.json'},
+        "config": {
+          "mark": {
+            "orient": "horizontal"
+          }
+        }
       });
     const props = bar.properties(model);
 

--- a/test/compile/mark/bar.test.ts
+++ b/test/compile/mark/bar.test.ts
@@ -35,29 +35,24 @@ describe('Mark: Bar', function() {
     });
   });
 
-  describe('horizontal, with log', function() {
+  describe('vertical, with log', function() {
     const model = parseUnitModel({
       "mark": "bar",
       "encoding": {
         "y": {"bin": true, "type": "quantitative", "field": "IMDB_Rating"},
         "x": {"scale": {"type": 'log'}, "type": "quantitative", "field": 'US_Gross', "aggregate": "mean"}
       },
-      "data": {"url": 'data/movies.json'},
-      "config": {
-        "mark": {
-          "orient": "horizontal"
-        }
-      }
+      "data": {"url": 'data/movies.json'}
     });
 
     const props = bar.properties(model);
 
-    it('should end on axis', function() {
-      assert.deepEqual(props.x2, {scale: 'x', value: 0});
+    it('should have y offset', function() {
+      assert.deepEqual(props.y2.offset, 1);
     });
 
-    it('should have no width', function(){
-      assert.isUndefined(props.width);
+    it('should have no height', function(){
+      assert.isUndefined(props.height);
     });
   });
 
@@ -86,21 +81,12 @@ describe('Mark: Bar', function() {
     const model = parseUnitModel({
         "mark": "bar",
         "encoding": {"x": {"type": "quantitative", "field": 'US_Gross', "aggregate": 'sum'}},
-        "data": {"url": 'data/movies.json'},
-        "config": {
-          "mark": {
-            "orient": "horizontal"
-          }
-        }
+        "data": {"url": 'data/movies.json'}
       });
     const props = bar.properties(model);
 
-    it('should end on axis', function() {
-      assert.deepEqual(props.x2, {scale: 'x', value: 0});
-    });
-
-    it('should have no width', function(){
-      assert.isUndefined(props.width);
+    it('should have y-offset', function() {
+      assert.deepEqual(props.y2.offset, -1);
     });
 
     it('should have y-offset', function(){

--- a/test/compile/mark/tick.test.ts
+++ b/test/compile/mark/tick.test.ts
@@ -29,6 +29,10 @@ describe('Mark: Tick', function() {
     it('should scale on x', function() {
       assert.deepEqual(props.xc, {scale: X, field: 'Horsepower'});
     });
+
+    it('width should tick thickness with orient vertical', function() {
+      assert.deepEqual(props.width, { value: 1});
+    });
   });
 
   describe('with quantitative y', function() {
@@ -45,6 +49,10 @@ describe('Mark: Tick', function() {
 
     it('should scale on y', function() {
       assert.deepEqual(props.yc, {scale: Y, field: 'Cylinders'});
+    });
+
+    it('height should tick thickness with orient horizontal', function() {
+      assert.deepEqual(props.height, { value: 1});
     });
   });
 
@@ -66,6 +74,14 @@ describe('Mark: Tick', function() {
 
     it('should scale on y', function() {
       assert.deepEqual(props.yc, {scale: Y, field: 'Cylinders'});
+    });
+
+    it('wiidth should be tick thickness with default orient vertical', function() {
+      assert.deepEqual(props.width, { value: 1});
+    });
+
+    it('height should be matched to field with default orient vertical', function() {
+      assert.deepEqual(props.height, { value: 14});
     });
   });
 


### PR DESCRIPTION
Fix #1347 
Bug is the default orient should be vertical, instead of horizontal.
Now this spec will give the following output correctly.
```
{
  "description": "Shows the relationship between horsepower and the numbver of cylinders using tick marks.",
  "data": {"url": "data/cars.json"},
  "mark": "tick",
  "encoding": {
    "x": {"field": "Horsepower", "type": "quantitative"},
    "y": {"field": "Cylinders", "type": "ordinal"}
  }
}
```


![vega](https://cloud.githubusercontent.com/assets/11696585/15161376/d4b362b4-16b2-11e6-916f-9e9a67352165.png)

