### PR TITLE
Fix mistaching in documentation for facet grid

### DIFF
--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -306,9 +306,9 @@ Facet cell configuration overrides [cell config](#cell-config) for faceted (trel
 
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
-| gridColor     | Color         | Color of the grid between facets. |
-| gridOpacity   | Number        | Opacity of the grid between facets. |
-| gridOffset    | Number        | Offset for grid between facets. |
+| color         | Color         | Color of the grid between facets. |
+| opacity       | Number        | Opacity of the grid between facets. |
+| offset        | Number        | Offset for grid between facets. |
 
 
 {:#facet-scale-config}


### PR DESCRIPTION
Fix the first part of #1237 
The problem of cannot change the color of the facet grid is because there's a mismatching in documentation, where `gridColor` should be `color`, where `gridOpacity` should be `opacity` and `gridOffset` should be `offset`. 

Now the following spec gives the correct output.

```
{
  "data": {"url": "data/cars.json"},
  "mark": "text",
  "encoding": {
    "row": {"field": "Origin","type": "ordinal"},
    "column": {"field": "Cylinders","type": "ordinal"},
    "color": {
      "aggregate": "mean",
      "field": "Horsepower",
      "type": "quantitative"
    },
    "text": {
      "aggregate": "count",
      "field": "*",
      "type": "quantitative"
    }
  },
  "config": {
    "grid": true,
    "mark": {"applyColorToBackground": true},
    "facet": {
      "cell": {"stroke": "blue","strokeWidth": 4},
      "grid": {"color": "red","opacity": 0.5,"offset": 10}
    }
  }
}
```

![vega 2](https://cloud.githubusercontent.com/assets/11696585/15265203/aad2c84e-1933-11e6-8c36-046768f0e7e5.png)