### PR TITLE
Add gapminder health vs income example to galleries

### DIFF
--- a/examples/specs/bubble_health_income.json
+++ b/examples/specs/bubble_health_income.json
@@ -1,0 +1,23 @@
+{
+  "description": "A bubble plot showing the correlation between health and income for 187 countries in the world.",
+  "data": {
+    "url": "data/gapminder-health-income.csv",
+    "formatType": "csv"
+  },
+  "mark": "circle",
+  "encoding": {
+    "y": {
+      "field": "health",
+      "type": "quantitative",
+      "scale": {"zero": false}
+    },
+    "x": {
+      "field": "income",
+      "type": "quantitative",
+      "scale": {"type": "log"}
+    },
+    "size": {"field": "population","type": "quantitative"},
+    "color": {"value": "#000"}
+  },
+  "config": {"cell": {"width": 500,"height": 300}}
+}

--- a/examples/vl-examples.json
+++ b/examples/vl-examples.json
@@ -59,6 +59,14 @@
       }
     },
     {
+      "name": "bubble_health_income",
+      "title": "Gapminder Bubble Plot",
+      "galleryParameters": {
+        "backgroundSize": "230%",
+        "backgroundPosition": "40% 20%"
+      }
+    },
+    {
       "name": "tick_strip",
       "title": "Strip Plot",
       "galleryParameters": {


### PR DESCRIPTION
Add gapminder health vs income example to vega-lite test gallery and site gallery.

test gallery look:
![screen shot 2016-05-17 at 7 49 06 pm](https://cloud.githubusercontent.com/assets/822034/15345985/7b81b3ec-1c68-11e6-85c5-d6e83a49c1ef.png)

site gallery look:
![vega-lite_example_gallery](https://cloud.githubusercontent.com/assets/822034/15345992/81ca1a82-1c68-11e6-87cc-1a53c0446472.png)
