### PR TITLE
Facet generates customized grid

### DIFF
--- a/src/compile/axis.ts
+++ b/src/compile/axis.ts
@@ -32,7 +32,7 @@ export function parseInnerAxis(channel: Channel, model: Model): VgAxis {
   // TODO: support adding ticks as well
 
   // TODO: replace any with Vega Axis Interface
-  let def = {
+  let def:any = {
     type: type,
     scale: model.scaleName(channel),
     grid: true,
@@ -58,6 +58,19 @@ export function parseInnerAxis(channel: Channel, model: Model): VgAxis {
                   axis[property];
     if (value !== undefined) {
       def[property] = value;
+    }
+  });
+
+  const props = model.axis(channel).properties || {};
+
+  // it might have more to be included here.
+  ['grid'].forEach(function(group) {
+    const value = properties[group] ?
+      properties[group](model, channel, props[group] || {}, def) :
+      props[group];
+    if (value !== undefined && keys(value).length > 0) {
+      def.properties = def.properties || {};
+      def.properties[group] = value;
     }
   });
 

--- a/src/compile/axis.ts
+++ b/src/compile/axis.ts
@@ -32,7 +32,7 @@ export function parseInnerAxis(channel: Channel, model: Model): VgAxis {
   // TODO: support adding ticks as well
 
   // TODO: replace any with Vega Axis Interface
-  let def:any = {
+  let def: any = {
     type: type,
     scale: model.scaleName(channel),
     grid: true,
@@ -63,7 +63,8 @@ export function parseInnerAxis(channel: Channel, model: Model): VgAxis {
 
   const props = model.axis(channel).properties || {};
 
-  // it might have more to be included here.
+  // For now, only need to add grid properties here because innerAxis is only for rendering grid.
+  // TODO: support add other properties for innerAxis
   ['grid'].forEach(function(group) {
     const value = properties[group] ?
       properties[group](model, channel, props[group] || {}, def) :

--- a/test/compile/axis.test.ts
+++ b/test/compile/axis.test.ts
@@ -29,6 +29,26 @@ describe('Axis', function() {
     });
   });
 
+  describe('parseInnerAxis', function() {
+    it('should produce a Vega inner axis object with correct type, scale and grid properties', function() {
+      const model = parseUnitModel({
+        mark: "point",
+        encoding: {
+          x:
+          {field: "a",
+           type: "quantitative",
+           axis: {grid: true, gridColor: "blue", gridWidth: 20}
+          }
+        }
+      });
+      const def = axis.parseInnerAxis(X, model);
+      assert.isObject(def);
+      assert.equal(def.type, 'x');
+      assert.equal(def.scale, 'x');
+      assert.deepEqual(def.properties.grid, {stroke: {value: "blue"}, strokeWidth: {value: 20}});
+    });
+  });
+
   describe('parseAxis', function() {
     it('should produce a Vega axis object with correct type and scale', function() {
       const model = parseUnitModel({


### PR DESCRIPTION
Fix the second part of #1237.
Now the spec below generate the right output.
```
{
  "data": {
    "values": [
      {"a": "A","b": 28,"c": "x"}, {"a": "B","b": 55,"c": "x"}, {"a": "C","b": 43,"c": "x"},
      {"a": "A","b": 28,"c": "y"}, {"a": "B","b": 55,"c": "y"}, {"a": "C","b": 43,"c": "y"}
    ]
  },
  "mark": "square",
  "encoding": {
    "column": {
      "field": "c", 
      "type": "ordinal"
    },
    "x": {
      "field": "a", 
      "type": "ordinal",
      "axis": {
        "grid": true,
        "layer": "front",
        "properties": {
          "labels": {
            "fill": { "value": "red" }
          },
          "grid": {
            "stroke": { "value": "red" },
            "strokeWidth": { "value": 5 }
          }
        }
      }
    },
    "y": {
      "field": "b", 
      "type": "quantitative",
      "axis": {
        "grid": true,
        "layer": "front",
        "properties": {
          "labels": {
            "fill": { "value": "green" }
          },
          "grid": {
            "stroke": { "value": "green" },
            "strokeWidth": { "value": 5 }
          }
        }
      }
    }
  }
}
```
![vega 3](https://cloud.githubusercontent.com/assets/11696585/15367766/505a3cbc-1cdf-11e6-87ed-2e072393a10d.png)
