### PR TITLE
[WIP] Will/labels

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -16,7 +16,8 @@ export enum Channel {
   COLOR = 'color' as any,
   TEXT = 'text' as any,
   DETAIL = 'detail' as any,
-  LABEL = 'label' as any,
+  ANCHOR = 'anchor' as any,
+  OFFSET = 'offset' as any,
   PATH = 'path' as any,
   ORDER = 'order' as any
 }
@@ -30,14 +31,15 @@ export const SIZE = Channel.SIZE;
 export const COLOR = Channel.COLOR;
 export const TEXT = Channel.TEXT;
 export const DETAIL = Channel.DETAIL;
-export const LABEL = Channel.LABEL;
+export const ANCHOR = Channel.ANCHOR;
+export const OFFSET = Channel.OFFSET;
 export const PATH = Channel.PATH;
 export const ORDER = Channel.ORDER;
 
-export const CHANNELS = [X, Y, ROW, COLUMN, SIZE, SHAPE, COLOR, PATH, ORDER, TEXT, DETAIL, LABEL];
+export const CHANNELS = [X, Y, ROW, COLUMN, SIZE, SHAPE, COLOR, PATH, ORDER, TEXT, DETAIL, ANCHOR, OFFSET];
 
 export const UNIT_CHANNELS = without(CHANNELS, [ROW, COLUMN]);
-export const UNIT_SCALE_CHANNELS = without(UNIT_CHANNELS, [PATH, ORDER, DETAIL, TEXT, LABEL]);
+export const UNIT_SCALE_CHANNELS = without(UNIT_CHANNELS, [PATH, ORDER, DETAIL, TEXT, ANCHOR, OFFSET]);
 export const NONSPATIAL_CHANNELS = without(UNIT_CHANNELS, [X, Y]);
 export const NONSPATIAL_SCALE_CHANNELS = without(UNIT_SCALE_CHANNELS, [X, Y]);
 
@@ -89,6 +91,8 @@ export function getSupportedMark(channel: Channel): SupportedMark {
     case SHAPE:
       return {point: true};
     case TEXT:
+    case ANCHOR:
+    case OFFSET:
       return {text: true};
     case PATH:
       return {line: true};
@@ -111,7 +115,8 @@ export function getSupportedRole(channel: Channel): SupportedRole {
     case X:
     case Y:
     case COLOR:
-    case LABEL:
+    case ANCHOR:
+    case OFFSET:
       return {
         measure: true,
         dimension: true
@@ -140,5 +145,5 @@ export function getSupportedRole(channel: Channel): SupportedRole {
 }
 
 export function hasScale(channel: Channel) {
-  return !contains([DETAIL, PATH, TEXT, LABEL, ORDER], channel);
+  return !contains([DETAIL, PATH, TEXT, ANCHOR, OFFSET, ORDER], channel);
 }

--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -1,4 +1,4 @@
-import {COLUMN, ROW, X, Y, SIZE, COLOR, SHAPE, TEXT, LABEL, Channel} from '../channel';
+import {COLUMN, ROW, X, Y, SIZE, COLOR, SHAPE, TEXT, ANCHOR, OFFSET, Channel} from '../channel';
 import {FieldDef, field, OrderChannelDef} from '../fielddef';
 import {SortOrder} from '../sort';
 import {QUANTITATIVE, ORDINAL, TEMPORAL} from '../type';
@@ -24,7 +24,8 @@ export function buildModel(spec: Spec, parent: Model, parentGivenName: string): 
   if (isUnitSpec(spec)) {
     return new UnitModel(spec, parent, parentGivenName);
   }
-
+  
+  console.log(spec);
   console.error('Invalid spec.');
   return null;
 }
@@ -147,8 +148,7 @@ function isAbbreviated(model: Model, channel: Channel, fieldDef: FieldDef) {
       return model.legend(channel).shortTimeLabels;
     case TEXT:
       return model.config().mark.shortTimeLabels;
-    case LABEL:
-      // TODO(#897): implement when we have label
+
   }
   return false;
 }

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -111,7 +111,7 @@ export class FacetModel extends Model {
   public has(channel: Channel): boolean {
     return !!this._facet[channel];
   }
-
+  
   public child() {
     return this._child;
   }

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -149,8 +149,8 @@ export class LayerModel extends Model {
   }
 
   public parseMark() {
-    this._children.forEach(function(child) {
-      child.parseMark();
+    this._children.forEach(function(child, _, siblings) {
+      child.parseMark(siblings);
     });
   }
 

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -85,7 +85,7 @@ export class LayerModel extends Model {
       child.parseScale();
 
       // FIXME: correctly implement independent scale
-      if (true) { // if shared/union scale
+      if (true && !child.isReferential()) { // if shared/union scale
         keys(child.component.scale).forEach(function(channel) {
           let childScales: ScaleComponents = child.component.scale[channel];
           if (!childScales) {

--- a/src/compile/layout.ts
+++ b/src/compile/layout.ts
@@ -8,7 +8,7 @@ import {VgData} from '../vega.schema';
 
 import {FacetModel} from './facet';
 import {LayerModel} from './layer';
-import {TEXT as TEXT_MARK} from '../mark';
+import {TEXT as TEXTMARK} from '../mark';
 import {Model} from './model';
 import {rawDomain} from './time';
 import {UnitModel} from './unit';
@@ -96,7 +96,7 @@ function unitSizeExpr(model: UnitModel, channel: Channel, nonOrdinalSize: number
       return nonOrdinalSize + '';
     }
   } else {
-    if (model.mark() === TEXT_MARK && channel === X) {
+    if (model.mark() === TEXTMARK && channel === X) {
       // for text table without x/y scale we need wider bandSize
       return model.config().scale.textBandWidth + '';
     }

--- a/src/compile/mark/area.ts
+++ b/src/compile/mark/area.ts
@@ -87,7 +87,7 @@ export namespace area {
     return p;
   }
 
-  export function labels(model: UnitModel) {
+  export function ref(model: UnitModel) {
     // TODO(#240): fill this method
     return undefined;
   }

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -188,7 +188,7 @@ export namespace bar {
         markConfig.barThinSize;
   }
 
-  export function labels(model: UnitModel) {
+  export function ref(model: UnitModel) {
     // TODO(#64): fill this method
     return undefined;
   }

--- a/src/compile/mark/label.ts
+++ b/src/compile/mark/label.ts
@@ -1,12 +1,12 @@
 import {UnitModel} from '../unit';
-import {X, Y, COLOR, TEXT, SIZE} from '../../channel';
+import {X, Y, COLOR, TEXT, SIZE, ANCHOR, OFFSET} from '../../channel';
 import {applyMarkConfig, applyColorAndOpacity, formatMixins} from '../common';
 import {extend, contains} from '../../util';
 import {QUANTITATIVE, ORDINAL, TEMPORAL} from '../../type';
 
-export namespace text {
+export namespace label {
   export function markType() {
-    return 'text';
+    return 'label';
   }
 
   export function background(model: UnitModel) {
@@ -32,34 +32,6 @@ export namespace text {
         
     const fieldDef = model.fieldDef(TEXT);
 
-    // x
-    if (model.has(X)) {
-      p.x = {
-        field: model.field(X, { binSuffix: '_mid' })
-      }
-      if (!referencedModel) {
-        p.x.scale = model.scaleName(X);
-      }
-    } else { // TODO: support x.value, x.datum
-      if (model.has(TEXT) && model.fieldDef(TEXT).type === QUANTITATIVE) {
-        p.x = { field: { group: 'width' }, offset: -5 };
-      } else {
-        p.x = { value: model.config().scale.textBandWidth / 2 };
-      }
-    }
-
-    // y
-    if (model.has(Y)) {
-      p.y = {
-        field: model.field(Y, { binSuffix: '_mid' })
-      };
-      if (!referencedModel) {
-        p.y.scale = model.scaleName(Y);
-      }
-    } else {
-      p.y = { value: model.config().scale.bandSize / 2 };
-    }
-
     // size
     if (model.has(SIZE)) {
       p.fontSize = {
@@ -81,7 +53,6 @@ export namespace text {
     } else {
       applyColorAndOpacity(p, model);
     }
-
 
     // text
     if (model.has(TEXT)) {

--- a/src/compile/mark/line.ts
+++ b/src/compile/mark/line.ts
@@ -51,7 +51,7 @@ export namespace line {
     return model.config().mark.lineSize;
   }
 
-  export function labels(model: UnitModel) {
+  export function ref(model: UnitModel) {
     // TODO(#240): fill this method
     return undefined;
   }

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -100,11 +100,30 @@ function parseNonPathMark(model: UnitModel, siblings: UnitModel[]) {
   
   const referential = model.isReferential() && siblings !== undefined;
   let referencedModel:UnitModel;
+  
   if (referential) {
     referencedModel = siblings.filter((s) => {
       return s.name('marks') == model.ref('marks');
     })[0];
     dataFrom = {mark: referencedModel.name('marks')};
+  }
+  
+  if (!!referencedModel) {
+      const markType = referencedModel.mark();
+  
+      // anchor
+      if (model.has(ANCHOR)) {
+        // based on mark type, place with x and y (reactive)
+      } else {
+        // default anchor
+      }
+    
+      // offset
+      if (model.has(OFFSET)) {
+        // based on mark type, place with x and y (reactive)
+      } else {
+        // default anchor
+      }
   }
   
   let marks = []; // TODO: vgMarks

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -1,7 +1,7 @@
 import {UnitModel} from '../unit';
 import {OrderChannelDef} from '../../fielddef';
 
-import {X, Y, COLOR, TEXT, SHAPE, PATH, ORDER, DETAIL, LABEL} from '../../channel';
+import {X, Y, COLOR, TEXT, SHAPE, PATH, ORDER, DETAIL, ANCHOR, OFFSET} from '../../channel';
 import {AREA, LINE, TEXT as TEXTMARK} from '../../mark';
 import {imputeTransform, stackTransform} from '../stack';
 import {contains, extend} from '../../util';
@@ -97,6 +97,7 @@ function parseNonPathMark(model: UnitModel) {
   const mark = model.mark();
   const isFaceted = model.parent() && model.parent().isFacet();
   const dataFrom = {data: model.dataTable()};
+  const ref = model.ref();
 
   let marks = []; // TODO: vgMarks
   if (mark === TEXTMARK &&
@@ -140,26 +141,6 @@ function parseNonPathMark(model: UnitModel) {
     // properties groups
     { properties: { update: markCompiler[mark].properties(model) } }
   ));
-
-  if (model.has(LABEL) && markCompiler[mark].labels) {
-    const labelProperties = markCompiler[mark].labels(model);
-
-    // check if we have label method for current mark type.
-    if (labelProperties !== undefined) { // If label is supported
-      // add label group
-      marks.push(extend(
-        {
-          name: model.name('label'),
-          type: 'text'
-        },
-        // If has facet, `from.data` will be added in the cell group.
-        // Otherwise, add it here.
-        isFaceted ? {} : {from: dataFrom},
-        // Properties
-        { properties: { update: labelProperties } }
-      ));
-    }
-  }
 
   return marks;
 }

--- a/src/compile/mark/point.ts
+++ b/src/compile/mark/point.ts
@@ -97,7 +97,7 @@ export namespace square {
     return point.properties(model, 'square');
   }
 
-  export function labels(model: UnitModel) {
+  export function ref(model: UnitModel) {
     // TODO(#240): fill this method
     return undefined;
   }

--- a/src/compile/mark/rule.ts
+++ b/src/compile/mark/rule.ts
@@ -65,7 +65,7 @@ export namespace rule {
     return model.config().mark.ruleSize;
   }
 
-  export function labels(model: UnitModel) {
+  export function ref(model: UnitModel) {
     // TODO(#240): fill this method
     return undefined;
   }

--- a/src/compile/mark/text.ts
+++ b/src/compile/mark/text.ts
@@ -22,24 +22,27 @@ export namespace text {
     };
   }
 
-  export function properties(model: UnitModel) {
+  export function properties(model: UnitModel, referencedModel?: UnitModel) {
     // TODO Use Vega's marks properties interface
     let p: any = {};
 
     applyMarkConfig(p, model,
       ['angle', 'align', 'baseline', 'dx', 'dy', 'font', 'fontWeight',
         'fontStyle', 'radius', 'theta', 'text']);
-
+        
     const fieldDef = model.fieldDef(TEXT);
-
-    // ref
-    if (model.isReferential()) {
+    
+    if (referencedModel) {
+      const markType = referencedModel.mark();
+  
+      // anchor
       if (model.has(ANCHOR)) {
         // based on mark type, place with x and y (reactive)
       } else {
         // default anchor
       }
-      
+    
+      // offset
       if (model.has(OFFSET)) {
         // based on mark type, place with x and y (reactive)
       } else {

--- a/src/compile/mark/text.ts
+++ b/src/compile/mark/text.ts
@@ -1,5 +1,5 @@
 import {UnitModel} from '../unit';
-import {X, Y, COLOR, TEXT, SIZE} from '../../channel';
+import {X, Y, COLOR, TEXT, SIZE, ANCHOR, OFFSET} from '../../channel';
 import {applyMarkConfig, applyColorAndOpacity, formatMixins} from '../common';
 import {extend, contains} from '../../util';
 import {QUANTITATIVE, ORDINAL, TEMPORAL} from '../../type';
@@ -31,6 +31,21 @@ export namespace text {
         'fontStyle', 'radius', 'theta', 'text']);
 
     const fieldDef = model.fieldDef(TEXT);
+
+    // ref
+    if (model.isReferential()) {
+      if (model.has(ANCHOR)) {
+        // based on mark type, place with x and y (reactive)
+      } else {
+        // default anchor
+      }
+      
+      if (model.has(OFFSET)) {
+        // based on mark type, place with x and y (reactive)
+      } else {
+        // default anchor
+      }
+    }
 
     // x
     if (model.has(X)) {
@@ -99,5 +114,10 @@ export namespace text {
     }
 
     return model.config().mark.fontSize;
+  }
+  
+  export function ref(model: UnitModel) {
+    // TODO(#240): fill this method
+    return undefined;
   }
 }

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -132,7 +132,7 @@ export abstract class Model {
 
   public abstract parseScale();
 
-  public abstract parseMark();
+  public abstract parseMark(siblings?: Model[]);
 
   public abstract parseAxis();
 
@@ -220,8 +220,8 @@ export abstract class Model {
     return this._parent;
   }
 
-  public name(text: string, delimiter: string = '_') {
-    return (this._name ? this._name + delimiter : '') + text;
+  public name(suffix: string, delimiter: string = '_') {
+    return (this._name ? this._name + delimiter : '') + suffix;
   }
 
   public description() {

--- a/src/compile/scale.ts
+++ b/src/compile/scale.ts
@@ -6,7 +6,7 @@ import {COLUMN, ROW, X, Y, SHAPE, SIZE, COLOR, TEXT, hasScale, Channel} from '..
 import {StackOffset} from '../config';
 import {SOURCE, STACKED_SCALE} from '../data';
 import {FieldDef, field, isMeasure} from '../fielddef';
-import {Mark, BAR, TEXT as TEXT_MARK, RULE, TICK} from '../mark';
+import {Mark, BAR, TEXT as TEXTMARK, RULE, TICK} from '../mark';
 import {Scale, ScaleType, NiceTime} from '../scale';
 import {TimeUnit} from '../timeunit';
 import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../type';
@@ -375,7 +375,7 @@ export function rangeMixins(scale: Scale, model: Model, channel: Channel): any {
         }
         const dimension = model.config().mark.orient === 'horizontal' ? Y : X;
         return {range: [model.config().mark.barThinSize, model.scale(dimension).bandSize]};
-      } else if (unitModel.mark() === TEXT_MARK) {
+      } else if (unitModel.mark() === TEXTMARK) {
         return {range: scaleConfig.fontSizeRange };
       } else if (unitModel.mark() === RULE) {
         return {range: scaleConfig.ruleSizeRange };

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -33,11 +33,13 @@ export class UnitModel extends Model {
   private _mark: Mark;
   private _encoding: Encoding;
   private _stack: StackProperties;
+  private _ref: string;
 
   constructor(spec: ExtendedUnitSpec, parent: Model, parentGivenName: string) {
     super(spec, parent, parentGivenName);
 
     const mark = this._mark = spec.mark;
+    this._ref = spec.ref;
     const encoding = this._encoding = this._initEncoding(mark, spec.encoding || {});
     const config = this._config = this._initConfig(spec.config, parent, mark, encoding);
 
@@ -224,6 +226,14 @@ export class UnitModel extends Model {
 
   public has(channel: Channel) {
     return vlEncoding.has(this._encoding, channel);
+  }
+  
+  public ref(): string {
+    return this._ref;
+  }
+  
+  public isReferential() {
+    return this._ref !== undefined;
   }
 
   public encoding() {

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -151,8 +151,8 @@ export class UnitModel extends Model {
     this.component.scale = parseScaleComponent(this);
   }
 
-  public parseMark() {
-    this.component.mark = parseMark(this);
+  public parseMark(siblings?: UnitModel[]) {    
+    this.component.mark = parseMark(this, siblings);
   }
 
   public parseAxis() {
@@ -228,8 +228,8 @@ export class UnitModel extends Model {
     return vlEncoding.has(this._encoding, channel);
   }
   
-  public ref(): string {
-    return this._ref;
+  public ref(suffix: string, delimiter: string = '_') {
+    return (this._ref ? this._ref + delimiter : '') + suffix;
   }
   
   public isReferential() {

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -43,6 +43,7 @@ export interface ExtendedUnitSpec extends BaseSpec {
    */
   mark: Mark;
   encoding: Encoding;
+  ref?: string;
 }
 
 export interface FacetSpec extends BaseSpec {
@@ -74,8 +75,9 @@ export function isExtendedUnitSpec(spec: ExtendedSpec): spec is ExtendedUnitSpec
   if (isSomeUnitSpec(spec)) {
     const hasRow = has(spec.encoding, ROW);
     const hasColumn = has(spec.encoding, COLUMN);
-
-    return hasRow || hasColumn;
+    const hasRef = spec['ref'] !== undefined;
+    
+    return (hasRow || hasColumn) || hasRef;
   }
 
   return false;
@@ -104,8 +106,9 @@ export function normalize(spec: ExtendedSpec): Spec {
   if (isExtendedUnitSpec(spec)) {
     const hasRow = has(spec.encoding, ROW);
     const hasColumn = has(spec.encoding, COLUMN);
+    const hasRef = spec['ref'] !== undefined; // TODO: @willium implement normalization for ref
 
-    // TODO: @arvind please  add interaction syntax here
+    // TODO: @arvind please add interaction syntax here
     let encoding = duplicate(spec.encoding);
     delete encoding.column;
     delete encoding.row;

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -75,9 +75,8 @@ export function isExtendedUnitSpec(spec: ExtendedSpec): spec is ExtendedUnitSpec
   if (isSomeUnitSpec(spec)) {
     const hasRow = has(spec.encoding, ROW);
     const hasColumn = has(spec.encoding, COLUMN);
-    const hasRef = spec['ref'] !== undefined;
     
-    return (hasRow || hasColumn) || hasRef;
+    return hasRow || hasColumn;
   }
 
   return false;
@@ -117,6 +116,7 @@ export function normalize(spec: ExtendedSpec): Spec {
       spec.name ? { name: spec.name } : {},
       spec.description ? { description: spec.description } : {},
       { data: spec.data },
+      { ref: spec.ref },
       spec.transform ? { transform: spec.transform } : {},
       {
         facet: extend(


### PR DESCRIPTION
Working on labels, considering implemented with a referential unitSpec paradigm. Essentially, given a a unit spec within a layered one, one can add "ref" to the top level and name a sibling unit spec. This is essentially saying "this mark is _reactive_ to this other one". This will give that spec access to the encoding channels `ANCHOR` and `OFFSET` which describe the relative location of that mark to the other. For the first use case, this will be for labels, but I could forsee it being used for other uses in the future. An example might be annotative pie charts above bars, or an image for a stock instead of the name? This might extend in usefulness on maps later too.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/vega/vega-lite/pull/1399%23discussion_r65519605%22%2C%20%22https%3A//github.com/vega/vega-lite/commit/687d26f687dca8659ed1e5f24febe68e008e65ce%23commitcomment-17711749%22%2C%20%22https%3A//github.com/vega/vega-lite/commit/687d26f687dca8659ed1e5f24febe68e008e65ce%23commitcomment-17711791%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20687d26f687dca8659ed1e5f24febe68e008e65ce%20src/compile/mark/text.ts%2024%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/vega/vega-lite/pull/1399%23discussion_r65519605%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20modified%20layering%20to%20pass%20through%20all%20siblings%20just%20so%20I%20could%20get%20this%20one%20line%20%28aka%2C%20what%20mark%20type%20is%20being%20referenced%29.%20Probably%20a%20better%20way%3F%22%2C%20%22created_at%22%3A%20%222016-06-02T10%3A55%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/356976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/willium%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/compile/mark/text.ts%3AL22-55%22%7D%2C%20%22Commit%20687d26f687dca8659ed1e5f24febe68e008e65ce%20src/compile/mark/mark.ts%2073%20159%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/vega/vega-lite/commit/687d26f687dca8659ed1e5f24febe68e008e65ce%23commitcomment-17711749%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22thought%20I%20was%20being%20clever%20here%2C%20but%20this%20probably%20won%27t%20work%20unless%20I%20also%20do%20it%20for%20scales.%20Layering%20seems%20to%20cause%20scales%20to%20be%20a%20real%20challenge%20here.%20%40domoritz%20%40kanitw%2C%20how%20can%20I%20make%20it%20so%20scales%20are%20not%20auto-generated%20as%20part%20of%20the%20encoding%20channel%20creation%3F%5Cr%5Cn%5Cr%5CnPer%20current%20implementation%3A%5Cr%5Cn%60%60%60%5Cr%5Cn%7B%5Cr%5Cn%20%20%20%20%20%20%5C%22mark%5C%22%3A%20%5C%22text%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%5C%22ref%5C%22%3A%20%5C%22myBar%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%5C%22encoding%5C%22%3A%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22x%5C%22%3A%20%7B%5C%22scale%5C%22%3A%20%5C%22x%5C%22%2C%5C%22field%5C%22%3A%20%5C%22ref.xc%5C%22%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22y%5C%22%3A%20%7B%5C%22scale%5C%22%3A%20%5C%22y%5C%22%2C%5C%22field%5C%22%3A%20%5C%22ref.y%5C%22%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22color%5C%22%3A%20%7B%5C%22value%5C%22%3A%20%5C%22%23000000%5C%22%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22text%5C%22%3A%20%7B%5C%22field%5C%22%3A%20%5C%22a%5C%22%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22anchor%5C%22%3A%20%7B%5C%22value%5C%22%3A%20%5C%22top-center%5C%22%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22offset%5C%22%3A%20%7B%5C%22value%5C%22%3A%2010%7D%5Cr%5Cn%20%20%20%20%20%20%7D%5Cr%5Cn%20%20%20%20%7D%5Cr%5Cn%60%60%60%5Cr%5Cnbecomes%5Cr%5Cn%60%60%60%5Cr%5Cn%7B%5Cr%5Cn%20%20%20%20%20%20%5C%22mark%5C%22%3A%20%5C%22text%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%5C%22ref%5C%22%3A%20%5C%22myBar%5C%22%2C%5Cr%5Cn%20%20%20%20%20%20%5C%22encoding%5C%22%3A%20%7B%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22x%5C%22%3A%20%7B%5C%22scale%5C%22%3A%20%5C%22x%5C%22%2C%5C%22field%5C%22%3A%20%5C%22xc%5C%22%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22y%5C%22%3A%20%7B%5C%22scale%5C%22%3A%20%5C%22y%5C%22%2C%5C%22field%5C%22%3A%20%5C%22y%5C%22%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22color%5C%22%3A%20%7B%5C%22value%5C%22%3A%20%5C%22%23000000%5C%22%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22text%5C%22%3A%20%7B%5C%22field%5C%22%3A%20%5C%22a%5C%22%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22anchor%5C%22%3A%20%7B%5C%22value%5C%22%3A%20%5C%22top-center%5C%22%7D%2C%5Cr%5Cn%20%20%20%20%20%20%20%20%5C%22offset%5C%22%3A%20%7B%5C%22value%5C%22%3A%2010%7D%5Cr%5Cn%20%20%20%20%20%20%7D%5Cr%5Cn%20%20%20%20%7D%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnI%20was%20able%20to%20cause%20the%20actual%20incorrect%20scales%20to%20not%20be%20generated%20w/%20%60if%20%28true%20%26%26%20%21child.isReferential%28%29%29%20%7B%20//%20if%20shared/union%20scale%60%20in%20%60layer.ts%60%20but%20that%20doesn%27t%20fix%20this%20encoding%20channel%20bit.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222016-06-02T10%3A43%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/356976%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/willium%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20sue%20I%20understand%20this%20issue%20without%20looking%20more%20at%20your%20code.%20However%2C%20note%20that%20how%20scales%20and%20data%20for%20layers%20work%20has%20fundamentally%20changed%20in%20https%3A//github.com/vega/vega-lite/pull/1304.%20%22%2C%20%22created_at%22%3A%20%222016-06-02T10%3A46%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/589034%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/domoritz%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/compile/mark/mark.ts%3AL159%20%28687d26f%29%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Commit 687d26f687dca8659ed1e5f24febe68e008e65ce src/compile/mark/mark.ts 73 159'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/vega/vega-lite/commit/687d26f687dca8659ed1e5f24febe68e008e65ce#commitcomment-17711749'>File: src/compile/mark/mark.ts:L159 (687d26f)</a></b>
- <a href='https://github.com/willium'><img border=0 src='https://avatars.githubusercontent.com/u/356976?v=3' height=16 width=16'></a> thought I was being clever here, but this probably won't work unless I also do it for scales. Layering seems to cause scales to be a real challenge here. @domoritz @kanitw, how can I make it so scales are not auto-generated as part of the encoding channel creation?
Per current implementation:
```
{
"mark": "text",
"ref": "myBar",
"encoding": {
"x": {"scale": "x","field": "ref.xc"},
"y": {"scale": "y","field": "ref.y"},
"color": {"value": "#000000"},
"text": {"field": "a"},
"anchor": {"value": "top-center"},
"offset": {"value": 10}
}
}
```
becomes
```
{
"mark": "text",
"ref": "myBar",
"encoding": {
"x": {"scale": "x","field": "xc"},
"y": {"scale": "y","field": "y"},
"color": {"value": "#000000"},
"text": {"field": "a"},
"anchor": {"value": "top-center"},
"offset": {"value": 10}
}
}
```
I was able to cause the actual incorrect scales to not be generated w/ `if (true && !child.isReferential()) { // if shared/union scale` in `layer.ts` but that doesn't fix this encoding channel bit.
- <a href='https://github.com/domoritz'><img border=0 src='https://avatars.githubusercontent.com/u/589034?v=3' height=16 width=16'></a> I'm not sue I understand this issue without looking more at your code. However, note that how scales and data for layers work has fundamentally changed in https://github.com/vega/vega-lite/pull/1304.
- [ ] <a href='#crh-comment-Pull 687d26f687dca8659ed1e5f24febe68e008e65ce src/compile/mark/text.ts 24'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/vega/vega-lite/pull/1399#discussion_r65519605'>File: src/compile/mark/text.ts:L22-55</a></b>
- <a href='https://github.com/willium'><img border=0 src='https://avatars.githubusercontent.com/u/356976?v=3' height=16 width=16'></a> I modified layering to pass through all siblings just so I could get this one line (aka, what mark type is being referenced). Probably a better way?


<a href='https://www.codereviewhub.com/vega/vega-lite/pull/1399?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/vega/vega-lite/pull/1399?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/vega/vega-lite/pull/1399'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>