### PR TITLE
Also filter NaN values

### DIFF
--- a/src/compile/data/nullfilter.ts
+++ b/src/compile/data/nullfilter.ts
@@ -73,7 +73,8 @@ export namespace nullFilter {
       [{
         type: 'filter',
         test: filteredFields.map(function(fieldName) {
-          return 'datum.' + fieldName + '!==null';
+          return '(datum.' + fieldName + '!==null' +
+            ' && !isNaN(datum.'+ fieldName + '))';
         }).join(' && ')
       }] : [];
   }


### PR DESCRIPTION
Fix #1411

Question
- Should we only filter this for date field?
- Should we rename `filterNull` to `filterInvalidValues` since it's no longer just null? 

Now temporal line chart sorts correctly!

<img width="326" alt="vega_editor" src="https://cloud.githubusercontent.com/assets/111269/15869151/f530de92-2c9f-11e6-8884-421fdcec4332.png">
