### PR TITLE
[WIP] Add pick method & overlay shortcut

### DIFF
--- a/examples/specs/overlay_area_full.json
+++ b/examples/specs/overlay_area_full.json
@@ -1,0 +1,29 @@
+{
+  "description": "Google's stock price over time.",
+  "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
+  "transform": {"filter": "datum.symbol==='GOOG'"},
+  "layers": [
+    {
+      "mark": "area",
+      "encoding": {
+        "x": {"field": "date","type": "temporal"},
+        "y": {"field": "price","type": "quantitative"}
+      }
+    },
+    {
+      "mark": "line",
+      "encoding": {
+        "x": {"field": "date","type": "temporal"},
+        "y": {"field": "price","type": "quantitative"}
+      }
+    },
+    {
+      "mark": "point",
+      "encoding": {
+        "x": {"field": "date","type": "temporal"},
+        "y": {"field": "price","type": "quantitative"}
+      },
+      "config": {"mark": {"filled": true}}
+    }
+  ]
+}

--- a/examples/specs/overlay_area_short.json
+++ b/examples/specs/overlay_area_short.json
@@ -1,0 +1,11 @@
+{
+  "description": "Google's stock price over time.",
+  "data": {"url": "data/stocks.csv", "format": {"type": "csv"}},
+  "transform": {"filter": "datum.symbol==='GOOG'"},
+  "mark": "area",
+  "encoding": {
+    "x": {"field": "date", "type": "temporal"},
+    "y": {"field": "price", "type": "quantitative"}
+  },
+  "config": {"overlay": {"point": true, "line": true}}
+}

--- a/examples/specs/overlay_line_full.json
+++ b/examples/specs/overlay_line_full.json
@@ -1,0 +1,25 @@
+{
+  "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
+  "transform": {"filter": "datum.symbol==='GOOG'"},
+  "layers": [
+    {
+      "description": "Google's stock price over time.",
+      "mark": "line",
+      "encoding": {
+        "x": {"field": "date","type": "temporal"},
+        "y": {"field": "price","type": "quantitative"},
+        "color": {"field": "symbol", "type": "nominal"}
+      }
+    },
+    {
+      "description": "Google's stock price over time.",
+      "mark": "point",
+      "encoding": {
+        "x": {"field": "date","type": "temporal"},
+        "y": {"field": "price","type": "quantitative"},
+        "color": {"field": "symbol", "type": "nominal"}
+      },
+      "config": {"mark": {"filled": true}}
+    }
+  ]
+}

--- a/examples/specs/overlay_line_short.json
+++ b/examples/specs/overlay_line_short.json
@@ -1,0 +1,12 @@
+{
+  "description": "Google's stock price over time.",
+  "data": {"url": "data/stocks.csv", "format": {"type": "csv"}},
+  "transform": {"filter": "datum.symbol==='GOOG'"},
+  "mark": "line",
+  "encoding": {
+    "x": {"field": "date", "type": "temporal"},
+    "y": {"field": "price", "type": "quantitative"},
+    "color": {"field": "symbol", "type": "nominal"}
+  },
+  "config": {"overlay": {"point": true}}
+}

--- a/src/compile/config.ts
+++ b/src/compile/config.ts
@@ -3,7 +3,7 @@ import {Config} from '../config';
 import {Encoding} from '../encoding';
 import {isAggregate, has} from '../encoding';
 import {isMeasure} from '../fielddef';
-import {POINT, LINE, TICK, CIRCLE, SQUARE, RULE, Mark} from '../mark';
+import {AREA, POINT, LINE, TICK, CIRCLE, SQUARE, RULE, Mark} from '../mark';
 import {contains, extend} from '../util';
 
 /**
@@ -21,11 +21,16 @@ export function initMarkConfig(mark: Mark, encoding: Encoding, config: Config) {
            }
            break;
          case 'opacity':
-           if (value === undefined && contains([POINT, TICK, CIRCLE, SQUARE], mark)) {
-             // point-based marks and bar
-             if (!isAggregate(encoding) || has(encoding, DETAIL)) {
-               cfg[property] = 0.7;
-             }
+           if (value === undefined) {
+            if (contains([POINT, TICK, CIRCLE, SQUARE], mark)) {
+              // point-based marks and bar
+              if (!isAggregate(encoding) || has(encoding, DETAIL)) {
+                cfg[property] = 0.7;
+              }
+            }
+            if (mark === AREA) {
+              cfg[property] = 0.6; // inspired by Tableau
+            }
            }
            break;
          case 'orient':

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,6 +141,40 @@ export enum Interpolate {
     MONOTONE = 'monotone' as any,
 }
 
+export enum AreaOverlay {
+  LINE = 'line' as any,
+  LINEPOINT = 'linepoint' as any,
+  NONE = 'none' as any
+}
+
+export interface OverlayConfig {
+  /**
+   * Whether to overlay line with point.
+   */
+  line?: boolean;
+
+  /**
+   * Type of overlay for area mark (line or linepoint)
+   */
+  area?: AreaOverlay;
+
+  /**
+   * Default style for the overlayed point.
+   */
+  pointStyle?: MarkConfig;
+
+  /**
+   * Default style for the overlayed point.
+   */
+  lineStyle?: MarkConfig;
+}
+
+export const defaultOverlayConfig: OverlayConfig = {
+  line: false,
+  pointStyle: {filled: true},
+  lineStyle: {}
+};
+
 export interface MarkConfig {
 
   // ---------- Color ----------
@@ -390,6 +424,9 @@ export interface Config {
   /** Mark Config */
   mark?: MarkConfig;
 
+  /** Mark Overlay Config */
+  overlay?: OverlayConfig;
+
   /** Scale Config */
   scale?: ScaleConfig;
 
@@ -409,6 +446,7 @@ export const defaultConfig: Config = {
 
   cell: defaultCellConfig,
   mark: defaultMarkConfig,
+  overlay: defaultOverlayConfig,
   scale: defaultScaleConfig,
   axis: defaultAxisConfig,
   legend: defaultLegendConfig,

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -11,7 +11,7 @@ import {stack} from './stack';
 import {Transform} from './transform';
 
 import * as vlEncoding from './encoding';
-import {duplicate, extend} from './util';
+import {duplicate, extend, pick} from './util';
 
 export interface BaseSpec {
   /**
@@ -146,24 +146,15 @@ export function normalize(spec: ExtendedSpec): Spec {
 }
 
 export function normalizeExtendedUnitSpec(spec: ExtendedUnitSpec) {
-  const hasRow = has(spec.encoding, ROW);
-  const hasColumn = has(spec.encoding, COLUMN);
-
   // TODO: @arvind please  add interaction syntax here
   let encoding = duplicate(spec.encoding);
   delete encoding.column;
   delete encoding.row;
 
   return extend(
-    spec.name ? { name: spec.name } : {},
-    spec.description ? { description: spec.description } : {},
-    { data: spec.data },
-    spec.transform ? { transform: spec.transform } : {},
+    pick(spec, ['name', 'description', 'data', 'transform']),
     {
-      facet: extend(
-        hasRow ? { row: spec.encoding.row } : {},
-        hasColumn ? { column: spec.encoding.column } : {}
-      ),
+      facet: pick(spec.encoding, ['row', 'column']),
       spec: {
         mark: spec.mark,
         encoding: encoding

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,12 +3,45 @@
 
 import * as stringify from 'json-stable-stringify';
 export {keys, extend, duplicate, isArray, vals, truncate, toMap, isObject, isString, isNumber, isBoolean} from 'datalib/src/util';
+import {duplicate as _duplicate} from 'datalib/src/util';
 export {range} from 'datalib/src/generate';
 export {has} from './encoding'
 export {FieldDef} from './fielddef';
 export {Channel} from './channel';
 
 import {isString, isNumber, isBoolean} from 'datalib/src/util';
+
+/**
+ * Creates an object composed of the picked object properties.
+ *
+ * Example:  (from lodash)
+ *
+ * var object = { 'a': 1, 'b': '2', 'c': 3 };
+ * pick(object, ['a', 'c']);
+ * // → { 'a': 1, 'c': 3 }
+ *
+ */
+export function pick(obj: any, props: string[]) {
+  let copy = {};
+  props.forEach((prop) => {
+    if (obj.hasOwnProperty(prop)) {
+      copy[prop] = obj[prop];
+    }
+  });
+  return copy;
+}
+
+/**
+ * The opposite of _.pick; this method creates an object composed of the own
+ * and inherited enumerable string keyed properties of object that are not omitted.
+ */
+export function omit(obj: any, props: string[]) {
+  let copy = _duplicate(obj);
+  props.forEach((prop) => {
+    delete copy[prop];
+  });
+  return copy;
+}
 
 export function hash(a: any) {
   if (isString(a) || isNumber(a) || isBoolean(a)) {

--- a/test/spec.test.ts
+++ b/test/spec.test.ts
@@ -64,4 +64,127 @@ describe('normalize()', function () {
       });
     });
   });
+
+  describe('normalizeOverlay', () => {
+    describe('line', () => {
+      it('should be normalized correctly', () => {
+        const spec: any = {
+          "description": "Google's stock price over time.",
+          "data": {"url": "data/stocks.csv", "format": {"type": "csv"}},
+          "transform": {"filter": "datum.symbol==='GOOG'"},
+          "mark": "line",
+          "encoding": {
+            "x": {"field": "date", "type": "temporal"},
+            "y": {"field": "price", "type": "quantitative"}
+          },
+          "config": {"overlay": {"line": true}}
+        };
+        const normalizedSpec = normalize(spec);
+        assert.deepEqual(normalizedSpec, {
+          "description": "Google's stock price over time.",
+          "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
+          "transform": {"filter": "datum.symbol==='GOOG'"},
+          "layers": [
+            {
+              "mark": "line",
+              "encoding": {
+                "x": {"field": "date","type": "temporal"},
+                "y": {"field": "price","type": "quantitative"}
+              }
+            },
+            {
+              "mark": "point",
+              "encoding": {
+                "x": {"field": "date","type": "temporal"},
+                "y": {"field": "price","type": "quantitative"}
+              },
+              "config": {"mark": {"filled": true}}
+            }
+          ]
+        });
+      });
+    });
+
+    describe('area', () => {
+      it('with linepoint should be normalized correctly', () => {
+        const spec: any = {
+          "description": "Google's stock price over time.",
+          "data": {"url": "data/stocks.csv", "format": {"type": "csv"}},
+          "transform": {"filter": "datum.symbol==='GOOG'"},
+          "mark": "area",
+          "encoding": {
+            "x": {"field": "date", "type": "temporal"},
+            "y": {"field": "price", "type": "quantitative"}
+          },
+          "config": {"overlay": {"area": 'linepoint'}}
+        };
+        const normalizedSpec = normalize(spec);
+        assert.deepEqual(normalizedSpec, {
+          "description": "Google's stock price over time.",
+          "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
+          "transform": {"filter": "datum.symbol==='GOOG'"},
+          "layers": [
+            {
+              "mark": "area",
+              "encoding": {
+                "x": {"field": "date","type": "temporal"},
+                "y": {"field": "price","type": "quantitative"}
+              }
+            },
+            {
+              "mark": "line",
+              "encoding": {
+                "x": {"field": "date","type": "temporal"},
+                "y": {"field": "price","type": "quantitative"}
+              }
+            },
+            {
+              "mark": "point",
+              "encoding": {
+                "x": {"field": "date","type": "temporal"},
+                "y": {"field": "price","type": "quantitative"}
+              },
+              "config": {"mark": {"filled": true}}
+            }
+          ]
+        });
+      });
+
+      it('with linepoint should be normalized correctly', () => {
+        const spec: any = {
+          "description": "Google's stock price over time.",
+          "data": {"url": "data/stocks.csv", "format": {"type": "csv"}},
+          "transform": {"filter": "datum.symbol==='GOOG'"},
+          "mark": "area",
+          "encoding": {
+            "x": {"field": "date", "type": "temporal"},
+            "y": {"field": "price", "type": "quantitative"}
+          },
+          "config": {"overlay": {"area": 'line'}}
+        };
+        const normalizedSpec = normalize(spec);
+        assert.deepEqual(normalizedSpec, {
+          "description": "Google's stock price over time.",
+          "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
+          "transform": {"filter": "datum.symbol==='GOOG'"},
+          "layers": [
+            {
+              "mark": "area",
+              "encoding": {
+                "x": {"field": "date","type": "temporal"},
+                "y": {"field": "price","type": "quantitative"}
+              }
+            },
+            {
+              "mark": "line",
+              "encoding": {
+                "x": {"field": "date","type": "temporal"},
+                "y": {"field": "price","type": "quantitative"}
+              }
+            }
+          ]
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fix #508   (Don't squash -- multiple things included)
- add pick, omit method 
- Also change area's default opacity to 0.6 (Inspired by Tableau and many other toolkits)

```
{
  "description": "Google's stock price over time.",
  "data": {"url": "data/stocks.csv", "format": {"type": "csv"}},
  "transform": {"filter": "datum.symbol==='GOOG'"},
  "mark": "line",
  "encoding": {
    "x": {"field": "date", "type": "temporal"},
    "y": {"field": "price", "type": "quantitative"},
    "color": {"field": "symbol", "type": "nominal"}
  },
  "config": {"overlay": {"line": true}}
}
```

is equivalent to 
```
{
  "layers": [
    {
      "description": "Google's stock price over time.",
      "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
      "transform": {"filter": "datum.symbol==='GOOG'"},
      "mark": "line",
      "encoding": {
        "x": {"field": "date","type": "temporal"},
        "y": {"field": "price","type": "quantitative"},
        "color": {"field": "symbol", "type": "nominal"}
      }
    },
    {
      "description": "Google's stock price over time.",
      "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
      "transform": {"filter": "datum.symbol==='GOOG'"},
      "mark": "point",
      "encoding": {
        "x": {"field": "date","type": "temporal"},
        "y": {"field": "price","type": "quantitative"},
        "color": {"field": "symbol", "type": "nominal"}
      },
      "config": {"mark": {"filled": true}}
    }
  ]
}
```

![vega_editor](https://cloud.githubusercontent.com/assets/111269/16178851/2718cdbc-3609-11e6-888d-54e308fea94a.png)



