### PR TITLE
Un-constrain shape from a fixed enum for custom shapes

### DIFF
--- a/examples/specs/scatter_shape_custom.json
+++ b/examples/specs/scatter_shape_custom.json
@@ -1,0 +1,17 @@
+{
+  "description": "A scatterplot with custom star shapes.",
+  "data": {"url": "data/cars.json"},
+  "mark": "point",
+  "encoding": {
+    "x": {"field": "Horsepower","type": "quantitative"},
+    "y": {"field": "Miles_per_Gallon","type": "quantitative"},
+    "color": {"field": "Cylinders", "type": "nominal"},
+    "size": {"field": "Weight_in_lbs", "type": "quantitative"}
+  },
+  "config": {
+    "mark": { 
+      "shape": "M0,0.2L0.2351,0.3236 0.1902,0.0618 0.3804,-0.1236 0.1175,-0.1618 0,-0.4 -0.1175,-0.1618 -0.3804,-0.1236 -0.1902,0.0618 -0.2351,0.3236 0,0.2Z"
+    }
+  }
+}
+

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -207,7 +207,7 @@ vg.embed('#horizontal_line', {
 
 | Property            | Type                | Description  |
 | :------------------ |:-------------------:| :------------|
-| shape               | Number              | The symbol shape to use. One of `"circle"`, `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`<span class="note-line">__Default value:__ `"circle"` </span> |
+| shape               | Number              | The symbol shape to use. One of `"circle"`, `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or else a custom SVG path string<span class="note-line">__Default value:__ `"circle"` </span> |
 
 
 ### Point Size Config (for Point, Circle, and Square Marks)

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -207,7 +207,7 @@ vg.embed('#horizontal_line', {
 
 | Property            | Type                | Description  |
 | :------------------ |:-------------------:| :------------|
-| shape               | Number              | The symbol shape to use. One of `"circle"`, `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or else a custom SVG path string<span class="note-line">__Default value:__ `"circle"` </span> |
+| shape               | Number              | The symbol shape to use. One of `"circle"`, `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or else a custom SVG path string.<span class="note-line">__Default value:__ `"circle"` </span> |
 
 
 ### Point Size Config (for Point, Circle, and Square Marks)

--- a/site/docs/encoding.md
+++ b/site/docs/encoding.md
@@ -46,7 +46,7 @@ Mark properties channels map data fields directly to visual properties of the ma
 | x, y          | [ChannelDef](#def)| X and Y coordinates for `point`, `circle`, `square`, `line`, `text`, and `tick`. (or to width and height for `bar` and `area` marks). |
 | color         | [ChannelDef](#def)| Color of the marks – either fill or stroke color based on mark type. (By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /   stroke color for `line` and `point`.) (See [scale range](scale.html#range) for more detail about color palettes.)  |
 | opacity         | [ChannelDef](#def)| Opacity of the marks – either can be a value or in a range. <span class="note-line"> __Default value:__ `[0.3, 0.8]` </span>.)  |
-| shape  | [ChannelDef](#def)| The symbol's shape (only for `point` marks). The supported values are `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`. |
+| shape  | [ChannelDef](#def)| The symbol's shape (only for `point` marks). The supported values are `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, `"triangle-down"`, or else a custom SVG path string. |
 | size  | [ChannelDef](#def)| Size of the mark. <br/>     • For `point`, `square` and `circle` – the symbol size, or pixel area of the mark. <br/> • For `bar` and `tick` – the bar and tick's size. <br/>      • For `text` – the text's font size. <br/>      • Size is currently unsupported for `line` and `area`.|
 | text  | [ChannelDef](#def)| Text of the `text` mark. |
 | column, row  | [ChannelDef](#def)| `row` and `column` are special encoding channels for [faceting](#facet). |

--- a/site/docs/legend.md
+++ b/site/docs/legend.md
@@ -64,7 +64,7 @@ The `legend` property object supports the following properties:
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
 | symbolColor   | String        | The color of the symbol. |
-| symbolShape   | String        | The shape of the legend symbol. One of `"circle"`, `"square"`, `"cross"`, `"diamond"`, `"triangle-up"` or `"triangle-down"` |
+| symbolShape   | String        | The shape of the legend symbol. One of `"circle"`, `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, `"triangle-down"`, or else a custom SVG path string |
 | symbolSize    | Number        | The size of the symbol, in pixels.  |
 | symbolStrokeWidth   | Number      | The width of the symbol's stroke. |
 

--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -124,7 +124,8 @@ export namespace properties {
         break;
     }
 
-    const filled = model.config().mark.filled;
+    const cfg = model.config();
+    const filled = cfg.mark.filled;
 
 
     let config = channel === COLOR ?
@@ -162,15 +163,26 @@ export namespace properties {
       // For non-color legend, apply color config if there is no fill / stroke config.
       // (For color, do not override scale specified!)
       symbols[filled ? 'fill' : 'stroke'] = symbols[filled ? 'fill' : 'stroke'] ||
-        {value: model.config().mark.color};
+        {value: cfg.mark.color};
     }
 
     if (legend.symbolColor !== undefined) {
       symbols.fill = {value: legend.symbolColor};
+    } else if (symbols.fill === undefined) {
+      // fall back to mark config colors for legend fill
+      if (cfg.mark.color !== undefined) {
+        symbols.fill = {value: cfg.mark.color};
+      } else if (cfg.mark.fill !== undefined) {
+        symbols.fill = {value: cfg.mark.fill};
+      } else if (cfg.mark.stroke !== undefined) {
+        symbols.fill = {value: cfg.mark.stroke};
+      }
     }
 
     if (legend.symbolShape !== undefined) {
       symbols.shape = {value: legend.symbolShape};
+    } else if (cfg.mark.shape !== undefined) {
+      symbols.shape = {value: cfg.mark.shape};
     }
 
     if (legend.symbolSize !== undefined) {

--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -175,7 +175,7 @@ export namespace properties {
       } else if (cfg.mark.fill !== undefined) {
         symbols.fill = {value: cfg.mark.fill};
       } else if (cfg.mark.stroke !== undefined) {
-        symbols.fill = {value: cfg.mark.stroke};
+        symbols.stroke = {value: cfg.mark.stroke};
       }
     }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -293,7 +293,7 @@ export interface MarkConfig {
 
   // ---------- Point ----------
   /**
-   * The symbol shape to use. One of circle (default), square, cross, diamond, triangle-up, or triangle-down.
+   * The symbol shape to use. One of circle (default), square, cross, diamond, triangle-up, or triangle-down, or a custom SVG path.
    */
   shape?: string;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -377,7 +377,7 @@ export interface MarkConfig {
 
 export const defaultMarkConfig: MarkConfig = {
   color: '#4682b4',
-  shape: "circle",
+  shape: 'circle',
   strokeWidth: 2,
   size: 30,
   barThinSize: 2,

--- a/src/config.ts
+++ b/src/config.ts
@@ -295,7 +295,7 @@ export interface MarkConfig {
   /**
    * The symbol shape to use. One of circle (default), square, cross, diamond, triangle-up, or triangle-down.
    */
-  shape?: Shape;
+  shape?: string;
 
   // ---------- Point Size (Point / Square / Circle) ----------
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -377,7 +377,7 @@ export interface MarkConfig {
 
 export const defaultMarkConfig: MarkConfig = {
   color: '#4682b4',
-  shape: Shape.CIRCLE,
+  shape: "circle",
   strokeWidth: 2,
   size: 30,
   barThinSize: 2,

--- a/src/config.ts
+++ b/src/config.ts
@@ -295,7 +295,7 @@ export interface MarkConfig {
   /**
    * The symbol shape to use. One of circle (default), square, cross, diamond, triangle-up, or triangle-down, or a custom SVG path.
    */
-  shape?: string;
+  shape?: Shape | string;
 
   // ---------- Point Size (Point / Square / Circle) ----------
   /**
@@ -377,7 +377,7 @@ export interface MarkConfig {
 
 export const defaultMarkConfig: MarkConfig = {
   color: '#4682b4',
-  shape: 'circle',
+  shape: Shape.CIRCLE,
   strokeWidth: 2,
   size: 30,
   barThinSize: 2,

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -43,7 +43,7 @@ export interface UnitEncoding {
   /**
    * The symbol's shape (only for `point` marks). The supported values are
    * `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,
-   * or `"triangle-down"`.
+   * or `"triangle-down"`, or else a custom SVG path string.
    */
   shape?: ChannelDefWithLegend; // TODO: maybe distinguish ordinal-only
 

--- a/src/legend.ts
+++ b/src/legend.ts
@@ -65,7 +65,7 @@ export interface LegendConfig {
   symbolColor?: string;
   /**
    * The shape of the legend symbol, can be the 'circle', 'square', 'cross', 'diamond',
-   * 'triangle-up', 'triangle-down'.
+   * 'triangle-up', 'triangle-down', or else a custom SVG path string.
    */
   symbolShape?: string;
   /**

--- a/test/compile/legend.test.ts
+++ b/test/compile/legend.test.ts
@@ -111,6 +111,23 @@ describe('Legend', function() {
         }), COLOR);
         assert.deepEqual(symbol.strokeWidth.value, 20);
     });
+
+    it('should create legend for SVG path', function() {
+      const symbol = legend.properties.symbols({field: 'a'}, {}, parseUnitModel({
+          mark: "point",
+          encoding: {
+            x: {field: "a", type: "nominal"},
+            color: {field: "a", type: "nominal"}
+          },
+          config: {
+            mark: {
+              shape: "M0,0.2L0.2351,0.3236 0.1902,0.0618 0.3804,-0.1236 0.1175,-0.1618 0,-0.4 -0.1175,-0.1618 -0.3804,-0.1236 -0.1902,0.0618 -0.2351,0.3236 0,0.2Z"
+            }
+          }
+        }), COLOR);
+
+        assert.deepEqual(symbol.shape.value, "M0,0.2L0.2351,0.3236 0.1902,0.0618 0.3804,-0.1236 0.1175,-0.1618 0,-0.4 -0.1175,-0.1618 -0.3804,-0.1236 -0.1902,0.0618 -0.2351,0.3236 0,0.2Z");
+    });
   });
 
   describe('properties.labels', function() {


### PR DESCRIPTION
Vega now permits custom shapes: https://github.com/vega/vega/wiki/Custom-Shapes

They work with vega-lite "out of the box":

```json
{
  "description": "A scatterplot with custom star shapes.",
  "data": {"url": "data/cars.json"},
  "mark": "point",
  "encoding": {
    "x": {"field": "Horsepower","type": "quantitative"},
    "y": {"field": "Miles_per_Gallon","type": "quantitative"},
    "size": {"field": "Cylinders", "type": "quantitative"}
  },
  "config": {
    "mark": { 
      "shape": "M0,0.2L0.2351,0.3236 0.1902,0.0618 0.3804,-0.1236 0.1175,-0.1618 0,-0.4 -0.1175,-0.1618 -0.3804,-0.1236 -0.1902,0.0618 -0.2351,0.3236 0,0.2Z"
    }
  }
}
```

![unknown-1](https://cloud.githubusercontent.com/assets/659086/16357035/244ca1a8-3ab9-11e6-9fd2-94995f583a6c.png)

However, this spec does not pass schema validation, since the SVG path is not one of a fixed set of enums. This PR removes the shape enum constraint so that custom SVG paths will pass schema validation.