### PR TITLE
Remove unused `vl.fieldDef.cardinality` and relevant method

### DIFF
--- a/src/spec.ts
+++ b/src/spec.ts
@@ -332,20 +332,10 @@ export function normalizeOverlay(spec: UnitSpec, overlayWithPoint: boolean, over
 
 // TODO: add vl.spec.validate & move stuff from vl.validate to here
 
-export function alwaysNoOcclusion(spec: ExtendedUnitSpec): boolean {
-  // FIXME raw OxQ with # of rows = # of O
-  return vlEncoding.isAggregate(spec.encoding);
-}
-
 export function fieldDefs(spec: ExtendedUnitSpec): FieldDef[] {
   // TODO: refactor this once we have composition
   return vlEncoding.fieldDefs(spec.encoding);
 };
-
-export function getCleanSpec(spec: ExtendedUnitSpec): ExtendedUnitSpec {
-  // TODO: move toSpec to here!
-  return spec;
-}
 
 export function isStacked(spec: ExtendedUnitSpec): boolean {
   return stack(spec.mark, spec.encoding, spec.config) !== null;

--- a/src/util.ts
+++ b/src/util.ts
@@ -156,16 +156,6 @@ function deepMerge_(dest, src) {
   return dest;
 }
 
-// FIXME remove this
-import * as dlBin from 'datalib/src/bins/bins';
-export function getbins(stats, maxbins) {
-  return dlBin({
-    min: stats.min,
-    max: stats.max,
-    maxbins: maxbins
-  });
-}
-
 export function unique<T>(values: T[], f?: (item: T) => string) {
   let results = [];
   var u = {}, v, i, n;

--- a/test/fielddef.test.ts
+++ b/test/fielddef.test.ts
@@ -1,28 +1,11 @@
 import {assert} from 'chai';
 
 import {AggregateOp} from '../src/aggregate';
-import {cardinality, title} from '../src/fielddef';
+import {title} from '../src/fielddef';
 import {TimeUnit} from '../src/timeunit';
 import {QUANTITATIVE, TEMPORAL} from '../src/type';
 
 describe('fieldDef', () => {
-  describe('cardinality()', function () {
-    describe('for Q', function () {
-      it('should return cardinality', function() {
-        const fieldDef = {field: '2', type: QUANTITATIVE};
-        const stats = {2:{distinct: 10, min:0, max:150}};
-        assert.equal(cardinality(fieldDef, stats), 10);
-      });
-    });
-
-    describe('for B(Q)', function(){
-      it('should return cardinality', function() {
-        const fieldDef = {field: '2', type: QUANTITATIVE, bin: {maxbins: 15}};
-        const stats = {2:{distinct: 10, min:0, max:150}};
-        assert.equal(cardinality(fieldDef, stats), 15);
-      });
-    });
-  });
   describe('title()', () => {
     it('should return title if the fieldDef has title', () => {
       const fieldDef = {field: '2', type: QUANTITATIVE, title: 'baz'};


### PR DESCRIPTION
Remove unused `vl.fieldDef.cardinality`, `vl.spec.alwaysNoOcclusion`, `vl.spec.getCleanSpec`
and relevant methods (which should be migrated to be a part of CompassQL's `Schema`)