### PR TITLE
Separate `CompareFilter` from `RangeFilter`

### DIFF
--- a/src/compile/data/filter.ts
+++ b/src/compile/data/filter.ts
@@ -1,5 +1,5 @@
 import {field} from '../../fielddef';
-import {isEqualFilter, isInFilter, isRangeFilter, Filter} from '../../filter';
+import {isEqualFilter, isInFilter, isRangeFilter, isCompareFilter, Filter} from '../../filter';
 import {isArray} from '../../util';
 
 import {FacetModel} from '../facet';
@@ -20,20 +20,18 @@ export namespace filter {
     } else if (isInFilter(filter)) {
       filterString = 'indexof(' + s(filter.in) + ', ' + field(filter, {datum: true}) + ') !== -1';
     } else if (isRangeFilter(filter)) {
-      if (!!filter.range) {
-        filterString = 'inrange(' + field(filter, {datum: true}) + ', ' + s(filter.range[0]) + ', ' + s(filter.range[1]) + ')';
-      } else {
-        const comparisons = [];
-        const operators = ['>','>=','<','<='];
-        ['gt','gte','lt','lte'].forEach(function (opName, idx) {
-          if (filter[opName] !== undefined) {
-            comparisons.push(field(filter, {datum: true}) + ' ' +
-              operators[idx] + // get actual operator
-              ' ' + filter[opName]);
-          }
-        });
-        filterString = comparisons.join(' && ');
-      }
+      filterString = 'inrange(' + field(filter, {datum: true}) + ', ' + s(filter.range[0]) + ', ' + s(filter.range[1]) + ')';
+    } else if (isCompareFilter(filter)) {
+      const comparisons = [];
+      const operators = ['>','>=','<','<='];
+      ['gt','gte','lt','lte'].forEach(function (opName, idx) {
+        if (filter[opName] !== undefined) {
+          comparisons.push(field(filter, {datum: true}) + ' ' +
+            operators[idx] + // get actual operator
+            ' ' + filter[opName]);
+        }
+      });
+      filterString = comparisons.join(' && ');
     } else {
       return filter as string;
     }

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -1,6 +1,6 @@
 import {isArray} from './util';
 
-export type Filter = EqualFilter | RangeFilter | InFilter;
+export type Filter = EqualFilter | RangeFilter | InFilter | CompareFilter;
 
 export interface EqualFilter {
   // TODO: support timeUnit, aggregate, bin
@@ -37,27 +37,7 @@ export interface RangeFilter {
    * @maxItems 2
    * @minItems 2
    */
-  range?: any;
-
-  /**
-   * Value that the `field`'s value should be less than 
-   */
-  lt?: number;
-
-  /**
-   * Value that the `field`'s value should be less than or equal to
-   */
-  lte?: number;
-
-  /**
-   * Value that the `field`'s value should be greater than
-   */
-  gt?: number;
-
-  /**
-   * Value that the `field`'s value should be greater than or equal to
-   */
-  gte?: number;
+  range: any;
 
   /**
    * If `true`, negate the logic. Default value : `false`
@@ -69,7 +49,101 @@ export function isRangeFilter(filter: any): filter is RangeFilter {
   if (filter && !!filter.field) {
     if (isArray(filter.range) && filter.range.length === 2) {
       return true;
-    } else if (filter.gt !==undefined || filter.gte!==undefined || filter.lt!==undefined || filter.lte!==undefined ) {
+    }
+  }
+  return false;
+}
+
+
+
+export type CompareFilter = LtFilter | LteFilter | GtFilter | GteFilter;
+  // TODO: add this once this issue is supported:
+  // https://github.com/YousefED/typescript-json-schema/issues/46
+  // Or undo splitting CompareFilter if the following issue is supported
+  // https://github.com/YousefED/typescript-json-schema/issues/47
+
+  // combination of lt/lte and gt/gte
+  // (LtFilter & GtFilter) |
+  // (LtFilter & GteFilter) |
+  // (LteFilter & GtFilter) |
+  // (LteFilter & GteFilter);
+
+export interface LtFilter {
+  /**
+   * Field to be filtered
+   */
+  field: string;
+
+  /**
+   * Value that the `field`'s value should be less than
+   */
+  lt: number;
+
+  /**
+   * If `true`, negate the logic. Default value : `false`
+   */
+  negate?: boolean;
+}
+
+
+export interface LteFilter {
+  /**
+   * Field to be filtered
+   */
+  field: string;
+
+  /**
+   * Value that the `field`'s value should be less than or equal to
+   */
+  lte: number;
+
+  /**
+   * If `true`, negate the logic. Default value : `false`
+   */
+  negate?: boolean;
+}
+
+
+export interface GtFilter {
+  /**
+   * Field to be filtered
+   */
+  field: string;
+
+  /**
+   * Value that the `field`'s value should be greater than
+   */
+  gt: number;
+
+  /**
+   * If `true`, negate the logic. Default value : `false`
+   */
+  negate?: boolean;
+}
+
+
+export interface GteFilter {
+  /**
+   * Field to be filtered
+   */
+  field: string;
+
+  /**
+   * Value that the `field`'s value should be greater than or equal to
+   */
+  gte: number;
+
+  /**
+   * If `true`, negate the logic. Default value : `false`
+   */
+  negate?: boolean;
+}
+
+
+
+export function isCompareFilter(filter: any): filter is CompareFilter {
+  if (filter && !!filter.field) {
+    if (filter.gt !==undefined || filter.gte!==undefined || filter.lt!==undefined || filter.lte!==undefined ) {
       return true;
     }
   }

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -1,12 +1,13 @@
 import {assert} from 'chai';
-import {isEqualFilter, isInFilter, isRangeFilter} from '../src/filter';
+import {isEqualFilter, isInFilter, isRangeFilter, isCompareFilter} from '../src/filter';
 
 describe('filter', () => {
   const equalFilter = {field: 'color', equal: 'red'};
   const inFilter = {field: 'color', in: ['red', 'yellow']};
   const rangeFilter = {field: 'x', range: [0, 5]};
-  const rangeFilter2 = {field: 'x', gte: 0};
-  const rangeFilter3 = {field: 'x', gte: 0, lt: 5 };
+  const compareFilter1 = {field: 'x', gte: 0};
+  const compareFilter2 = {field: 'x', gte: 0, lt: 5 };
+
   const exprFilter = 'datum.x===5';
 
   describe('isEqualFilter', () => {
@@ -34,15 +35,26 @@ describe('filter', () => {
   });
 
   describe('isRangeFilter', () => {
-    it('should return true for an range filter', () => {
+    it('should return true for a range filter', () => {
       assert.isTrue(isRangeFilter(rangeFilter));
-      assert.isTrue(isRangeFilter(rangeFilter2));
-      assert.isTrue(isRangeFilter(rangeFilter3));
     });
 
     it('should return false for other filters', () => {
-      [inFilter, equalFilter, exprFilter].forEach((filter) => {
+      [inFilter, equalFilter, exprFilter, compareFilter1, compareFilter2].forEach((filter) => {
         assert.isFalse(isRangeFilter(filter));
+      });
+    });
+  });
+
+  describe('isCompareFilter', () => {
+    it('should return true for a compare filter', () => {
+      assert.isTrue(isCompareFilter(compareFilter1));
+      assert.isTrue(isCompareFilter(compareFilter2));
+    });
+
+    it('should return false for other filters', () => {
+      [inFilter, equalFilter, exprFilter, rangeFilter].forEach((filter) => {
+        assert.isFalse(isCompareFilter(filter));
       });
     });
   });


### PR DESCRIPTION
Separate `CompareFilter` from `RangeFilter` so that we can satisfy `oneOf` condition in the JSON schema.

Note that we need either https://github.com/YousefED/typescript-json-schema/issues/46
or https://github.com/YousefED/typescript-json-schema/issues/47 to
support combination of lt/lte and gt/gte in the schema.  (The logic works fine but those combo will fail to validate)

For now, let's support non-combo version for `CompareFilter`.