### PR TITLE
[WIP] Get fieldDefs for for LayerSpec, FacetSpec, ExtendedFacetSpec

### DIFF
--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -13,11 +13,11 @@ import {LayerModel} from './layer';
 import {Model} from './model';
 import {template as timeUnitTemplate} from '../timeunit';
 import {UnitModel} from './unit';
-import {Spec, isUnitSpec, isFacetSpec, isLayerSpec} from '../spec';
+import {Spec, isUnitSpec, isSomeFacetSpec, isLayerSpec} from '../spec';
 
 
 export function buildModel(spec: Spec, parent: Model, parentGivenName: string): Model {
-  if (isFacetSpec(spec)) {
+  if (isSomeFacetSpec(spec)) {
     return new FacetModel(spec, parent, parentGivenName);
   }
 

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -340,7 +340,14 @@ export function normalizeOverlay(spec: UnitSpec, overlayWithPoint: boolean, over
 /* Accumulate non-duplicate fieldDefs in a dictionary */
 function accumulate(dict: any, fieldDefs: FieldDef[]): any {
   fieldDefs.forEach(function(fieldDef) {
-    let key = hash(fieldDef);
+    // Consider only pure fieldDef properties (ignoring scale, axis, legend)
+    var pureFieldDef = ['field', 'type', 'value', 'timeUnit', 'bin', 'aggregate'].reduce((f, key) => {
+      if (fieldDef[key] !== undefined) {
+        f[key] = fieldDef[key];
+      }
+      return f;
+    }, {});
+    let key = hash(pureFieldDef);
     dict[key] = dict[key] || fieldDef;
   });
   return dict;

--- a/test/spec.test.ts
+++ b/test/spec.test.ts
@@ -287,6 +287,38 @@ describe('fieldDefs()', function() {
     ]);
   });
 
+  it('should get all non-duplicate fieldDefs from all layers in a LayerSpec (merging duplicate fields with different scale types)', function() {
+    const layerSpec: any = {
+      "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
+      "transform": {"filter": "datum.symbol==='GOOG'"},
+      "layers": [
+        {
+          "description": "Google's stock price over time.",
+          "mark": "line",
+          "encoding": {
+            "x": {"field": "date","type": "temporal"},
+            "y": {"field": "price","type": "quantitative"}
+          }
+        },
+        {
+          "description": "Google's stock price over time.",
+          "mark": "point",
+          "encoding": {
+            "x": {"field": "date","type": "temporal"},
+            "y": {"field": "price","type": "quantitative"},
+            "color": {"field": "date","type": "temporal", "scale": {"type": "pow"}}
+          },
+          "config": {"mark": {"filled": true}}
+        }
+      ]
+    };
+
+    assert.deepEqual(fieldDefs(layerSpec), [
+      {"field": "date","type": "temporal"},
+      {"field": "price","type": "quantitative"}
+    ]);
+  });
+
   it('should get all non-duplicate fieldDefs from facet and layers in a FacetSpec', function() {
     const facetSpec: any = {
       "data": {"url": "data/movies.json"},

--- a/test/spec.test.ts
+++ b/test/spec.test.ts
@@ -2,7 +2,7 @@
 
 import {assert} from 'chai';
 
-import {normalize} from '../src/spec';
+import {normalize, fieldDefs} from '../src/spec';
 
 // describe('isStacked()') -- tested as part of stackOffset in stack.test.ts
 
@@ -234,5 +234,76 @@ describe('normalize()', function () {
         "y2": { "aggregate": "max", "field": "people", "type": "quantitative" }
       }
     });
+  });
+});
+
+describe('fieldDefs()', function() {
+  it('should get all non-duplicate fieldDefs from an encoding', function() {
+    const spec: any = {
+      "data": {"url": "data/cars.json"},
+      "mark": "point",
+      "encoding": {
+        "x": {"field": "Horsepower","type": "quantitative"},
+        "y": {"field": "Miles_per_Gallon","type": "quantitative"}
+      }
+    };
+
+    assert.deepEqual(fieldDefs(spec), [
+      {"field": "Horsepower","type": "quantitative"},
+      {"field": "Miles_per_Gallon","type": "quantitative"}
+    ]);
+  });
+
+  it('should get all non-duplicate fieldDefs from all layers in a LayerSpec', function() {
+    const layerSpec: any = {
+      "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
+      "transform": {"filter": "datum.symbol==='GOOG'"},
+      "layers": [
+        {
+          "description": "Google's stock price over time.",
+          "mark": "line",
+          "encoding": {
+            "x": {"field": "date","type": "temporal"},
+            "y": {"field": "price","type": "quantitative"}
+          }
+        },
+        {
+          "description": "Google's stock price over time.",
+          "mark": "point",
+          "encoding": {
+            "x": {"field": "date","type": "temporal"},
+            "y": {"field": "price","type": "quantitative"},
+            "color": {"field": "symbol", "type": "nominal"}
+          },
+          "config": {"mark": {"filled": true}}
+        }
+      ]
+    };
+
+    assert.deepEqual(fieldDefs(layerSpec), [
+      {"field": "date","type": "temporal"},
+      {"field": "price","type": "quantitative"},
+      {"field": "symbol", "type": "nominal"}
+    ]);
+  });
+
+  it('should get all non-duplicate fieldDefs from facet and layers in a FacetSpec', function() {
+    const facetSpec: any = {
+      "data": {"url": "data/movies.json"},
+      "facet": {"row": {"field": "MPAA_Rating","type": "ordinal"}},
+      "spec": {
+        "mark": "point",
+        "encoding": {
+          "x": {"field": "Worldwide_Gross","type": "quantitative"},
+          "y": {"field": "US_DVD_Sales","type": "quantitative"}
+        }
+      }
+    };
+
+    assert.deepEqual(fieldDefs(facetSpec), [
+      {"field": "MPAA_Rating","type": "ordinal"},
+      {"field": "Worldwide_Gross","type": "quantitative"},
+      {"field": "US_DVD_Sales","type": "quantitative"}
+    ]);
   });
 });


### PR DESCRIPTION
- [x] `vl.spec.fieldDefs()` returns all non-duplicate `fieldDefs` in all layers in a LayerSpec (Fix https://github.com/vega/vega-lite/issues/1476) 
- [x] `vl.spec.fieldDefs()` returns all non-duplicate `fieldDefs` from `facet` and `spec` in a FacetSpec
- [x] `vl.spec.fieldDefs()` returns all non-duplicate `fieldDefs` from `facet` and `spec` in ExtendedFacetSpec
- [x] Add unit test