### PR TITLE
Correct scale.domain schema: it can only be a number[] or string[], but not string.

### DIFF
--- a/src/scale.ts
+++ b/src/scale.ts
@@ -108,9 +108,9 @@ export const defaultFacetScaleConfig: FacetScaleConfig = {
 export interface Scale {
   type?: ScaleType;
   /**
-   * The domain of the scale, representing the set of data values. For quantitative data, this can take the form of a two-element array with minimum and maximum values. For ordinal/categorical data, this may be an array of valid input values. The domain may also be specified by a reference to a data source.
+   * The domain of the scale, representing the set of data values. For quantitative data, this can take the form of a two-element array with minimum and maximum values. For ordinal/categorical data, this may be an array of valid input values.
    */
-  domain?: string | number[] | string[]; // TODO: declare vgDataDomain
+  domain?: number[] | string[]; // TODO: declare vgDataDomain
   /**
    * The range of the scale, representing the set of visual values. For numeric values, the range can take the form of a two-element array with minimum and maximum values. For ordinal or quantized data, the range may by an array of desired output values, which are mapped to elements in the specified domain. For ordinal scales only, the range can be defined using a DataRef: the range values are then drawn dynamically from a backing data set.
    */


### PR DESCRIPTION
Correct `scale.domain` schema: it can only be a number[] or string[], but not string.