### PR TITLE
Add timeunit date conversion method

### DIFF
--- a/src/timeunit.ts
+++ b/src/timeunit.ts
@@ -57,7 +57,7 @@ export function isSingleTimeUnit(timeUnit: TimeUnit) {
  * i.e. ('yearmonth', '2000-12-04 07:58:14') -> '2000-12-01 00:00:00'
  * Note: the base date is Jan 01 1900 00:00:00
  */
-export function convert(unit: TimeUnit, date: Date, utc: boolean): Date {
+export function convert(unit: TimeUnit, date: Date): Date {
   const result: Date = new Date(0, 0, 1, 0, 0, 0, 0); // start with uniform date
   SINGLE_TIMEUNITS.forEach(function(singleUnit) {
     if (containsTimeUnit(unit, singleUnit)) {

--- a/src/timeunit.ts
+++ b/src/timeunit.ts
@@ -63,9 +63,13 @@ export function convert(unit: TimeUnit, date: Date): Date {
     if (containsTimeUnit(unit, singleUnit)) {
       switch (singleUnit) {
         case TimeUnit.DAY:
-          throw 'Cannot convert to TimeUnits containing \'day\'';
+          throw new Error('Cannot convert to TimeUnits containing \'day\'');
         case TimeUnit.YEAR:
           result.setFullYear(date.getFullYear());
+          break;
+        case TimeUnit.QUARTER:
+          // indicate quarter by setting month to be the first of the quarter i.e. may (4) -> april (3)
+          result.setMonth((Math.floor(date.getMonth() / 3)) * 3);
           break;
         case TimeUnit.MONTH:
           result.setMonth(date.getMonth());
@@ -85,18 +89,9 @@ export function convert(unit: TimeUnit, date: Date): Date {
         case TimeUnit.MILLISECONDS:
           result.setMilliseconds(date.getMilliseconds());
           break;
-        case TimeUnit.QUARTER:
-          result.setMonth((Math.floor(date.getMonth() / 3)) * 3);
-          break;
       }
     }
   });
-
-  // handle weird 'quartermonth' and 'yearquartermonth' cases (should just keep month, ignore quarter)
-  // TODO: remove this code once timeunits with both 'quarter' and 'month' are no longer supported
-  if (containsTimeUnit(unit, TimeUnit.QUARTER) && containsTimeUnit(unit, TimeUnit.MONTH)) {
-    result.setMonth(date.getMonth());
-  }
 
   return result;
 }

--- a/src/timeunit.ts
+++ b/src/timeunit.ts
@@ -4,14 +4,14 @@ import {ScaleType} from './scale';
 import {Dict, contains, keys, range} from './util';
 
 export enum TimeUnit {
-  YEAR = 'year' as any, // ???
-  MONTH = 'month' as any, // done
-  DAY = 'day' as any, // done
-  DATE = 'date' as any, // done
-  HOURS = 'hours' as any, // done
-  MINUTES = 'minutes' as any, // done
-  SECONDS = 'seconds' as any, // done
-  MILLISECONDS = 'milliseconds' as any, // ???
+  YEAR = 'year' as any,
+  MONTH = 'month' as any,
+  DAY = 'day' as any,
+  DATE = 'date' as any,
+  HOURS = 'hours' as any,
+  MINUTES = 'minutes' as any,
+  SECONDS = 'seconds' as any,
+  MILLISECONDS = 'milliseconds' as any,
   YEARMONTH = 'yearmonth' as any,
   // Note: don't add MONTH DATE because it will be incorrect
   // since days on a leap year will be shifted by one if
@@ -24,7 +24,7 @@ export enum TimeUnit {
   HOURSMINUTESSECONDS = 'hoursminutesseconds' as any,
   MINUTESSECONDS = 'minutesseconds' as any,
   SECONDSMILLISECONDS = 'secondsmilliseconds' as any,
-  QUARTER = 'quarter' as any, // done
+  QUARTER = 'quarter' as any,
   YEARQUARTER = 'yearquarter' as any,
   QUARTERMONTH = 'quartermonth' as any,
   YEARQUARTERMONTH = 'yearquartermonth' as any,
@@ -57,46 +57,47 @@ export function isSingleTimeUnit(timeUnit: TimeUnit) {
  * i.e. ('yearmonth', '2000-12-04 07:58:14') -> '2000-12-00 00:00:00'
  */
 export function convert(unit: TimeUnit, date: Date, utc: boolean): Date {
-  const result: Date = new Date(0, 0, 0, 0, 0, 0, 0); // start with uniform date
-  // handle some units individually
-  if (unit === TimeUnit.QUARTERMONTH) {
-    // not sure how to handle this unit. Just put month (since you can infer quarter from month)?
-  } else {
-    SINGLE_TIMEUNITS.forEach(function(singleUnit) {
-      if (containsTimeUnit(unit, singleUnit)) {
-        // can ignore TimeUnit.DAY
-        switch (singleUnit) {
-          case TimeUnit.YEAR:
-            result.setFullYear(date.getFullYear());
-            break;
-          case TimeUnit.MONTH:
-            if (containsTimeUnit(unit, TimeUnit.DATE)) {
-              result.setMonth(date.getMonth(), date.getDate());
-            } else {
-              result.setMonth(date.getMonth(), 1);
-            }
-            break;
-          case TimeUnit.DATE:
-            result.setDate(date.getDate());
-            break;
-          case TimeUnit.HOURS:
-            result.setHours(date.getHours());
-            break;
-          case TimeUnit.MINUTES:
-            result.setMinutes(date.getMinutes());
-            break;
-          case TimeUnit.SECONDS:
-            result.setSeconds(date.getSeconds());
-            break;
-          case TimeUnit.MILLISECONDS:
-            result.setMilliseconds(date.getMilliseconds());
-            break;
-          case TimeUnit.QUARTER:
-            result.setMonth(Math.floor(date.getMonth() / 3));
-        }
+  const result: Date = new Date(0, 0, 1, 0, 0, 0, 0); // start with uniform date
+  SINGLE_TIMEUNITS.forEach(function(singleUnit) {
+    if (containsTimeUnit(unit, singleUnit)) {
+      // can ignore TimeUnit.DAY
+      switch (singleUnit) {
+        case TimeUnit.DAY:
+          throw 'Cannot convert to TimeUnits containing \'day\'';
+        case TimeUnit.YEAR:
+          result.setFullYear(date.getFullYear());
+          break;
+        case TimeUnit.MONTH:
+          result.setMonth(date.getMonth());
+          break;
+        case TimeUnit.DATE:
+          result.setDate(date.getDate());
+          break;
+        case TimeUnit.HOURS:
+          result.setHours(date.getHours());
+          break;
+        case TimeUnit.MINUTES:
+          result.setMinutes(date.getMinutes());
+          break;
+        case TimeUnit.SECONDS:
+          result.setSeconds(date.getSeconds());
+          break;
+        case TimeUnit.MILLISECONDS:
+          result.setMilliseconds(date.getMilliseconds());
+          break;
+        case TimeUnit.QUARTER:
+          result.setMonth((Math.floor(date.getMonth() / 3)) * 3);
+          break;
       }
-    });
+    }
+  });
+
+  // handle weird 'quartermonth' and 'yearquartermonth' cases (should just keep month, ignore quarter)
+  // TODO: remove this code once timeunits with both 'quarter' and 'month' are no longer supported
+  if (containsTimeUnit(unit, TimeUnit.QUARTER) && containsTimeUnit(unit, TimeUnit.MONTH)) {
+    result.setMonth(date.getMonth());
   }
+
   return result;
 }
 

--- a/src/timeunit.ts
+++ b/src/timeunit.ts
@@ -54,13 +54,13 @@ export function isSingleTimeUnit(timeUnit: TimeUnit) {
 
 /**
  * Converts a date to only have the measurements relevant to the specified unit
- * i.e. ('yearmonth', '2000-12-04 07:58:14') -> '2000-12-00 00:00:00'
+ * i.e. ('yearmonth', '2000-12-04 07:58:14') -> '2000-12-01 00:00:00'
+ * Note: the base date is Jan 01 1900 00:00:00
  */
 export function convert(unit: TimeUnit, date: Date, utc: boolean): Date {
   const result: Date = new Date(0, 0, 1, 0, 0, 0, 0); // start with uniform date
   SINGLE_TIMEUNITS.forEach(function(singleUnit) {
     if (containsTimeUnit(unit, singleUnit)) {
-      // can ignore TimeUnit.DAY
       switch (singleUnit) {
         case TimeUnit.DAY:
           throw 'Cannot convert to TimeUnits containing \'day\'';

--- a/src/timeunit.ts
+++ b/src/timeunit.ts
@@ -4,14 +4,14 @@ import {ScaleType} from './scale';
 import {Dict, contains, keys, range} from './util';
 
 export enum TimeUnit {
-  YEAR = 'year' as any,
-  MONTH = 'month' as any,
-  DAY = 'day' as any,
-  DATE = 'date' as any,
-  HOURS = 'hours' as any,
-  MINUTES = 'minutes' as any,
-  SECONDS = 'seconds' as any,
-  MILLISECONDS = 'milliseconds' as any,
+  YEAR = 'year' as any, // ???
+  MONTH = 'month' as any, // done
+  DAY = 'day' as any, // done
+  DATE = 'date' as any, // done
+  HOURS = 'hours' as any, // done
+  MINUTES = 'minutes' as any, // done
+  SECONDS = 'seconds' as any, // done
+  MILLISECONDS = 'milliseconds' as any, // ???
   YEARMONTH = 'yearmonth' as any,
   YEARMONTHDATE = 'yearmonthdate' as any,
   YEARMONTHDATEHOURS = 'yearmonthdatehours' as any,
@@ -21,7 +21,7 @@ export enum TimeUnit {
   HOURSMINUTESSECONDS = 'hoursminutesseconds' as any,
   MINUTESSECONDS = 'minutesseconds' as any,
   SECONDSMILLISECONDS = 'secondsmilliseconds' as any,
-  QUARTER = 'quarter' as any,
+  QUARTER = 'quarter' as any, // done
   YEARQUARTER = 'yearquarter' as any,
   QUARTERMONTH = 'quartermonth' as any,
   YEARQUARTERMONTH = 'yearquartermonth' as any,
@@ -47,6 +47,54 @@ const SINGLE_TIMEUNIT_INDEX: Dict<boolean> = SINGLE_TIMEUNITS.reduce((d, timeUni
 
 export function isSingleTimeUnit(timeUnit: TimeUnit) {
   return !!SINGLE_TIMEUNIT_INDEX[timeUnit];
+}
+
+/**
+ * Converts a date to only have the measurements relevant to the specified unit
+ * i.e. ('yearmonth', '2000-12-04 07:58:14') -> '2000-12-00 00:00:00'
+ */
+export function convert(unit: TimeUnit, date: Date, utc: boolean): Date {
+  const result: Date = new Date(0, 0, 0, 0, 0, 0, 0); // start with uniform date
+  // handle some units individually
+  if (unit === TimeUnit.QUARTERMONTH) {
+    // not sure how to handle this unit. Just put month (since you can infer quarter from month)?
+  } else {
+    SINGLE_TIMEUNITS.forEach(function(singleUnit) {
+      if (containsTimeUnit(unit, singleUnit)) {
+        // can ignore TimeUnit.DAY
+        switch (singleUnit) {
+          case TimeUnit.YEAR:
+            result.setFullYear(date.getFullYear());
+            break;
+          case TimeUnit.MONTH:
+            if (containsTimeUnit(unit, TimeUnit.DATE)) {
+              result.setMonth(date.getMonth(), date.getDate());
+            } else {
+              result.setMonth(date.getMonth(), 1);
+            }
+            break;
+          case TimeUnit.DATE:
+            result.setDate(date.getDate());
+            break;
+          case TimeUnit.HOURS:
+            result.setHours(date.getHours());
+            break;
+          case TimeUnit.MINUTES:
+            result.setMinutes(date.getMinutes());
+            break;
+          case TimeUnit.SECONDS:
+            result.setSeconds(date.getSeconds());
+            break;
+          case TimeUnit.MILLISECONDS:
+            result.setMilliseconds(date.getMilliseconds());
+            break;
+          case TimeUnit.QUARTER:
+            result.setMonth(Math.floor(date.getMonth() / 3));
+        }
+      }
+    });
+  }
+  return result;
 }
 
 export const MULTI_TIMEUNITS = [

--- a/test/timeunit.test.ts
+++ b/test/timeunit.test.ts
@@ -117,6 +117,12 @@ describe('timeUnit', () => {
   });
 
   describe('convert', function () {
+    it('should throw an error for the DAY timeunit', function() {
+      assert.throws(function() {
+        convert(TimeUnit.DAY, new Date(2000, 11, 2, 23, 59, 59, 999));
+      }, Error, 'Cannot convert to TimeUnits containing \'day\'');
+    });
+
     it('should return expected result for YEARQUARTER', function() {
       const date: Date = convert(TimeUnit.YEARQUARTER, new Date(2000, 11, 2, 23, 59, 59, 999));
       assert.equal(date.getTime(), new Date(2000, 9, 1, 0, 0, 0, 0).getTime());

--- a/test/timeunit.test.ts
+++ b/test/timeunit.test.ts
@@ -1,7 +1,7 @@
 import {assert} from 'chai';
 
 import {ScaleType} from '../src/scale';
-import {TimeUnit, containsTimeUnit, defaultScaleType, fieldExpr} from '../src/timeunit';
+import {TimeUnit, containsTimeUnit, defaultScaleType, fieldExpr, convert} from '../src/timeunit';
 
 
 describe('timeUnit', () => {
@@ -113,6 +113,68 @@ describe('timeUnit', () => {
         fieldExpr(TimeUnit.MILLISECONDS, 'x'),
         'datetime(0, 0, 1, 0, 0, 0, milliseconds(datum.x))'
       );
+    });
+  });
+
+  describe('convert', function () {
+    it('should return expected result for YEARQUARTER', function() {
+      const date: Date = convert(TimeUnit.YEARQUARTER, new Date(2000, 11, 2, 23, 59, 59, 999));
+      assert.equal(date.getTime(), new Date(2000, 9, 1, 0, 0, 0, 0).getTime());
+    });
+
+    it('should return expected result for YEARQUARTERMONTH', function() {
+      const date: Date = convert(TimeUnit.YEARQUARTERMONTH, new Date(2000, 11, 2, 23, 59, 59, 999));
+      assert.equal(date.getTime(), new Date(2000, 11, 1, 0, 0, 0, 0).getTime());
+    });
+
+    it('should return expected result for YEARMONTH', function() {
+      const date: Date = convert(TimeUnit.YEARMONTH, new Date(2000, 11, 2, 23, 59, 59, 999));
+      assert.equal(date.getTime(), new Date(2000, 11, 1, 0, 0, 0, 0).getTime());
+    });
+
+    it('should return expected result for YEARMONTHDATE', function() {
+      const date: Date = convert(TimeUnit.YEARMONTHDATE, new Date(2000, 11, 2, 23, 59, 59, 999));
+      assert.equal(date.getTime(), new Date(2000, 11, 2, 0, 0, 0, 0).getTime());
+    });
+
+    it('should return expected result for YEARMONTHDATEHOURS', function() {
+      const date: Date = convert(TimeUnit.YEARMONTHDATEHOURS, new Date(2000, 11, 2, 23, 59, 59, 999));
+      assert.equal(date.getTime(), new Date(2000, 11, 2, 23, 0, 0, 0).getTime());
+    });
+
+    it('should return expected result for YEARMONTHDATEHOURSMINUTES', function() {
+      const date: Date = convert(TimeUnit.YEARMONTHDATEHOURSMINUTES, new Date(2000, 11, 2, 23, 59, 59, 999));
+      assert.equal(date.getTime(), new Date(2000, 11, 2, 23, 59, 0, 0).getTime());
+    });
+
+    it('should return expected result for YEARMONTHDATEHOURSMINUTESSECONDS', function() {
+      const date: Date = convert(TimeUnit.YEARMONTHDATEHOURSMINUTESSECONDS, new Date(2000, 11, 2, 23, 59, 59, 999));
+      assert.equal(date.getTime(), new Date(2000, 11, 2, 23, 59, 59, 0).getTime());
+    });
+
+    it('should return expected result for QUARTERMONTH', function() {
+      const date: Date = convert(TimeUnit.QUARTERMONTH, new Date(2000, 11, 2, 23, 59, 59, 999));
+      assert.equal(date.getTime(), new Date(1900, 11, 1, 0, 0, 0, 0).getTime());
+    });
+
+    it('should return expected result for HOURSMINUTES', function() {
+      const date: Date = convert(TimeUnit.HOURSMINUTES, new Date(2000, 11, 2, 23, 59, 59, 999));
+      assert.equal(date.getTime(), new Date(1900, 0, 1, 23, 59, 0, 0).getTime());
+    });
+
+    it('should return expected result for HOURSMINUTESSECONDS', function() {
+      const date: Date = convert(TimeUnit.HOURSMINUTESSECONDS, new Date(2000, 11, 2, 23, 59, 59, 999));
+      assert.equal(date.getTime(), new Date(1900, 0, 1, 23, 59, 59, 0).getTime());
+    });
+
+    it('should return expected result for MINUTESSECONDS', function() {
+      const date: Date = convert(TimeUnit.MINUTESSECONDS, new Date(2000, 11, 2, 23, 59, 59, 999));
+      assert.equal(date.getTime(), new Date(1900, 0, 1, 0, 59, 59, 0).getTime());
+    });
+
+    it('should return expected result for SECONDSMILLISECONDS', function() {
+      const date: Date = convert(TimeUnit.SECONDSMILLISECONDS, new Date(2000, 11, 2, 23, 59, 59, 999));
+      assert.equal(date.getTime(), new Date(1900, 0, 1, 0, 0, 59, 999).getTime());
     });
   });
 });


### PR DESCRIPTION
Adds the `timeunit.convert` method, which takes in a date and timeunit and returns a date that only has the specified timeunits from the provided date. Example:

convert('yearmonth', '2000-12-04 07:58:14') -> '2000-12-00 00:00:00'