### PR TITLE
Move `getFilterExpression` method from src/compile/data/filter.ts to src/filter.ts as `expression`

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -1,6 +1,5 @@
 import {DateTime, dateTimeExpr, isDateTime} from './datetime';
 import {field} from './fielddef';
-
 import {TimeUnit, fieldExpr as timeUnitFieldExpr, isSingleTimeUnit} from './timeunit';
 import {isArray, isString} from './util';
 

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -1,6 +1,8 @@
-import {DateTime} from './datetime';
-import {TimeUnit} from './timeunit';
-import {isArray} from './util';
+import {DateTime, dateTimeExpr, isDateTime} from './datetime';
+import {field} from './fielddef';
+
+import {TimeUnit, fieldExpr as timeUnitFieldExpr, isSingleTimeUnit} from './timeunit';
+import {isArray, isString} from './util';
 
 export type Filter = EqualFilter | RangeFilter | InFilter ;
 
@@ -84,4 +86,53 @@ export interface InFilter {
 
 export function isInFilter(filter: any): filter is InFilter {
   return filter && !!filter.field && isArray(filter.in);
+}
+
+export function expression(filter: Filter | string) {
+  if (isString(filter)) {
+    return filter as string;
+  } else { // Filter Object
+    const fieldExpr = filter.timeUnit ?
+      // For timeUnit, cast into integer with time() so we can use ===, inrange, indexOf to compare values directly.
+        // TODO: We calculate timeUnit on the fly here. Consider if we would like to consolidate this with timeUnit pipeline
+        // TODO: support utc
+      ('time(' + timeUnitFieldExpr(filter.timeUnit, filter.field) + ')') :
+      field(filter, {datum: true});
+
+    if (isEqualFilter(filter)) {
+      return fieldExpr + '===' + valueExpr(filter.equal, filter.timeUnit);
+    } else if (isInFilter(filter)) {
+      return 'indexof([' +
+        filter.in.map((v) => valueExpr(v, filter.timeUnit)).join(',') +
+        '], ' + fieldExpr + ') !== -1';
+    } else if (isRangeFilter(filter)) {
+      const lower = filter.range[0];
+      const upper = filter.range[1];
+
+      if (lower !== null &&  upper !== null) {
+        return 'inrange(' + fieldExpr + ', ' +
+          valueExpr(lower, filter.timeUnit) + ', ' +
+          valueExpr(upper, filter.timeUnit) + ')';
+      } else if (lower !== null) {
+        return fieldExpr + ' >= ' + lower;
+      } else if (upper !== null) {
+        return fieldExpr + ' <= ' + upper;
+      }
+    }
+  }
+  return undefined;
+}
+
+function valueExpr(v: any, timeUnit: TimeUnit) {
+  if (isDateTime(v)) {
+    const expr = dateTimeExpr(v, true);
+    return 'time(' + expr + ')';
+  }
+  if (isSingleTimeUnit(timeUnit)) {
+    const datetime: DateTime = {};
+    datetime[timeUnit] = v;
+    const expr = dateTimeExpr(datetime, true);
+    return 'time(' + expr + ')';
+  }
+  return JSON.stringify(v);
 }

--- a/test/compile/data/filter.test.ts
+++ b/test/compile/data/filter.test.ts
@@ -1,80 +1,10 @@
 /* tslint:disable:quotemark */
-
 import {assert} from 'chai';
 
 import {parseUnitModel} from '../../util';
-import {TimeUnit} from '../../../src/timeunit';
 import {filter} from '../../../src/compile/data/filter';
 
 describe('compile/data/filter', () => {
-  describe('getFilterExpression', () => {
-    it('should return a correct expression for an EqualFilter', () => {
-      const expr = filter.getFilterExpression({field: 'color', equal: 'red'});
-      assert.equal(expr, 'datum["color"]==="red"');
-    });
-
-    it('should return a correct expression for an EqualFilter with datetime object', () => {
-      const expr = filter.getFilterExpression({
-        field: 'date',
-        equal: {
-          month: 'January'
-        }
-      });
-      assert.equal(expr, 'datum["date"]===time(datetime(0, 0, 1, 0, 0, 0, 0))');
-    });
-
-    it('should return a correct expression for an EqualFilter with time unit and datetime object', () => {
-      const expr = filter.getFilterExpression({
-        timeUnit: TimeUnit.MONTH,
-        field: 'date',
-        equal: {
-          month: 'January'
-        }
-      });
-      assert.equal(expr, 'time(datetime(0, month(datum["date"]), 1, 0, 0, 0, 0))===time(datetime(0, 0, 1, 0, 0, 0, 0))');
-    });
-
-    it('should return a correct expression for an EqualFilter with datetime ojbect', () => {
-      const expr = filter.getFilterExpression({
-        timeUnit: TimeUnit.MONTH,
-        field: 'date',
-        equal: 'January'
-      });
-      assert.equal(expr, 'time(datetime(0, month(datum["date"]), 1, 0, 0, 0, 0))===time(datetime(0, 0, 1, 0, 0, 0, 0))');
-    });
-
-    it('should return a correct expression for an InFilter', () => {
-      const expr = filter.getFilterExpression({field: 'color', in: ['red', 'yellow']});
-      assert.equal(expr, 'indexof(["red","yellow"], datum["color"]) !== -1');
-    });
-
-    it('should return a correct expression for a RangeFilter', () => {
-      const expr = filter.getFilterExpression({field: 'x', range: [0, 5]});
-      assert.equal(expr, 'inrange(datum["x"], 0, 5)');
-    });
-
-    it('should return a correct expression for a RangeFilter with no lower bound', () => {
-      const expr = filter.getFilterExpression({field: 'x', range: [null, 5]});
-      assert.equal(expr, 'datum["x"] <= 5');
-    });
-
-    it('should return a correct expression for a RangeFilter with no upper bound', () => {
-      const expr = filter.getFilterExpression({field: 'x', range: [0, null]});
-      assert.equal(expr, 'datum["x"] >= 0');
-    });
-
-
-    it('should return undefined for a RangeFilter with no bound', () => {
-      const expr = filter.getFilterExpression({field: 'x', range: [null, null]});
-      assert.equal(expr, undefined);
-    });
-
-    it('should return a correct expression for an expression filter', () => {
-      const expr = filter.getFilterExpression('datum["x"]===5');
-      assert.equal(expr, 'datum["x"]===5');
-    });
-  });
-
   describe('parse', () => {
     it('should return a correct expression for an array of filter', () => {
       const model = parseUnitModel({

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -1,5 +1,6 @@
 import {assert} from 'chai';
-import {isEqualFilter, isInFilter, isRangeFilter} from '../src/filter';
+import {expression, isEqualFilter, isInFilter, isRangeFilter} from '../src/filter';
+import {TimeUnit} from '../src/timeunit';
 
 describe('filter', () => {
   const equalFilter = {field: 'color', equal: 'red'};
@@ -40,6 +41,74 @@ describe('filter', () => {
       [inFilter, equalFilter, exprFilter].forEach((filter) => {
         assert.isFalse(isRangeFilter(filter));
       });
+    });
+  });
+
+  describe('expression', () => {
+    it('should return a correct expression for an EqualFilter', () => {
+      const expr = expression({field: 'color', equal: 'red'});
+      assert.equal(expr, 'datum["color"]==="red"');
+    });
+
+    it('should return a correct expression for an EqualFilter with datetime object', () => {
+      const expr = expression({
+        field: 'date',
+        equal: {
+          month: 'January'
+        }
+      });
+      assert.equal(expr, 'datum["date"]===time(datetime(0, 0, 1, 0, 0, 0, 0))');
+    });
+
+    it('should return a correct expression for an EqualFilter with time unit and datetime object', () => {
+      const expr = expression({
+        timeUnit: TimeUnit.MONTH,
+        field: 'date',
+        equal: {
+          month: 'January'
+        }
+      });
+      assert.equal(expr, 'time(datetime(0, month(datum["date"]), 1, 0, 0, 0, 0))===time(datetime(0, 0, 1, 0, 0, 0, 0))');
+    });
+
+    it('should return a correct expression for an EqualFilter with datetime ojbect', () => {
+      const expr = expression({
+        timeUnit: TimeUnit.MONTH,
+        field: 'date',
+        equal: 'January'
+      });
+      assert.equal(expr, 'time(datetime(0, month(datum["date"]), 1, 0, 0, 0, 0))===time(datetime(0, 0, 1, 0, 0, 0, 0))');
+    });
+
+    it('should return a correct expression for an InFilter', () => {
+      const expr = expression({field: 'color', in: ['red', 'yellow']});
+      assert.equal(expr, 'indexof(["red","yellow"], datum["color"]) !== -1');
+    });
+
+    it('should return a correct expression for a RangeFilter', () => {
+      const expr = expression({field: 'x', range: [0, 5]});
+      assert.equal(expr, 'inrange(datum["x"], 0, 5)');
+    });
+
+    it('should return a correct expression for a RangeFilter with no lower bound', () => {
+      const expr = expression({field: 'x', range: [null, 5]});
+      assert.equal(expr, 'datum["x"] <= 5');
+    });
+
+    it('should return a correct expression for a RangeFilter with no upper bound', () => {
+      const expr = expression({field: 'x', range: [0, null]});
+      assert.equal(expr, 'datum["x"] >= 0');
+    });
+
+
+    it('should return undefined for a RangeFilter with no bound', () => {
+      const expr = expression({field: 'x', range: [null, null]});
+      assert.equal(expr, undefined);
+    });
+
+    it('should return a correct expression for an expression filter', () => {
+      const expr = expression('datum["x"]===5');
+      assert.equal(expr, 'datum["x"]===5');
     });
   });
 });


### PR DESCRIPTION
Fix #1491 

- Move src/compile/data/filter.ts's getFilterExpression to be expresssion in src/filter.ts
- Move src/compile/data/filter.ts's valueExpr to src/filter.ts (method is required by expression)