### PR TITLE
Fix bugs in `filterInvalid`

### DIFF
--- a/src/compile/data/data.ts
+++ b/src/compile/data/data.ts
@@ -1,3 +1,4 @@
+import {FieldDef} from '../../fielddef';
 import {Formula} from '../../transform';
 import {keys, Dict, StringSet} from '../../util';
 import {VgData, VgTransform} from '../../vega.schema';
@@ -31,7 +32,7 @@ export interface DataComponent {
   formatParse: Dict<string>;
 
   /** String set of fields for null filtering */
-  nullFilter: Dict<boolean>;
+  nullFilter: Dict<FieldDef>;
 
   /** Hashset of a formula object */
   calculate: Dict<Formula>;

--- a/src/compile/data/nullfilter.ts
+++ b/src/compile/data/nullfilter.ts
@@ -1,5 +1,6 @@
 import {FieldDef} from '../../fielddef';
-import {extend, keys, differ, Dict} from '../../util';
+import {QUANTITATIVE, TEMPORAL} from '../../type';
+import {contains, extend, keys, differ, Dict} from '../../util';
 
 import {FacetModel} from './../facet';
 import {LayerModel} from './../layer';
@@ -27,13 +28,15 @@ export namespace nullFilter {
     }
 
     return model.reduce(function(aggregator, fieldDef: FieldDef) {
-      if (filterInvalid ||
-        (filterInvalid === undefined && fieldDef.field && fieldDef.field !== '*' && DEFAULT_NULL_FILTERS[fieldDef.type])) {
-        aggregator[fieldDef.field] = true;
-      } else {
-        // define this so we know that we don't filter nulls for this field
-        // this makes it easier to merge into parents
-        aggregator[fieldDef.field] = false;
+      if (fieldDef.field !== '*') { // Ignore * for count(*) fields.
+        if (filterInvalid ||
+          (filterInvalid === undefined && fieldDef.field && DEFAULT_NULL_FILTERS[fieldDef.type])) {
+          aggregator[fieldDef.field] = fieldDef;
+        } else {
+          // define this so we know that we don't filter nulls for this field
+          // this makes it easier to merge into parents
+          aggregator[fieldDef.field] = null;
+        }
       }
       return aggregator;
     }, {});
@@ -62,7 +65,7 @@ export namespace nullFilter {
 
     model.children().forEach((child) => {
       const childDataComponent = child.component.data;
-      if (model.compatibleSource(child) && !differ(childDataComponent.nullFilter, nullFilterComponent)) {
+      if (model.compatibleSource(child) && !differ<FieldDef>(childDataComponent.nullFilter, nullFilterComponent)) {
         extend(nullFilterComponent, childDataComponent.nullFilter);
         delete childDataComponent.nullFilter;
       }
@@ -73,17 +76,24 @@ export namespace nullFilter {
 
   /** Convert the hashset of fields to a filter transform.  */
   export function assemble(component: DataComponent) {
-    const filteredFields = keys(component.nullFilter).filter((field) => {
-      // only include fields that has value = true
-      return component.nullFilter[field];
-    });
-    return filteredFields.length > 0 ?
+    const filters = keys(component.nullFilter).reduce((_filters, field) => {
+      const fieldDef = component.nullFilter[field];
+      if (fieldDef !== null) {
+        _filters.push('datum["' + fieldDef.field + '"] !==null');
+        if (contains([QUANTITATIVE, TEMPORAL], fieldDef.type)) {
+          // TODO(https://github.com/vega/vega-lite/issues/1436):
+          // We can be even smarter and add NaN filter for N,O that are numbers
+          // based on the `parse` property once we have it.
+          _filters.push('!isNaN(datum["'+ fieldDef.field + '"]');
+        }
+      }
+      return _filters;
+    }, []);
+
+    return filters.length > 0 ?
       [{
         type: 'filter',
-        test: filteredFields.map(function(fieldName) {
-          return '(datum["' + fieldName + '"] !==null' +
-            ' && !isNaN(datum["'+ fieldName + '"]))';
-        }).join(' && ')
+        test: '(' + filters.join(') && (')  + ')'
       }] : [];
   }
 }

--- a/test/compile/data.test.ts
+++ b/test/compile/data.test.ts
@@ -283,9 +283,9 @@ describe('data: nullFilter', function() {
     it('should add filterNull for Q and T by default', function () {
       const model = parseUnitModel(spec);
       assert.deepEqual(nullFilter.parseUnit(model), {
-        qq: true,
-        tt: true,
-        oo: false
+        qq: {field: 'qq', type: "quantitative"},
+        tt: {field: 'tt', type: "temporal"},
+        oo: null
       });
     });
 
@@ -296,9 +296,9 @@ describe('data: nullFilter', function() {
         }
       }));
       assert.deepEqual(nullFilter.parseUnit(model), {
-        qq: true,
-        tt: true,
-        oo: true
+        qq: {field: 'qq', type: "quantitative"},
+        tt: {field: 'tt', type: "temporal"},
+        oo: {field: 'oo', type: "ordinal"}
       });
     });
 
@@ -309,10 +309,28 @@ describe('data: nullFilter', function() {
         }
       }));
       assert.deepEqual(nullFilter.parseUnit(model), {
-        qq: false,
-        tt: false,
-        oo: false
+        qq: null,
+        tt: null,
+        oo: null
       });
+    });
+
+    it ('should add no null filter for count field', () => {
+      const model = parseUnitModel({
+        transform: {
+          filterNull: true
+        },
+        mark: "point",
+        encoding: {
+          y: {aggregate: 'count', field: '*', type: "quantitative"}
+        }
+      });
+
+      assert.deepEqual(nullFilter.parseUnit(model), {});
+    });
+
+    describe('assemble', () => {
+      // TODO:
     });
   });
 


### PR DESCRIPTION
- Only add `NaN` filter for quantitative and temporal fields
- Don't add filters for `*` (of count fields)

cc: @domoritz  I'll merge this as this solves problem in https://github.com/uwdata/voyager2/issues/82, but feel free to send a follow up comment.