### PR TITLE
Filled Incorrect Color Legend for Point Mark Chart

### DIFF
--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -122,12 +122,11 @@ export namespace properties {
     const cfg = model.config();
     const filled = cfg.mark.filled;
 
-
     let config = channel === COLOR ?
         /* For color's legend, do not set fill (when filled) or stroke (when unfilled) property from config because the the legend's `fill` or `stroke` scale should have precedence */
         without(FILL_STROKE_CONFIG, [ filled ? 'fill' : 'stroke', 'strokeDash', 'strokeDashOffset']) :
         /* For other legend, no need to omit. */
-         without(FILL_STROKE_CONFIG, ['strokeDash', 'strokeDashOffset']);
+        without(FILL_STROKE_CONFIG, ['strokeDash', 'strokeDashOffset']);
 
     config = without(config, ['strokeDash', 'strokeDashOffset']);
 
@@ -170,9 +169,7 @@ export namespace properties {
       symbols.fill = {value: legend.symbolColor};
     } else if (symbols.fill === undefined) {
       // fall back to mark config colors for legend fill
-      if (cfg.mark.color !== undefined) {
-        symbols.fill = {value: cfg.mark.color};
-      } else if (cfg.mark.fill !== undefined) {
+      if (cfg.mark.fill !== undefined) {
         symbols.fill = {value: cfg.mark.fill};
       } else if (cfg.mark.stroke !== undefined) {
         symbols.stroke = {value: cfg.mark.stroke};


### PR DESCRIPTION
- Remove incorrect line added in #1446 

This is not the most ideal fix.  We should refactor it before the next major release but at least it's removing the bug.   

Fix #1500

Now the same spec in #1500 looks okay like this: 

![vega_editor](https://cloud.githubusercontent.com/assets/111269/17679875/5e4e744c-62f2-11e6-8a80-e48f41f3f207.png)