### PR TITLE
Make `nullFilter` comes after `formula` transform

### DIFF
--- a/src/compile/data/source.ts
+++ b/src/compile/data/source.ts
@@ -106,8 +106,8 @@ export namespace source {
       // null filter comes first so transforms are not performed on null values
       // time and bin should come before filter so we can filter by time and bin
       sourceData.transform = [].concat(
-        nullFilter.assemble(component),
         formula.assemble(component),
+        nullFilter.assemble(component),
         filter.assemble(component),
         bin.assemble(component),
         timeUnit.assemble(component)

--- a/test/compile/data.test.ts
+++ b/test/compile/data.test.ts
@@ -87,8 +87,8 @@ describe('data', function () {
         }
       });
       const transform = compileAssembleData(model)[0].transform;
-      assert.deepEqual(transform[0].type, 'filter');
-      assert.deepEqual(transform[1].type, 'formula');
+      assert.deepEqual(transform[0].type, 'formula');
+      assert.deepEqual(transform[1].type, 'filter');
       assert.deepEqual(transform[2].type, 'filter');
       assert.deepEqual(transform[3].type, 'bin');
       assert.deepEqual(transform[4].type, 'formula');


### PR DESCRIPTION
Fix #1453, Fix #1485

cc: @domoritz  turns out this is a 1-line quick fix for now but you'll have to make sure that it still works correctly in your layering branch, which completely rewrites this part of logic. 