### PR TITLE
For specific channel (e.g. x) use `model.encoding().x` instead of `model.fieldDef(X)`

### DIFF
--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -43,8 +43,8 @@ export const FILL_STROKE_CONFIG = union(STROKE_CONFIG, FILL_CONFIG);
 
 export function applyColorAndOpacity(p, model: UnitModel) {
   const filled = model.config().mark.filled;
-  const colorFieldDef = model.fieldDef(COLOR);
-  const opacityFieldDef = model.fieldDef(OPACITY);
+  const colorFieldDef = model.encoding().color;
+  const opacityFieldDef = model.encoding().opacity;
 
   // Apply fill stroke config first so that color field / value can override
   // fill / stroke

--- a/src/compile/data/colorrank.ts
+++ b/src/compile/data/colorrank.ts
@@ -3,9 +3,9 @@ import {ORDINAL} from '../../type';
 import {extend, vals, flatten, Dict} from '../../util';
 import {VgTransform} from '../../vega.schema';
 
-import {FacetModel} from './../facet';
-import {LayerModel} from './../layer';
-import {Model} from './../model';
+import {FacetModel} from '../facet';
+import {LayerModel} from '../layer';
+import {UnitModel} from '../unit';
 
 import {DataComponent} from './data';
 
@@ -18,9 +18,9 @@ export namespace colorRank {
   /**
    * Return hash dict from a color field's name to the sort and rank transforms
    */
-  export function parseUnit(model: Model) {
+  export function parseUnit(model: UnitModel) {
     let colorRankComponent: Dict<VgTransform[]> = {};
-    if (model.has(COLOR) && model.fieldDef(COLOR).type === ORDINAL) {
+    if (model.has(COLOR) && model.encoding().color.type === ORDINAL) {
       colorRankComponent[model.field(COLOR)] = [{
         type: 'sort',
         by: model.field(COLOR)

--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -25,7 +25,7 @@ export function parseLegendComponent(model: UnitModel): Dict<VgLegend> {
 function getLegendDefWithScale(model: UnitModel, channel: Channel): VgLegend {
   switch (channel) {
     case COLOR:
-      const fieldDef = model.fieldDef(COLOR);
+      const fieldDef = model.encoding().color;
       const scale = model.scaleName(useColorLegendScale(fieldDef) ?
         // To produce ordinal legend (list, rather than linear range) with correct labels:
         // - For an ordinal field, provide an ordinal scale that maps rank values to field values
@@ -147,8 +147,8 @@ export namespace properties {
         // for color legend scale, we need to override
         value = { scale: model.scaleName(COLOR), field: 'data' };
       }
-    } else if (model.fieldDef(COLOR).value) {
-      value = { value: model.fieldDef(COLOR).value };
+    } else if (model.encoding().color && model.encoding().color.value) {
+      value = { value: model.encoding().color.value };
     }
 
     if (value !== undefined) {

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -70,32 +70,32 @@ export namespace bar {
         };
         p.width = {value: sizeValue(model, X)};
       }
-    } else if (model.fieldDef(X).bin) {
-      if (model.has(SIZE) && orient !== Orient.HORIZONTAL) {
-        // For vertical chart that has binned X and size,
-        // center bar and apply size to width.
-        p.xc = {
-          scale: model.scaleName(X),
-          field: model.field(X, { binSuffix: 'mid' })
-        };
-        p.width = {
-          scale: model.scaleName(SIZE),
-          field: model.field(SIZE)
-        };
-      } else {
-        p.x = {
-          scale: model.scaleName(X),
-          field: model.field(X, { binSuffix: 'start' }),
-          offset: 1
-        };
-        p.x2 = {
-          scale: model.scaleName(X),
-          field: model.field(X, { binSuffix: 'end' })
-        };
-      }
     } else { // x is dimension or unspecified
       if (model.has(X)) { // is ordinal
-        if (model.scale(X).bandSize === BANDSIZE_FIT) {
+        if (model.encoding().x.bin) {
+          if (model.has(SIZE) && orient !== Orient.HORIZONTAL) {
+            // For vertical chart that has binned X and size,
+            // center bar and apply size to width.
+            p.xc = {
+              scale: model.scaleName(X),
+              field: model.field(X, { binSuffix: 'mid' })
+            };
+            p.width = {
+              scale: model.scaleName(SIZE),
+              field: model.field(SIZE)
+            };
+          } else {
+            p.x = {
+              scale: model.scaleName(X),
+              field: model.field(X, { binSuffix: 'start' }),
+              offset: 1
+            };
+            p.x2 = {
+              scale: model.scaleName(X),
+              field: model.field(X, { binSuffix: 'end' })
+            };
+          }
+        } else if (model.scale(X).bandSize === BANDSIZE_FIT) {
           p.x = {
             scale: model.scaleName(X),
             field: model.field(X),
@@ -178,34 +178,34 @@ export namespace bar {
         };
         p.height = { value: sizeValue(model, Y) };
       }
-    } else if (model.fieldDef(Y).bin) {
-      if (model.has(SIZE) && orient === Orient.HORIZONTAL) {
-        // For horizontal chart that has binned Y and size,
-        // center bar and apply size to height.
-        p.yc = {
-          scale: model.scaleName(Y),
-          field: model.field(Y, { binSuffix: 'mid' })
-        };
-        p.height = {
-          scale: model.scaleName(SIZE),
-          field: model.field(SIZE)
-        };
-      } else {
-        // Otherwise, simply use <field>_start, <field>_end
-        p.y = {
-          scale: model.scaleName(Y),
-          field: model.field(Y, { binSuffix: 'start' })
-        };
-        p.y2 = {
-          scale: model.scaleName(Y),
-          field: model.field(Y, { binSuffix: 'end' }),
-          offset: 1
-        };
-      }
     } else { // y is ordinal or unspecified
 
       if (model.has(Y)) { // is ordinal
-         if (model.scale(Y).bandSize === BANDSIZE_FIT) {
+        if (model.encoding().y.bin) {
+          if (model.has(SIZE) && orient === Orient.HORIZONTAL) {
+            // For horizontal chart that has binned Y and size,
+            // center bar and apply size to height.
+            p.yc = {
+              scale: model.scaleName(Y),
+              field: model.field(Y, { binSuffix: 'mid' })
+            };
+            p.height = {
+              scale: model.scaleName(SIZE),
+              field: model.field(SIZE)
+            };
+          } else {
+            // Otherwise, simply use <field>_start, <field>_end
+            p.y = {
+              scale: model.scaleName(Y),
+              field: model.field(Y, { binSuffix: 'start' })
+            };
+            p.y2 = {
+              scale: model.scaleName(Y),
+              field: model.field(Y, { binSuffix: 'end' }),
+              offset: 1
+            };
+          }
+        } else if (model.scale(Y).bandSize === BANDSIZE_FIT) {
           p.y = {
             scale: model.scaleName(Y),
             field: model.field(Y),
@@ -243,7 +243,7 @@ export namespace bar {
 
   // TODO: make this a mixins
   function sizeValue(model: UnitModel, channel: Channel) {
-    const fieldDef = model.fieldDef(SIZE);
+    const fieldDef = model.encoding().size;
     if (fieldDef && fieldDef.value !== undefined) {
        return fieldDef.value;
     }

--- a/src/compile/mark/rule.ts
+++ b/src/compile/mark/rule.ts
@@ -85,7 +85,7 @@ export namespace rule {
   }
 
   function sizeValue(model: UnitModel) {
-    const fieldDef = model.fieldDef(SIZE);
+    const fieldDef = model.encoding().size;
     if (fieldDef && fieldDef.value !== undefined) {
        return fieldDef.value;
     }

--- a/src/compile/mark/text.ts
+++ b/src/compile/mark/text.ts
@@ -21,7 +21,7 @@ export namespace text {
       height: { field: { group: 'height' } },
       fill: {
         scale: model.scaleName(COLOR),
-        field: model.field(COLOR, model.fieldDef(COLOR).type === ORDINAL ? {prefix: 'rank'} : {})
+        field: model.field(COLOR, model.encoding().color.type === ORDINAL ? {prefix: 'rank'} : {})
       }
     };
   }
@@ -35,7 +35,7 @@ export namespace text {
         'fontStyle', 'radius', 'theta', 'text']);
 
     const config = model.config();
-    const textFieldDef = model.fieldDef(TEXT);
+    const textFieldDef = model.encoding().text;
 
     p.x = x(model.encoding().x, model.scaleName(X), config, textFieldDef);
 
@@ -43,7 +43,7 @@ export namespace text {
 
     p.fontSize = size(model.encoding().size, model.scaleName(SIZE), config);
 
-    p.text = text(model.encoding().text, model.scaleName(TEXT), config);
+    p.text = text(textFieldDef, model.scaleName(TEXT), config);
 
     if (model.config().mark.applyColorToBackground && !model.has(X) && !model.has(Y)) {
       p.fill = {value: 'black'}; // TODO: add rules for swapping between black and white

--- a/test/compile/scale.test.ts
+++ b/test/compile/scale.test.ts
@@ -23,7 +23,7 @@ describe('Scale', function() {
           }
         }
       });
-      const fieldDef = model.fieldDef(DETAIL);
+      const fieldDef = model.encoding().detail;
       assert.deepEqual(scaleType(null, fieldDef, DETAIL, model.mark()), null);
     });
 
@@ -38,7 +38,7 @@ describe('Scale', function() {
           }
         }
       });
-      const fieldDef = model.fieldDef(Y);
+      const fieldDef = model.encoding().y;
       const scale = model.scale(Y);
       assert.deepEqual(scaleType(scale, fieldDef, Y, model.mark()), ScaleType.TIME);
     });
@@ -54,7 +54,7 @@ describe('Scale', function() {
           }
         }
       });
-      const fieldDef = model.fieldDef(Y);
+      const fieldDef = model.encoding().y;
       const scale = model.scale(Y);
       assert.deepEqual(scaleType(scale, fieldDef, Y, model.mark()), ScaleType.ORDINAL);
     });
@@ -70,7 +70,7 @@ describe('Scale', function() {
           }
         }
       });
-      const fieldDef = model.fieldDef(ROW);
+      const fieldDef = model.encoding().row;
       const scale = model.scale(ROW);
       assert.deepEqual(scaleType(scale, fieldDef, ROW, model.mark()), ScaleType.ORDINAL);
     });

--- a/test/compile/timeunit.test.ts
+++ b/test/compile/timeunit.test.ts
@@ -14,7 +14,7 @@ describe('TimeUnit', function() {
           x: {timeUnit: 'month', field:'a', type: "temporal", axis: {shortTimeLabels: true}}
         }
       });
-      assert.equal(template(model.fieldDef(X).timeUnit, 'datum["data"]', model.axis(X).shortTimeLabels), '{{datum["data"] | time:\'%b\'}}');
+      assert.equal(template(model.encoding().x.timeUnit, 'datum["data"]', model.axis(X).shortTimeLabels), '{{datum["data"] | time:\'%b\'}}');
     });
 
     it('should get the right time template when shortTimeLabels is unspecified', function() {
@@ -24,7 +24,7 @@ describe('TimeUnit', function() {
           x: {timeUnit: 'month', field:'a', type: "temporal"}
         }
       });
-      assert.equal(template(model.fieldDef(X).timeUnit, 'datum["data"]', model.axis(X).shortTimeLabels), '{{datum["data"] | time:\'%B\'}}');
+      assert.equal(template(model.encoding().x.timeUnit, 'datum["data"]', model.axis(X).shortTimeLabels), '{{datum["data"] | time:\'%B\'}}');
     });
 
     it('should get the right time template when timeUnit is week and shortTimeLabels is true', function() {
@@ -35,7 +35,7 @@ describe('TimeUnit', function() {
         }
       });
 
-      assert.equal(template(model.fieldDef(X).timeUnit, 'datum["data"]', model.axis(X).shortTimeLabels), undefined);
+      assert.equal(template(model.encoding().x.timeUnit, 'datum["data"]', model.axis(X).shortTimeLabels), undefined);
     });
   });
 });


### PR DESCRIPTION
This way we always get the type correctly.  