### PR TITLE
Add month-date back since we use year 0 

### DIFF
--- a/src/timeunit.ts
+++ b/src/timeunit.ts
@@ -13,13 +13,13 @@ export enum TimeUnit {
   SECONDS = 'seconds' as any,
   MILLISECONDS = 'milliseconds' as any,
   YEARMONTH = 'yearmonth' as any,
-  // Note: don't add MONTH DATE because it will be incorrect
-  // since days on a leap year will be shifted by one if
-  // we only add
   YEARMONTHDATE = 'yearmonthdate' as any,
   YEARMONTHDATEHOURS = 'yearmonthdatehours' as any,
   YEARMONTHDATEHOURSMINUTES = 'yearmonthdatehoursminutes' as any,
   YEARMONTHDATEHOURSMINUTESSECONDS = 'yearmonthdatehoursminutesseconds' as any,
+
+  // MONTHDATE always include 29 February since we use year 0th (which is a leap year)
+  MONTHDATE = 'monthdate' as any,
   HOURSMINUTES = 'hoursminutes' as any,
   HOURSMINUTESSECONDS = 'hoursminutesseconds' as any,
   MINUTESSECONDS = 'minutesseconds' as any,


### PR DESCRIPTION
thus we automatically include February 29th.

I believe this is the correct behavior.

Fix #1557