### PR TITLE
Correct quarter's domain to produce correct month

### DIFF
--- a/src/timeunit.ts
+++ b/src/timeunit.ts
@@ -200,7 +200,7 @@ export function rawDomain(timeUnit: TimeUnit, channel: Channel) {
     case TimeUnit.MONTH:
       return range(0, 12);
     case TimeUnit.QUARTER:
-      return [0,3,6,9];
+      return [0,1,2,3]; // Q1-Q4 (0th-index)
   }
 
   return null;


### PR DESCRIPTION
The domain should be [0,1,2,3] instead of [0,3,6,9] since the output dateTimeExpr multiplies the quarter value by 3

Fix #1531, Fix #1532

I haven't inspected each individual value in the plot as we don't have tooltip in the editor yet, but the output seems correct to me.  (cc: @zeningqu)

Thanks @willium for hinting

![vega_editor](https://cloud.githubusercontent.com/assets/111269/19018077/85e96dca-887e-11e6-8166-e3f85afd8957.png)
