### PR TITLE
Make filterInvalid read from parent to make sure that we always correctly filter invalid values.

### DIFF
--- a/src/compile/data/filter.ts
+++ b/src/compile/data/filter.ts
@@ -18,7 +18,7 @@ export namespace filter {
    */
 
   export function parse(model: Model): string {
-    const filter = model.transform().filter;
+    const filter = model.filter();
     if (isArray(filter)) {
       return '(' +
         filter.map((f) => expression(f))

--- a/src/compile/data/formatparse.ts
+++ b/src/compile/data/formatparse.ts
@@ -9,7 +9,7 @@ import {Model} from './../model';
 export namespace formatParse {
   // TODO: need to take calculate into account across levels when merging
   function parse(model: Model): Dict<string> {
-    const calcFieldMap = (model.transform().calculate || []).reduce(function(fieldMap, formula) {
+    const calcFieldMap = (model.calculate() || []).reduce(function(fieldMap, formula) {
       fieldMap[formula.field] = true;
       return fieldMap;
     }, {});

--- a/src/compile/data/formula.ts
+++ b/src/compile/data/formula.ts
@@ -10,7 +10,7 @@ import {DataComponent} from './data';
 
 export namespace formula {
   function parse(model: Model): Dict<Formula> {
-    return (model.transform().calculate || []).reduce(function(formulaComponent, formula) {
+    return (model.calculate() || []).reduce(function(formulaComponent, formula) {
       formulaComponent[hash(formula)] = formula;
       return formulaComponent;
     }, {} as Dict<Formula>);

--- a/src/compile/data/nullfilter.ts
+++ b/src/compile/data/nullfilter.ts
@@ -19,13 +19,7 @@ const DEFAULT_NULL_FILTERS = {
 export namespace nullFilter {
   /** Return Hashset of fields for null filtering (key=field, value = true). */
   function parse(model: Model): Dict<boolean> {
-    const transform = model.transform();
-    let filterInvalid = transform.filterInvalid;
-
-    if (filterInvalid === undefined && transform['filterNull'] !== undefined) {
-      filterInvalid = transform['filterNull'];
-      console.warn('filterNull is deprecated. Please use filterInvalid instead.');
-    }
+    const filterInvalid = model.filterInvalid();
 
     return model.reduce(function(aggregator, fieldDef: FieldDef) {
       if (fieldDef.field !== '*') { // Ignore * for count(*) fields.

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -109,6 +109,14 @@ export abstract class Model {
     this._description = spec.description;
     this._transform = spec.transform;
 
+    if (spec.transform) {
+      if (spec.transform.filterInvalid === undefined &&
+          spec.transform['filterNull'] !== undefined) {
+        spec.transform.filterInvalid = spec.transform['filterNull'];
+        console.warn('filterNull is deprecated. Please use filterInvalid instead.');
+      }
+    }
+
     this.component = {data: null, layout: null, mark: null, scale: null, axis: null, axisGroup: null, gridGroup: null, legend: null};
   }
 
@@ -261,8 +269,21 @@ export abstract class Model {
 
   public abstract dataTable(): string;
 
-  public transform(): Transform {
-    return this._transform || {};
+  // TRANSFORMS
+  public calculate() {
+    return this._transform ? this._transform.calculate : undefined;
+  }
+
+  public filterInvalid() {
+    const transform = this._transform || {};
+    if (transform.filterInvalid === undefined) {
+      return this.parent() ? this.parent().filterInvalid() : undefined;
+    }
+    return transform.filterInvalid;
+  }
+
+  public filter() {
+    return this._transform ? this._transform.filter : undefined;
   }
 
   /** Get "field" reference for vega */

--- a/test/compile/data.test.ts
+++ b/test/compile/data.test.ts
@@ -302,6 +302,19 @@ describe('data: nullFilter', function() {
       });
     });
 
+    it('should add no null filter if filterInvalid is false', function () {
+      const model = parseUnitModel(mergeDeep(spec, {
+        transform: {
+          filterInvalid: false
+        }
+      }));
+      assert.deepEqual(nullFilter.parseUnit(model), {
+        qq: null,
+        tt: null,
+        oo: null
+      });
+    });
+
     it('should add no null filter if filterNull is false', function () {
       const model = parseUnitModel(mergeDeep(spec, {
         transform: {


### PR DESCRIPTION
- Make filterInvalid read from parent to make sure that we always correctly filter invalid values.
  - Fix #1534 – apply filterInvalid for inner spec of a faceted plot
- Replace `model.transform()` with `model.calculate|filter|filterInvalid()` to avoid calling filterInvalid directly