### PR TITLE
Remove browserify-versionify to fix webpack/browserify compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
   "devDependencies": {
     "browser-sync": "~2.16.0",
     "browserify": "~13.1.0",
-    "browserify-versionify": "~1.0.6",
     "chai": "~3.5.0",
     "cheerio": "~0.22.0",
     "exorcist": "~0.4.0",
@@ -80,10 +79,5 @@
     "datalib": "~1.7.2",
     "json-stable-stringify": "~1.0.1",
     "yargs": "~5.0.0"
-  },
-  "browserify": {
-    "transform": [
-      "browserify-versionify"
-    ]
   }
 }

--- a/src/vl.ts
+++ b/src/vl.ts
@@ -22,4 +22,4 @@ export import type = require('./type');
 export import util = require('./util');
 export import validate = require('./validate');
 
-export const version = '__VERSION__';
+export const version = require('../package.json').version;


### PR DESCRIPTION
This pulls the version directly from `package.json` and removes the need for a transform to enable better compatibility with build tools like browserify and webpack. Note webpack users will still need to have the [json-loader](https://github.com/webpack/json-loader) enabled. 

This is related to vega/vega#369 in the overall goal of improving compatibility with the javascript ecosystem.

Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [ ] Provide a test case & update the documentation under `site/docs/`
- [x] Make lint and test pass. (Run `npm run lint` and `npm run test`)
- [x] Make sure you have merged `master` into your branch. 
- [x] Provide a concise title so that we can just copy it to our release note. 
  - Use imperative mood and present tense.
  - Mention relevant issues. (e.g., `#1`)
  

