### PR TITLE
DateTime support for scale.domain, axis.values, legend.values

### DIFF
--- a/examples/specs/point_custom_time_domain_values.vl.json
+++ b/examples/specs/point_custom_time_domain_values.vl.json
@@ -1,0 +1,22 @@
+{
+  "description": "Google's stock price over time.",
+  "data": {"url": "data/stocks.csv", "format": {"type": "csv"}},
+  "transform": {"filter": "datum.symbol==='GOOG'"},
+  "mark": "point",
+  "encoding": {
+    "x": {
+      "field": "date", "type": "temporal",
+      "scale": {"domain": [{"year": 2005, "month": 1}, {"year": 2009}]},
+      "axis": {"values": [{"year": 2005}, {"year": 2007}, {"year": 2009}]}
+    },
+    "y": {"field": "price", "type": "quantitative"},
+    "color": {
+      "field": "date", "type": "temporal",
+      "scale": {"domain": [{"year": 2004}, {"year": 2010}]},
+      "legend": {
+        "values": [{"year": 2004}, {"year": 2007}, {"year": 2010}],
+        "format": "%y"
+      }
+    }
+  }
+}

--- a/site/docs/axis.md
+++ b/site/docs/axis.md
@@ -85,7 +85,7 @@ Axis properties can be customized by setting `axis` to an axis property object. 
 | tickSizeMinor | Number        | The size, in pixels, of minor ticks.|
 | tickSizeEnd   | Number        | The size, in pixels, of end ticks.|
 | tickWidth   	| Number        | The width, in pixels, of ticks.|
-| values        | Array         | Explicitly set the visible axis tick values.|
+| values        | Number[] &#124; [DateTime[]](transform.html#datetime) | Explicitly set the visible axis tick values. |
 
 ### Title
 
@@ -94,7 +94,7 @@ Axis properties can be customized by setting `axis` to an axis property object. 
 | title         | String        | A title for the axis. <span class="note-line">__Default value:__  derived from the field's name and transformation function applied e.g, "field_name", "SUM(field_name)", "BIN(field_name)", "YEAR(field_name)".</span> |
 | titleColor	| String 		| The color of the title. |
 | titleFont		| String 		| The font of title (e.g., `Helvetica Neue`). |
-| titleFontWeight	| Number 	 	|  The font weight of title (e.g., `bold`). | 
+| titleFontWeight	| Number 	 	|  The font weight of title (e.g., `bold`). |
 | titleFontSize	| Number 		| The font size of title, in pixels. <span class="note-line">__Default value:__ 10. </span> |
 | titleOffset   | Number        | The offset (in pixels) from the axis at which to place the title.|
 | titleMaxLength  | Integer     | Max length for axis title when the title is automatically generated from the field\'s description. <span class="note-line">__Default value:__  automatically determined based on the cell size (`config.cell.width`, `config.cell.height`) and `characterWidth` property.</span> |

--- a/site/docs/legend.md
+++ b/site/docs/legend.md
@@ -45,7 +45,8 @@ The `legend` property object supports the following properties:
 | :------------ |:-------------:| :------------- |
 | orient        | String        | The orientation of the legend. One of `"left"` or `"right"`. This determines how the legend is positioned within the scene. <span class="note-line">__Default value:__  derived from [legend config](config.html#legend-config)'s `orient` (`"right"` by default).</span>|
 | offset        | Number        | The offset, in pixels, by which to displace the legend from the edge of the enclosing group or data rectangle. <span class="note-line">__Default value:__  derived from [legend config](config.html#legend-config)'s `offset` (`0` by default).</span> |
-| values        | Array         | Explicitly set the visible legend values.|
+| values        | Array &#124; [DateTime[]](transform.html#datetime) | Explicitly set the visible legend values. |
+
 
 ### Labels
 

--- a/site/docs/scale.md
+++ b/site/docs/scale.md
@@ -91,7 +91,7 @@ Custom domain values can be specified via the scale's `domain` property.
 
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
-| domain        | Array         | Custom domain values. For quantitative data, this can take the form of a two-element array with minimum and maximum values.  For ordinal data, this is an array representing all values and their orders. |
+| domain        | Array         | Custom domain values. <br/> • For _quantitative_ data, this can take the form of a two-element array with minimum and maximum values. <br/> • For _temporal_ data, this can, this can be a two-element array with minimum and maximum values in the form of either timestamp numbers or the [DateTime](transform.html#datetime) definition object.  <br/> • For _ordinal_ or _nominal_ data, this is an array representing all values and their orders.   |
 
 <!-- TODO:
 - Decide if we should write about custom domain for ordinal scale.

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -1,3 +1,4 @@
+import {DateTime} from './datetime';
 
 export enum AxisOrient {
     TOP = 'top' as any,
@@ -219,5 +220,5 @@ export interface Axis extends AxisConfig {
    * A title for the axis. Shows field name and its function by default.
    */
   title?: string;
-  values?: number[];
+  values?: number[] | DateTime[];
 }

--- a/src/compile/axis.ts
+++ b/src/compile/axis.ts
@@ -1,5 +1,6 @@
 import {AxisOrient} from '../axis';
 import {COLUMN, ROW, X, Y, Channel} from '../channel';
+import {DateTime, isDateTime, timestamp} from '../datetime';
 import {title as fieldDefTitle} from '../fielddef';
 import {NOMINAL, ORDINAL, TEMPORAL} from '../type';
 import {contains, keys, extend, truncate, Dict} from '../util';
@@ -94,9 +95,9 @@ export function parseAxis(channel: Channel, model: Model): VgAxis {
   // 1.2. Add properties
   [
     // a) properties with special rules (so it has axis[property] methods) -- call rule functions
-    'format', 'grid', 'layer', 'offset', 'orient', 'tickSize', 'ticks', 'tickSizeEnd', 'title', 'titleOffset',
+    'format', 'grid', 'layer', 'offset', 'orient', 'tickSize', 'ticks', 'tickSizeEnd', 'title', 'titleOffset', 'values',
     // b) properties without rules, only produce default values in the schema, or explicit value if specified
-    'tickPadding', 'tickSize', 'tickSizeMajor', 'tickSizeMinor', 'values', 'subdivide'
+    'tickPadding', 'tickSize', 'tickSizeMajor', 'tickSizeMinor','subdivide'
   ].forEach(function(property) {
     let method: (model: Model, channel: Channel, def:any)=>any;
 
@@ -217,7 +218,6 @@ export function tickSizeEnd(model: Model, channel: Channel) {
   return undefined;
 }
 
-
 export function title(model: Model, channel: Channel) {
   const axis = model.axis(channel);
   if (axis.title !== undefined) {
@@ -250,6 +250,17 @@ export function titleOffset(model: Model, channel: Channel) {
       return titleOffset;
   }
   return undefined;
+}
+
+export function values(model: Model, channel: Channel) {
+  const vals = model.axis(channel).values;
+  if (vals && isDateTime(vals[0])) {
+    return (vals as DateTime[]).map((dt) => {
+      // normalize = true as end user won't put 0 = January
+      return timestamp(dt, true);
+    });
+  }
+  return vals;
 }
 
 export namespace properties {

--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -1,5 +1,6 @@
 import {COLOR, SIZE, SHAPE, OPACITY, Channel} from '../channel';
 import {Config} from '../config';
+import {DateTime, isDateTime, timestamp} from '../datetime';
 import {FieldDef} from '../fielddef';
 import {Legend} from '../legend';
 import {title as fieldTitle} from '../fielddef';
@@ -59,9 +60,13 @@ export function parseLegend(model: UnitModel, channel: Channel): VgLegend {
   if (format) {
     def.format = format;
   }
+  const vals = values(legend);
+  if (vals) {
+    def.values = vals;
+  }
 
   // 1.2 Add properties without rules
-  ['offset', 'orient', 'values'].forEach(function(property) {
+  ['offset', 'orient'].forEach(function(property) {
     const value = legend[property];
     if (value !== undefined) {
       def[property] = value;
@@ -89,6 +94,17 @@ export function title(legend: Legend, fieldDef: FieldDef, config: Config) {
   }
 
   return fieldTitle(fieldDef, config);
+}
+
+export function values(legend: Legend) {
+  const vals = legend.values;
+  if (vals && isDateTime(vals[0])) {
+    return (vals as DateTime[]).map((dt) => {
+      // normalize = true as end user won't put 0 = January
+      return timestamp(dt, true);
+    });
+  }
+  return vals;
 }
 
 // we have to use special scales for ordinal or binned fields for the color channel

--- a/src/compile/scale.ts
+++ b/src/compile/scale.ts
@@ -5,6 +5,7 @@ import {SHARED_DOMAIN_OPS} from '../aggregate';
 import {COLUMN, ROW, X, Y, X2, Y2, SHAPE, SIZE, COLOR, OPACITY, TEXT, hasScale, Channel} from '../channel';
 import {Orient} from '../config';
 import {SOURCE, STACKED_SCALE} from '../data';
+import {DateTime, isDateTime, timestamp} from '../datetime';
 import {FieldDef, field, isMeasure} from '../fielddef';
 import {Mark, BAR, TEXT as TEXTMARK, RULE, TICK} from '../mark';
 import {Scale, ScaleConfig, ScaleType, NiceTime, BANDSIZE_FIT, BandSize} from '../scale';
@@ -241,6 +242,11 @@ export function domain(scale: Scale, model: Model, channel:Channel): any {
   const fieldDef = model.fieldDef(channel);
 
   if (scale.domain) { // explicit value
+    if (isDateTime(scale.domain[0])) {
+      return (scale.domain as DateTime[]).map((dt) => {
+        return timestamp(dt, true);
+      });
+    }
     return scale.domain;
   }
 

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -123,6 +123,48 @@ function normalizeDay(d: string | number) {
   }
 }
 
+export function timestamp(d: DateTime, normalize) {
+  const date = new Date(0, 0, 1, 0, 0, 0, 0); // start with uniform date
+
+  // FIXME support UTC
+  // FIXME what about day
+
+  if (d.year !== undefined) {
+    date.setFullYear(d.year);
+  }
+  if (d.quarter !== undefined) {
+    const quarter = normalize ? normalizeQuarter(d.quarter) : d.quarter;
+    date.setMonth(+quarter * 3);
+  }
+
+  if (d.month !== undefined) {
+    const month = normalize ? normalizeMonth(d.month) : d.month;
+    date.setMonth(+month);
+  }
+
+  if (d.date !== undefined) {
+    date.setDate(d.date);
+  }
+
+  if (d.hours !== undefined) {
+    date.setHours(d.hours);
+  }
+
+  if (d.minutes !== undefined) {
+    date.setMinutes(d.minutes);
+  }
+
+  if (d.seconds !== undefined) {
+    date.setSeconds(d.seconds);
+  }
+
+  if (d.milliseconds !== undefined) {
+    date.setMilliseconds(d.milliseconds);
+  }
+
+  return date.getTime();
+}
+
 /**
  * Return Vega Expression for a particular date time.
  * @param d

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -1,6 +1,11 @@
 // DateTime definition object
 
-import {duplicate, isNumber} from './util';
+import {duplicate, keys, isNumber} from './util';
+
+/*
+ * A designated year that starts on Sunday.
+ */
+const SUNDAY_YEAR = 2006;
 
 /**
  * Object for defining datetime in Vega-Lite Filter.
@@ -127,11 +132,26 @@ export function timestamp(d: DateTime, normalize) {
   const date = new Date(0, 0, 1, 0, 0, 0, 0); // start with uniform date
 
   // FIXME support UTC
-  // FIXME what about day
+
+  if (d.day !== undefined) {
+    if (keys(d).length > 1) {
+      console.warn('Dropping day from datetime', JSON.stringify(d),
+          'as day cannot be combined with other units.');
+      d = duplicate(d);
+      delete d.day;
+    } else {
+      // Use a year that has 1/1 as Sunday so we can setDate below
+      date.setFullYear(SUNDAY_YEAR);
+
+      const day = normalize ? normalizeDay(d.day) : d.day;
+      date.setDate(+day + 1); // +1 since date start at 1 in JS
+    }
+  }
 
   if (d.year !== undefined) {
     date.setFullYear(d.year);
   }
+
   if (d.quarter !== undefined) {
     const quarter = normalize ? normalizeQuarter(d.quarter) : d.quarter;
     date.setMonth(+quarter * 3);
@@ -174,14 +194,11 @@ export function dateTimeExpr(d: DateTime | DateTimeExpr, normalize = false) {
   const units = [];
 
   if (normalize && d.day !== undefined) {
-    for (let unit of ['year', 'quarter', 'month', 'date']) {
-      if (d[unit] !== undefined) {
-        console.warn('Dropping day from datetime', JSON.stringify(d),
-          'as day cannot be combined with', unit);
-        d = duplicate(d);
-        delete d.day;
-        break;
-      }
+    if (keys(d).length > 1) {
+      console.warn('Dropping day from datetime', JSON.stringify(d),
+          'as day cannot be combined with other units.');
+      d = duplicate(d);
+      delete d.day;
     }
   }
 
@@ -189,7 +206,7 @@ export function dateTimeExpr(d: DateTime | DateTimeExpr, normalize = false) {
     units.push(d.year);
   } else if (d.day !== undefined) {
     // Set year to 2006 for working with day since January 1 2006 is a Sunday
-    units.push(2006);
+    units.push(SUNDAY_YEAR);
   } else {
     units.push(0);
   }

--- a/src/legend.ts
+++ b/src/legend.ts
@@ -1,3 +1,5 @@
+import {DateTime} from './datetime';
+
 export interface LegendConfig {
   /**
    * The orientation of the legend. One of "left" or "right". This determines how the legend is positioned within the scene. The default is "right".
@@ -116,7 +118,7 @@ export interface Legend extends LegendConfig {
   /**
    * Explicitly set the visible legend values.
    */
-  values?: Array<any>;
+  values?: Array<any> | Array<DateTime>;
 }
 
 export const defaultLegendConfig: LegendConfig = {

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -1,3 +1,5 @@
+import {DateTime} from './datetime';
+
 export enum ScaleType {
     LINEAR = 'linear' as any,
     LOG = 'log' as any,
@@ -116,7 +118,7 @@ export interface Scale {
   /**
    * The domain of the scale, representing the set of data values. For quantitative data, this can take the form of a two-element array with minimum and maximum values. For ordinal/categorical data, this may be an array of valid input values.
    */
-  domain?: number[] | string[]; // TODO: declare vgDataDomain
+  domain?: number[] | string[] | DateTime[];
   /**
    * The range of the scale, representing the set of visual values. For numeric values, the range can take the form of a two-element array with minimum and maximum values. For ordinal or quantized data, the range may by an array of desired output values, which are mapped to elements in the specified domain. For ordinal scales only, the range can be defined using a DataRef: the range values are then drawn dynamically from a backing data set.
    */

--- a/test/compile/axis.test.ts
+++ b/test/compile/axis.test.ts
@@ -336,6 +336,38 @@ describe('Axis', function() {
     });
   });
 
+  describe('values', () => {
+    it('should return correct timestamp values for DateTimes', () => {
+      const values = axis.values(parseModel({
+        mark: "point",
+        encoding: {
+          y: {field: 'a', type: 'temporal', axis: {values: [{year: 1970}, {year: 1980}]}}
+        }
+      }), Y);
+
+      // Timezone offset in milliseconds
+      const timeZoneOffsetMs = new Date().getTimezoneOffset() * 60000;
+
+      assert.deepEqual(values, [
+        // 0 = new Date(1970, 0).getTime() - new Date().getTimezoneOffset() * 60000
+        0 + timeZoneOffsetMs,
+        // 315532800000 = new Date(1980, 0).getTime() - new Date().getTimezoneOffset() * 60000
+        315532800000 + timeZoneOffsetMs
+      ]);
+    });
+
+    it('should simply return values for non-DateTime', () => {
+      const values = axis.values(parseModel({
+        mark: "point",
+        encoding: {
+          y: {field: 'a', type: 'quantitative', axis: {values: [1,2,3,4]}}
+        }
+      }), Y);
+
+      assert.deepEqual(values, [1,2,3,4]);
+    });
+  });
+
   describe('properties.axis()', function() {
     it('axisColor should change axis\'s color', function() {
         const model = parseModel({

--- a/test/compile/legend.test.ts
+++ b/test/compile/legend.test.ts
@@ -38,6 +38,29 @@ describe('Legend', function() {
     });
   });
 
+  describe('values()', () => {
+    it('should return correct timestamp values for DateTimes', () => {
+      const values = legend.values({values: [{year: 1970}, {year: 1980}]});
+
+      // Timezone offset in milliseconds
+      const timeZoneOffsetMs = new Date().getTimezoneOffset() * 60000;
+
+      assert.deepEqual(values, [
+        // 0 = new Date(1970, 0).getTime() - new Date().getTimezoneOffset() * 60000
+        0 + timeZoneOffsetMs,
+        // 315532800000 = new Date(1980, 0).getTime() - new Date().getTimezoneOffset() * 60000
+        315532800000 + timeZoneOffsetMs
+      ]);
+    });
+
+    it('should simply return values for non-DateTime', () => {
+      const values = legend.values({values: [1,2,3,4]});
+
+      assert.deepEqual(values, [1,2,3,4]);
+    });
+
+  });
+
   describe('properties.symbols', function() {
     it('should initialize if filled', function() {
       const symbol = legend.properties.symbols({field: 'a'}, {}, parseUnitModel({

--- a/test/compile/scale.test.ts
+++ b/test/compile/scale.test.ts
@@ -177,6 +177,21 @@ describe('Scale', function() {
           assert.deepEqual(_domain.data, SUMMARY);
         });
 
+      it('should return the right custom domain', () => {
+        const model = parseUnitModel({
+          mark: "point",
+          encoding: {
+            y: {
+              field: 'horsepower',
+              type: "quantitative",
+              scale: {domain: [0,200]}
+            }
+          }
+        });
+        const _domain = domain(model.scale(Y), model, Y);
+
+        assert.deepEqual(_domain, [0, 200]);
+      });
 
       it('should return the aggregated domain if useRawDomain is false', function() {
           const model = parseUnitModel({
@@ -271,6 +286,30 @@ describe('Scale', function() {
               sort: {field: 'yearmonth_origin', op: 'min'}
             });
           });
+
+      it('should return the right custom domain with DateTime objects', () => {
+        const model = parseUnitModel({
+          mark: "point",
+          encoding: {
+            y: {
+              field: 'year',
+              type: "temporal",
+              scale: {domain: [{year: 1970}, {year: 1980}]}
+            }
+          }
+        });
+        const _domain = domain(model.scale(Y), model, Y);
+
+        // Timezone offset in milliseconds
+        const timeZoneOffsetMs = new Date().getTimezoneOffset() * 60000;
+
+        assert.deepEqual(_domain, [
+          // 0 = new Date(1970, 0).getTime() - new Date().getTimezoneOffset() * 60000
+          0 + timeZoneOffsetMs,
+          // 315532800000 = new Date(1980, 0).getTime() - new Date().getTimezoneOffset() * 60000
+          315532800000 + timeZoneOffsetMs
+        ]);
+      });
     });
 
     describe('for ordinal', function() {

--- a/test/datetime.test.ts
+++ b/test/datetime.test.ts
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import {dateTimeExpr} from '../src/datetime';
+import {dateTimeExpr, timestamp} from '../src/datetime';
 
 
 describe('datetime', () => {
@@ -66,5 +66,30 @@ describe('datetime', () => {
     });
 
     // Note: Other part of coverage handled by timeUnit.fieldExpr's test
+  });
+
+  describe('timestamp', () => {
+    it('should produce correct timestamp', () => {
+      // new Date(1234, 5, 6, 7, 8, 9, 123).getTime() - new Date().getTimezoneOffset() * 60000
+      // = -23212371110877
+      assert.equal(timestamp({
+        year: 1234,
+        month: 'June', // 5 = June
+        date: 6,
+        hours: 7,
+        minutes: 8,
+        seconds: 9,
+        milliseconds: 123
+      }, true), -23212371110877 + new Date().getTimezoneOffset() * 60000);
+    });
+
+    it('should produce correct timestamp for quarter', () => {
+      // new Date(1234, 6).getTime() - new Date().getTimezoneOffset() * 60000
+      // = -23212371110877
+      assert.equal(timestamp({
+        year: 1234,
+        quarter: 3,
+      }, true), -23210236800000 + new Date().getTimezoneOffset() * 60000);
+    });
   });
 });

--- a/test/datetime.test.ts
+++ b/test/datetime.test.ts
@@ -91,5 +91,13 @@ describe('datetime', () => {
         quarter: 3,
       }, true), -23210236800000 + new Date().getTimezoneOffset() * 60000);
     });
+
+    it('should produce correct timestamp for day', () => {
+      // new Date(2006, 0, 2).getTime() - new Date().getTimezoneOffset() * 60000
+      // = 1136160000000
+      assert.equal(timestamp({
+        day: 'monday'
+      }, true), 1136160000000 + new Date().getTimezoneOffset() * 60000);
+    });
   });
 });


### PR DESCRIPTION
Fix #1516 

Please see each commit for details.  (Don't squash -- they are atomic!) 