### PR TITLE
Adjust Stack Rules

### DIFF
--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -112,7 +112,7 @@ By default, `point` marks have filled borders and are transparent inside. Settin
 
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
-| opacity       | Number        | The overall opacity (value between [0,1]). <span class="note-line">__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks and `1` otherwise. </span>|
+| opacity       | Number        | The overall opacity (value between [0,1]). <span class="note-line">__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or [layered `bar` charts](http://vega.github.io/vega-editor/?mode=vega-lite&spec=bar_layered_transparent&showEditor=1) and `1` otherwise. </span>|
 | fillOpacity   | Number        | The fill opacity (value between [0,1]). <span class="note-line">__Default value:__ `1` </span>|
 | strokeOpacity | Number        | The stroke opacity (value between [0,1]). <span class="note-line">__Default value:__ `1` </span> |
 
@@ -133,7 +133,7 @@ By default, `point` marks have filled borders and are transparent inside. Settin
 
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
-| stacked       | string        | Stacking modes for `bar` and `area` marks. <br/> • `zero` - stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](mark.html#stacked-bar-chart) and [area](mark.html#stacked-area-chart) chart). <br/> • `normalize` - stacking with normalized domain (for creating normalized stacked [bar](mark.html#normalized-stacked-bar-chart) and [area](mark.html#normalized-stacked-area-chart) chart). <br/> • `center` - stacking with center baseline (for [streamgraph](mark.html#streamgraph)). <br/> • `none` - No-stacking. This will produces layered [bar](mark.html#layered-bar-chart) and area chart. <span class="note-line">__Default value:__ `zero` if applicable (`bar` or `area` marks with `color`, `opacity`, `size`, or `detail` channel mapped to a group-by field).</span>|
+| stacked       | string        | Stacking modes for `bar` and `area` marks. <br/> • `zero` - stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](mark.html#stacked-bar-chart) and [area](mark.html#stacked-area-chart) chart). <br/> • `normalize` - stacking with normalized domain (for creating normalized stacked [bar](mark.html#normalized-stacked-bar-chart) and [area](mark.html#normalized-stacked-area-chart) chart). <br/> • `center` - stacking with center baseline (for [streamgraph](mark.html#streamgraph)). <br/> • `none` - No-stacking. This will produce layered [bar](mark.html#layered-bar-chart) and area chart. <span class="note-line">__Default value:__ `zero` for plots with all of the following conditions: (1) `bar` or `area` marks (2) `color`, `opacity`, `size`, or `detail` channel mapped to a group-by field (3) One ordinal or nominal axis, and (4) one quantitative axis with linear scale and summative aggregation function (e.g., `sum`, `count`).</span>|
 
 {:#interpolate}
 ### Interpolation (for Line and Area Marks)

--- a/src/aggregate.ts
+++ b/src/aggregate.ts
@@ -49,7 +49,9 @@ export const AGGREGATE_OPS = [
 export const SUM_OPS = [
     AggregateOp.COUNT,
     AggregateOp.SUM,
-    AggregateOp.DISTINCT
+    AggregateOp.DISTINCT,
+    AggregateOp.VALID,
+    AggregateOp.MISSING
 ];
 
 export const SHARED_DOMAIN_OPS = [

--- a/src/compile/config.ts
+++ b/src/compile/config.ts
@@ -1,17 +1,17 @@
-import {X, Y, DETAIL} from '../channel';
+import {X, Y, COLOR, SIZE, DETAIL} from '../channel';
 import {Config, Orient, MarkConfig} from '../config';
 import {Encoding, isAggregate, has} from '../encoding';
 import {isMeasure} from '../fielddef';
 import {BAR, AREA, POINT, LINE, TICK, CIRCLE, SQUARE, RULE, TEXT, Mark} from '../mark';
 import {ScaleType} from '../scale';
+import {StackProperties} from '../stack';
 import {TEMPORAL} from '../type';
 import {contains, extend} from '../util';
 import {scaleType} from '../compile/scale';
-
 /**
  * Augment config.mark with rule-based default values.
  */
-export function initMarkConfig(mark: Mark, encoding: Encoding, config: Config) {
+export function initMarkConfig(mark: Mark, encoding: Encoding, stacked: StackProperties, config: Config) {
    return extend(
      ['filled', 'opacity', 'orient', 'align'].reduce(function(cfg, property: string) {
        const value = config.mark[property];
@@ -25,8 +25,13 @@ export function initMarkConfig(mark: Mark, encoding: Encoding, config: Config) {
          case 'opacity':
            if (value === undefined) {
             if (contains([POINT, TICK, CIRCLE, SQUARE], mark)) {
-              // point-based marks and bar
+              // point-based marks
               if (!isAggregate(encoding) || has(encoding, DETAIL)) {
+                cfg[property] = 0.7;
+              }
+            }
+            if (mark === BAR && !stacked) {
+              if (has(encoding, COLOR) || has(encoding, DETAIL) || has(encoding, SIZE)) {
                 cfg[property] = 0.7;
               }
             }

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -58,7 +58,9 @@ export class UnitModel extends Model {
 
     const mark = this._mark = spec.mark;
     const encoding = this._encoding = this._initEncoding(mark, spec.encoding || {});
-    const config = this._config = this._initConfig(spec.config, parent, mark, encoding);
+
+    this._stack = stack(mark, encoding, ((spec.config || {}).mark || {}).stacked);
+    const config = this._config = this._initConfig(spec.config, parent, mark, encoding, this._stack);
 
     this._scale =  this._initScale(mark, encoding, config, providedWidth, providedHeight);
     this._axis = this._initAxis(encoding, config);
@@ -72,7 +74,7 @@ export class UnitModel extends Model {
     );
 
     // calculate stack properties
-    this._stack = stack(mark, encoding, config);
+
   }
 
   private _initEncoding(mark: Mark, encoding: Encoding) {
@@ -101,7 +103,7 @@ export class UnitModel extends Model {
     return encoding;
   }
 
-  private _initConfig(specConfig: Config, parent: Model, mark: Mark, encoding: Encoding) {
+  private _initConfig(specConfig: Config, parent: Model, mark: Mark, encoding: Encoding, stack: StackProperties) {
     let config = mergeDeep(duplicate(defaultConfig), parent ? parent.config() : {}, specConfig);
     let hasFacetParent = false;
     while (parent !== null) {
@@ -116,7 +118,7 @@ export class UnitModel extends Model {
       config.cell = extend({}, config.cell, config.facet.cell);
     }
 
-    config.mark = initMarkConfig(mark, encoding, config);
+    config.mark = initMarkConfig(mark, encoding, stack, config);
     return config;
   }
 

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -343,5 +343,7 @@ export function fieldDefs(spec: ExtendedUnitSpec): FieldDef[] {
 };
 
 export function isStacked(spec: ExtendedUnitSpec): boolean {
-  return stack(spec.mark, spec.encoding, spec.config) !== null;
+  return stack(spec.mark, spec.encoding,
+           (spec.config && spec.config.mark) ? spec.config.mark.stacked : undefined
+         ) !== null;
 }

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -2,6 +2,7 @@ import {Channel, STACK_GROUP_CHANNELS, X, Y} from './channel';
 import {Config} from './config';
 import {Encoding, has, isAggregate} from './encoding';
 import {Mark, BAR, AREA} from './mark';
+import {ScaleType} from './scale';
 import {contains} from './util';
 
 export enum StackOffset {
@@ -62,9 +63,18 @@ export function stack(mark: Mark, encoding: Encoding, config: Config): StackProp
   const yIsAggregate = hasYField && !!encoding.y.aggregate;
 
   if (xIsAggregate !== yIsAggregate) {
+    const fieldChannel = xIsAggregate ? X : Y;
+    const fieldChannelScale = encoding[fieldChannel].scale;
+
+    if (fieldChannelScale && fieldChannelScale.type && fieldChannelScale.type !== ScaleType.LINEAR) {
+      console.warn('Cannot stack non-linear (' + fieldChannelScale.type + ') scale');
+      return null;
+      return null;
+    }
+
     return {
       groupbyChannel: xIsAggregate ? (hasYField ? Y : null) : (hasXField ? X : null),
-      fieldChannel: xIsAggregate ? X : Y,
+      fieldChannel: fieldChannel,
       stackByChannels: stackByChannels,
       offset: stacked || StackOffset.ZERO
     };

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -1,5 +1,4 @@
 import {Channel, STACK_GROUP_CHANNELS, X, Y} from './channel';
-import {Config} from './config';
 import {Encoding, has, isAggregate} from './encoding';
 import {Mark, BAR, AREA} from './mark';
 import {ScaleType} from './scale';
@@ -26,9 +25,7 @@ export interface StackProperties {
   offset: StackOffset;
 }
 
-export function stack(mark: Mark, encoding: Encoding, config: Config): StackProperties {
-  const stacked = (config && config.mark) ? config.mark.stacked : undefined;
-
+export function stack(mark: Mark, encoding: Encoding, stacked: StackOffset): StackProperties {
   // Should not have stack explicitly disabled
   if (contains([StackOffset.NONE, null, false], stacked)) {
     return null;
@@ -68,7 +65,6 @@ export function stack(mark: Mark, encoding: Encoding, config: Config): StackProp
 
     if (fieldChannelScale && fieldChannelScale.type && fieldChannelScale.type !== ScaleType.LINEAR) {
       console.warn('Cannot stack non-linear (' + fieldChannelScale.type + ') scale');
-      return null;
       return null;
     }
 

--- a/test/stack.test.ts
+++ b/test/stack.test.ts
@@ -1,6 +1,7 @@
 /* tslint:disable:quotemark */
 
 import {assert} from 'chai';
+import {AggregateOp} from '../src/aggregate';
 import {X, Y, DETAIL} from '../src/channel';
 import {BAR, AREA, PRIMITIVE_MARKS} from '../src/mark';
 import {ScaleType} from '../src/scale';
@@ -170,6 +171,29 @@ describe('stack', () => {
             "mark": mark,
             "encoding": {
               "x": {"field": "a", "type": "quantitative", "aggregate": "sum", "scale": {"type": scaleType}},
+              "y": {"field": "variety", "type": "nominal"},
+              "color": {"field": "site", "type": "nominal"}
+            },
+            "config": {
+              "mark": {"stacked": stacked}
+            }
+          };
+          assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
+          assert.isFalse(isStacked(spec as any));
+        });
+      });
+    });
+  });
+
+  it('should always be disabled if the aggregated axis has non-summative aggregate', () => {
+    [undefined, StackOffset.CENTER, StackOffset.NONE, StackOffset.ZERO, StackOffset.NORMALIZE].forEach((stacked) => {
+      [AggregateOp.AVERAGE, AggregateOp.VARIANCE, AggregateOp.Q3].forEach((aggregate) => {
+        PRIMITIVE_MARKS.forEach((mark) => {
+          const spec = {
+            "data": {"url": "data/barley.json"},
+            "mark": mark,
+            "encoding": {
+              "x": {"field": "a", "type": "quantitative", "aggregate": aggregate},
               "y": {"field": "variety", "type": "nominal"},
               "color": {"field": "site", "type": "nominal"}
             },

--- a/test/stack.test.ts
+++ b/test/stack.test.ts
@@ -27,7 +27,7 @@ describe('stack', () => {
             "mark": {"stacked": stacked}
           }
         };
-        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config));
+        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
         assert.isFalse(isStacked(spec as any));
       });
     });
@@ -48,7 +48,7 @@ describe('stack', () => {
             "mark": {"stacked": stacked}
           }
         };
-        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config));
+        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
         assert.isFalse(isStacked(spec as any));
       });
     });
@@ -68,7 +68,7 @@ describe('stack', () => {
             "mark": {"stacked": stacked}
           }
         };
-        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config));
+        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
         assert.isFalse(isStacked(spec as any));
       });
     });
@@ -89,7 +89,7 @@ describe('stack', () => {
             "mark": {"stacked": stacked}
           }
         };
-        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config));
+        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
         assert.isFalse(isStacked(spec as any));
       });
     });
@@ -111,7 +111,7 @@ describe('stack', () => {
             "mark": {"stacked": stacked}
           }
         };
-        const _stack = stack(spec.mark, spec.encoding as any, spec.config);
+        const _stack = stack(spec.mark, spec.encoding as any, spec.config.mark.stacked);
         assert.isOk(_stack);
         assert.isTrue(isStacked(spec as any));
         assert.equal(_stack.stackByChannels[0], DETAIL);
@@ -134,7 +134,7 @@ describe('stack', () => {
             "mark": {"stacked": stacked}
           }
         };
-        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config));
+        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
         assert.isFalse(isStacked(spec as any));
       });
     });
@@ -155,7 +155,7 @@ describe('stack', () => {
             "mark": {"stacked": stacked}
           }
         };
-        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config));
+        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
         assert.isFalse(isStacked(spec as any));
       });
     });
@@ -196,7 +196,7 @@ describe('stack', () => {
             "color": {"field": "site", "type": "nominal"}
           }
         };
-        const _stack = stack(spec.mark, spec.encoding as any, null);
+        const _stack = stack(spec.mark, spec.encoding as any, undefined);
         assert.equal(_stack.fieldChannel, X);
         assert.equal(_stack.groupbyChannel, Y);
         assert.isTrue(isStacked(spec as any));
@@ -213,7 +213,7 @@ describe('stack', () => {
             "color": {"field": "site", "type": "nominal"}
           }
         };
-        const _stack = stack(spec.mark, spec.encoding as any, null);
+        const _stack = stack(spec.mark, spec.encoding as any, undefined);
         assert.equal(_stack.fieldChannel, X);
         assert.equal(_stack.groupbyChannel, null);
         assert.isTrue(isStacked(spec as any));
@@ -231,7 +231,7 @@ describe('stack', () => {
             "color": {"field": "site", "type": "nominal"}
           }
         };
-        const _stack = stack(spec.mark, spec.encoding as any, null);
+        const _stack = stack(spec.mark, spec.encoding as any, undefined);
         assert.equal(_stack.fieldChannel, Y);
         assert.equal(_stack.groupbyChannel, X);
         assert.isTrue(isStacked(spec as any));
@@ -248,7 +248,7 @@ describe('stack', () => {
             "color": {"field": "site", "type": "nominal"}
           }
         };
-        const _stack = stack(spec.mark, spec.encoding as any, null);
+        const _stack = stack(spec.mark, spec.encoding as any, undefined);
         assert.equal(_stack.fieldChannel, Y);
         assert.equal(_stack.groupbyChannel, null);
         assert.isTrue(isStacked(spec as any));
@@ -268,7 +268,7 @@ describe('stack', () => {
             "color": {"field": "site", "type": "nominal"}
           }
         };
-        assert.equal(stack(spec.mark, spec.encoding as any, null).offset, StackOffset.ZERO);
+        assert.equal(stack(spec.mark, spec.encoding as any, undefined).offset, StackOffset.ZERO);
         assert.isTrue(isStacked(spec as any));
       });
     });
@@ -288,7 +288,7 @@ describe('stack', () => {
               "mark": {"stacked": stacked}
             }
           };
-          assert.equal(stack(spec.mark, spec.encoding as any, spec.config).offset, stacked);
+          assert.equal(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked).offset, stacked);
           assert.equal(isStacked(spec as any), StackOffset.NONE !== stacked);
         });
       });

--- a/test/stack.test.ts
+++ b/test/stack.test.ts
@@ -3,6 +3,7 @@
 import {assert} from 'chai';
 import {X, Y, DETAIL} from '../src/channel';
 import {BAR, AREA, PRIMITIVE_MARKS} from '../src/mark';
+import {ScaleType} from '../src/scale';
 import {stack, StackOffset} from '../src/stack';
 import {isStacked} from '../src/spec';
 import {without} from '../src/util';
@@ -156,6 +157,29 @@ describe('stack', () => {
         };
         assert.isNull(stack(spec.mark, spec.encoding as any, spec.config));
         assert.isFalse(isStacked(spec as any));
+      });
+    });
+  });
+
+  it('should always be disabled if the aggregated axis has non-linear scale', () => {
+    [undefined, StackOffset.CENTER, StackOffset.NONE, StackOffset.ZERO, StackOffset.NORMALIZE].forEach((stacked) => {
+      [ScaleType.LOG, ScaleType.POW, ScaleType.SQRT].forEach((scaleType) => {
+        PRIMITIVE_MARKS.forEach((mark) => {
+          const spec = {
+            "data": {"url": "data/barley.json"},
+            "mark": mark,
+            "encoding": {
+              "x": {"field": "a", "type": "quantitative", "aggregate": "sum", "scale": {"type": scaleType}},
+              "y": {"field": "variety", "type": "nominal"},
+              "color": {"field": "site", "type": "nominal"}
+            },
+            "config": {
+              "mark": {"stacked": stacked}
+            }
+          };
+          assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
+          assert.isFalse(isStacked(spec as any));
+        });
       });
     });
   });


### PR DESCRIPTION
(You can review each atomic commit individually.)
- Disable stack when the aggregated axis is a non-linear scale.
- Use opacity = 0.7 for unstacked bar with color/detail/size  (This will make it clearer that the output is a layered bar chart.) 
- Only automatically enable stacking if the aggregation op is summative

Fix #1582