### PR TITLE
Eliminate value property for axis/legend config

### DIFF
--- a/src/compile/axis.ts
+++ b/src/compile/axis.ts
@@ -3,7 +3,7 @@ import {COLUMN, ROW, X, Y, Channel} from '../channel';
 import {DateTime, isDateTime, timestamp} from '../datetime';
 import {title as fieldDefTitle} from '../fielddef';
 import {NOMINAL, ORDINAL, TEMPORAL} from '../type';
-import {contains, keys, extend, truncate, Dict} from '../util';
+import {contains, keys, extend, truncate, Dict, prosSpecMapping} from '../util';
 import {VgAxis} from '../vega.schema';
 
 import {numberFormat, timeTemplate} from './common';
@@ -266,6 +266,7 @@ export function values(model: Model, channel: Channel) {
 export namespace properties {
   export function axis(model: Model, channel: Channel, axisPropsSpec) {
     const axis = model.axis(channel);
+    axisPropsSpec = prosSpecMapping(axisPropsSpec);
 
     return extend(
       axis.axisColor !== undefined ?
@@ -280,6 +281,7 @@ export namespace properties {
 
   export function grid(model: Model, channel: Channel, gridPropsSpec) {
     const axis = model.axis(channel);
+    gridPropsSpec = prosSpecMapping(gridPropsSpec);
 
     return extend(
       axis.gridColor !== undefined ? { stroke: {value: axis.gridColor}} : {},
@@ -294,6 +296,7 @@ export namespace properties {
     const fieldDef = model.fieldDef(channel);
     const axis = model.axis(channel);
     const config = model.config();
+    labelsSpec = prosSpecMapping(labelsSpec);
 
     if (!axis.labels) {
       return extend({
@@ -376,7 +379,12 @@ export namespace properties {
 
   export function ticks(model: Model, channel: Channel, ticksPropsSpec) {
     const axis = model.axis(channel);
-
+    ticksPropsSpec = prosSpecMapping(ticksPropsSpec);
+    console.log(extend(
+      axis.tickColor !== undefined ? {stroke : {value: axis.tickColor} } : {},
+      axis.tickWidth !== undefined ? {strokeWidth: {value: axis.tickWidth} } : {},
+      ticksPropsSpec || {}
+    ));
     return extend(
       axis.tickColor !== undefined ? {stroke : {value: axis.tickColor} } : {},
       axis.tickWidth !== undefined ? {strokeWidth: {value: axis.tickWidth} } : {},
@@ -386,6 +394,7 @@ export namespace properties {
 
   export function title(model: Model, channel: Channel, titlePropsSpec) {
     const axis = model.axis(channel);
+    titlePropsSpec = prosSpecMapping(titlePropsSpec);
 
     return extend(
       axis.titleColor !== undefined ? {stroke : {value: axis.titleColor} } : {},

--- a/src/compile/axis.ts
+++ b/src/compile/axis.ts
@@ -380,11 +380,6 @@ export namespace properties {
   export function ticks(model: Model, channel: Channel, ticksPropsSpec) {
     const axis = model.axis(channel);
     ticksPropsSpec = prosSpecMapping(ticksPropsSpec);
-    console.log(extend(
-      axis.tickColor !== undefined ? {stroke : {value: axis.tickColor} } : {},
-      axis.tickWidth !== undefined ? {strokeWidth: {value: axis.tickWidth} } : {},
-      ticksPropsSpec || {}
-    ));
     return extend(
       axis.tickColor !== undefined ? {stroke : {value: axis.tickColor} } : {},
       axis.tickWidth !== undefined ? {strokeWidth: {value: axis.tickWidth} } : {},

--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -6,7 +6,7 @@ import {Legend} from '../legend';
 import {title as fieldTitle} from '../fielddef';
 import {AREA, BAR, TICK, TEXT, LINE, POINT, CIRCLE, SQUARE} from '../mark';
 import {ORDINAL, TEMPORAL} from '../type';
-import {extend, keys, without, Dict} from '../util';
+import {extend, keys, without, Dict, prosSpecMapping} from '../util';
 
 import {applyMarkConfig, FILL_STROKE_CONFIG, numberFormat, timeTemplate} from './common';
 import {COLOR_LEGEND, COLOR_LEGEND_LABEL} from './scale';
@@ -117,6 +117,7 @@ export namespace properties {
     let symbols:any = {};
     const mark = model.mark();
     const legend = model.legend(channel);
+    symbolsSpec = prosSpecMapping(symbolsSpec);
 
     switch (mark) {
       case BAR:
@@ -218,6 +219,7 @@ export namespace properties {
   export function labels(fieldDef: FieldDef, labelsSpec, model: UnitModel, channel: Channel) {
     const legend = model.legend(channel);
     const config = model.config();
+    labelsSpec = prosSpecMapping(labelsSpec);
 
     let labels:any = {};
 
@@ -272,6 +274,7 @@ export namespace properties {
 
   export function title(fieldDef: FieldDef, titleSpec, model: UnitModel, channel: Channel) {
     const legend = model.legend(channel);
+    titleSpec = prosSpecMapping(titleSpec);
 
     let titles:any = {};
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,7 +3,7 @@
 
 import * as stringify from 'json-stable-stringify';
 export {keys, extend, duplicate, isArray, vals, truncate, toMap, isObject, isString, isNumber, isBoolean} from 'datalib/src/util';
-import {duplicate as _duplicate} from 'datalib/src/util';
+import {duplicate as _duplicate, keys} from 'datalib/src/util';
 import {isString, isNumber, isBoolean} from 'datalib/src/util';
 
 /**
@@ -221,4 +221,12 @@ export function differ<T>(dict: Dict<T>, other: Dict<T>) {
     }
   }
   return false;
+}
+
+export function prosSpecMapping(prosSpec) {
+  var newSpec = keys(prosSpec).reduce(function(a, k) {
+      a[k] = {value: prosSpec[k]};
+      return a;
+    }, {});
+  return newSpec;
 }

--- a/test/compile/axis.test.ts
+++ b/test/compile/axis.test.ts
@@ -390,6 +390,17 @@ describe('Axis', function() {
         const axes = axis.properties.axis(model, X, {});
         assert.equal(axes.strokeWidth.value, 2);
     });
+
+    it('axis\'s strokeWidth should change axis\'s width', function() {
+        const model = parseModel({
+        mark: "point",
+        encoding: {
+          x: {field: "a", type: "quantitative"}
+        }
+      });
+        const axes = axis.properties.axis(model, X, {strokeWidth: 2});
+        assert.equal(axes.strokeWidth.value, 2);
+    });
   });
 
   describe('properties.grid()', function(){
@@ -424,6 +435,17 @@ describe('Axis', function() {
       });
         const axes = axis.properties.grid(model, X, {});
         assert.equal(axes.strokeWidth.value, 2);
+    });
+
+    it('grid\'s strokeDashOffset should change grid\'s dash offset', function(){
+        const model = parseModel({
+        mark: "point",
+        encoding: {
+          x: {field: "a", type: "quantitative", axis: {grid: true}}
+        }
+      });
+        const axes = axis.properties.grid(model, X, {strokeDashOffset: [2]});
+        assert.deepEqual(axes.strokeDashOffset.value, [2]);
     });
 
     it('gridDash should change grid\'s dash offset', function(){
@@ -540,6 +562,17 @@ describe('Axis', function() {
       const labels = axis.properties.labels(model, X, {}, {});
       assert.equal(labels.fontSize.value, 20);
     });
+
+    it('tick\'s label\'s fontSize should change with axis\'s label\'s font size', function() {
+      const model = parseModel({
+        mark: "point",
+        encoding: {
+          x: {field: "a"}
+        }
+      });
+      const labels = axis.properties.labels(model, X, {fontSize: 20}, {});
+      assert.equal(labels.fontSize.value, 20);
+    });
   });
 
   describe('properties.ticks()', function() {
@@ -554,7 +587,7 @@ describe('Axis', function() {
         assert.equal(axes.stroke.value, '#123');
     });
 
-    it('tickWidth should change axis\'s ticks\'s color', function() {
+    it('tickWidth should change axis\'s ticks\'s width', function() {
         const model = parseModel({
         mark: "point",
         encoding: {
@@ -562,6 +595,17 @@ describe('Axis', function() {
         }
       });
         const axes = axis.properties.ticks(model, X, {});
+        assert.equal(axes.strokeWidth.value, 13);
+    });
+
+    it('tick\'s strokeWidth should change axis\'s ticks\'s width', function() {
+        const model = parseModel({
+        mark: "point",
+        encoding: {
+          x: {field: "a", type: "quantitative"}
+        }
+      });
+        const axes = axis.properties.ticks(model, X, {strokeWidth: 13});
         assert.equal(axes.strokeWidth.value, 13);
     });
   });
@@ -608,6 +652,17 @@ describe('Axis', function() {
         }
       });
         const axes = axis.properties.title(model, X, {});
+        assert.equal(axes.fontWeight.value, 'bold');
+    });
+
+    it('title\'s fontWeight should change axis\'s title\'s font weight', function() {
+        const model = parseModel({
+        mark: "point",
+        encoding: {
+          x: {field: "a", type: "quantitative"}
+        }
+      });
+        const axes = axis.properties.title(model, X, {fontWeight: 'bold'});
         assert.equal(axes.fontWeight.value, 'bold');
     });
   });

--- a/test/compile/legend.test.ts
+++ b/test/compile/legend.test.ts
@@ -147,6 +147,16 @@ describe('Legend', function() {
         assert.deepEqual(symbol.strokeWidth.value, 20);
     });
 
+    it('should return specific width of the symbol', function() {
+      const symbol = legend.properties.symbols({field: 'a'}, {strokeWidth: 20}, parseUnitModel({
+          mark: "point",
+          encoding: {
+            x: {field: "a", type: "nominal"},
+            color: {field: "a", type: "nominal"}}
+        }), COLOR);
+        assert.deepEqual(symbol.strokeWidth.value, 20);
+    });
+
     it('should create legend for SVG path', function() {
       const symbol = legend.properties.symbols({field: 'a'}, {}, parseUnitModel({
           mark: "point",
@@ -172,6 +182,16 @@ describe('Legend', function() {
           encoding: {
             x: {field: "a", type: "nominal"},
             color: {field: "a", type: "nominal", legend: {"labelAlign": "left"}}}
+        }), COLOR);
+        assert.deepEqual(label.align.value, "left");
+    });
+
+    it('should return alignment value of the label', function() {
+      const label = legend.properties.labels({field: 'a'}, {align: "left"}, parseUnitModel({
+          mark: "point",
+          encoding: {
+            x: {field: "a", type: "nominal"},
+            color: {field: "a", type: "nominal"}}
         }), COLOR);
         assert.deepEqual(label.align.value, "left");
     });
@@ -254,6 +274,17 @@ describe('Legend', function() {
         }), COLOR);
         assert.deepEqual(title.stroke.value, "black");
     });
+
+    it('should return color of the title', function() {
+      const title = legend.properties.title({field: 'a'}, {stroke: "black"}, parseUnitModel({
+          mark: "point",
+          encoding: {
+            x: {field: "a", type: "nominal"},
+            color: {field: "a", type: "nominal"}}
+        }), COLOR);
+        assert.deepEqual(title.stroke.value, "black");
+    });
+
 
     it('should return font of the title', function() {
       const title = legend.properties.title({field: 'a'}, {}, parseUnitModel({


### PR DESCRIPTION
Fixed #1306 
Eliminate the value property for axis and legend properties option. 
For example, if we want to specify the font size of axis title, we need to do

```
{
  "mark": "bar",
  "data": {
    "values": [
      {"a": "A","b": 28}, {"a": "B","b": 55}, {"a": "C","b": 43},
      {"a": "D","b": 91}, {"a": "E","b": 81}, {"a": "F","b": 53},
      {"a": "G","b": 19}, {"a": "H","b": 87}, {"a": "I","b": 52}
    ]
  },
  "encoding": {
    "y": {"field": "a", "type": "ordinal"},
    "x": {"field": "b", "type": "quantitative"}
  },
  "config": {
      "axis": {
        "properties": {
           "title": {
             "fontSize": {"value": 30}
          }
        }
      }
  }
}
```

or

```
{
  "mark": "bar",
  "data": {
    "values": [
      {"a": "A","b": 28}, {"a": "B","b": 55}, {"a": "C","b": 43},
      {"a": "D","b": 91}, {"a": "E","b": 81}, {"a": "F","b": 53},
      {"a": "G","b": 19}, {"a": "H","b": 87}, {"a": "I","b": 52}
    ]
  },
  "encoding": {
    "y": {"field": "a", "type": "ordinal", "axis": {"titleFontSize": 20}},
    "x": {"field": "b", "type": "quantitative", "axis": {"titleFontSize": 20}}
  }
}
```

For the first input, now we can do 
`"axis": { "properties": { "title": { "fontSize": 30 } } }`
instead of 
`"axis": { "properties": { "title": { "fontSize": {"value": 30} } } }`
