### PR TITLE
Add 'types' field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "description": "Vega-lite provides a higher-level grammar for visual analysis, comparable to ggplot or Tableau, that generates complete Vega specifications.",
   "main": "src/vl.js",
+  "types": "src/vl.ts",
   "bin": {
     "vl2png": "./bin/vl2png",
     "vl2svg": "./bin/vl2svg",


### PR DESCRIPTION
This way the distributed npm package correctly points at its typescript entrypoint. I would rather this pointed at a generated `.d.ts` file, personally, as pointing at normal `.ts` files has historically caused issues... but the build output doesn't currently specify `declarations: true`, so that'd need to be done first.

Prior to this change, the module resolves a little like so:
```
======== Resolving module 'vega-lite' from 'C:/Users/wwigh/Github/glacier/glacier/src/index.ts'. ========
Module resolution kind is not specified, using 'NodeJs'.
Loading module 'vega-lite' from 'node_modules' folder.
File 'C:/src/node_modules/vega-lite.ts' does not exist.
File 'C:/src/node_modules/vega-lite.tsx' does not exist.
File 'C:/src/node_modules/vega-lite.d.ts' does not exist.
Found 'package.json' at 'C:/src/node_modules/vega-lite/package.json'.
'package.json' does not have 'types' field.
File 'C:/src/node_modules/vega-lite/index.ts' does not exist.
File 'C:/src/node_modules/vega-lite/index.tsx' does not exist.
File 'C:/src/node_modules/vega-lite/index.d.ts' does not exist.
File 'C:/src/node_modules/@types/vega-lite.ts' does not exist.
File 'C:/src/node_modules/@types/vega-lite.tsx' does not exist.
File 'C:/src/node_modules/@types/vega-lite.d.ts' does not exist.
File 'C:/src/node_modules/@types/vega-lite/package.json' does not exist.
File 'C:/src/node_modules/@types/vega-lite/index.ts' does not exist.
File 'C:/src/node_modules/@types/vega-lite/index.tsx' does not exist.
File 'C:/src/node_modules/@types/vega-lite/index.d.ts' does not exist.
======== Module name 'vega-lite' was not resolved. ========
index.ts(2,21): error TS2307: Cannot find module 'vega-lite'.
```