### PR TITLE
Axis.titleColor/legend.labelColor/legend.titleColor maps to fill …

### DIFF
--- a/src/compile/axis.ts
+++ b/src/compile/axis.ts
@@ -388,7 +388,7 @@ export namespace properties {
     const axis = model.axis(channel);
 
     return extend(
-      axis.titleColor !== undefined ? {stroke : {value: axis.titleColor} } : {},
+      axis.titleColor !== undefined ? {fill : {value: axis.titleColor} } : {},
       axis.titleFont !== undefined ? {font: {value: axis.titleFont}} : {},
       axis.titleFontSize !== undefined ? {fontSize: {value: axis.titleFontSize}} : {},
       axis.titleFontWeight !== undefined ? {fontWeight: {value: axis.titleFontWeight}} : {},

--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -250,7 +250,7 @@ export namespace properties {
     }
 
     if (legend.labelColor !== undefined) {
-      labels.stroke = {value: legend.labelColor};
+      labels.fill = {value: legend.labelColor};
     }
 
     if (legend.labelFont !== undefined) {
@@ -276,7 +276,7 @@ export namespace properties {
     let titles:any = {};
 
     if (legend.titleColor !== undefined) {
-      titles.stroke = {value: legend.titleColor};
+      titles.fill = {value: legend.titleColor};
     }
 
     if (legend.titleFont !== undefined) {

--- a/test/compile/axis.test.ts
+++ b/test/compile/axis.test.ts
@@ -570,7 +570,7 @@ describe('Axis', function() {
         }
       });
         const axes = axis.properties.title(model, X, {});
-        assert.equal(axes.stroke.value, '#abc');
+        assert.equal(axes.fill.value, '#abc');
     });
 
     it('titleFont should change axis\'s title\'s font', function() {

--- a/test/compile/legend.test.ts
+++ b/test/compile/legend.test.ts
@@ -178,7 +178,7 @@ describe('Legend', function() {
             x: {field: "a", type: "nominal"},
             color: {field: "a", type: "nominal", legend: {"labelColor": "blue"}}}
         }), COLOR);
-        assert.deepEqual(label.stroke.value, "blue");
+        assert.deepEqual(label.fill.value, "blue");
     });
 
     it('should return font of the label', function() {
@@ -247,7 +247,7 @@ describe('Legend', function() {
             x: {field: "a", type: "nominal"},
             color: {field: "a", type: "nominal", legend: {"titleColor": "black"}}}
         }), COLOR);
-        assert.deepEqual(title.stroke.value, "black");
+        assert.deepEqual(title.fill.value, "black");
     });
 
     it('should return font of the title', function() {


### PR DESCRIPTION
Fix #1592 
Now axis.titleColor, legend.labelColor, legend.labelColor will change the value of `fill` instead of `stroke`


Example:
```
{
  "data": {"url": "data/unemployment-across-industries.json"},
  "mark": "area",
  "encoding": {
    "x": {
      "timeUnit": "yearmonth",
      "field": "date",
      "type": "temporal",
      "scale": {"nice": "month"},
      "axis": {
        "axisWidth": 0,
        "titleFontSize": 30,
        "format": "%Y",
        "labelAngle": 0,
        "titleColor": "grey"
      }
    },
    "y": {
      "aggregate": "sum",
      "field": "count",
      "type": "quantitative"
    }
  },
  "config": {"cell": {"width": 300,"height": 200}}
}
```

now will have an output as below

![vega 1](https://cloud.githubusercontent.com/assets/11696585/19537151/c9d85374-9603-11e6-87cf-faff0da22dd0.png)
