### PR TITLE
Enable declaration emit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,7 @@ examples/images/*
 examples/all-examples.json
 **/*.js.map
 **/*.js
+src/**/*.d.ts
+test/**/*.d.ts
+site/**/*.d.ts
 .jekyll-metadata

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ examples/all-examples.json
 src/**/*.d.ts
 test/**/*.d.ts
 site/**/*.d.ts
+examples/**/*.d.ts
 .jekyll-metadata

--- a/.npmignore
+++ b/.npmignore
@@ -29,3 +29,5 @@ _config.yml
 .vscode
 .editorconfig
 vl.sublime-project
+**/*.ts
+!**/*.d.ts

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   ],
   "description": "Vega-lite provides a higher-level grammar for visual analysis, comparable to ggplot or Tableau, that generates complete Vega specifications.",
   "main": "src/vl.js",
+  "types": "src/vl.d.ts",
   "bin": {
     "vl2png": "./bin/vl2png",
     "vl2svg": "./bin/vl2svg",
@@ -24,7 +25,7 @@
     "build:images": "npm run data && scripts/generate-images.sh",
     "build:toc": "bundle exec jekyll build --incremental -q && scripts/generate-toc",
     "cover": "npm run pretest && istanbul cover node_modules/.bin/_mocha -- --recursive",
-    "clean": "rm -f vega-lite.* vega-lite-schema.json & find src -name '*.js*' -type f -delete & find test -name '*.js*' -type f -delete & find site -name '*.js*' -type f -delete & rm -rf examples/_diff examples/_original examples/_output examples/images && rm -rf data",
+    "clean": "rm -f vega-lite.* vega-lite-schema.json & find src -name '*.js*' -type f -delete & find test -name '*.js*' -type f -delete & find test -name '*.d.ts' -type f -delete & find site -name '*.js*' -type f -delete & rm -rf examples/_diff examples/_original examples/_output examples/images && rm -rf data",
     "data": "rsync -r node_modules/vega-datasets/data/* data",
     "deploy": "scripts/deploy.sh",
     "deploy:gh": "scripts/deploy-gh.sh",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -32,6 +32,10 @@ if ! [ -f src/vl.js ]; then
   echo "${RED} src/vl.js not found.  Typescripts may be not compiled.${NC}"
   exit 1;
 fi
+if ! [ -f src/vl.d.ts ]; then
+  echo "${RED} src/vl.d.ts not found.  Typescript declarations may be not compiled.${NC}"
+  exit 1;
+fi
 
 npm publish
 # exit if npm publish failed

--- a/site/static/main.ts
+++ b/site/static/main.ts
@@ -2,6 +2,9 @@
 
 declare const BASEURL, hljs;
 
+// IIFE to prevent function declarations from moving into the global scope
+(() => {
+
 function trim(str: string) {
   return str.replace(/^\s+|\s+$/g, '');
 }
@@ -85,7 +88,7 @@ function renderGallery() {
       // try to retrieve specs for a gallery group from in vl-examples.json
       try {
         galleryGroupSpecs = VL_SPECS[galleryGroupName];
-      } catch (error){
+      } catch (error) {
         console.log(error.message);
         return;
       }
@@ -124,3 +127,5 @@ function renderGallery() {
     }
   });
 }
+
+})();

--- a/src/compile/data/bin.ts
+++ b/src/compile/data/bin.ts
@@ -15,7 +15,7 @@ export namespace bin {
     return `format('${format}', ${expr})`;
   }
 
-  export function parseUnit(model: Model): Dict<VgTransform[]> {
+  function parse(model: Model): Dict<VgTransform[]> {
     return model.reduce(function(binComponent, fieldDef: FieldDef, channel: Channel) {
       const bin = model.fieldDef(channel).bin;
       if (bin) {
@@ -65,8 +65,10 @@ export namespace bin {
     }, {});
   }
 
+  export const parseUnit: (model: Model) => Dict<VgTransform[]> = parse;
+
   export function parseFacet(model: FacetModel) {
-    let binComponent = parseUnit(model);
+    let binComponent = parse(model);
 
     const childDataComponent = model.child().component.data;
 
@@ -80,7 +82,7 @@ export namespace bin {
   }
 
   export function parseLayer(model: LayerModel) {
-    let binComponent = parseUnit(model);
+    let binComponent = parse(model);
 
     model.children().forEach((child) => {
       const childDataComponent = child.component.data;

--- a/src/compile/data/bin.ts
+++ b/src/compile/data/bin.ts
@@ -15,7 +15,7 @@ export namespace bin {
     return `format('${format}', ${expr})`;
   }
 
-  function parse(model: Model): Dict<VgTransform[]> {
+  export function parseUnit(model: Model): Dict<VgTransform[]> {
     return model.reduce(function(binComponent, fieldDef: FieldDef, channel: Channel) {
       const bin = model.fieldDef(channel).bin;
       if (bin) {
@@ -65,10 +65,8 @@ export namespace bin {
     }, {});
   }
 
-  export const parseUnit = parse;
-
   export function parseFacet(model: FacetModel) {
-    let binComponent = parse(model);
+    let binComponent = parseUnit(model);
 
     const childDataComponent = model.child().component.data;
 
@@ -82,7 +80,7 @@ export namespace bin {
   }
 
   export function parseLayer(model: LayerModel) {
-    let binComponent = parse(model);
+    let binComponent = parseUnit(model);
 
     model.children().forEach((child) => {
       const childDataComponent = child.component.data;

--- a/src/compile/data/formatparse.ts
+++ b/src/compile/data/formatparse.ts
@@ -10,7 +10,7 @@ import {Model} from './../model';
 
 export namespace formatParse {
   // TODO: need to take calculate into account across levels when merging
-  export function parseUnit(model: Model): Dict<string> {
+  function parse(model: Model): Dict<string> {
     const calcFieldMap = (model.calculate() || []).reduce(function(fieldMap, formula) {
       fieldMap[formula.field] = true;
       return fieldMap;
@@ -71,8 +71,10 @@ export namespace formatParse {
     return parseComponent;
   }
 
+  export const parseUnit: (model: Model) => Dict<string> = parse;
+
   export function parseFacet(model: FacetModel) {
-    let parseComponent = parseUnit(model);
+    let parseComponent = parse(model);
 
     // If child doesn't have its own data source, but has its own parse, then merge
     const childDataComponent = model.child().component.data;
@@ -85,7 +87,7 @@ export namespace formatParse {
 
   export function parseLayer(model: LayerModel) {
     // note that we run this before source.parseLayer
-    let parseComponent = parseUnit(model);
+    let parseComponent = parse(model);
     model.children().forEach((child) => {
       const childDataComponent = child.component.data;
       if (model.compatibleSource(child) && !differ(childDataComponent.formatParse, parseComponent)) {

--- a/src/compile/data/formatparse.ts
+++ b/src/compile/data/formatparse.ts
@@ -10,7 +10,7 @@ import {Model} from './../model';
 
 export namespace formatParse {
   // TODO: need to take calculate into account across levels when merging
-  function parse(model: Model): Dict<string> {
+  export function parseUnit(model: Model): Dict<string> {
     const calcFieldMap = (model.calculate() || []).reduce(function(fieldMap, formula) {
       fieldMap[formula.field] = true;
       return fieldMap;
@@ -71,10 +71,8 @@ export namespace formatParse {
     return parseComponent;
   }
 
-  export const parseUnit = parse;
-
   export function parseFacet(model: FacetModel) {
-    let parseComponent = parse(model);
+    let parseComponent = parseUnit(model);
 
     // If child doesn't have its own data source, but has its own parse, then merge
     const childDataComponent = model.child().component.data;
@@ -87,7 +85,7 @@ export namespace formatParse {
 
   export function parseLayer(model: LayerModel) {
     // note that we run this before source.parseLayer
-    let parseComponent = parse(model);
+    let parseComponent = parseUnit(model);
     model.children().forEach((child) => {
       const childDataComponent = child.component.data;
       if (model.compatibleSource(child) && !differ(childDataComponent.formatParse, parseComponent)) {

--- a/src/compile/data/formula.ts
+++ b/src/compile/data/formula.ts
@@ -9,17 +9,15 @@ import {DataComponent} from './data';
 
 
 export namespace formula {
-  function parse(model: Model): Dict<Formula> {
+  export function parseUnit(model: Model): Dict<Formula> {
     return (model.calculate() || []).reduce(function(formulaComponent, formula) {
       formulaComponent[hash(formula)] = formula;
       return formulaComponent;
     }, {} as Dict<Formula>);
   }
 
-  export const parseUnit = parse;
-
   export function parseFacet(model: FacetModel) {
-    let formulaComponent = parse(model);
+    let formulaComponent = parseUnit(model);
 
     const childDataComponent = model.child().component.data;
 
@@ -32,7 +30,7 @@ export namespace formula {
   }
 
   export function parseLayer(model: LayerModel) {
-    let formulaComponent = parse(model);
+    let formulaComponent = parseUnit(model);
     model.children().forEach((child) => {
       const childDataComponent = child.component.data;
       if (!childDataComponent.source && childDataComponent.calculate) {

--- a/src/compile/data/formula.ts
+++ b/src/compile/data/formula.ts
@@ -19,7 +19,7 @@ export namespace formula {
   export const parseUnit: (model: Model) => Dict<Formula> = parse;
 
   export function parseFacet(model: FacetModel) {
-    let formulaComponent = parseUnit(model);
+    let formulaComponent = parse(model);
 
     const childDataComponent = model.child().component.data;
 

--- a/src/compile/data/formula.ts
+++ b/src/compile/data/formula.ts
@@ -9,12 +9,14 @@ import {DataComponent} from './data';
 
 
 export namespace formula {
-  export function parseUnit(model: Model): Dict<Formula> {
+  function parse(model: Model): Dict<Formula> {
     return (model.calculate() || []).reduce(function(formulaComponent, formula) {
       formulaComponent[hash(formula)] = formula;
       return formulaComponent;
     }, {} as Dict<Formula>);
   }
+
+  export const parseUnit: (model: Model) => Dict<Formula> = parse;
 
   export function parseFacet(model: FacetModel) {
     let formulaComponent = parseUnit(model);
@@ -30,7 +32,7 @@ export namespace formula {
   }
 
   export function parseLayer(model: LayerModel) {
-    let formulaComponent = parseUnit(model);
+    let formulaComponent = parse(model);
     model.children().forEach((child) => {
       const childDataComponent = child.component.data;
       if (!childDataComponent.source && childDataComponent.calculate) {

--- a/src/compile/data/nullfilter.ts
+++ b/src/compile/data/nullfilter.ts
@@ -18,7 +18,7 @@ const DEFAULT_NULL_FILTERS = {
 // TODO: rename to invalidFilter
 export namespace nullFilter {
   /** Return Hashset of fields for null filtering (key=field, value = true). */
-  function parse(model: Model): Dict<boolean> {
+  export function parseUnit(model: Model): Dict<boolean> {
     const filterInvalid = model.filterInvalid();
 
     return model.reduce(function(aggregator, fieldDef: FieldDef) {
@@ -36,10 +36,8 @@ export namespace nullFilter {
     }, {});
   }
 
-  export const parseUnit = parse;
-
   export function parseFacet(model: FacetModel) {
-    let nullFilterComponent = parse(model);
+    let nullFilterComponent = parseUnit(model);
 
     const childDataComponent = model.child().component.data;
 
@@ -55,7 +53,7 @@ export namespace nullFilter {
     // note that we run this before source.parseLayer
 
     // FIXME: null filters are not properly propagated right now
-    let nullFilterComponent = parse(model);
+    let nullFilterComponent = parseUnit(model);
 
     model.children().forEach((child) => {
       const childDataComponent = child.component.data;

--- a/src/compile/data/nullfilter.ts
+++ b/src/compile/data/nullfilter.ts
@@ -18,7 +18,7 @@ const DEFAULT_NULL_FILTERS = {
 // TODO: rename to invalidFilter
 export namespace nullFilter {
   /** Return Hashset of fields for null filtering (key=field, value = true). */
-  export function parseUnit(model: Model): Dict<boolean> {
+  function parse(model: Model): Dict<boolean> {
     const filterInvalid = model.filterInvalid();
 
     return model.reduce(function(aggregator, fieldDef: FieldDef) {
@@ -36,8 +36,10 @@ export namespace nullFilter {
     }, {});
   }
 
+  export const parseUnit: (model: Model) => Dict<boolean> = parse;
+
   export function parseFacet(model: FacetModel) {
-    let nullFilterComponent = parseUnit(model);
+    let nullFilterComponent = parse(model);
 
     const childDataComponent = model.child().component.data;
 
@@ -53,7 +55,7 @@ export namespace nullFilter {
     // note that we run this before source.parseLayer
 
     // FIXME: null filters are not properly propagated right now
-    let nullFilterComponent = parseUnit(model);
+    let nullFilterComponent = parse(model);
 
     model.children().forEach((child) => {
       const childDataComponent = child.component.data;

--- a/src/compile/data/source.ts
+++ b/src/compile/data/source.ts
@@ -14,7 +14,7 @@ import {formula} from './formula';
 import {timeUnit} from './timeunit';
 
 export namespace source {
-  function parse(model: Model): VgData {
+  export function parseUnit(model: Model): VgData {
     let data = model.data();
 
     if (data) {
@@ -58,10 +58,8 @@ export namespace source {
     return undefined;
   }
 
-  export const parseUnit = parse;
-
   export function parseFacet(model: FacetModel) {
-    let sourceData = parse(model);
+    let sourceData = parseUnit(model);
     if (!model.child().component.data.source) {
       // If the child does not have its own source, have to rename its source.
       model.child().renameData(model.child().dataName(SOURCE), model.dataName(SOURCE));
@@ -71,7 +69,7 @@ export namespace source {
   }
 
   export function parseLayer(model: LayerModel) {
-    let sourceData = parse(model);
+    let sourceData = parseUnit(model);
     model.children().forEach((child) => {
       const childData = child.component.data;
 

--- a/src/compile/data/source.ts
+++ b/src/compile/data/source.ts
@@ -14,7 +14,7 @@ import {formula} from './formula';
 import {timeUnit} from './timeunit';
 
 export namespace source {
-  export function parseUnit(model: Model): VgData {
+  function parse(model: Model): VgData {
     let data = model.data();
 
     if (data) {
@@ -58,8 +58,10 @@ export namespace source {
     return undefined;
   }
 
+  export const parseUnit: (model: Model) => VgData = parse;
+
   export function parseFacet(model: FacetModel) {
-    let sourceData = parseUnit(model);
+    let sourceData = parse(model);
     if (!model.child().component.data.source) {
       // If the child does not have its own source, have to rename its source.
       model.child().renameData(model.child().dataName(SOURCE), model.dataName(SOURCE));
@@ -69,7 +71,7 @@ export namespace source {
   }
 
   export function parseLayer(model: LayerModel) {
-    let sourceData = parseUnit(model);
+    let sourceData = parse(model);
     model.children().forEach((child) => {
       const childData = child.component.data;
 

--- a/src/compile/data/timeunit.ts
+++ b/src/compile/data/timeunit.ts
@@ -12,7 +12,7 @@ import {Model} from '../model';
 import {DataComponent} from './data';
 
 export namespace timeUnit {
-  function parse(model: Model): Dict<VgTransform> {
+  export function parseUnit(model: Model): Dict<VgTransform> {
     return model.reduce(function(timeUnitComponent, fieldDef: FieldDef, channel: Channel) {
       if (fieldDef.type === TEMPORAL && fieldDef.timeUnit) {
 
@@ -28,10 +28,8 @@ export namespace timeUnit {
     }, {});
   }
 
-  export const parseUnit = parse;
-
   export function parseFacet(model: FacetModel) {
-    let timeUnitComponent = parse(model);
+    let timeUnitComponent = parseUnit(model);
 
     const childDataComponent = model.child().component.data;
 
@@ -44,7 +42,7 @@ export namespace timeUnit {
   }
 
   export function parseLayer(model: LayerModel) {
-    let timeUnitComponent = parse(model);
+    let timeUnitComponent = parseUnit(model);
     model.children().forEach((child) => {
       const childDataComponent = child.component.data;
       if (!childDataComponent.source) {

--- a/src/compile/data/timeunit.ts
+++ b/src/compile/data/timeunit.ts
@@ -12,7 +12,7 @@ import {Model} from '../model';
 import {DataComponent} from './data';
 
 export namespace timeUnit {
-  export function parseUnit(model: Model): Dict<VgTransform> {
+  function parse(model: Model): Dict<VgTransform> {
     return model.reduce(function(timeUnitComponent, fieldDef: FieldDef, channel: Channel) {
       if (fieldDef.type === TEMPORAL && fieldDef.timeUnit) {
 
@@ -28,8 +28,10 @@ export namespace timeUnit {
     }, {});
   }
 
+  export const parseUnit: (model: Model) => Dict<VgTransform> = parse;
+
   export function parseFacet(model: FacetModel) {
-    let timeUnitComponent = parseUnit(model);
+    let timeUnitComponent = parse(model);
 
     const childDataComponent = model.child().component.data;
 
@@ -42,7 +44,7 @@ export namespace timeUnit {
   }
 
   export function parseLayer(model: LayerModel) {
-    let timeUnitComponent = parseUnit(model);
+    let timeUnitComponent = parse(model);
     model.children().forEach((child) => {
       const childDataComponent = child.component.data;
       if (!childDataComponent.source) {

--- a/src/compile/data/timeunitdomain.ts
+++ b/src/compile/data/timeunitdomain.ts
@@ -13,7 +13,7 @@ import {DataComponent} from './data';
 
 
 export namespace timeUnitDomain {
-  function parse(model: Model): StringSet {
+  export function parseUnit(model: Model): StringSet {
     return model.reduce(function(timeUnitDomainMap, fieldDef: FieldDef, channel: Channel) {
       if (fieldDef.timeUnit) {
         const domain = imputedDomain(fieldDef.timeUnit, channel);
@@ -25,16 +25,14 @@ export namespace timeUnitDomain {
     }, {});
   }
 
-  export const parseUnit = parse;
-
   export function parseFacet(model: FacetModel) {
     // always merge with child
-    return extend(parse(model), model.child().component.data.timeUnitDomain);
+    return extend(parseUnit(model), model.child().component.data.timeUnitDomain);
   }
 
   export function parseLayer(model: LayerModel) {
     // always merge with children
-    return extend(parse(model), model.children().forEach((child) => {
+    return extend(parseUnit(model), model.children().forEach((child) => {
       return child.component.data.timeUnitDomain;
     }));
   }

--- a/src/compile/data/timeunitdomain.ts
+++ b/src/compile/data/timeunitdomain.ts
@@ -13,7 +13,7 @@ import {DataComponent} from './data';
 
 
 export namespace timeUnitDomain {
-  export function parseUnit(model: Model): StringSet {
+  function parse(model: Model): StringSet {
     return model.reduce(function(timeUnitDomainMap, fieldDef: FieldDef, channel: Channel) {
       if (fieldDef.timeUnit) {
         const domain = imputedDomain(fieldDef.timeUnit, channel);
@@ -25,14 +25,16 @@ export namespace timeUnitDomain {
     }, {});
   }
 
+  export const parseUnit: (model: Model) => StringSet = parse;
+
   export function parseFacet(model: FacetModel) {
     // always merge with child
-    return extend(parseUnit(model), model.child().component.data.timeUnitDomain);
+    return extend(parse(model), model.child().component.data.timeUnitDomain);
   }
 
   export function parseLayer(model: LayerModel) {
     // always merge with children
-    return extend(parseUnit(model), model.children().forEach((child) => {
+    return extend(parse(model), model.children().forEach((child) => {
       return child.component.data.timeUnitDomain;
     }));
   }

--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -13,6 +13,11 @@ import {COLOR_LEGEND, COLOR_LEGEND_LABEL} from './scale';
 import {UnitModel} from './unit';
 import {VgLegend} from '../vega.schema';
 
+/* tslint:disable:no-unused-variable */
+// These imports exist so the TS compiler can name publicly exported members in
+// The automatically created .d.ts correctly
+import {Bin} from '../bin';
+/* tslint:enable:no-unused-variable */
 
 export function parseLegendComponent(model: UnitModel): Dict<VgLegend> {
   return [COLOR, SIZE, SHAPE, OPACITY].reduce(function(legendComponent, channel) {

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -15,6 +15,12 @@ import {VgData, VgMarkGroup, VgScale, VgAxis, VgLegend} from '../vega.schema';
 import {DataComponent} from './data/data';
 import {LayoutComponent} from './layout';
 import {ScaleComponents} from './scale';
+/* tslint:disable:no-unused-variable */
+// These imports exist so the TS compiler can name publicly exported members in
+// The automatically created .d.ts correctly
+import {Formula} from '../transform';
+import {OneOfFilter, EqualFilter, RangeFilter} from '../filter';
+/* tslint:enable:no-unused-variable */
 
 /**
  * Composable Components that are intermediate results of the parsing phase of the
@@ -42,7 +48,7 @@ export interface Component {
   mark: VgMarkGroup[];
 }
 
-class NameMap {
+class NameMap implements NameMapShape {
   private _nameMap: Dict<string>;
 
   constructor() {
@@ -64,6 +70,11 @@ class NameMap {
   }
 }
 
+export interface NameMapShape {
+  rename(oldname: string, newName: string): void;
+  get(name: string): string;
+}
+
 export abstract class Model {
   protected _parent: Model;
   protected _name: string;
@@ -72,13 +83,13 @@ export abstract class Model {
   protected _data: Data;
 
   /** Name map for data sources, which can be renamed by a model's parent. */
-  protected _dataNameMap: NameMap;
+  protected _dataNameMap: NameMapShape;
 
   /** Name map for scales, which can be renamed by a model's parent. */
-  protected _scaleNameMap: NameMap;
+  protected _scaleNameMap: NameMapShape;
 
   /** Name map for size, which can be renamed by a model's parent. */
-  protected _sizeNameMap: NameMap;
+  protected _sizeNameMap: NameMapShape;
 
   protected _transform: Transform;
   protected _scale: Dict<Scale>;

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -48,7 +48,7 @@ export interface Component {
   mark: VgMarkGroup[];
 }
 
-class NameMap implements NameMapShape {
+class NameMap implements NameMapInterface {
   private _nameMap: Dict<string>;
 
   constructor() {
@@ -70,7 +70,7 @@ class NameMap implements NameMapShape {
   }
 }
 
-export interface NameMapShape {
+export interface NameMapInterface {
   rename(oldname: string, newName: string): void;
   get(name: string): string;
 }
@@ -83,13 +83,13 @@ export abstract class Model {
   protected _data: Data;
 
   /** Name map for data sources, which can be renamed by a model's parent. */
-  protected _dataNameMap: NameMapShape;
+  protected _dataNameMap: NameMapInterface;
 
   /** Name map for scales, which can be renamed by a model's parent. */
-  protected _scaleNameMap: NameMapShape;
+  protected _scaleNameMap: NameMapInterface;
 
   /** Name map for size, which can be renamed by a model's parent. */
-  protected _sizeNameMap: NameMapShape;
+  protected _sizeNameMap: NameMapInterface;
 
   protected _transform: Transform;
   protected _scale: Dict<Scale>;

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -11,13 +11,13 @@ const SUNDAY_YEAR = 2006;
  * @minimum 1
  * @maximum 12
  */
-type Month = number;
+export type Month = number;
 
 /**
  * @minimum 1
  * @maximum 7
  */
-type Day = number;
+export type Day = number;
 
 /**
  * Object for defining datetime in Vega-Lite Filter.

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -5,7 +5,7 @@ import {ExtendedUnitSpec} from './spec';
 import {toMap} from './util';
 import {BAR} from './mark';
 
-interface RequiredChannelMap {
+export interface RequiredChannelMap {
   [mark: string]: Array<string>;
 }
 
@@ -19,7 +19,7 @@ export const DEFAULT_REQUIRED_CHANNEL_MAP: RequiredChannelMap = {
   area: ['x', 'y']
 };
 
-interface SupportedChannelMap {
+export interface SupportedChannelMap {
   [mark: string]: {
     [channel: string]: number
   };

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -10,11 +10,11 @@ export interface VgData {
   transform?: any;
 }
 
-type VgParentRef = {
+export type VgParentRef = {
   parent: string
 };
 
-type VgFieldRef = string | VgParentRef | VgParentRef[];
+export type VgFieldRef = string | VgParentRef | VgParentRef[];
 
 export type VgDataRef = {
   data: string,

--- a/src/vl.ts
+++ b/src/vl.ts
@@ -22,4 +22,4 @@ export import type = require('./type');
 export import util = require('./util');
 export import validate = require('./validate');
 
-export const version = require('../package.json').version;
+export const version: string = require('../package.json').version;

--- a/test/util.ts
+++ b/test/util.ts
@@ -2,9 +2,10 @@ import {buildModel} from '../src/compile/common';
 import {UnitModel} from '../src/compile/unit';
 import {ExtendedUnitSpec, normalize} from '../src/spec';
 import {contains} from '../src/util';
+import {Model} from '../src/compile/model';
 
 // TODO: rename to parseModel
-export function parseModel(inputSpec) {
+export function parseModel(inputSpec): Model {
   const spec = normalize(inputSpec);
   return buildModel(spec, null, '');
 }

--- a/test/util.ts
+++ b/test/util.ts
@@ -4,7 +4,6 @@ import {ExtendedUnitSpec, normalize} from '../src/spec';
 import {contains} from '../src/util';
 import {Model} from '../src/compile/model';
 
-// TODO: rename to parseModel
 export function parseModel(inputSpec): Model {
   const spec = normalize(inputSpec);
   return buildModel(spec, null, '');

--- a/test/util.ts
+++ b/test/util.ts
@@ -10,8 +10,6 @@ export function parseModel(inputSpec): Model {
   return buildModel(spec, null, '');
 }
 
-
-// TODO: rename to parseUnitModel
 /**
  * Call new Model without worrying about types.
  * We use this in tests to allow using raw JSON.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "jsx": "react",
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
-    "declaration": false,
+    "declaration": true,
     "noImplicitAny": false,
     "removeComments": true,
     "noLib": false,


### PR DESCRIPTION
Consuming `vega-lite` as a commonjs package via the typescript compiler was difficult/impossible, as, rather than shipping with generated type definition files, it shipped with the original source typescript. This caused issues where compiler setting mismatches (`noImplicitAny`, `strictNullChecks`, and so on) would expose issues in `vega-lite`'s implementation as part of a consumer's build, which is undesirable.

Turning on declaration emit (and fixing declaration visibility errors), allows the compiler to automatically generate declaration files for the project, which make the project easy to use by a typescript consumer.

