### PR TITLE
Only return scaleName if the scale exists

### DIFF
--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -172,7 +172,7 @@ export class FacetModel extends Model {
         // for each scale, need to rename
         vals(scaleComponent[channel]).forEach(function(scale) {
           const scaleNameWithoutPrefix = scale.name.substr(child.name('').length);
-          const newName = model.name(scaleNameWithoutPrefix);
+          const newName = model.scaleName(scaleNameWithoutPrefix, true);
           child.renameScale(scale.name, newName);
           scale.name = newName;
         });

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -172,7 +172,7 @@ export class FacetModel extends Model {
         // for each scale, need to rename
         vals(scaleComponent[channel]).forEach(function(scale) {
           const scaleNameWithoutPrefix = scale.name.substr(child.name('').length);
-          const newName = model.scaleName(scaleNameWithoutPrefix);
+          const newName = model.name(scaleNameWithoutPrefix);
           child.renameScale(scale.name, newName);
           scale.name = newName;
         });

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -163,7 +163,7 @@ export class LayerModel extends Model {
           // rename child scales to parent scales
           vals(childScales).forEach(function(scale) {
             const scaleNameWithoutPrefix = scale.name.substr(child.name('').length);
-            const newName = model.name(scaleNameWithoutPrefix);
+            const newName = model.scaleName(scaleNameWithoutPrefix, true);
             child.renameScale(scale.name, newName);
             scale.name = newName;
           });

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -163,7 +163,7 @@ export class LayerModel extends Model {
           // rename child scales to parent scales
           vals(childScales).forEach(function(scale) {
             const scaleNameWithoutPrefix = scale.name.substr(child.name('').length);
-            const newName = model.scaleName(scaleNameWithoutPrefix);
+            const newName = model.name(scaleNameWithoutPrefix);
             child.renameScale(scale.name, newName);
             scale.name = newName;
           });

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -9,12 +9,13 @@ import {Scale, ScaleType} from '../scale';
 import {SortField, SortOrder} from '../sort';
 import {BaseSpec} from '../spec';
 import {Transform} from '../transform';
-import {extend, flatten, vals, warning, Dict} from '../util';
+import {contains, extend, flatten, vals, warning, Dict} from '../util';
 import {VgData, VgMarkGroup, VgScale, VgAxis, VgLegend} from '../vega.schema';
 
 import {DataComponent} from './data/data';
 import {LayoutComponent} from './layout';
-import {ScaleComponents} from './scale';
+import {ScaleComponents, COLOR_LEGEND, COLOR_LEGEND_LABEL} from './scale';
+
 /* tslint:disable:no-unused-variable */
 // These imports exist so the TS compiler can name publicly exported members in
 // The automatically created .d.ts correctly
@@ -59,9 +60,14 @@ class NameMap implements NameMapInterface {
     this._nameMap[oldName] = newName;
   }
 
+
+  public has(name: string): boolean {
+    return this._nameMap[name] !== undefined;
+  }
+
   public get(name: string): string {
     // If the name appears in the _nameMap, we need to read its new name.
-    // We have to loop over the dict just in case, the new name also gets renamed.
+    // We have to loop over the dict just in case the new name also gets renamed.
     while (this._nameMap[name]) {
       name = this._nameMap[name];
     }
@@ -326,9 +332,24 @@ export abstract class Model {
     this._scaleNameMap.rename(oldName, newName);
   }
 
-  /** returns scale name for a given channel */
-  public scaleName(channel: Channel|string): string {
-    return this._scaleNameMap.get(this.name(channel + ''));
+
+  /**
+   * @return scale name for a given channel after the scale has been parsed and named.
+   * (DO NOT USE THIS METHOD DURING SCALE PARSING, use model.name() instead)
+   */
+  public scaleName(originalScaleName: Channel|string): string {
+    const channel = contains([COLOR_LEGEND, COLOR_LEGEND_LABEL], originalScaleName) ? 'color' : originalScaleName;
+    // If there is a scale for the channel, it should either
+    // be in the _scale mapping or exist in the name map
+    if (
+        // in the scale map (the scale is not merged by its parent)
+        (this._scale && this._scale[channel]) ||
+        // in the scale name map (the the scale get merged by its parent)
+        this._scaleNameMap.has(this.name(originalScaleName + ''))
+      ) {
+      return this._scaleNameMap.get(this.name(originalScaleName + ''));
+    }
+    return undefined;
   }
 
   public sort(channel: Channel): SortField | SortOrder {

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -78,6 +78,7 @@ class NameMap implements NameMapInterface {
 
 export interface NameMapInterface {
   rename(oldname: string, newName: string): void;
+  has(name: string): boolean;
   get(name: string): string;
 }
 

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -337,8 +337,16 @@ export abstract class Model {
    * @return scale name for a given channel after the scale has been parsed and named.
    * (DO NOT USE THIS METHOD DURING SCALE PARSING, use model.name() instead)
    */
-  public scaleName(originalScaleName: Channel|string): string {
+  public scaleName(originalScaleName: Channel|string, parse?: boolean): string {
     const channel = contains([COLOR_LEGEND, COLOR_LEGEND_LABEL], originalScaleName) ? 'color' : originalScaleName;
+
+    if (parse) {
+      // During the parse phase always return a value
+      // No need to refer to rename map because a scale can't be renamed
+      // before it has the original name.
+      return this.name(originalScaleName + '');
+    }
+
     // If there is a scale for the channel, it should either
     // be in the _scale mapping or exist in the name map
     if (

--- a/src/compile/scale.ts
+++ b/src/compile/scale.ts
@@ -72,7 +72,7 @@ function parseMainScale(model: Model, fieldDef: FieldDef, channel: Channel) {
   const scale = model.scale(channel);
   const sort = model.sort(channel);
   let scaleDef: any = {
-    name: model.name(channel + ''),
+    name: model.scaleName(channel + '', true),
     type: scale.type,
   };
 
@@ -127,7 +127,7 @@ function parseMainScale(model: Model, fieldDef: FieldDef, channel: Channel) {
  */
 function parseColorLegendScale(model: Model, fieldDef: FieldDef): ScaleComponent {
   return {
-    name: model.name(COLOR_LEGEND),
+    name: model.scaleName(COLOR_LEGEND, true),
     type: ScaleType.ORDINAL,
     domain: {
       data: model.dataTable(),
@@ -144,7 +144,7 @@ function parseColorLegendScale(model: Model, fieldDef: FieldDef): ScaleComponent
  */
 function parseBinColorLegendLabel(model: Model, fieldDef: FieldDef): ScaleComponent {
   return {
-    name: model.name(COLOR_LEGEND_LABEL),
+    name: model.scaleName(COLOR_LEGEND_LABEL, true),
     type: ScaleType.ORDINAL,
     domain: {
       data: model.dataTable(),

--- a/src/compile/scale.ts
+++ b/src/compile/scale.ts
@@ -72,7 +72,7 @@ function parseMainScale(model: Model, fieldDef: FieldDef, channel: Channel) {
   const scale = model.scale(channel);
   const sort = model.sort(channel);
   let scaleDef: any = {
-    name: model.scaleName(channel),
+    name: model.name(channel + ''),
     type: scale.type,
   };
 
@@ -127,7 +127,7 @@ function parseMainScale(model: Model, fieldDef: FieldDef, channel: Channel) {
  */
 function parseColorLegendScale(model: Model, fieldDef: FieldDef): ScaleComponent {
   return {
-    name: model.scaleName(COLOR_LEGEND),
+    name: model.name(COLOR_LEGEND),
     type: ScaleType.ORDINAL,
     domain: {
       data: model.dataTable(),
@@ -144,7 +144,7 @@ function parseColorLegendScale(model: Model, fieldDef: FieldDef): ScaleComponent
  */
 function parseBinColorLegendLabel(model: Model, fieldDef: FieldDef): ScaleComponent {
   return {
-    name: model.scaleName(COLOR_LEGEND_LABEL),
+    name: model.name(COLOR_LEGEND_LABEL),
     type: ScaleType.ORDINAL,
     domain: {
       data: model.dataTable(),


### PR DESCRIPTION
Use `model.name()` during scale parsing to name scale
and make `model.scaleName()` only return values if the scale exists.

This is a good preparation for supporting projection.
I don't think I'll do projection now given how much that changes in Vega 3,
but since I have already done this part and it does no harm to the current code. 
Let's merge this part first.  

I have checked that all vega output of example specs remain the same. 