### PR TITLE
Kick Off 2.0 Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Vega-Lite
 
+**NOTE: The `master` branch now hosts ongoing Vega-Lite 2.0 pre-release development.  This is a work in progress that will introduce a number of MAJOR changes including migration to Vega v3 and D3 v4, as well as composition and interaction support described in [our research publication](http://idl.cs.washington.edu/papers/vega-lite).  For a more stable version, please use Vega-Lite v1. We have released v1.3 as our final MINOR release and created branch `1.3` as our v1 maintenance branch.**
+
 [![Build Status](https://travis-ci.org/vega/vega-lite.svg?branch=master)](https://travis-ci.org/vega/vega-lite)
 [![npm dependencies](https://david-dm.org/vega/vega-lite.svg)](https://www.npmjs.com/package/vega-lite)
 [![npm version](https://img.shields.io/npm/v/vega-lite.svg)](https://www.npmjs.com/package/vega-lite)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vega-lite",
   "author": "Jeffrey Heer, Dominik Moritz, Kanit \"Ham\" Wongsuphasawat",
-  "version": "1.3.0",
+  "version": "2.0.0-alpha.0",
   "collaborators": [
     "Kanit Wongsuphasawat <kanitw@gmail.com> (http://kanitw.yellowpigz.com)",
     "Dominik Moritz <domoritz@cs.washington.edu> (http://www.domoritz.de)",

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -37,7 +37,10 @@ if ! [ -f src/vl.d.ts ]; then
   exit 1;
 fi
 
-npm publish
+# Use NPM tag to prevent people getting this by default when running `npm install``
+# https://medium.com/@mbostock/prereleases-and-npm-e778fc5e2420#.i9ko1erii
+npm publish --tag pre
+
 # exit if npm publish failed
 rc=$?
 if [[ $rc != 0 ]]; then
@@ -68,5 +71,6 @@ git checkout master
 git push --tags
 # now the published tag contains build files which work great with bower.
 
+# TODO: re-publish to github pages when we are ready to release 2.0.
 #  3. GITHUB PAGES PUBLISH
-. ./scripts/deploy-gh.sh
+# . ./scripts/deploy-gh.sh


### PR DESCRIPTION
- Bump version  
- use "pre" tag with `npm publish`
- do not push to gh-pages