### PR TITLE
[WIP] Getting the right scale in mark

### DIFF
--- a/src/compile/mark/mark-common.ts
+++ b/src/compile/mark/mark-common.ts
@@ -1,0 +1,41 @@
+import {ScaleComponent} from '../scale';
+
+import {X, Y, Channel} from '../../channel';
+import {FieldDef, FieldRefOption, field} from '../../fielddef';
+import {ScaleType} from '../../scale';
+import {VgValueRef} from '../../vega.schema';
+
+export function normalFieldRef(fieldDef: FieldDef, scale: ScaleComponent, channel: Channel, defaultValue?): VgValueRef {
+  // TODO: datum support
+
+  if (fieldDef) {
+    if (fieldDef.field) {
+      let opt: FieldRefOption = {};
+      if (scale.type === ScaleType.ORDINAL) {
+        opt = {binSuffix: 'range'};
+      } else {
+        opt = {binSuffix: 'mid'};
+      }
+      return {
+        scale: scale.name,
+        field: field(fieldDef, opt)
+      };
+    } else if (fieldDef.value) {
+      return {
+        value: fieldDef.value
+      };
+    }
+  }
+
+  if (defaultValue) {
+    return {value: defaultValue};
+  }
+  return undefined;
+}
+
+export function stackEndRef(fieldDef: FieldDef, scale: ScaleComponent): VgValueRef {
+  return {
+    scale: scale.name,
+    field: field(fieldDef, { suffix: 'end' })
+  };
+}

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -323,6 +323,28 @@ export abstract class Model {
     return this._scale[channel];
   }
 
+  /**
+   * Return parsed (Vega) scale for a particular channel
+   */
+  public parsedScale(channel: Channel): VgScale {
+    return this._parsedScale(this.scaleName(channel));
+  }
+  protected _parsedScale(name: string): VgScale {
+    if (name) {
+      if (this.component.scale) {
+        const scaleComponents = this.component.scale[name];
+        if (scaleComponents.main) {
+          return scaleComponents.main;
+        }
+      }
+
+      if (this._parent) {
+        return this._parent._parsedScale(name);
+      }
+    }
+    return undefined;
+  }
+
   // TODO: rename to hasOrdinalScale
   public isOrdinalScale(channel: Channel) {
     const scale = this.scale(channel);
@@ -332,7 +354,6 @@ export abstract class Model {
   public renameScale(oldName: string, newName: string) {
     this._scaleNameMap.rename(oldName, newName);
   }
-
 
   /**
    * @return scale name for a given channel after the scale has been parsed and named.


### PR DESCRIPTION
Scale gets merged / etc in composition.  We need some way to get the right scale name and type in marks.  This is one such attempt.   However, I don't like the fact that this approach will couple mark properties method with prior parse phase and make all our unit tests for marks broken. 

There should be away that still make mark standalone.  A few options in mind:
a) Instead of having `component.scale`, replace `model._scale` with the component after parsing.
b) have a common model method for doing so. 

 (I haven't tried hacking any of these, so they might lead to a different set of problems.)

For now, I'll start another PR to refactor marks to use common set of FieldRef methods first
