### PR TITLE
Extract common methods for marks

### DIFF
--- a/src/compile/mark/area.ts
+++ b/src/compile/mark/area.ts
@@ -1,14 +1,9 @@
-import {VgValueRef} from '../../vega.schema';
-
 import {X, Y} from '../../channel';
 import {Orient} from '../../config';
-import {FieldDef, field} from '../../fielddef';
-import {Scale, ScaleType} from '../../scale';
-import {StackProperties} from '../../stack';
-import {contains} from '../../util';
 
 import {applyColorAndOpacity, applyMarkConfig} from '../common';
 import {UnitModel} from '../unit';
+import * as ref from './valueref';
 
 export namespace area {
   export function markType() {
@@ -26,143 +21,20 @@ export namespace area {
 
     const stack = model.stack();
 
-    p.x = x(model.encoding().x, model.scaleName(X), model.scale(X), orient, stack);
-    p.y = y(model.encoding().y, model.scaleName(Y), model.scale(Y), orient, stack);
+    // TODO: refactor how refer to scale as discussed in https://github.com/vega/vega-lite/pull/1613
 
-    // Have only x2 or y2
-    const _x2 = x2(model.encoding().x, model.encoding().x2, model.scaleName(X), model.scale(X), orient, stack);
-    if (_x2) {
-      p.x2 = _x2;
-    }
+    p.x = ref.stackableX(model.encoding().x, model.scaleName(X), model.scale(X), stack, 'baseX');
+    p.y = ref.stackableY(model.encoding().y, model.scaleName(Y), model.scale(Y), stack, 'baseY');
 
-    const _y2 = y2(model.encoding().y, model.encoding().y2, model.scaleName(Y), model.scale(Y), orient, stack);
-    if (_y2) {
-      p.y2 = _y2;
+    // Have only x2 or y2 based on orientation
+    if (orient === Orient.HORIZONTAL) {
+      p.x2 = ref.stackableX2(model.encoding().x, model.encoding().x2, model.scaleName(X), model.scale(X), stack, 'baseX');
+    } else {
+      p.y2 = ref.stackableY2(model.encoding().y, model.encoding().y2, model.scaleName(Y), model.scale(Y), stack, 'baseY');
     }
 
     applyColorAndOpacity(p, model);
     applyMarkConfig(p, model, ['interpolate', 'tension']);
     return p;
-  }
-
-  export function x(fieldDef: FieldDef, scaleName: string, scale: Scale, orient: Orient, stack: StackProperties): VgValueRef {
-    if (stack && X === stack.fieldChannel) { // Stacked Measure
-      return {
-        scale: scaleName,
-        field: field(fieldDef, { suffix: 'start' })
-      };
-    } else if (fieldDef) {
-      if (fieldDef.field) {
-        return {
-          scale: scaleName,
-          field: field(fieldDef, { binSuffix: 'mid' })
-        };
-      } else if (fieldDef.value) {
-        return {
-          scale: scaleName,
-          value: fieldDef.value
-        };
-      }
-    }
-
-    return { value: 0 };
-  }
-
-  export function x2(xFieldDef: FieldDef, x2FieldDef: FieldDef, scaleName: string, scale: Scale, orient: Orient, stack: StackProperties): VgValueRef {
-    // x
-    if (orient === Orient.HORIZONTAL) {
-      if (stack && X === stack.fieldChannel) { // Stacked Measure
-        return {
-          scale: scaleName,
-          field: field(xFieldDef, { suffix: 'end' })
-        };
-      } else if (x2FieldDef) {
-        if (x2FieldDef.field) {
-          return {
-            scale: scaleName,
-            field: field(x2FieldDef)
-          };
-        } else if (x2FieldDef.value) {
-          return {
-            scale: scaleName,
-            value: x2FieldDef.value
-          };
-        }
-      }
-
-      // Log / Time / UTC scale do not support zero
-      if (contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.type) || scale.zero === false) {
-        return {
-          value: 0
-        };
-      }
-
-      return {
-        scale: scaleName,
-        value: 0
-      };
-    }
-    return undefined;
-  }
-
-  export function y(fieldDef: FieldDef, scaleName: string, scale: Scale, orient: Orient, stack: StackProperties): VgValueRef {
-    if (stack && Y === stack.fieldChannel) { // Stacked Measure
-      return {
-        scale: scaleName,
-        field: field(fieldDef, { suffix: 'start' })
-      };
-    } else if (fieldDef) {
-      if (fieldDef.field) {
-        return {
-          scale: scaleName,
-          field: field(fieldDef, { binSuffix: 'mid' })
-        };
-      } else if (fieldDef.value) {
-        return {
-          scale: scaleName,
-          value: fieldDef.value
-        };
-      }
-    }
-    return { value: 0 };
-  }
-
-  export function y2(yFieldDef: FieldDef, y2FieldDef: FieldDef,
-      scaleName: string, scale: Scale, orient: Orient, stack: StackProperties): VgValueRef {
-
-    if (orient !== Orient.HORIZONTAL) {
-      if (stack && Y === stack.fieldChannel) { // Stacked Measure
-        return {
-          scale: scaleName,
-          field: field(yFieldDef, { suffix: 'end' })
-        };
-      } else if (y2FieldDef) {
-        // y2
-        if (y2FieldDef.field) {
-          return {
-            scale: scaleName,
-            field: field(y2FieldDef)
-          };
-        } else if (y2FieldDef.value) {
-          return {
-            scale: scaleName,
-            value: y2FieldDef.value
-          };
-        }
-      }
-
-      // Log / Time / UTC scale do not support zero
-      if (contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.type) || scale.zero === false) {
-        return {
-          field: {group: 'height'}
-        };
-      }
-
-      return {
-        scale: scaleName,
-        value: 0
-      };
-    }
-    return undefined;
   }
 }

--- a/src/compile/mark/line.ts
+++ b/src/compile/mark/line.ts
@@ -30,9 +30,8 @@ export namespace line {
     return p;
   }
 
-  // TODO: drop line's size earlier in the process
-  // NOTE: this is different from other size because
-  // Vega does not support variable line size
+  // NOTE: This is different from other size because
+  // Vega does not support variable line size.
   function size(fieldDef: FieldDef, config: Config) {
     if (fieldDef && fieldDef.value !== undefined) {
        return { value: fieldDef.value};

--- a/src/compile/mark/rule.ts
+++ b/src/compile/mark/rule.ts
@@ -1,11 +1,8 @@
 import {X, Y, SIZE} from '../../channel';
-import {Config, Orient} from '../../config';
-import {FieldDef, field} from '../../fielddef';
-
-import {VgValueRef} from '../../vega.schema';
-
-import {UnitModel} from '../unit';
 import {applyColorAndOpacity} from '../common';
+import {Orient} from '../../config';
+import {UnitModel} from '../unit';
+import * as ref from './valueref';
 
 export namespace rule {
   export function markType() {
@@ -17,96 +14,26 @@ export namespace rule {
     const orient = model.config().mark.orient;
     const config = model.config();
 
-    p.x = x(model.encoding().x, model.scaleName(X));
-    p.y = y(model.encoding().y, model.scaleName(Y));
+    // TODO: refactor how refer to scale as discussed in https://github.com/vega/vega-lite/pull/1613
+    // TODO: consider if we can apply stack here.
+
+    p.x = ref.normal(model.encoding().x, model.scaleName(X), model.scale(X), 'baseX');
+    p.y = ref.normal(model.encoding().y, model.scaleName(Y), model.scale(Y), 'baseY');
 
     if(orient === Orient.VERTICAL) {
-      p.y2 = y2(model.encoding().y2, model.scaleName(Y));
+      p.y2 = ref.normal(model.encoding().y2, model.scaleName(Y), model.scale(Y), 'baseOrMaxY');
     } else {
-      p.x2 = x2(model.encoding().x2, model.scaleName(X));
+      p.x2 = ref.normal(model.encoding().x2, model.scaleName(X), model.scale(X), 'baseOrMaxX');
     }
 
     // FIXME: this function would overwrite strokeWidth but shouldn't
     applyColorAndOpacity(p, model);
 
-    p.strokeWidth = size(model.encoding().size, model.scaleName(SIZE), config);
+
+    p.strokeWidth = ref.normal(model.encoding().size, model.scaleName(SIZE), model.scale(SIZE), {
+      value: config.mark.ruleSize
+    });
 
     return p;
-  }
-
-  function x(fieldDef: FieldDef, scaleName: string): VgValueRef {
-    if (fieldDef) {
-      return {
-        scale: scaleName,
-        field: field(fieldDef, { binSuffix: 'mid' })
-      };
-    } else {
-      return { value: 0 };
-    }
-  }
-
-  function y(fieldDef: FieldDef, scaleName: string): VgValueRef {
-    if (fieldDef) {
-      return {
-        scale: scaleName,
-        field: field(fieldDef, { binSuffix: 'mid' })
-      };
-    } else {
-      return {field: {group: 'height'}};
-    }
-  }
-
-  function y2(fieldDef: FieldDef, scaleName: string): VgValueRef {
-    if (fieldDef) {
-      return {
-        scale: scaleName,
-        field: field(fieldDef, { binSuffix: 'mid' })
-      };
-    } else { // Default
-      // TODO: log scale / zero = false?
-      if (scaleName) {
-        // If there is a scale, put y2 on the axis
-        return {
-          scale: scaleName,
-          value: 0
-        };
-      }
-      // Otherwise, put it on the axis
-      return {value: 0};
-    }
-  }
-
-  function x2(fieldDef: FieldDef, scaleName: string): VgValueRef {
-    if (fieldDef) {
-      return {
-        scale: scaleName,
-        field: field(fieldDef, { binSuffix: 'mid' })
-      };
-    } else { // Default
-      // TODO: log scale / zero = false?
-      if (scaleName) {
-        // If there is a scale, put x2 on the axis
-        return {
-          scale: scaleName,
-          value: 0
-        };
-      }
-      return { field: { group: 'width' } };
-    }
-  }
-
-  function size(fieldDef: FieldDef, scaleName: string, config: Config): VgValueRef {
-    if (fieldDef) {
-      if (fieldDef.field) {
-        return {
-          scale: scaleName,
-          field: field(fieldDef) // TODO: what's the missing suffix
-        };
-      } else if (fieldDef.value) {
-        return {value: fieldDef.value};
-      }
-    }
-
-    return {value: config.mark.ruleSize};
   }
 }

--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -1,0 +1,167 @@
+import {X, Y} from '../../channel';
+import {Config} from '../../config';
+import {FieldDef, FieldRefOption, field} from '../../fielddef';
+import {Scale, ScaleType} from '../../scale';
+import {StackProperties} from '../../stack';
+import {contains} from '../../util';
+import {VgValueRef} from '../../vega.schema';
+
+// TODO: we need to find a way to refactor these so that scaleName is a part of scale
+// but that's complicated.  For now, this is a huge step moving forward.
+
+export function stackableX(fieldDef: FieldDef, scaleName: string, scale: Scale,
+    stack: StackProperties, defaultRef: VgValueRef): VgValueRef {
+  if (fieldDef && stack && X === stack.fieldChannel) {
+    // x use stack_end so that stacked line's point mark use stack_end too.
+    return stackRef(fieldDef, scaleName, 'end');
+  }
+  return normal(fieldDef, scaleName, scale, defaultRef);
+}
+
+export function stackableY(fieldDef: FieldDef, scaleName: string, scale: Scale,
+    stack: StackProperties, defaultRef: VgValueRef): VgValueRef {
+  if (fieldDef && stack && Y === stack.fieldChannel) {
+    // y use stack_end so that stacked line's point mark use stack_end too.
+    return stackRef(fieldDef, scaleName, 'end');
+  }
+  return normal(fieldDef, scaleName, scale, defaultRef);
+}
+
+export function stackableX2(xFieldDef: FieldDef, x2FieldDef: FieldDef, scaleName: string, scale: Scale,
+    stack: StackProperties, defaultRef: VgValueRef): VgValueRef {
+  if (xFieldDef && stack && X === stack.fieldChannel) {
+    return stackRef(xFieldDef, scaleName, 'start');
+  }
+  return normal(x2FieldDef, scaleName, scale, defaultRef);
+}
+
+export function stackableY2(yFieldDef: FieldDef, y2FieldDef: FieldDef, scaleName: string, scale: Scale,
+    stack: StackProperties, defaultRef: VgValueRef): VgValueRef {
+  if (yFieldDef && stack && Y === stack.fieldChannel) {
+    return stackRef(yFieldDef, scaleName, 'start');
+  }
+  return normal(y2FieldDef, scaleName, scale, defaultRef);
+}
+
+export function normal(fieldDef: FieldDef, scaleName: string, scale: Scale,
+defaultRef: VgValueRef | 'baseX' | 'baseY' | 'baseOrMaxX' | 'baseOrMaxY'): VgValueRef {
+  // TODO: datum support
+
+  if (fieldDef) {
+    if (fieldDef.field) {
+      let opt: FieldRefOption = {};
+      if (scale.type === ScaleType.ORDINAL) {
+        opt = {binSuffix: 'range'};
+      } else {
+        opt = {binSuffix: 'mid'};
+      }
+      return {
+        scale: scaleName,
+        field: field(fieldDef, opt)
+      };
+    } else if (fieldDef.value) {
+      return {
+        value: fieldDef.value
+      };
+    }
+  }
+
+  if (defaultRef) {
+    switch (defaultRef) {
+      case 'baseX':
+        return baseX(scaleName, scale);
+      case 'baseY':
+        return baseY(scaleName, scale);
+      case 'baseOrMaxX':
+        return baseOrMaxX(scaleName, scale);
+      case 'baseOrMaxY':
+        return baseOrMaxY(scaleName, scale);
+    }
+    return defaultRef;
+  }
+  return undefined;
+}
+
+export function stackRef(fieldDef: FieldDef, scaleName: string, suffix: string): VgValueRef {
+  return {
+    scale: scaleName,
+    field: field(fieldDef, {suffix: suffix})
+  };
+}
+
+export function zeroOrXAxis(): VgValueRef {
+  return {};
+}
+
+export function midX(config: Config): VgValueRef {
+  // TODO: For fit-mode, use middle of the width
+  return {value: config.scale.bandSize / 2};
+}
+
+export function midY(config: Config): VgValueRef {
+  // TODO: For fit-mode, use middle of the width
+  return {value: config.scale.bandSize / 2};
+}
+
+function baseX(scaleName: string, scale: Scale): VgValueRef {
+  if (scaleName) {
+    // Log / Time / UTC scale do not support zero
+    if (!contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.type) &&
+      scale.zero !== false) {
+
+      return {
+        scale: scaleName,
+        value: 0
+      };
+    }
+  }
+  // Put the mark on the x-axis
+  return {value: 0};
+}
+
+function baseOrMaxX(scaleName: string, scale: Scale): VgValueRef {
+  if (scaleName) {
+    // Log / Time / UTC scale do not support zero
+    if (!contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.type) &&
+      scale.zero !== false) {
+
+      return {
+        scale: scaleName,
+        value: 0
+      };
+    }
+  }
+  return {field: {group: 'width'}};
+}
+
+function baseY(scaleName: string, scale: Scale): VgValueRef {
+  if (scaleName) {
+    // Log / Time / UTC scale do not support zero
+    if (!contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.type) &&
+      scale.zero !== false) {
+
+      return {
+        scale: scaleName,
+        value: 0
+      };
+    }
+  }
+  // Put the mark on the y-axis
+  return {field: {group: 'height'}};
+}
+
+function baseOrMaxY(scaleName: string, scale: Scale): VgValueRef {
+  if (scaleName) {
+    // Log / Time / UTC scale do not support zero
+    if (!contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.type) &&
+      scale.zero !== false) {
+
+      return {
+        scale: scaleName,
+        value: 0
+      };
+    }
+  }
+  // Put the mark on the y-axis
+  return {value: 0};
+}

--- a/src/compile/scale.ts
+++ b/src/compile/scale.ts
@@ -281,7 +281,10 @@ export function domain(scale: Scale, model: Model, channel:Channel): any {
   if (useRawDomain) { // useRawDomain - only Q/T
     return {
       data: SOURCE,
-      field: model.field(channel, {noAggregate: true})
+      field: model.field(channel, {
+        // no aggregate rather than nofn as bin and timeUnit is fine
+        noAggregate: true
+      })
     };
   } else if (fieldDef.bin) { // bin
     if (scale.type === ScaleType.ORDINAL) {

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -5,7 +5,7 @@ import {Axis} from './axis';
 import {Bin} from './bin';
 import {Config} from './config';
 import {Legend} from './legend';
-import {Scale, ScaleType} from './scale';
+import {Scale} from './scale';
 import {SortField, SortOrder} from './sort';
 import {TimeUnit} from './timeunit';
 import {Type, NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from './type';
@@ -96,12 +96,8 @@ export interface FieldRefOption {
   noAggregate?: boolean;
   /** Wrap the field inside datum[...] per Vega convention */
   datum?: boolean;
-  /** replace fn with custom function prefix */
-  fn?: string;
   /** prepend fn with custom function prefix */
   prefix?: string;
-  /** scaleType */
-  scaleType?: ScaleType;
   /** append suffix to the field ref for bin (default='start') */
   binSuffix?: string;
   /** append suffix to the field ref (general) */
@@ -116,19 +112,12 @@ export function field(fieldDef: FieldDef, opt: FieldRefOption = {}) {
   if (isCount(fieldDef)) {
     field = 'count';
   } else {
-    let fn = opt.fn;
+    let fn = undefined;
 
     if (!opt.nofn) {
       if (fieldDef.bin) {
         fn = 'bin';
-
-        suffix = opt.binSuffix || (
-          opt.scaleType === ScaleType.ORDINAL ?
-            // For ordinal scale type, use `range` as suffix.
-            'range' :
-            // For non-ordinal scale or unknown, use `start` as suffix.
-            'start'
-        );
+        suffix = opt.binSuffix;
       } else if (!opt.noAggregate && fieldDef.aggregate) {
         fn = String(fieldDef.aggregate);
       } else if (fieldDef.timeUnit) {

--- a/test/compile/mark/area.test.ts
+++ b/test/compile/mark/area.test.ts
@@ -89,12 +89,9 @@ describe('Mark: Area', function() {
 
     const props = area.properties(model);
 
-    it('should have the correct value for y', () => {
-      assert.deepEqual(props.y, {scale: 'y', field: 'count_start'});
-    });
-
-    it('should have the correct value for y2', () => {
-      assert.deepEqual(props.y2, {scale: 'y', field: 'count_end'});
+    it('should have the correct value for y and y2', () => {
+      assert.deepEqual(props.y, {scale: 'y', field: 'count_end'});
+      assert.deepEqual(props.y2, {scale: 'y', field: 'count_start'});
     });
 
     it('should have correct orient', () => {
@@ -186,12 +183,9 @@ describe('Mark: Area', function() {
 
     const props = area.properties(model);
 
-    it('should have the correct value for x', () => {
-      assert.deepEqual(props.x, {scale: 'x', field: 'count_start'});
-    });
-
-    it('should have the correct value for x2', () => {
-      assert.deepEqual(props.x2, {scale: 'x', field: 'count_end'});
+    it('should have the correct value for x and x2', () => {
+      assert.deepEqual(props.x, {scale: 'x', field: 'count_end'});
+      assert.deepEqual(props.x2, {scale: 'x', field: 'count_start'});
     });
 
     it('should have correct orient', () => {

--- a/test/compile/mark/bar.test.ts
+++ b/test/compile/mark/bar.test.ts
@@ -52,7 +52,7 @@ describe('Mark: Bar', function() {
     });
   });
 
-  describe('simple horizontal binned', function() {
+  describe('horizontal binned', function() {
     const model = parseUnitModel({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
@@ -64,13 +64,13 @@ describe('Mark: Bar', function() {
     const props = bar.properties(model);
 
     it('should draw bar with y and y2', function() {
-      assert.deepEqual(props.y, {scale: 'y', field: 'bin_Horsepower_start'});
-      assert.deepEqual(props.y2, {scale: 'y', field: 'bin_Horsepower_end', offset: 1}); // TODO: markConfig.binnedBarOffset
-      assert.isUndefined(props.width);
+      assert.deepEqual(props.y2, {scale: 'y', field: 'bin_Horsepower_start'});
+      assert.deepEqual(props.y, {scale: 'y', field: 'bin_Horsepower_end', offset: 1}); // TODO: markConfig.binnedBarOffset
+      assert.isUndefined(props.height);
     });
   });
 
-  describe('simple vertical binned', function() {
+  describe('vertical binned', function() {
     const model = parseUnitModel({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
@@ -82,10 +82,9 @@ describe('Mark: Bar', function() {
     const props = bar.properties(model);
 
     it('should draw bar with x and x2', function() {
-      assert.deepEqual(props.x, {scale: 'x', field: 'bin_Horsepower_start', offset: 1}); // TODO: markConfig.binnedBarOffset
-      assert.deepEqual(props.x2, {scale: 'x', field: 'bin_Horsepower_end'});
-      // FIXME this line should be brought back when I refactor Bar
-      // assert.isUndefined(props.width);
+      assert.deepEqual(props.x2, {scale: 'x', field: 'bin_Horsepower_start', offset: 1}); // TODO: markConfig.binnedBarOffset
+      assert.deepEqual(props.x, {scale: 'x', field: 'bin_Horsepower_end'});
+      assert.isUndefined(props.width);
     });
   });
 
@@ -107,7 +106,7 @@ describe('Mark: Bar', function() {
     });
   });
 
-  describe('simple vertical binned with size', function() {
+  describe('vertical binned with size', function() {
     const model = parseUnitModel({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
@@ -260,9 +259,9 @@ describe('Mark: Bar', function() {
       assert.deepEqual(props.y, {scale: 'y', field: 'sum_US_Gross'});
       assert.deepEqual(props.y2, {scale: 'y', value: 0});
       assert.isUndefined(props.height);
-      assert.deepEqual(props.x, {
-        value: 0,
-        offset: 2
+      assert.deepEqual(props.xc, {
+        value: 10.5,
+        offset: 1
       });
     });
   });
@@ -313,10 +312,7 @@ describe('Mark: Bar', function() {
       assert.deepEqual(props.x, {scale: 'x', field: 'sum_US_Gross'});
       assert.deepEqual(props.x2, {scale: 'x', value: 0});
       assert.isUndefined(props.width);
-      assert.deepEqual(props.y2, {
-        field: {group: 'height'},
-        offset: -1
-      });
+      assert.deepEqual(props.yc, {value: 10.5});
     });
   });
 

--- a/test/compile/mark/line.test.ts
+++ b/test/compile/mark/line.test.ts
@@ -47,6 +47,25 @@ describe('Mark: Line', function() {
     });
   });
 
+
+  describe('with x, y, size', function () {
+    const model = parseUnitModel({
+      "data": {"url": "data/barley.json"},
+      "mark": "line",
+      "encoding": {
+        "x": {"field": "year", "type": "ordinal"},
+        "y": {"field": "yield", "type": "quantitative", "aggregate": "mean"},
+        "size": {"field": "Acceleration", "type": "quantitative", "aggregate": "mean"}
+      }
+    });
+    const props = line.properties(model);
+
+    it('should drop size field', function () {
+      // If size field is dropped, then strokeWidth only have value
+      assert.deepEqual(props.strokeWidth, {value: 2});
+    });
+  });
+
   describe('with stacked y', function() {
     const model = parseUnitModel({
       "data": {"url": "data/barley.json"},


### PR DESCRIPTION
Fix #1284

Common methods are in `src/compile/mark/valueref.ts`.
Mark's code is now cut by roughly half (-711, +376)

More details in each (atomic) commit. 