### PR TITLE
Enable noImplicitAny

### DIFF
--- a/examples/examples.test.ts
+++ b/examples/examples.test.ts
@@ -14,16 +14,16 @@ const validator = new zSchema({
 const vlSchema = require('../vega-lite-schema.json');
 const vgSchema = require('../node_modules/vega/vega-schema.json');
 
-function validateVL(spec) {
+function validateVL(spec: vl.spec.ExtendedSpec) {
   const valid = validator.validate(spec, vlSchema);
   const errors = validator.getLastErrors();
   if (!valid) {
     console.log(inspect(errors, { depth: 10, colors: true }));
   }
-  assert(valid, errors && errors.map((err) => {return err.message; }).join(', '));
+  assert(valid, errors && errors.map((err: Error) => {return err.message; }).join(', '));
 }
 
-function validateVega(spec) {
+function validateVega(spec: vl.spec.ExtendedSpec) {
   const vegaSpec = vl.compile(spec).spec;
 
   const valid = validator.validate(vegaSpec, vgSchema);
@@ -32,13 +32,13 @@ function validateVega(spec) {
     console.log(vegaSpec.marks[0].marks[0].properties);
     console.log(inspect(errors, { depth: 10, colors: true }));
   }
-  assert(valid, errors && errors.map((err) => {return err.message; }).join(', '));
+  assert(valid, errors && errors.map((err: Error) => {return err.message; }).join(', '));
 }
 
 describe('Examples', function() {
   const examples = fs.readdirSync('examples/specs');
 
-  examples.forEach(function(example) {
+  examples.forEach(function(example: string) {
     if (path.extname(example) !== '.json') { return; }
     const jsonSpec = JSON.parse(fs.readFileSync('examples/specs/' + example));
 

--- a/site/static/main.ts
+++ b/site/static/main.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:no-unused-variable */
 
-declare const BASEURL, hljs;
+declare const BASEURL: string, hljs: any;
 
 // IIFE to prevent function declarations from moving into the global scope
 (() => {
@@ -81,9 +81,9 @@ function renderGallery() {
       d3.select(this).call(renderGalleryGroup);
     });
 
-    function renderGalleryGroup (selection) {
+    function renderGalleryGroup (selection: d3.Selection<any>) {
       const galleryGroupName = selection.attr('data-gallery-group');
-      let galleryGroupSpecs;
+      let galleryGroupSpecs: any[];
 
       // try to retrieve specs for a gallery group from in vl-examples.json
       try {

--- a/site/static/test-gallery.ts
+++ b/site/static/test-gallery.ts
@@ -1,7 +1,7 @@
 d3.select('#vl-version').text(vl.version);
 d3.select('#vg-version').text(vg.version);
 
-d3.json('examples/all-examples.json', function(examples) {
+d3.json('examples/all-examples.json', function(examples: string[]) {
   render();
 
   function render() {
@@ -28,7 +28,7 @@ d3.json('examples/all-examples.json', function(examples) {
             export: false
           }
         };
-        vg.embed('.viz#'+ example + '> div.view', embedSpec, function(err) {
+        vg.embed('.viz#'+ example + '> div.view', embedSpec, function(err: any) {
           if (err) {
             console.error(err);
           }

--- a/src/aggregate.ts
+++ b/src/aggregate.ts
@@ -1,26 +1,52 @@
 
-export enum AggregateOp {
-    VALUES = 'values' as any,
-    COUNT = 'count' as any,
-    VALID = 'valid' as any,
-    MISSING = 'missing' as any,
-    DISTINCT = 'distinct' as any,
-    SUM = 'sum' as any,
-    MEAN = 'mean' as any,
-    AVERAGE = 'average' as any,
-    VARIANCE = 'variance' as any,
-    VARIANCEP = 'variancep' as any,
-    STDEV = 'stdev' as any,
-    STDEVP = 'stdevp' as any,
-    MEDIAN = 'median' as any,
-    Q1 = 'q1' as any,
-    Q3 = 'q3' as any,
-    MODESKEW = 'modeskew' as any,
-    MIN = 'min' as any,
-    MAX = 'max' as any,
-    ARGMIN = 'argmin' as any,
-    ARGMAX = 'argmax' as any,
+export namespace AggregateOp {
+    export const VALUES: 'values' = 'values';
+    export type VALUES = typeof VALUES;
+    export const COUNT: 'count' = 'count';
+    export type COUNT = typeof COUNT;
+    export const VALID: 'valid' = 'valid';
+    export type VALID = typeof VALID;
+    export const MISSING: 'missing' = 'missing';
+    export type MISSING = typeof MISSING;
+    export const DISTINCT: 'distinct' = 'distinct';
+    export type DISTINCT = typeof DISTINCT;
+    export const SUM: 'sum' = 'sum';
+    export type SUM = typeof SUM;
+    export const MEAN: 'mean' = 'mean';
+    export type MEAN = typeof MEAN;
+    export const AVERAGE: 'average' = 'average';
+    export type AVERAGE = typeof AVERAGE;
+    export const VARIANCE: 'variance' = 'variance';
+    export type VARIANCE = typeof VARIANCE;
+    export const VARIANCEP: 'variancep' = 'variancep';
+    export type VARIANCEP = typeof VARIANCEP;
+    export const STDEV: 'stdev' = 'stdev';
+    export type STDEV = typeof STDEV;
+    export const STDEVP: 'stdevp' = 'stdevp';
+    export type STDEVP = typeof STDEVP;
+    export const MEDIAN: 'median' = 'median';
+    export type MEDIAN = typeof MEDIAN;
+    export const Q1: 'q1' = 'q1';
+    export type Q1 = typeof Q1;
+    export const Q3: 'q3' = 'q3';
+    export type Q3 = typeof Q3;
+    export const MODESKEW: 'modeskew' = 'modeskew';
+    export type MODESKEW = typeof MODESKEW;
+    export const MIN: 'min' = 'min';
+    export type MIN = typeof MIN;
+    export const MAX: 'max' = 'max';
+    export type MAX = typeof MAX;
+    export const ARGMIN: 'argmin' = 'argmin';
+    export type ARGMIN = typeof ARGMIN;
+    export const ARGMAX: 'argmax' = 'argmax';
+    export type ARGMAX = typeof ARGMAX;
 }
+export type AggregateOp = AggregateOp.ARGMAX | AggregateOp.ARGMIN | AggregateOp.AVERAGE
+  | AggregateOp.COUNT | AggregateOp.DISTINCT | AggregateOp.MAX | AggregateOp.MEAN
+  | AggregateOp.MEDIAN | AggregateOp.MIN | AggregateOp.MISSING | AggregateOp.MODESKEW
+  | AggregateOp.Q1 | AggregateOp.Q3 | AggregateOp.STDEV | AggregateOp.STDEVP
+  | AggregateOp.SUM | AggregateOp.VALID | AggregateOp.VALUES | AggregateOp.VARIANCE
+  | AggregateOp.VARIANCEP;
 
 export const AGGREGATE_OPS = [
     AggregateOp.VALUES,

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -1,11 +1,16 @@
 import {DateTime} from './datetime';
 
-export enum AxisOrient {
-    TOP = 'top' as any,
-    RIGHT = 'right' as any,
-    LEFT = 'left' as any,
-    BOTTOM = 'bottom' as any
+export namespace AxisOrient {
+    export const TOP: 'top' = 'top';
+    export type TOP = typeof TOP;
+    export const RIGHT: 'right' = 'right';
+    export type RIGHT = typeof RIGHT;
+    export const LEFT: 'left' = 'left';
+    export type LEFT = typeof LEFT;
+    export const BOTTOM: 'bottom' = 'bottom';
+    export type BOTTOM = typeof BOTTOM;
 }
+export type AxisOrient = AxisOrient.TOP | AxisOrient.RIGHT | AxisOrient.LEFT | AxisOrient.BOTTOM;
 
 export interface AxisConfig {
   // ---------- General ----------

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -6,23 +6,42 @@
 import {Mark} from './mark';
 import {contains, without} from './util';
 
-export enum Channel {
-  X = 'x' as any,
-  Y = 'y' as any,
-  X2 = 'x2' as any,
-  Y2 = 'y2' as any,
-  ROW = 'row' as any,
-  COLUMN = 'column' as any,
-  SHAPE = 'shape' as any,
-  SIZE = 'size' as any,
-  COLOR = 'color' as any,
-  TEXT = 'text' as any,
-  DETAIL = 'detail' as any,
-  LABEL = 'label' as any,
-  PATH = 'path' as any,
-  ORDER = 'order' as any,
-  OPACITY = 'opacity' as any
+export namespace Channel {
+  export const X: 'x' = 'x';
+  export type X = typeof X;
+  export const Y: 'y' = 'y';
+  export type Y = typeof Y;
+  export const X2: 'x2' = 'x2';
+  export type X2 = typeof X2;
+  export const Y2: 'y2' = 'y2';
+  export type Y2 = typeof Y2;
+  export const ROW: 'row' = 'row';
+  export type ROW = typeof ROW;
+  export const COLUMN: 'column' = 'column';
+  export type COLUMN = typeof COLUMN;
+  export const SHAPE: 'shape' = 'shape';
+  export type SHAPE = typeof SHAPE;
+  export const SIZE: 'size' = 'size';
+  export type SIZE = typeof SIZE;
+  export const COLOR: 'color' = 'color';
+  export type COLOR = typeof COLOR;
+  export const TEXT: 'text' = 'text';
+  export type TEXT = typeof TEXT;
+  export const DETAIL: 'detail' = 'detail';
+  export type DETAIL = typeof DETAIL;
+  export const LABEL: 'label' = 'label';
+  export type LABEL = typeof LABEL;
+  export const PATH: 'path' = 'path';
+  export type PATH = typeof PATH;
+  export const ORDER: 'order' = 'order';
+  export type ORDER = typeof ORDER;
+  export const OPACITY: 'opacity' = 'opacity';
+  export type OPACITY = typeof OPACITY;
 }
+export type Channel = Channel.X | Channel.Y | Channel.X2 | Channel.Y2 | Channel.ROW
+  | Channel.COLUMN | Channel.SHAPE | Channel.SIZE | Channel.COLOR
+  | Channel.TEXT | Channel.DETAIL | Channel.LABEL | Channel.PATH
+  | Channel.ORDER | Channel.OPACITY;
 
 export const X = Channel.X;
 export const Y = Channel.Y;

--- a/src/compile/axis.ts
+++ b/src/compile/axis.ts
@@ -11,7 +11,7 @@ import {Model} from './model';
 import {UnitModel} from './unit';
 
 // https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#11-ambient-declarations
-declare let exports;
+declare let exports: any;
 
 export function parseAxisComponent(model: Model, axisChannels: Channel[]): Dict<VgAxis> {
   return axisChannels.reduce(function(axis, channel) {
@@ -164,7 +164,7 @@ export function grid(model: Model, channel: Channel) {
   );
 }
 
-export function layer(model: Model, channel: Channel, def) {
+export function layer(model: Model, channel: Channel, def: {grid?: boolean}) {
   const layer = model.axis(channel).layer;
   if (layer !== undefined) {
     return layer;
@@ -227,7 +227,7 @@ export function title(model: Model, channel: Channel) {
   // if not defined, automatically determine axis title from field def
   const fieldTitle = fieldDefTitle(model.fieldDef(channel), model.config());
 
-  let maxLength;
+  let maxLength: number;
   if (axis.titleMaxLength) {
     maxLength = axis.titleMaxLength;
   } else if (channel === X && !model.isOrdinalScale(X)) {
@@ -264,7 +264,7 @@ export function values(model: Model, channel: Channel) {
 }
 
 export namespace properties {
-  export function axis(model: Model, channel: Channel, axisPropsSpec) {
+  export function axis(model: Model, channel: Channel, axisPropsSpec: any) {
     const axis = model.axis(channel);
 
     return extend(
@@ -278,7 +278,7 @@ export namespace properties {
     );
   }
 
-  export function grid(model: Model, channel: Channel, gridPropsSpec) {
+  export function grid(model: Model, channel: Channel, gridPropsSpec: any) {
     const axis = model.axis(channel);
 
     return extend(
@@ -290,7 +290,7 @@ export namespace properties {
     );
   }
 
-  export function labels(model: Model, channel: Channel, labelsSpec, def) {
+  export function labels(model: Model, channel: Channel, labelsSpec: any, def: {orient?: string, type?: string}) {
     const fieldDef = model.fieldDef(channel);
     const axis = model.axis(channel);
     const config = model.config();
@@ -374,7 +374,7 @@ export namespace properties {
     return keys(labelsSpec).length === 0 ? undefined : labelsSpec;
   }
 
-  export function ticks(model: Model, channel: Channel, ticksPropsSpec) {
+  export function ticks(model: Model, channel: Channel, ticksPropsSpec: any) {
     const axis = model.axis(channel);
 
     return extend(
@@ -384,7 +384,7 @@ export namespace properties {
     );
   }
 
-  export function title(model: Model, channel: Channel, titlePropsSpec) {
+  export function title(model: Model, channel: Channel, titlePropsSpec: any) {
     const axis = model.axis(channel);
 
     return extend(

--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -8,7 +8,7 @@ import {FieldDef, field, OrderChannelDef} from '../fielddef';
 import {SortOrder} from '../sort';
 import {TimeUnit} from '../timeunit';
 import {QUANTITATIVE, ORDINAL} from '../type';
-import {contains, union} from '../util';
+import {contains, union, Dict} from '../util';
 
 import {FacetModel} from './facet';
 import {LayerModel} from './layer';
@@ -16,7 +16,7 @@ import {Model} from './model';
 import {template as timeUnitTemplate} from '../timeunit';
 import {UnitModel} from './unit';
 import {Spec, isUnitSpec, isSomeFacetSpec, isLayerSpec} from '../spec';
-
+import {VgValueRef} from '../vega.schema';
 
 export function buildModel(spec: Spec, parent: Model, parentGivenName: string): Model {
   if (isSomeFacetSpec(spec)) {
@@ -56,8 +56,8 @@ export function applyColorAndOpacity(p: any, model: UnitModel) {
     applyMarkConfig(p, model, STROKE_CONFIG);
   }
 
-  let colorValue: {scale: string, field: {prefix?: 'rank'}} | {value: string | number | true};
-  let opacityValue: {scale: string, field: {prefix?: 'rank'}} | {value: string | number | true};;
+  let colorValue: VgValueRef;
+  let opacityValue: VgValueRef;
   if (model.has(COLOR)) {
     colorValue = {
       scale: model.scaleName(COLOR),
@@ -99,7 +99,7 @@ export function applyColorAndOpacity(p: any, model: UnitModel) {
   }
 }
 
-export function applyConfig(properties: {[index: string]: {value: any}}, config: any, propsList: string[]) {
+export function applyConfig(properties: Dict<any>, config: any, propsList: string[]) {
   propsList.forEach(function(property) {
     const value = config[property];
     if (value !== undefined) {

--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -43,7 +43,7 @@ export const FILL_CONFIG = ['fill', 'fillOpacity',
 
 export const FILL_STROKE_CONFIG = union(STROKE_CONFIG, FILL_CONFIG);
 
-export function applyColorAndOpacity(p, model: UnitModel) {
+export function applyColorAndOpacity(p: any, model: UnitModel) {
   const filled = model.config().mark.filled;
   const colorFieldDef = model.encoding().color;
   const opacityFieldDef = model.encoding().opacity;
@@ -56,8 +56,8 @@ export function applyColorAndOpacity(p, model: UnitModel) {
     applyMarkConfig(p, model, STROKE_CONFIG);
   }
 
-  let colorValue;
-  let opacityValue;
+  let colorValue: {scale: string, field: {prefix?: 'rank'}} | {value: string | number | true};
+  let opacityValue: {scale: string, field: {prefix?: 'rank'}} | {value: string | number | true};;
   if (model.has(COLOR)) {
     colorValue = {
       scale: model.scaleName(COLOR),
@@ -99,7 +99,7 @@ export function applyColorAndOpacity(p, model: UnitModel) {
   }
 }
 
-export function applyConfig(properties, config, propsList: string[]) {
+export function applyConfig(properties: {[index: string]: {value: any}}, config: any, propsList: string[]) {
   propsList.forEach(function(property) {
     const value = config[property];
     if (value !== undefined) {
@@ -109,7 +109,7 @@ export function applyConfig(properties, config, propsList: string[]) {
   return properties;
 }
 
-export function applyMarkConfig(marksProperties, model: UnitModel, propsList: string[]) {
+export function applyMarkConfig(marksProperties: any, model: UnitModel, propsList: string[]) {
   return applyConfig(marksProperties, model.config().mark, propsList);
 }
 

--- a/src/compile/data/bin.ts
+++ b/src/compile/data/bin.ts
@@ -11,12 +11,12 @@ import {Model} from './../model';
 import {DataComponent} from './data';
 
 export namespace bin {
-  function numberFormatExpr(format, expr) {
+  function numberFormatExpr(format: string, expr: string) {
     return `format('${format}', ${expr})`;
   }
 
   function parse(model: Model): Dict<VgTransform[]> {
-    return model.reduce(function(binComponent, fieldDef: FieldDef, channel: Channel) {
+    return model.reduce(function(binComponent: Dict<VgTransform[]>, fieldDef: FieldDef, channel: Channel) {
       const bin = model.fieldDef(channel).bin;
       if (bin) {
         let binTrans = extend({
@@ -37,7 +37,7 @@ export namespace bin {
           binTrans.maxbins = autoMaxBins(channel);
         }
 
-        const transform = [binTrans];
+        const transform: VgTransform[] = [binTrans];
         const isOrdinalColor = model.isOrdinalScale(channel) || channel === COLOR;
         // color ramp has type linear or time, we have to create new bin_range field
         // with correct number format

--- a/src/compile/data/formatparse.ts
+++ b/src/compile/data/formatparse.ts
@@ -1,4 +1,4 @@
-import {isDateTime} from '../../datetime';
+import {isDateTime, DateTime} from '../../datetime';
 import {FieldDef, isCount} from '../../fielddef';
 import {isOneOfFilter, isEqualFilter, isRangeFilter} from '../../filter';
 import {QUANTITATIVE, TEMPORAL} from '../../type';
@@ -24,7 +24,7 @@ export namespace formatParse {
       filter = [filter];
     }
     filter.forEach((f) => {
-      let val = null;
+      let val: string | number | boolean | DateTime = null;
       // For EqualFilter, just use the equal property.
       // For RangeFilter and OneOfFilter, all array members should have
       // the same type, so we only use the first one.

--- a/src/compile/data/formula.ts
+++ b/src/compile/data/formula.ts
@@ -44,7 +44,7 @@ export namespace formula {
   }
 
   export function assemble(component: DataComponent) {
-    return vals(component.calculate).reduce(function(transform, formula) {
+    return vals(component.calculate).reduce(function(transform: any, formula: any) {
       transform.push(extend({ type: 'formula' }, formula));
       return transform;
     }, []);

--- a/src/compile/data/nullfilter.ts
+++ b/src/compile/data/nullfilter.ts
@@ -21,7 +21,7 @@ export namespace nullFilter {
   function parse(model: Model): Dict<boolean> {
     const filterInvalid = model.filterInvalid();
 
-    return model.reduce(function(aggregator, fieldDef: FieldDef) {
+    return model.reduce(function(aggregator: Dict<FieldDef>, fieldDef: FieldDef) {
       if (fieldDef.field !== '*') { // Ignore * for count(*) fields.
         if (filterInvalid ||
           (filterInvalid === undefined && fieldDef.field && DEFAULT_NULL_FILTERS[fieldDef.type])) {

--- a/src/compile/data/stackscale.ts
+++ b/src/compile/data/stackscale.ts
@@ -22,7 +22,7 @@ export namespace stackScale {
       const groupbyChannel = stackProps.groupbyChannel;
       const fieldChannel = stackProps.fieldChannel;
 
-      let fields = [];
+      let fields: string[] = [];
       const field = model.field(groupbyChannel);
       if (field) {
         fields.push(field);
@@ -71,7 +71,7 @@ export namespace stackScale {
     return null;
   }
 
-  export function parseLayer(model: LayerModel) {
+  export function parseLayer(model: LayerModel): VgData {
     // TODO
     return null;
   }

--- a/src/compile/data/timeunit.ts
+++ b/src/compile/data/timeunit.ts
@@ -13,7 +13,7 @@ import {DataComponent} from './data';
 
 export namespace timeUnit {
   function parse(model: Model): Dict<VgTransform> {
-    return model.reduce(function(timeUnitComponent, fieldDef: FieldDef, channel: Channel) {
+    return model.reduce(function(timeUnitComponent: Dict<VgTransform>, fieldDef: FieldDef, channel: Channel) {
       if (fieldDef.type === TEMPORAL && fieldDef.timeUnit) {
 
         const hash = field(fieldDef);

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -12,6 +12,7 @@ import {FacetSpec} from '../spec';
 import {getFullName} from '../type';
 import {contains, extend, keys, vals, flatten, duplicate, mergeDeep, Dict} from '../util';
 import {VgData, VgMarkGroup} from '../vega.schema';
+import {StackProperties} from '../stack';
 
 import {parseAxis, parseInnerAxis, gridShow, parseAxisComponent} from './axis';
 import {buildModel} from './common';
@@ -147,7 +148,7 @@ export class FacetModel extends Model {
     return this.facet()[channel];
   }
 
-  public stack() {
+  public stack(): StackProperties {
     return null; // this is only a property for UnitModel
   }
 
@@ -184,7 +185,7 @@ export class FacetModel extends Model {
         scaleComponent[channel] = child.component.scale[channel];
 
         // for each scale, need to rename
-        vals(scaleComponent[channel]).forEach(function(scale) {
+        vals(scaleComponent[channel]).forEach(function(scale: any) {
           const scaleNameWithoutPrefix = scale.name.substr(child.name('').length);
           const newName = model.scaleName(scaleNameWithoutPrefix, true);
           child.renameScale(scale.name, newName);
@@ -270,7 +271,7 @@ export class FacetModel extends Model {
     this._child.component.legend = {};
   }
 
-  public assembleParentGroupProperties() {
+  public assembleParentGroupProperties(): any {
     return null;
   }
 
@@ -338,7 +339,7 @@ function getFacetGroupProperties(model: FacetModel) {
 
 function parseAxisGroup(model: FacetModel, channel: Channel) {
   // TODO: add a case where inner spec is not a unit (facet/layer/concat)
-  let axisGroup = null;
+  let axisGroup: any = null;
 
   const child = model.child();
   if (child.has(channel)) {

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -11,6 +11,7 @@ import {UnitModel} from './unit';
 import {buildModel} from './common';
 import {FieldDef} from '../fielddef';
 import {ScaleComponents} from './scale';
+import {StackProperties} from '../stack';
 import {VgData, VgAxis, VgLegend, isUnionedDomain, isDataRefDomain, VgDataRef} from '../vega.schema';
 
 
@@ -80,7 +81,7 @@ export class LayerModel extends Model {
     return null; // layer does not have field defs
   }
 
-  public stack() {
+  public stack(): StackProperties {
     return null; // this is only a property for UnitModel
   }
 
@@ -163,7 +164,7 @@ export class LayerModel extends Model {
           }
 
           // rename child scales to parent scales
-          vals(childScales).forEach(function(scale) {
+          vals(childScales).forEach(function(scale: any) {
             const scaleNameWithoutPrefix = scale.name.substr(child.name('').length);
             const newName = model.scaleName(scaleNameWithoutPrefix, true);
             child.renameScale(scale.name, newName);
@@ -202,11 +203,11 @@ export class LayerModel extends Model {
     });
   }
 
-  public parseAxisGroup() {
+  public parseAxisGroup(): void {
     return null;
   }
 
-  public parseGridGroup() {
+  public parseGridGroup(): void {
     return null;
   }
 
@@ -228,7 +229,7 @@ export class LayerModel extends Model {
     });
   }
 
-  public assembleParentGroupProperties() {
+  public assembleParentGroupProperties(): any {
     return null;
   }
 
@@ -256,11 +257,11 @@ export class LayerModel extends Model {
     }));
   }
 
-  public channels() {
+  public channels(): Channel[] {
     return [];
   }
 
-  protected mapping() {
+  protected mapping(): any {
     return null;
   }
 

--- a/src/compile/layout.ts
+++ b/src/compile/layout.ts
@@ -48,7 +48,7 @@ export function assembleLayout(model: Model, layoutData: VgData[]): VgData[] {
           summarize: distinctFields.map(function(field) {
             return { field: field, ops: ['distinct'] };
           })
-        }].concat(formula)
+        } as any].concat(formula)
       } : {
         name: model.dataName(LAYOUT),
         values: [{}],

--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -11,7 +11,7 @@ import {extend, keys, without, Dict} from '../util';
 import {applyMarkConfig, FILL_STROKE_CONFIG, numberFormat, timeTemplate} from './common';
 import {COLOR_LEGEND, COLOR_LEGEND_LABEL} from './scale';
 import {UnitModel} from './unit';
-import {VgLegend} from '../vega.schema';
+import {VgLegend, VgValueRef} from '../vega.schema';
 
 /* tslint:disable:no-unused-variable */
 // These imports exist so the TS compiler can name publicly exported members in
@@ -162,7 +162,7 @@ export namespace properties {
       delete symbols.opacity;
     }
 
-    let value: {scale: string, field: {prefix?: 'rank'}} | {value: string | number | boolean};;
+    let value: VgValueRef;
     if (model.has(COLOR) && channel === COLOR) {
       if (useColorLegendScale(fieldDef)) {
         // for color legend scale, we need to override

--- a/src/compile/legend.ts
+++ b/src/compile/legend.ts
@@ -118,7 +118,7 @@ export function useColorLegendScale(fieldDef: FieldDef) {
 }
 
 export namespace properties {
-  export function symbols(fieldDef: FieldDef, symbolsSpec, model: UnitModel, channel: Channel) {
+  export function symbols(fieldDef: FieldDef, symbolsSpec: any, model: UnitModel, channel: Channel) {
     let symbols:any = {};
     const mark = model.mark();
     const legend = model.legend(channel);
@@ -162,7 +162,7 @@ export namespace properties {
       delete symbols.opacity;
     }
 
-    let value;
+    let value: {scale: string, field: {prefix?: 'rank'}} | {value: string | number | boolean};;
     if (model.has(COLOR) && channel === COLOR) {
       if (useColorLegendScale(fieldDef)) {
         // for color legend scale, we need to override
@@ -220,7 +220,7 @@ export namespace properties {
     return keys(symbols).length > 0 ? symbols : undefined;
   }
 
-  export function labels(fieldDef: FieldDef, labelsSpec, model: UnitModel, channel: Channel) {
+  export function labels(fieldDef: FieldDef, labelsSpec: any, model: UnitModel, channel: Channel) {
     const legend = model.legend(channel);
     const config = model.config();
 
@@ -275,7 +275,7 @@ export namespace properties {
     return keys(labels).length > 0 ? labels : undefined;
   }
 
-  export function title(fieldDef: FieldDef, titleSpec, model: UnitModel, channel: Channel) {
+  export function title(fieldDef: FieldDef, titleSpec: any, model: UnitModel, channel: Channel) {
     const legend = model.legend(channel);
 
     let titles:any = {};

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -116,23 +116,23 @@ export namespace bar {
     if (markConfig.barSize) {
       return markConfig.barSize;
     }
-    if (typeof scale.bandSize === 'string') {
+    if (scale && typeof scale.bandSize === 'string') {
       throw new Error('Default size is not able to handle non-numeric sizes');
     }
-    if (typeof config.scale.bandSize === 'string') {
+    if (config && config.scale && typeof config.scale.bandSize === 'string') {
       throw new Error('Default size is not able to handle non-numeric sizes');
     }
     // BAR's size is applied on either X or Y
     return scale && scale.type === ScaleType.ORDINAL ?
         // For ordinal scale or single bar, we can use bandSize - 1
         // (-1 so that the border of the bar falls on exact pixel)
-        scale.bandSize - 1 :
+        (scale.bandSize as number) - 1 :
         // TODO: {band: true} ?
       scaleName ?
         // set to thinBarWidth by default for non-ordinal scale
         markConfig.barThinSize :
         // if there is no size (x or y) axis, just use bandSize -1
         // TODO: revise if we really need the -1
-        config.scale.bandSize - 1;
+        (config.scale.bandSize as number) - 1;
   }
 }

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -116,6 +116,12 @@ export namespace bar {
     if (markConfig.barSize) {
       return markConfig.barSize;
     }
+    if (typeof scale.bandSize === 'string') {
+      throw new Error('Default size is not able to handle non-numeric sizes');
+    }
+    if (typeof config.scale.bandSize === 'string') {
+      throw new Error('Default size is not able to handle non-numeric sizes');
+    }
     // BAR's size is applied on either X or Y
     return scale && scale.type === ScaleType.ORDINAL ?
         // For ordinal scale or single bar, we can use bandSize - 1

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -2,7 +2,7 @@ import {X, Y, COLOR, TEXT, SHAPE, PATH, ORDER, OPACITY, DETAIL, STACK_GROUP_CHAN
 import {Orient} from '../../config';
 import {has, isAggregate} from '../../encoding';
 import {OrderChannelDef, FieldDef, field} from '../../fielddef';
-import {AREA, LINE, TEXT as TEXTMARK, Mark} from '../../mark';
+import {AREA, LINE, TEXT as TEXTMARK} from '../../mark';
 import {ScaleType} from '../../scale';
 import {isSortField} from '../../sort';
 import {contains, extend, isArray} from '../../util';
@@ -104,7 +104,7 @@ function parseNonPathMark(model: UnitModel) {
   const isFaceted = model.parent() && model.parent().isFacet();
   const dataFrom = {data: model.dataTable()};
 
-  let marks: Mark[] = []; // TODO: vgMarks
+  let marks: any[] = []; // TODO: vgMarks
   if (mark === TEXTMARK &&
     model.has(COLOR) &&
     model.config().mark.applyColorToBackground && !model.has(X) && !model.has(Y)

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -2,7 +2,7 @@ import {X, Y, COLOR, TEXT, SHAPE, PATH, ORDER, OPACITY, DETAIL, STACK_GROUP_CHAN
 import {Orient} from '../../config';
 import {has, isAggregate} from '../../encoding';
 import {OrderChannelDef, FieldDef, field} from '../../fielddef';
-import {AREA, LINE, TEXT as TEXTMARK} from '../../mark';
+import {AREA, LINE, TEXT as TEXTMARK, Mark} from '../../mark';
 import {ScaleType} from '../../scale';
 import {isSortField} from '../../sort';
 import {contains, extend, isArray} from '../../util';
@@ -104,7 +104,7 @@ function parseNonPathMark(model: UnitModel) {
   const isFaceted = model.parent() && model.parent().isFacet();
   const dataFrom = {data: model.dataTable()};
 
-  let marks = []; // TODO: vgMarks
+  let marks: Mark[] = []; // TODO: vgMarks
   if (mark === TEXTMARK &&
     model.has(COLOR) &&
     model.config().mark.applyColorToBackground && !model.has(X) && !model.has(Y)

--- a/src/compile/mark/tick.ts
+++ b/src/compile/mark/tick.ts
@@ -6,6 +6,7 @@ import {VgValueRef} from '../../vega.schema';
 
 import {applyColorAndOpacity} from '../common';
 import {UnitModel} from '../unit';
+import {BandSize} from '../../scale';
 import * as ref from './valueref';
 
 export namespace tick {
@@ -35,14 +36,17 @@ export namespace tick {
     return p;
   }
 
-  function size(fieldDef: FieldDef, scaleName: string, scale: Scale, config: Config, scaleBandSize: number): VgValueRef {
-    let defaultSize;
+  function size(fieldDef: FieldDef, scaleName: string, scale: Scale, config: Config, scaleBandSize: number | BandSize): VgValueRef {
+    let defaultSize: number;
     if (config.mark.tickSize) {
       defaultSize = config.mark.tickSize;
     } else {
       const bandSize = scaleBandSize !== undefined ?
         scaleBandSize :
         config.scale.bandSize;
+      if (typeof bandSize !== 'number') {
+        throw new Error('Function does not handle non-numeric bandSize');
+      }
       defaultSize = bandSize / 1.5;
     }
 

--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -112,11 +112,17 @@ defaultRef: VgValueRef | 'base' | 'baseOrMax'): VgValueRef {
 
 export function midX(config: Config): VgValueRef {
   // TODO: For fit-mode, use middle of the width
+  if (typeof config.scale.bandSize === 'string') {
+    throw new Error('midX can not handle string bandSizes');
+  }
   return {value: config.scale.bandSize / 2};
 }
 
 export function midY(config: Config): VgValueRef {
   // TODO: For fit-mode, use middle of the width
+  if (typeof config.scale.bandSize === 'string') {
+    throw new Error('midX can not handle string bandSizes');
+  }
   return {value: config.scale.bandSize / 2};
 }
 

--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -113,6 +113,7 @@ defaultRef: VgValueRef | 'base' | 'baseOrMax'): VgValueRef {
 export function midX(config: Config): VgValueRef {
   // TODO: For fit-mode, use middle of the width
   if (typeof config.scale.bandSize === 'string') {
+    // TODO: use band: 0.5 when we migrate to Vega 3
     throw new Error('midX can not handle string bandSizes');
   }
   return {value: config.scale.bandSize / 2};
@@ -121,6 +122,7 @@ export function midX(config: Config): VgValueRef {
 export function midY(config: Config): VgValueRef {
   // TODO: For fit-mode, use middle of the width
   if (typeof config.scale.bandSize === 'string') {
+    // TODO: use band: 0.5 when we migrate to Vega 3
     throw new Error('midX can not handle string bandSizes');
   }
   return {value: config.scale.bandSize / 2};

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -18,12 +18,15 @@ import {DataComponent} from './data/data';
 import {LayoutComponent} from './layout';
 import {ScaleComponents, COLOR_LEGEND, COLOR_LEGEND_LABEL} from './scale';
 
+import {StackProperties} from '../stack';
+
 /* tslint:disable:no-unused-variable */
 // These imports exist so the TS compiler can name publicly exported members in
 // The automatically created .d.ts correctly
 import {Formula} from '../transform';
 import {OneOfFilter, EqualFilter, RangeFilter} from '../filter';
 /* tslint:enable:no-unused-variable */
+
 
 /**
  * Composable Components that are intermediate results of the parsing phase of the
@@ -151,23 +154,23 @@ export abstract class Model {
     this.parseMark(); // depends on data name and scale name, axisGroup, gridGroup and children's scale, axis, legend and mark.
   }
 
-  public abstract parseData();
+  public abstract parseData(): void;
 
-  public abstract parseSelectionData();
+  public abstract parseSelectionData(): void;
 
-  public abstract parseLayoutData();
+  public abstract parseLayoutData(): void;
 
-  public abstract parseScale();
+  public abstract parseScale(): void;
 
-  public abstract parseMark();
+  public abstract parseMark(): void;
 
-  public abstract parseAxis();
+  public abstract parseAxis(): void;
 
-  public abstract parseLegend();
+  public abstract parseLegend(): void;
 
   // TODO: revise if these two methods make sense for shared scale concat
-  public abstract parseAxisGroup();
-  public abstract parseGridGroup();
+  public abstract parseAxisGroup(): void;
+  public abstract parseGridGroup(): void;
 
 
   public abstract assembleData(data: VgData[]): VgData[];
@@ -227,13 +230,13 @@ export abstract class Model {
     return group;
   }
 
-  public abstract assembleParentGroupProperties(cellConfig: CellConfig);
+  public abstract assembleParentGroupProperties(cellConfig: CellConfig): any;
 
   public abstract channels(): Channel[];
 
-  protected abstract mapping();
+  protected abstract mapping(): any;
 
-  public reduce(f: (acc: any, fd: FieldDef, c: Channel) => any, init, t?: any) {
+  public reduce<T>(f: (acc: any, fd: FieldDef, c: Channel) => any, init: T, t?: any) {
     return reduce(this.mapping(), f, init, t);
   }
 
@@ -292,7 +295,7 @@ export abstract class Model {
     return this._transform ? this._transform.calculate : undefined;
   }
 
-  public filterInvalid() {
+  public filterInvalid(): boolean {
     const transform = this._transform || {};
     if (transform.filterInvalid === undefined) {
       return this.parent() ? this.parent().filterInvalid() : undefined;
@@ -365,7 +368,7 @@ export abstract class Model {
     return (this.mapping()[channel] || {}).sort;
   }
 
-  public abstract stack();
+  public abstract stack(): StackProperties;
 
   public axis(channel: Channel): Axis {
     return this._axis[channel];

--- a/src/compile/scale.ts
+++ b/src/compile/scale.ts
@@ -1,5 +1,5 @@
 // https://github.com/Microsoft/TypeScript/blob/master/doc/spec.md#11-ambient-declarations
-declare var exports;
+declare var exports: any;
 
 import * as log from '../log';
 
@@ -390,7 +390,7 @@ function _useRawDomain (scale: Scale, model: Model, channel: Channel) {
     // only applied to aggregate table
     fieldDef.aggregate &&
     // only activated if used with aggregate functions that produces values ranging in the domain of the source data
-    SHARED_DOMAIN_OPS.indexOf(fieldDef.aggregate) >= 0 &&
+    SHARED_DOMAIN_OPS.indexOf(fieldDef.aggregate as any) >= 0 &&
     (
       // Q always uses quantitative scale except when it's binned.
       // Binned field has similar values in both the source table and the summary table
@@ -467,6 +467,9 @@ export function rangeMixins(scale: Scale, model: Model, channel: Channel): any {
       }
 
       const bandSize = pointBandSize(unitModel);
+      if (typeof bandSize === 'string') {
+        throw new Error('rangeMixins does not handle string bandSizes');
+      }
 
       return {range: [9, (bandSize - 2) * (bandSize - 2)]};
     case SHAPE:
@@ -495,9 +498,10 @@ function pointBandSize(model: UnitModel) {
   if (hasX && hasY) {
     return xIsMeasure !== yIsMeasure ?
       model.scale(xIsMeasure ? Y : X).bandSize :
+      // TODO: Remove casts and hande string bandSizes
       Math.min(
-        model.scale(X).bandSize || scaleConfig.bandSize,
-        model.scale(Y).bandSize || scaleConfig.bandSize
+        (model.scale(X).bandSize || scaleConfig.bandSize) as number,
+        (model.scale(Y).bandSize || scaleConfig.bandSize) as number
       );
   } else if (hasY) {
     return yIsMeasure ? model.config().scale.bandSize : model.scale(Y).bandSize;
@@ -540,7 +544,7 @@ export function nice(scale: Scale, channel: Channel, fieldDef: FieldDef): boolea
 }
 
 
-export function padding(scale: Scale, channel: Channel, __, ___, scaleDef) {
+export function padding(scale: Scale, channel: Channel, __: any, ___: any, scaleDef: any) {
   /* Padding is only allowed for X and Y.
    *
    * Basically it doesn't make sense to add padding for color and size.

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -107,7 +107,7 @@ export class UnitModel extends Model {
 
       if (isArray(encoding[channel])) {
         // Array of fieldDefs for detail channel (or production rule)
-        encoding[channel] = encoding[channel].reduce((fieldDefs, fieldDef) => {
+        encoding[channel] = encoding[channel].reduce((fieldDefs: FieldDef[], fieldDef: FieldDef) => {
           if (fieldDef.field === undefined && fieldDef.value === undefined) { // TODO: datum
             log.warn(log.message.emptyFieldDef(fieldDef, channel));
           } else {
@@ -188,6 +188,9 @@ export class UnitModel extends Model {
         // for text table without x/y scale we need wider bandSize
         this._width = scaleConfig.textBandWidth;
       } else {
+        if (typeof scaleConfig.bandSize === 'string') {
+          throw new Error('_initSize does not handle string bandSizes');
+        }
         this._width = scaleConfig.bandSize;
       }
     }
@@ -199,6 +202,9 @@ export class UnitModel extends Model {
         this._height = cellConfig.height;
       } // else: Do nothing, use dynamic height .
     } else {
+      if (typeof scaleConfig.bandSize === 'string') {
+        throw new Error('_initSize does not handle string bandSizes');
+      }
       this._height = scaleConfig.bandSize;
     }
   }
@@ -272,11 +278,11 @@ export class UnitModel extends Model {
     this.component.axis = parseAxisComponent(this, [X, Y]);
   }
 
-  public parseAxisGroup() {
+  public parseAxisGroup(): void {
     return null;
   }
 
-  public parseGridGroup() {
+  public parseGridGroup(): void {
     return null;
   }
 
@@ -312,7 +318,7 @@ export class UnitModel extends Model {
     return this._stack;
   }
 
-  public toSpec(excludeConfig?, excludeData?) {
+  public toSpec(excludeConfig?: any, excludeData?: any) {
     const encoding = duplicate(this._encoding);
     let spec: any;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,76 +79,121 @@ export const defaultFacetConfig: FacetConfig = {
   cell: defaultFacetCellConfig
 };
 
-export enum FontWeight {
-    NORMAL = 'normal' as any,
-    BOLD = 'bold' as any
+export namespace FontWeight {
+    export const NORMAL: 'normal' = 'normal';
+    export type NORMAL = typeof NORMAL;
+    export const BOLD: 'bold' = 'bold';
+    export type BOLD = typeof BOLD;
 }
+export type FontWeight = FontWeight.NORMAL | FontWeight.BOLD;
 
-export enum Shape {
-    CIRCLE = 'circle' as any,
-    SQUARE = 'square' as any,
-    CROSS = 'cross' as any,
-    DIAMOND = 'diamond' as any,
-    TRIANGLEUP = 'triangle-up' as any,
-    TRIANGLEDOWN = 'triangle-down' as any,
+export namespace Shape {
+    export const CIRCLE: 'circle' = 'circle';
+    export type CIRCLE = typeof CIRCLE;
+    export const SQUARE: 'square' = 'square';
+    export type SQUARE = typeof SQUARE;
+    export const CROSS: 'cross' = 'cross';
+    export type CROSS = typeof CROSS;
+    export const DIAMOND: 'diamond' = 'diamond';
+    export type DIAMOND = typeof DIAMOND;
+    export const TRIANGLEUP: 'triangle-up' = 'triangle-up';
+    export type TRIANGLEUP = typeof TRIANGLEUP;
+    export const TRIANGLEDOWN: 'triangle-down' = 'triangle-down';
+    export type TRIANGLEDOWN = typeof TRIANGLEDOWN;
 }
+export type Shape = Shape.CIRCLE | Shape.SQUARE | Shape.CROSS | Shape.DIAMOND | Shape.TRIANGLEUP | Shape.TRIANGLEDOWN;
 
-export enum Orient {
-  HORIZONTAL = 'horizontal' as any,
-  VERTICAL = 'vertical' as any
+export namespace Orient {
+    export const HORIZONTAL: 'horizontal' = 'horizontal';
+    export type HORIZONTAL = typeof HORIZONTAL;
+    export const VERTICAL: 'vertical' = 'vertical';
+    export type VERTICAL = typeof VERTICAL;
 }
+export type Orient = Orient.HORIZONTAL | Orient.VERTICAL;
 
-export enum HorizontalAlign {
-    LEFT = 'left' as any,
-    RIGHT = 'right' as any,
-    CENTER = 'center' as any,
+export namespace HorizontalAlign {
+    export const LEFT: 'left' = 'left';
+    export type LEFT = typeof LEFT;
+    export const RIGHT: 'right' = 'right';
+    export type RIGHT = typeof RIGHT;
+    export const CENTER: 'center' = 'center';
+    export type CENTER = typeof CENTER;
 }
+export type HorizontalAlign = HorizontalAlign.LEFT | HorizontalAlign.RIGHT | HorizontalAlign.CENTER;
 
-export enum VerticalAlign {
-    TOP = 'top' as any,
-    MIDDLE = 'middle' as any,
-    BOTTOM = 'bottom' as any,
+export namespace VerticalAlign {
+    export const TOP: 'top' = 'top';
+    export type TOP = typeof TOP;
+    export const MIDDLE: 'middle' = 'middle';
+    export type MIDDLE = typeof MIDDLE;
+    export const BOTTOM: 'bottom' = 'bottom';
+    export type BOTTOM = typeof BOTTOM;
 }
+export type VerticalAlign = VerticalAlign.TOP | VerticalAlign.MIDDLE | VerticalAlign.BOTTOM;
 
-export enum FontStyle {
-    NORMAL = 'normal' as any,
-    ITALIC = 'italic' as any,
+export namespace FontStyle {
+    export const NORMAL: 'normal' = 'normal';
+    export type NORMAL = typeof NORMAL;
+    export const ITALIC: 'italic' = 'italic';
+    export type ITALIC = typeof ITALIC;
 }
+export type FontStyle = FontStyle.NORMAL | FontStyle.ITALIC;
 
-export enum Interpolate {
+export namespace Interpolate {
     /** piecewise linear segments, as in a polyline */
-    LINEAR = 'linear' as any,
+    export const LINEAR: 'linear' = 'linear';
+    export type LINEAR = typeof LINEAR;
     /** close the linear segments to form a polygon */
-    LINEAR_CLOSED = 'linear-closed' as any,
+    export const LINEAR_CLOSED: 'linear-closed' = 'linear-closed';
+    export type LINEAR_CLOSED = typeof LINEAR_CLOSED;
     /** alternate between horizontal and vertical segments, as in a step function */
-    STEP = 'step' as any,
+    export const STEP: 'step' = 'step';
+    export type STEP = typeof STEP;
     /** alternate between vertical and horizontal segments, as in a step function */
-    STEP_BEFORE = 'step-before' as any,
+    export const STEP_BEFORE: 'step-before' = 'step-before';
+    export type STEP_BEFORE = typeof STEP_BEFORE;
     /** alternate between horizontal and vertical segments, as in a step function */
-    STEP_AFTER = 'step-after' as any,
+    export const STEP_AFTER: 'step-after' = 'step-after';
+    export type STEP_AFTER = typeof STEP_AFTER;
     /** a B-spline, with control point duplication on the ends */
-    BASIS = 'basis' as any,
+    export const BASIS: 'basis' = 'basis';
+    export type BASIS = typeof BASIS;
     /** an open B-spline; may not intersect the start or end */
-    BASIS_OPEN = 'basis-open' as any,
+    export const BASIS_OPEN: 'basis-open' = 'basis-open';
+    export type BASIS_OPEN = typeof BASIS_OPEN;
     /** a closed B-spline, as in a loop */
-    BASIS_CLOSED = 'basis-closed' as any,
+    export const BASIS_CLOSED: 'basis-closed' = 'basis-closed';
+    export type BASIS_CLOSED = typeof BASIS_CLOSED;
     /** a Cardinal spline, with control point duplication on the ends */
-    CARDINAL = 'cardinal' as any,
+    export const CARDINAL: 'cardinal' = 'cardinal';
+    export type CARDINAL = typeof CARDINAL;
     /** an open Cardinal spline; may not intersect the start or end, but will intersect other control points */
-    CARDINAL_OPEN = 'cardinal-open' as any,
+    export const CARDINAL_OPEN: 'cardinal-open' = 'cardinal-open';
+    export type CARDINAL_OPEN = typeof CARDINAL_OPEN;
     /** a closed Cardinal spline, as in a loop */
-    CARDINAL_CLOSED = 'cardinal-closed' as any,
+    export const CARDINAL_CLOSED: 'cardinal-closed' = 'cardinal-closed';
+    export type CARDINAL_CLOSED = typeof CARDINAL_CLOSED;
     /** equivalent to basis, except the tension parameter is used to straighten the spline */
-    BUNDLE = 'bundle' as any,
+    export const BUNDLE: 'bundle' = 'bundle';
+    export type BUNDLE = typeof BUNDLE;
     /** cubic interpolation that preserves monotonicity in y */
-    MONOTONE = 'monotone' as any,
+    export const MONOTONE: 'monotone' = 'monotone';
+    export type MONOTONE = typeof MONOTONE;
 }
+export type Interpolate = Interpolate.BASIS | Interpolate.BASIS_CLOSED | Interpolate.BASIS_OPEN
+  | Interpolate.BUNDLE | Interpolate.CARDINAL | Interpolate.CARDINAL_CLOSED | Interpolate.CARDINAL_OPEN
+  | Interpolate.LINEAR | Interpolate.LINEAR_CLOSED | Interpolate.MONOTONE | Interpolate.STEP
+  | Interpolate.STEP_AFTER | Interpolate.STEP_BEFORE;
 
-export enum AreaOverlay {
-  LINE = 'line' as any,
-  LINEPOINT = 'linepoint' as any,
-  NONE = 'none' as any
+export namespace AreaOverlay {
+  export const LINE: 'line' = 'line';
+  export type LINE = typeof LINE;
+  export const LINEPOINT: 'linepoint' = 'linepoint';
+  export type LINEPOINT = typeof LINEPOINT;
+  export const NONE: 'none' = 'none';
+  export type NONE = typeof NONE;
 }
+export type AreaOverlay = AreaOverlay.LINE | AreaOverlay.LINEPOINT | AreaOverlay.NONE;
 
 export interface OverlayConfig {
   /**

--- a/src/data.ts
+++ b/src/data.ts
@@ -39,12 +39,17 @@ export interface DataFormat {
   mesh?: string;
 }
 
-export enum DataFormatType {
-    JSON = 'json' as any,
-    CSV = 'csv' as any,
-    TSV = 'tsv' as any,
-    TOPOJSON = 'topojson' as any
+export namespace DataFormatType {
+    export const JSON: 'json' = 'json';
+    export type JSON = typeof JSON;
+    export const CSV: 'csv' = 'csv';
+    export type CSV = typeof CSV;
+    export const TSV: 'tsv' = 'tsv';
+    export type TSV = typeof TSV;
+    export const TOPOJSON: 'topojson' = 'topojson';
+    export type TOPOJSON = typeof TOPOJSON;
 }
+export type DataFormatType = DataFormatType.JSON | DataFormatType.CSV | DataFormatType.TSV | DataFormatType.TOPOJSON;
 
 export interface Data {
   /**
@@ -63,12 +68,17 @@ export interface Data {
   values?: any[];
 }
 
-export enum DataTable {
-  SOURCE = 'source' as any,
-  SUMMARY = 'summary' as any,
-  STACKED_SCALE = 'stacked_scale' as any,
-  LAYOUT = 'layout' as any
+export namespace DataTable {
+  export const SOURCE: 'source' = 'source';
+  export type SOURCE = typeof SOURCE;
+  export const SUMMARY: 'summary' = 'summary';
+  export type SUMMARY = typeof SUMMARY;
+  export const STACKED_SCALE: 'stacked_scale' = 'stacked_scale';
+  export type STACKED_SCALE = typeof STACKED_SCALE;
+  export const LAYOUT: 'layout' = 'layout';
+  export type LAYOUT = typeof LAYOUT;
 }
+export type DataTable = DataTable.SOURCE | DataTable.SUMMARY | DataTable.STACKED_SCALE | DataTable.LAYOUT;
 
 export const SUMMARY = DataTable.SUMMARY;
 export const SOURCE = DataTable.SOURCE;

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -165,7 +165,7 @@ function normalizeDay(d: string | number) {
   }
 }
 
-export function timestamp(d: DateTime, normalize) {
+export function timestamp(d: DateTime, normalize: boolean) {
   const date = new Date(0, 0, 1, 0, 0, 0, 0); // start with uniform date
 
   // FIXME support UTC
@@ -227,7 +227,7 @@ export function timestamp(d: DateTime, normalize) {
  * @param normalize whether to normalize quarter, month, day.
  */
 export function dateTimeExpr(d: DateTime | DateTimeExpr, normalize = false) {
-  const units = [];
+  const units: (string | number)[] = [];
 
   if (normalize && d.day !== undefined) {
     if (keys(d).length > 1) {

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -118,11 +118,11 @@ export function isRanged(encoding: Encoding) {
 }
 
 export function fieldDefs(encoding: Encoding): FieldDef[] {
-  let arr = [];
+  let arr: FieldDef[] = [];
   CHANNELS.forEach(function(channel) {
     if (has(encoding, channel)) {
       if (isArray(encoding[channel])) {
-        encoding[channel].forEach(function(fieldDef) {
+        encoding[channel].forEach(function(fieldDef: FieldDef) {
           arr.push(fieldDef);
         });
       } else {
@@ -143,7 +143,7 @@ export function forEach(mapping: any,
   Object.keys(mapping).forEach((c: any) => {
     const channel: Channel = c;
     if (isArray(mapping[channel])) {
-      mapping[channel].forEach(function(fieldDef) {
+      mapping[channel].forEach(function(fieldDef: FieldDef) {
         f.call(thisArg, fieldDef, channel);
       });
     } else {
@@ -152,17 +152,17 @@ export function forEach(mapping: any,
   });
 }
 
-export function reduce(mapping: any,
+export function reduce<T>(mapping: any,
     f: (acc: any, fd: FieldDef, c: Channel) => any,
-    init, thisArg?: any) {
+    init: T, thisArg?: any) {
   if (!mapping) {
     return init;
   }
 
-  return Object.keys(mapping).reduce((r, c: any) => {
+  return Object.keys(mapping).reduce((r: T, c: any) => {
     const channel: Channel = c;
     if (isArray(mapping[channel])) {
-      return mapping[channel].reduce(function(r1, fieldDef) {
+      return mapping[channel].reduce(function(r1: T, fieldDef: FieldDef) {
         return f.call(thisArg, r1, fieldDef, channel);
       }, r);
     } else {

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -112,7 +112,7 @@ export function field(fieldDef: FieldDef, opt: FieldRefOption = {}) {
   if (isCount(fieldDef)) {
     field = 'count';
   } else {
-    let fn = undefined;
+    let fn: string = undefined;
 
     if (!opt.nofn) {
       if (fieldDef.bin) {

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -105,7 +105,7 @@ export function expression(filter: Filter | string) {
       return fieldExpr + '===' + valueExpr(filter.equal, filter.timeUnit);
     } else if (isOneOfFilter(filter)) {
       // "oneOf" was formerly "in" -- so we need to add backward compatibility
-      const oneOf = filter.oneOf || filter['in'];
+      const oneOf: typeof filter.oneOf = filter.oneOf || filter['in'];
       return 'indexof([' +
         oneOf.map((v) => valueExpr(v, filter.timeUnit)).join(',') +
         '], ' + fieldExpr + ') !== -1';

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -105,7 +105,7 @@ export function expression(filter: Filter | string) {
       return fieldExpr + '===' + valueExpr(filter.equal, filter.timeUnit);
     } else if (isOneOfFilter(filter)) {
       // "oneOf" was formerly "in" -- so we need to add backward compatibility
-      const oneOf: typeof filter.oneOf = filter.oneOf || filter['in'];
+      const oneOf: OneOfFilter[] = filter.oneOf || filter['in'];
       return 'indexof([' +
         oneOf.map((v) => valueExpr(v, filter.timeUnit)).join(',') +
         '], ' + fieldExpr + ') !== -1';

--- a/src/legend.ts
+++ b/src/legend.ts
@@ -1,4 +1,5 @@
 import {DateTime} from './datetime';
+import {Shape} from './config';
 
 export interface LegendConfig {
   /**
@@ -103,7 +104,7 @@ export interface LegendConfig {
   /**
    * The font weight of the legend title.
    */
-  titleFontWeight?: string;
+  titleFontWeight?: number;
   /**
    * Optional mark property definitions for custom legend styling.
    */
@@ -126,6 +127,8 @@ export interface Legend extends LegendConfig {
    * Explicitly set the visible legend values.
    */
   values?: number[] | string[] | DateTime[];
+
+  shape?: Shape;
 }
 
 export const defaultLegendConfig: LegendConfig = {

--- a/src/log.ts
+++ b/src/log.ts
@@ -26,25 +26,25 @@ let current: LoggerInterface = main;
  * Logger tool for checking if the code throws correct warning
  */
 export class LocalLogger implements LoggerInterface {
-  public warns = [];
-  public infos = [];
-  public debugs = [];
+  public warns: any[] = [];
+  public infos: any[] = [];
+  public debugs: any[] = [];
 
   public level() {
     return this;
   }
 
-  public warn(...args) {
+  public warn(...args: any[]) {
     this.warns.push(...args);
     return this;
   }
 
-  public info(...args) {
+  public info(...args: any[]) {
     this.infos.push(...args);
     return this;
   }
 
-  public debug(...args) {
+  public debug(...args: any[]) {
     this.debugs.push(...args);
     return this;
   }
@@ -72,15 +72,15 @@ export function reset() {
   return current;
 }
 
-export function warn(...args) {
+export function warn(...args: any[]) {
   current.warn.apply(current, arguments);
 }
 
-export function info(...args) {
+export function info(...args: any[]) {
   current.info.apply(current, arguments);
 }
 
-export function debug(...args) {
+export function debug(...args: any[]) {
   current.debug.apply(current, arguments);
 }
 
@@ -102,7 +102,7 @@ export namespace message {
     return `${channel} dropped as it is incompatible with ${markOrFacet}`;
   }
 
-  export function facetChannelShouldBeDiscrete(channel) {
+  export function facetChannelShouldBeDiscrete(channel: string) {
     return `${channel} encoding should be discrete (ordinal / nominal / binned).`;
   }
 
@@ -115,7 +115,7 @@ export namespace message {
     return 'Cannot clearly determine orientation for ' + mark + ' since both x and y channel encode discrete or empty fields.';
   }
 
-  export function orientOverridden(original, actual) {
+  export function orientOverridden(original: string, actual: string) {
     return `Specified orient ${original} overridden with ${actual}`;
   }
 
@@ -145,7 +145,7 @@ export namespace message {
   }
 
   // TIMEUNIT
-  export function invalidTimeUnit(unitName: string, value) {
+  export function invalidTimeUnit(unitName: string, value: string | number) {
     return `Invalid ${unitName}: ${value}`;
   }
 

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -1,16 +1,28 @@
-export enum Mark {
-  AREA = 'area' as any,
-  BAR = 'bar' as any,
-  LINE = 'line' as any,
-  POINT = 'point' as any,
-  TEXT = 'text' as any,
-  TICK = 'tick' as any,
-  RECT = 'rect' as any,
-  RULE = 'rule' as any,
-  CIRCLE = 'circle' as any,
-  SQUARE = 'square' as any,
-  ERRORBAR = 'errorBar' as any
+export namespace Mark {
+  export const AREA: 'area' = 'area';
+  export type AREA = typeof AREA;
+  export const BAR: 'bar' = 'bar';
+  export type BAR = typeof BAR;
+  export const LINE: 'line' = 'line';
+  export type LINE = typeof LINE;
+  export const POINT: 'point' = 'point';
+  export type POINT = typeof POINT;
+  export const TEXT: 'text' = 'text';
+  export type TEXT = typeof TEXT;
+  export const TICK: 'tick' = 'tick';
+  export type TICK = typeof TICK;
+  export const RECT: 'rect' = 'rect';
+  export type RECT = typeof RECT;
+  export const RULE: 'rule' = 'rule';
+  export type RULE = typeof RULE;
+  export const CIRCLE: 'circle' = 'circle';
+  export type CIRCLE = typeof CIRCLE;
+  export const SQUARE: 'square' = 'square';
+  export type SQUARE = typeof SQUARE;
+  export const ERRORBAR: 'errorBar' = 'errorBar';
+  export type ERRORBAR = typeof ERRORBAR;
 }
+export type Mark = Mark.AREA | Mark.BAR | Mark.LINE | Mark.POINT | Mark.TEXT | Mark.TICK | Mark.RECT | Mark.RULE | Mark.CIRCLE | Mark.SQUARE | Mark.ERRORBAR;
 
 export const AREA = Mark.AREA;
 export const BAR = Mark.BAR;

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -110,7 +110,7 @@ export interface ScaleConfig {
   // let's not make a config.
 }
 
-export const defaultScaleConfig: ScaleConfig = {
+export const defaultScaleConfig = {
   round: true,
   textBandWidth: 90,
   bandSize: 21,

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -1,30 +1,53 @@
 import {DateTime} from './datetime';
 
-export enum ScaleType {
-    LINEAR = 'linear' as any,
-    LOG = 'log' as any,
-    POW = 'pow' as any,
-    SQRT = 'sqrt' as any,
-    QUANTILE = 'quantile' as any,
-    QUANTIZE = 'quantize' as any,
-    ORDINAL = 'ordinal' as any,
-    TIME = 'time' as any,
-    UTC  = 'utc' as any,
+export namespace ScaleType {
+    export const LINEAR: 'linear' = 'linear';
+    export type LINEAR = typeof LINEAR;
+    export const LOG: 'log' = 'log';
+    export type LOG = typeof LOG;
+    export const POW: 'pow' = 'pow';
+    export type POW = typeof POW;
+    export const SQRT: 'sqrt' = 'sqrt';
+    export type SQRT = typeof SQRT;
+    export const QUANTILE: 'quantile' = 'quantile';
+    export type QUANTILE = typeof QUANTILE;
+    export const QUANTIZE: 'quantize' = 'quantize';
+    export type QUANTIZE = typeof QUANTIZE;
+    export const ORDINAL: 'ordinal' = 'ordinal';
+    export type ORDINAL = typeof ORDINAL;
+    export const TIME: 'time' = 'time';
+    export type TIME = typeof TIME;
+    export const UTC: 'utc'  = 'utc';
+    export type UTC = typeof UTC;
 }
+export type ScaleType = ScaleType.LINEAR | ScaleType.LOG | ScaleType.POW
+  | ScaleType.SQRT | ScaleType.QUANTILE | ScaleType.QUANTIZE
+  | ScaleType.ORDINAL | ScaleType.TIME | ScaleType.UTC;
 
-export enum NiceTime {
-    SECOND = 'second' as any,
-    MINUTE = 'minute' as any,
-    HOUR = 'hour' as any,
-    DAY = 'day' as any,
-    WEEK = 'week' as any,
-    MONTH = 'month' as any,
-    YEAR = 'year' as any,
+export namespace NiceTime {
+    export const SECOND: 'second' = 'second';
+    export type SECOND = typeof SECOND;
+    export const MINUTE: 'minute' = 'minute';
+    export type MINUTE = typeof MINUTE;
+    export const HOUR: 'hour' = 'hour';
+    export type HOUR = typeof HOUR;
+    export const DAY: 'day' = 'day';
+    export type DAY = typeof DAY;
+    export const WEEK: 'week' = 'week';
+    export type WEEK = typeof WEEK;
+    export const MONTH: 'month' = 'month';
+    export type MONTH = typeof MONTH;
+    export const YEAR: 'year' = 'year';
+    export type YEAR = typeof YEAR;
 }
+export type NiceTime = NiceTime.SECOND | NiceTime.MINUTE | NiceTime.HOUR
+  | NiceTime.DAY | NiceTime.WEEK | NiceTime.MONTH | NiceTime.YEAR;
 
-export enum BandSize {
-  FIT = 'fit' as any
+export namespace BandSize {
+  export const FIT: 'fit' = 'fit';
+  export type FIT = typeof FIT;
 }
+export type BandSize = BandSize.FIT;
 
 export const BANDSIZE_FIT = BandSize.FIT;
 

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,10 +1,14 @@
 import {AggregateOp} from './aggregate';
 
-export enum SortOrder {
-    ASCENDING = 'ascending' as any,
-    DESCENDING = 'descending' as any,
-    NONE = 'none' as any,
+export namespace SortOrder {
+    export const ASCENDING: 'ascending' = 'ascending';
+    export type ASCENDING = typeof ASCENDING;
+    export const DESCENDING: 'descending' = 'descending';
+    export type DESCENDING = typeof DESCENDING;
+    export const NONE: 'none' = 'none';
+    export type NONE = typeof NONE;
 }
+export type SortOrder = SortOrder.ASCENDING | SortOrder.DESCENDING | SortOrder.NONE;
 
 export interface SortField {
   /**

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -81,7 +81,7 @@ export interface ExtendedUnitSpec extends BaseSpec {
    * One of `"bar"`, `"circle"`, `"square"`, `"tick"`, `"line"`,
    * `"area"`, `"point"`, `"rule"`, and `"text"`.
    */
-  mark: Mark;
+  mark?: Mark;
 
   /**
    * A key-value mapping between encoding channels and definition of fields.

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -7,12 +7,17 @@ import {Mark, BAR, AREA, POINT, CIRCLE, SQUARE, LINE, RULE, TEXT, TICK} from './
 import {ScaleType} from './scale';
 import {contains} from './util';
 
-export enum StackOffset {
-  ZERO = 'zero' as any,
-  CENTER = 'center' as any,
-  NORMALIZE = 'normalize' as any,
-  NONE = 'none' as any
+export namespace StackOffset {
+  export const ZERO: 'zero' = 'zero';
+  export type ZERO = typeof ZERO;
+  export const CENTER: 'center' = 'center';
+  export type CENTER = typeof CENTER;
+  export const NORMALIZE: 'normalize' = 'normalize';
+  export type NORMALIZE = typeof NORMALIZE;
+  export const NONE: 'none' = 'none';
+  export type NONE = typeof NONE;
 }
+export type StackOffset = StackOffset.ZERO | StackOffset.CENTER | StackOffset.NORMALIZE | StackOffset.NONE;
 
 export interface StackProperties {
   /** Dimension axis of the stack ('x' or 'y'). */
@@ -33,7 +38,7 @@ export const STACK_BY_DEFAULT_MARKS = [BAR, AREA];
 
 export function stack(mark: Mark, encoding: Encoding, stacked: StackOffset): StackProperties {
   // Should not have stack explicitly disabled
-  if (contains([StackOffset.NONE, null, false], stacked)) {
+  if (contains<string | boolean>([StackOffset.NONE, null, false], stacked)) {
     return null;
   }
 

--- a/src/timeunit.ts
+++ b/src/timeunit.ts
@@ -8,6 +8,8 @@ export namespace TimeUnit {
   export type YEAR = typeof YEAR;
   export const MONTH: 'month' = 'month';
   export type MONTH = typeof MONTH;
+  export const WEEK: 'week' =  'week';
+  export type WEEK = typeof WEEK;
   export const DAY: 'day' = 'day';
   export type DAY = typeof DAY;
   export const DATE: 'date' = 'date';
@@ -51,7 +53,7 @@ export namespace TimeUnit {
   export const YEARQUARTERMONTH: 'yearquartermonth' = 'yearquartermonth';
   export type YEARQUARTERMONTH = typeof YEARQUARTERMONTH;
 }
-export type TimeUnit = TimeUnit.YEAR | TimeUnit.MONTH | TimeUnit.DAY | TimeUnit.DATE | TimeUnit.HOURS
+export type TimeUnit = TimeUnit.YEAR | TimeUnit.MONTH | TimeUnit.WEEK | TimeUnit.DAY | TimeUnit.DATE | TimeUnit.HOURS
   | TimeUnit.MINUTES | TimeUnit.SECONDS | TimeUnit.MILLISECONDS | TimeUnit.YEARMONTH
   | TimeUnit.YEARMONTHDATE | TimeUnit.YEARMONTHDATEHOURS | TimeUnit.YEARMONTHDATEHOURSMINUTES
   | TimeUnit.YEARMONTHDATEHOURSMINUTESSECONDS | TimeUnit.MONTHDATE | TimeUnit.HOURSMINUTES
@@ -63,6 +65,7 @@ export const SINGLE_TIMEUNITS = [
   TimeUnit.YEAR,
   TimeUnit.QUARTER,
   TimeUnit.MONTH,
+  TimeUnit.WEEK,
   TimeUnit.DAY,
   TimeUnit.DATE,
   TimeUnit.HOURS,
@@ -152,6 +155,7 @@ export const TIMEUNITS = [
   TimeUnit.YEAR,
   TimeUnit.QUARTER,
   TimeUnit.MONTH,
+  TimeUnit.WEEK,
   TimeUnit.DAY,
   TimeUnit.DATE,
   TimeUnit.HOURS,

--- a/src/timeunit.ts
+++ b/src/timeunit.ts
@@ -3,32 +3,60 @@ import {ScaleType} from './scale';
 import {Dict, keys} from './util';
 import * as log from './log';
 
-export enum TimeUnit {
-  YEAR = 'year' as any,
-  MONTH = 'month' as any,
-  DAY = 'day' as any,
-  DATE = 'date' as any,
-  HOURS = 'hours' as any,
-  MINUTES = 'minutes' as any,
-  SECONDS = 'seconds' as any,
-  MILLISECONDS = 'milliseconds' as any,
-  YEARMONTH = 'yearmonth' as any,
-  YEARMONTHDATE = 'yearmonthdate' as any,
-  YEARMONTHDATEHOURS = 'yearmonthdatehours' as any,
-  YEARMONTHDATEHOURSMINUTES = 'yearmonthdatehoursminutes' as any,
-  YEARMONTHDATEHOURSMINUTESSECONDS = 'yearmonthdatehoursminutesseconds' as any,
+export namespace TimeUnit {
+  export const YEAR: 'year' = 'year';
+  export type YEAR = typeof YEAR;
+  export const MONTH: 'month' = 'month';
+  export type MONTH = typeof MONTH;
+  export const DAY: 'day' = 'day';
+  export type DAY = typeof DAY;
+  export const DATE: 'date' = 'date';
+  export type DATE = typeof DATE;
+  export const HOURS: 'hours' = 'hours';
+  export type HOURS = typeof HOURS;
+  export const MINUTES: 'minutes' = 'minutes';
+  export type MINUTES = typeof MINUTES;
+  export const SECONDS: 'seconds' = 'seconds';
+  export type SECONDS = typeof SECONDS;
+  export const MILLISECONDS: 'milliseconds' = 'milliseconds';
+  export type MILLISECONDS = typeof MILLISECONDS;
+  export const YEARMONTH: 'yearmonth' = 'yearmonth';
+  export type YEARMONTH = typeof YEARMONTH;
+  export const YEARMONTHDATE: 'yearmonthdate' = 'yearmonthdate';
+  export type YEARMONTHDATE = typeof YEARMONTHDATE;
+  export const YEARMONTHDATEHOURS: 'yearmonthdatehours' = 'yearmonthdatehours';
+  export type YEARMONTHDATEHOURS = typeof YEARMONTHDATEHOURS;
+  export const YEARMONTHDATEHOURSMINUTES: 'yearmonthdatehoursminutes' = 'yearmonthdatehoursminutes';
+  export type YEARMONTHDATEHOURSMINUTES = typeof YEARMONTHDATEHOURSMINUTES;
+  export const YEARMONTHDATEHOURSMINUTESSECONDS: 'yearmonthdatehoursminutesseconds' = 'yearmonthdatehoursminutesseconds';
+  export type YEARMONTHDATEHOURSMINUTESSECONDS = typeof YEARMONTHDATEHOURSMINUTESSECONDS;
 
-  // MONTHDATE always include 29 February since we use year 0th (which is a leap year)
-  MONTHDATE = 'monthdate' as any,
-  HOURSMINUTES = 'hoursminutes' as any,
-  HOURSMINUTESSECONDS = 'hoursminutesseconds' as any,
-  MINUTESSECONDS = 'minutesseconds' as any,
-  SECONDSMILLISECONDS = 'secondsmilliseconds' as any,
-  QUARTER = 'quarter' as any,
-  YEARQUARTER = 'yearquarter' as any,
-  QUARTERMONTH = 'quartermonth' as any,
-  YEARQUARTERMONTH = 'yearquartermonth' as any,
+  // MONTHDATE always include 29 February since we use year 0th (which is a leap year);
+  export const MONTHDATE: 'monthdate' = 'monthdate';
+  export type MONTHDATE = typeof MONTHDATE;
+  export const HOURSMINUTES: 'hoursminutes' = 'hoursminutes';
+  export type HOURSMINUTES = typeof HOURSMINUTES;
+  export const HOURSMINUTESSECONDS: 'hoursminutesseconds' = 'hoursminutesseconds';
+  export type HOURSMINUTESSECONDS = typeof HOURSMINUTESSECONDS;
+  export const MINUTESSECONDS: 'minutesseconds' = 'minutesseconds';
+  export type MINUTESSECONDS = typeof MINUTESSECONDS;
+  export const SECONDSMILLISECONDS: 'secondsmilliseconds' = 'secondsmilliseconds';
+  export type SECONDSMILLISECONDS = typeof SECONDSMILLISECONDS;
+  export const QUARTER: 'quarter' = 'quarter';
+  export type QUARTER = typeof QUARTER;
+  export const YEARQUARTER: 'yearquarter' = 'yearquarter';
+  export type YEARQUARTER = typeof YEARQUARTER;
+  export const QUARTERMONTH: 'quartermonth' = 'quartermonth';
+  export type QUARTERMONTH = typeof QUARTERMONTH;
+  export const YEARQUARTERMONTH: 'yearquartermonth' = 'yearquartermonth';
+  export type YEARQUARTERMONTH = typeof YEARQUARTERMONTH;
 }
+export type TimeUnit = TimeUnit.YEAR | TimeUnit.MONTH | TimeUnit.DAY | TimeUnit.DATE | TimeUnit.HOURS
+  | TimeUnit.MINUTES | TimeUnit.SECONDS | TimeUnit.MILLISECONDS | TimeUnit.YEARMONTH
+  | TimeUnit.YEARMONTHDATE | TimeUnit.YEARMONTHDATEHOURS | TimeUnit.YEARMONTHDATEHOURSMINUTES
+  | TimeUnit.YEARMONTHDATEHOURSMINUTESSECONDS | TimeUnit.MONTHDATE | TimeUnit.HOURSMINUTES
+  | TimeUnit.HOURSMINUTESSECONDS | TimeUnit.MINUTESSECONDS | TimeUnit.SECONDSMILLISECONDS
+  | TimeUnit.QUARTER | TimeUnit.YEARQUARTER | TimeUnit.QUARTERMONTH | TimeUnit.YEARQUARTERMONTH;
 
 /** Time Unit that only corresponds to only one part of Date objects. */
 export const SINGLE_TIMEUNITS = [
@@ -120,7 +148,29 @@ export function isMultiTimeUnit(timeUnit: TimeUnit) {
   return !!MULTI_TIMEUNIT_INDEX[timeUnit];
 }
 
-export const TIMEUNITS = SINGLE_TIMEUNITS.concat(MULTI_TIMEUNITS);
+export const TIMEUNITS = [
+  TimeUnit.YEAR,
+  TimeUnit.QUARTER,
+  TimeUnit.MONTH,
+  TimeUnit.DAY,
+  TimeUnit.DATE,
+  TimeUnit.HOURS,
+  TimeUnit.MINUTES,
+  TimeUnit.SECONDS,
+  TimeUnit.MILLISECONDS,
+  TimeUnit.YEARQUARTER,
+  TimeUnit.YEARQUARTERMONTH,
+  TimeUnit.YEARMONTH,
+  TimeUnit.YEARMONTHDATE,
+  TimeUnit.YEARMONTHDATEHOURS,
+  TimeUnit.YEARMONTHDATEHOURSMINUTES,
+  TimeUnit.YEARMONTHDATEHOURSMINUTESSECONDS,
+  TimeUnit.QUARTERMONTH,
+  TimeUnit.HOURSMINUTES,
+  TimeUnit.HOURSMINUTESSECONDS,
+  TimeUnit.MINUTESSECONDS,
+  TimeUnit.SECONDSMILLISECONDS
+];
 
 /** Returns true if fullTimeUnit contains the timeUnit, false otherwise. */
 export function containsTimeUnit(fullTimeUnit: TimeUnit, timeUnit: TimeUnit) {
@@ -135,7 +185,7 @@ export function containsTimeUnit(fullTimeUnit: TimeUnit, timeUnit: TimeUnit) {
     );
 }
 
-export function defaultScaleType(timeUnit: TimeUnit) {
+export function defaultScaleType(timeUnit: TimeUnit): ScaleType {
    switch (timeUnit) {
     case TimeUnit.HOURS:
     case TimeUnit.DAY:
@@ -163,7 +213,7 @@ export function fieldExpr(fullTimeUnit: TimeUnit, field: string): string {
     }
   }
 
-  let d: DateTimeExpr = SINGLE_TIMEUNITS.reduce((_d, tu: TimeUnit) => {
+  let d = SINGLE_TIMEUNITS.reduce((_d: DateTimeExpr, tu: TimeUnit) => {
     if (containsTimeUnit(fullTimeUnit, tu)) {
       _d[tu] = func(tu);
     }
@@ -180,7 +230,7 @@ export function fieldExpr(fullTimeUnit: TimeUnit, field: string): string {
 }
 
 /** returns the smallest nice unit for scale.nice */
-export function smallestUnit(timeUnit): string {
+export function smallestUnit(timeUnit: TimeUnit): string {
   if (!timeUnit) {
     return undefined;
   }
@@ -218,7 +268,7 @@ export function template(timeUnit: TimeUnit, field: string, shortTimeLabels: boo
     return undefined;
   }
 
-  let dateComponents = [];
+  let dateComponents: string[] = [];
   let template = '';
   const hasYear = containsTimeUnit(timeUnit, TimeUnit.YEAR);
 
@@ -242,7 +292,7 @@ export function template(timeUnit: TimeUnit, field: string, shortTimeLabels: boo
     dateComponents.push(shortTimeLabels ? '%y' : '%Y');
   }
 
-  let timeComponents = [];
+  let timeComponents: string[] = [];
 
   if (containsTimeUnit(timeUnit, TimeUnit.HOURS)) {
     timeComponents.push('%H');
@@ -257,7 +307,7 @@ export function template(timeUnit: TimeUnit, field: string, shortTimeLabels: boo
     timeComponents.push('%L');
   }
 
-  let dateTimeComponents = [];
+  let dateTimeComponents: string[] = [];
   if (dateComponents.length > 0) {
     dateTimeComponents.push(dateComponents.join(' '));
   }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -16,6 +16,12 @@ export interface Transform {
    * Calculate new field(s) using the provided expresssion(s). Calculation are applied before filter.
    */
   calculate?: Formula[];
+
+  /**
+   * DEPRECATED
+   * Whether to filter `null` from the data.
+   */
+  filterNull?: boolean;
 }
 
 /**

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -16,12 +16,6 @@ export interface Transform {
    * Calculate new field(s) using the provided expresssion(s). Calculation are applied before filter.
    */
   calculate?: Formula[];
-
-  /**
-   * DEPRECATED
-   * Whether to filter `null` from the data.
-   */
-  filterNull?: boolean;
 }
 
 /**

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,11 +1,16 @@
 /** Constants and utilities for data type */
 
-export enum Type {
-  QUANTITATIVE = 'quantitative' as any,
-  ORDINAL = 'ordinal' as any,
-  TEMPORAL = 'temporal' as any,
-  NOMINAL = 'nominal' as any
+export namespace Type {
+  export const QUANTITATIVE: 'quantitative' = 'quantitative';
+  export type QUANTITATIVE = typeof QUANTITATIVE;
+  export const ORDINAL: 'ordinal' = 'ordinal';
+  export type ORDINAL = typeof ORDINAL;
+  export const TEMPORAL: 'temporal' = 'temporal';
+  export type TEMPORAL = typeof TEMPORAL;
+  export const NOMINAL: 'nominal' = 'nominal';
+  export type NOMINAL = typeof NOMINAL;
 }
+export type Type = Type.QUANTITATIVE | Type.ORDINAL | Type.TEMPORAL | Type.NOMINAL;
 
 export const QUANTITATIVE = Type.QUANTITATIVE;
 export const ORDINAL = Type.ORDINAL;

--- a/src/util.ts
+++ b/src/util.ts
@@ -37,7 +37,7 @@ export function range(start: number, stop?: number, step?: number): Array<number
   if ((stop - start) / step === Infinity) {
     throw new Error('Infinite range');
   }
-  var range = [], i = -1, j;
+  var range: number[] = [], i = -1, j: number;
   if (step < 0) {
     /* tslint:disable */
     while ((j = start + step * ++i) > stop) {
@@ -86,7 +86,7 @@ export function union<T>(array: Array<T>, other: Array<T>) {
   return array.concat(without(other, array));
 }
 
-export function forEach(obj, f: (a, d, k, o) => any, thisArg?) {
+export function forEach(obj: any, f: (a: any, d: string, k: any, o: any) => any, thisArg?: any) {
   if (obj.forEach) {
     obj.forEach.call(thisArg, f);
   } else {
@@ -98,7 +98,7 @@ export function forEach(obj, f: (a, d, k, o) => any, thisArg?) {
   }
 }
 
-export function reduce(obj, f: (a, i, d, k, o) => any, init, thisArg?) {
+export function reduce(obj: any, f: (a: any, i: any, d: any, k: any, o: any) => any, init: any, thisArg?: any) {
   if (obj.reduce) {
     return obj.reduce.call(thisArg, f, init);
   } else {
@@ -111,11 +111,11 @@ export function reduce(obj, f: (a, i, d, k, o) => any, init, thisArg?) {
   }
 }
 
-export function map(obj, f: (a, d, k, o) => any, thisArg?) {
+export function map(obj: any, f: (a: any, d: any, k: any, o: any) => any, thisArg?: any) {
   if (obj.map) {
     return obj.map.call(thisArg, f);
   } else {
-    let output = [];
+    let output: any[] = [];
     for (let k in obj) {
       if (obj.hasOwnProperty(k)) {
         output.push(f.call(thisArg, obj[k], k, obj));
@@ -125,7 +125,7 @@ export function map(obj, f: (a, d, k, o) => any, thisArg?) {
   }
 }
 
-export function some<T>(arr: Array<T>, f: (d: T, k?, i?) => boolean) {
+export function some<T>(arr: Array<T>, f: (d: T, k?: any, i?: any) => boolean) {
   let i = 0;
   for (let k = 0; k<arr.length; k++) {
     if (f(arr[k], k, i++)) {
@@ -135,7 +135,7 @@ export function some<T>(arr: Array<T>, f: (d: T, k?, i?) => boolean) {
   return false;
 }
 
-export function every<T>(arr: Array<T>, f: (d: T, k?, i?) => boolean) {
+export function every<T>(arr: Array<T>, f: (d: T, k?: any, i?: any) => boolean) {
   let i = 0;
   for (let k = 0; k<arr.length; k++) {
     if (!f(arr[k], k, i++)) {
@@ -149,7 +149,7 @@ export function flatten(arrays: any[]) {
   return [].concat.apply([], arrays);
 }
 
-export function mergeDeep(dest, ...src: any[]) {
+export function mergeDeep(dest: any, ...src: any[]) {
   for (let i = 0; i < src.length; i++) {
     dest = deepMerge_(dest, src[i]);
   }
@@ -157,7 +157,7 @@ export function mergeDeep(dest, ...src: any[]) {
 };
 
 // recursively merges src into dest
-function deepMerge_(dest, src) {
+function deepMerge_(dest: any, src: any) {
   if (typeof src !== 'object' || src === null) {
     return dest;
   }
@@ -180,11 +180,11 @@ function deepMerge_(dest, src) {
   return dest;
 }
 
-export function unique<T>(values: T[], f?: (item: T) => string) {
-  let results = [];
-  var u = {}, v, i, n;
+export function unique<T>(values: T[], f: (item: T) => string) {
+  let results: any[] = [];
+  var u = {}, v: string, i: number, n: number;
   for (i = 0, n = values.length; i < n; ++i) {
-    v = f ? f(values[i]) : values[i];
+    v = f(values[i]);
     if (v in u) {
       continue;
     }

--- a/test/compile/config.test.ts
+++ b/test/compile/config.test.ts
@@ -186,8 +186,8 @@ describe('Config', function() {
         "mark": "rule",
         "encoding": {
           "x": {"type": "ordinal", "field": "foo"},
-          "y": {"type": "quanitative", "field": "bar"},
-          "y2": {"type": "quanitative", "field": "baz"}
+          "y": {"type": "quantitative", "field": "bar"},
+          "y2": {"type": "quantitative", "field": "baz"}
         },
       });
       assert.equal(orient(model.mark(), model.encoding(), {}), Orient.VERTICAL);
@@ -198,8 +198,8 @@ describe('Config', function() {
         "mark": "rule",
         "encoding": {
           "y": {"type": "ordinal", "field": "foo"},
-          "x": {"type": "quanitative", "field": "bar"},
-          "x2": {"type": "quanitative", "field": "baz"}
+          "x": {"type": "quantitative", "field": "bar"},
+          "x2": {"type": "quantitative", "field": "baz"}
         },
       });
       assert.equal(orient(model.mark(), model.encoding(), {}), Orient.HORIZONTAL);
@@ -209,8 +209,8 @@ describe('Config', function() {
       const model = parseUnitModel({
         "mark": "rule",
         "encoding": {
-          "x": {"type": "quanitative", "field": "bar"},
-          "x2": {"type": "quanitative", "field": "baz"}
+          "x": {"type": "quantitative", "field": "bar"},
+          "x2": {"type": "quantitative", "field": "baz"}
         },
       });
       assert.equal(orient(model.mark(), model.encoding()), Orient.HORIZONTAL);
@@ -220,8 +220,8 @@ describe('Config', function() {
       const model = parseUnitModel({
         "mark": "rule",
         "encoding": {
-          "y": {"type": "quanitative", "field": "bar"},
-          "y2": {"type": "quanitative", "field": "baz"}
+          "y": {"type": "quantitative", "field": "bar"},
+          "y2": {"type": "quantitative", "field": "baz"}
         },
       });
       assert.equal(orient(model.mark(), model.encoding()), Orient.VERTICAL);

--- a/test/compile/data.test.ts
+++ b/test/compile/data.test.ts
@@ -18,8 +18,9 @@ import {DataComponent} from '../../src/compile/data/data';
 import {Model} from '../../src/compile/model';
 import {parseUnitModel} from '../util';
 import {mergeDeep, vals} from '../../src/util';
+import {ExtendedUnitSpec} from '../../src/spec';
 
-function compileAssembleData(model) {
+function compileAssembleData(model: Model) {
   model.parseData();
   return assembleData(model, []);
 }
@@ -273,7 +274,7 @@ describe('data: bin', function() {
 
 describe('data: nullFilter', function() {
   describe('compileUnit', function() {
-    const spec = {
+    const spec: ExtendedUnitSpec = {
       mark: "point",
       encoding: {
         y: {field: 'qq', type: "quantitative"},

--- a/test/compile/data/filter.test.ts
+++ b/test/compile/data/filter.test.ts
@@ -8,7 +8,7 @@ describe('compile/data/filter', () => {
   describe('parse', () => {
     it('should return a correct expression for an array of filter', () => {
       const model = parseUnitModel({
-        "data": {"value": []},
+        "data": {"values": []},
         "transform": {
           "filter": [
             {field: 'color', equal: 'red'},
@@ -29,7 +29,7 @@ describe('compile/data/filter', () => {
 
     it('should return a correct expression for a single filter', () => {
       const model = parseUnitModel({
-        "data": {"value": []},
+        "data": {"values": []},
         "transform": {
           "filter": 'datum["x"]===5'
         }

--- a/test/compile/data/timeunit.test.ts
+++ b/test/compile/data/timeunit.test.ts
@@ -10,7 +10,7 @@ describe('compile/data/timeunitdomain', () => {
     it('should return a dictionary of formula transform', () => {
 
       const model = parseUnitModel({
-        "data": {"value": []},
+        "data": {"values": []},
         "mark": "point",
         "encoding": {
           "x": {field: 'a', type: 'temporal', timeUnit: 'month'}

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -6,6 +6,7 @@ import {FacetModel} from '../../src/compile/facet';
 import {SHAPE, ROW} from '../../src/channel';
 import {POINT} from '../../src/mark';
 import {FacetSpec} from '../../src/spec';
+import {Facet} from '../../src/facet';
 import {ORDINAL} from '../../src/type';
 import {parseFacetModel} from '../util';
 
@@ -24,9 +25,9 @@ describe('FacetModel', function() {
     it('should drop unsupported channel and throws warning', () => {
       log.runLocalLogger((localLogger) => {
         const model = parseFacetModel({
-          facet: {
+          facet: ({
             shape: {field: 'a', type: 'quantitative'}
-          },
+          }) as Facet, // Cast to allow invalid facet type for test
           spec: {
             mark: 'point'
           }

--- a/test/compile/mark/area.test.ts
+++ b/test/compile/mark/area.test.ts
@@ -5,13 +5,14 @@ import {parseUnitModel} from '../../util';
 import {extend} from '../../../src/util';
 import {X, Y, COLOR} from '../../../src/channel';
 import {area} from '../../../src/compile/mark/area';
+import {ExtendedUnitSpec} from '../../../src/spec';
 
 describe('Mark: Area', function() {
   it('should return the correct mark type', function() {
     assert.equal(area.markType(), 'area');
   });
 
-  function verticalArea(moreEncoding = {}) {
+  function verticalArea(moreEncoding = {}): ExtendedUnitSpec {
     return {
       "mark": "area",
       "encoding": extend(
@@ -103,7 +104,7 @@ describe('Mark: Area', function() {
     });
   });
 
-  function horizontalArea(moreEncoding = {}) {
+  function horizontalArea(moreEncoding = {}): ExtendedUnitSpec {
     return {
       "mark": "area",
       "encoding": extend(

--- a/test/compile/mark/point.test.ts
+++ b/test/compile/mark/point.test.ts
@@ -5,14 +5,15 @@ import {parseUnitModel} from '../../util';
 import {extend} from '../../../src/util';
 import {X, Y, SIZE, COLOR, SHAPE} from '../../../src/channel';
 import {point, square, circle} from '../../../src/compile/mark/point';
+import {ExtendedUnitSpec} from '../../../src/spec';
 
 describe('Mark: Point', function() {
   it('should return the correct mark type', function() {
     assert.equal(point.markType(), 'symbol');
   });
 
-  function pointXY(moreEncoding = {}) {
-    const spec = {
+  function pointXY(moreEncoding = {}): ExtendedUnitSpec {
+    return {
       "mark": "point",
       "encoding": extend(
         {
@@ -23,7 +24,6 @@ describe('Mark: Point', function() {
       ),
       "data": {"url": "data/barley.json"}
     };
-    return spec;
   }
 
   describe('with x', function() {

--- a/test/compile/mark/text.test.ts
+++ b/test/compile/mark/text.test.ts
@@ -4,6 +4,7 @@ import {assert} from 'chai';
 import {parseUnitModel} from '../../util';
 import {text} from '../../../src/compile/mark/text';
 import {X, Y} from '../../../src/channel';
+import {ExtendedUnitSpec} from '../../../src/spec';
 
 describe('Mark: Text', function() {
   it('should return correct marktype', function() {
@@ -11,7 +12,7 @@ describe('Mark: Text', function() {
   });
 
   describe('with nothing', function() {
-    const spec = {
+    const spec: ExtendedUnitSpec = {
       "mark": "text",
       "encoding": {},
       "data": {"url": "data/cars.json"}
@@ -65,7 +66,7 @@ describe('Mark: Text', function() {
   });
 
   describe('with quantitative and format', function() {
-    const spec = {
+    const spec: ExtendedUnitSpec = {
       "mark": "text",
       "encoding": {
         "text": {"field": "foo", "type": "quantitative"}
@@ -85,7 +86,7 @@ describe('Mark: Text', function() {
   });
 
   describe('with temporal', function() {
-    const spec = {
+    const spec: ExtendedUnitSpec = {
       "mark": "text",
       "encoding": {
         "text": {"field": "foo", "type": "temporal"}
@@ -100,7 +101,7 @@ describe('Mark: Text', function() {
   });
 
   describe('with x, y, text (ordinal)', function() {
-    const spec = {
+    const spec: ExtendedUnitSpec = {
       "mark": "text",
       "encoding": {
         "x": {"field": "Acceleration", "type": "ordinal"},
@@ -129,7 +130,7 @@ describe('Mark: Text', function() {
   });
 
   describe('with row, column, text, and color', function() {
-    const spec = {
+    const spec: ExtendedUnitSpec = {
         "mark": "text",
         "encoding": {
           "row": {"field": "Origin", "type": "ordinal"},
@@ -173,7 +174,7 @@ describe('Mark: Text', function() {
   });
 
   describe('with row, column, text, and color and mark configs(applyColorToBackground, opacity)', function() {
-    const spec = {
+    const spec: ExtendedUnitSpec = {
         "mark": "text",
         "encoding": {
           "row": {"field": "Origin", "type": "ordinal"},

--- a/test/compile/scale.test.ts
+++ b/test/compile/scale.test.ts
@@ -20,7 +20,7 @@ describe('Scale', function() {
           detail: {
             field: 'a',
             type: 'temporal',
-            timeUnit: 'yearMonth'
+            timeUnit: 'yearmonth'
           }
         }
       });
@@ -35,7 +35,7 @@ describe('Scale', function() {
           y: {
             field: 'a',
             type: 'temporal',
-            timeUnit: 'yearMonth'
+            timeUnit: 'yearmonth'
           }
         }
       });
@@ -67,7 +67,7 @@ describe('Scale', function() {
           shape: {
             field: 'a',
             type: 'temporal',
-            timeUnit: 'yearMonth'
+            timeUnit: 'yearmonth'
           }
         }
       });
@@ -85,7 +85,7 @@ describe('Scale', function() {
             shape: {
               field: 'a',
               type: 'temporal',
-              timeUnit: 'yearMonth',
+              timeUnit: 'yearmonth',
               scale: {type: 'linear'}
             }
           }
@@ -331,7 +331,7 @@ describe('Scale', function() {
 
     describe('for ordinal', function() {
       it('should return correct domain with the provided sort property', function() {
-        const sortDef = {op: 'min', field:'Acceleration'};
+        const sortDef = {op: 'min' as 'min', field:'Acceleration'};
         const model = parseUnitModel({
             mark: "point",
             encoding: {

--- a/test/stack.test.ts
+++ b/test/stack.test.ts
@@ -9,7 +9,7 @@ import {X, Y, DETAIL} from '../src/channel';
 import {BAR, AREA, RECT, PRIMITIVE_MARKS} from '../src/mark';
 import {ScaleType} from '../src/scale';
 import {stack, StackOffset, STACK_BY_DEFAULT_MARKS, STACKABLE_MARKS} from '../src/stack';
-import {isStacked} from '../src/spec';
+import {isStacked, ExtendedUnitSpec} from '../src/spec';
 
 describe('stack', () => {
   const NON_STACKABLE_MARKS = [RECT];
@@ -17,7 +17,7 @@ describe('stack', () => {
   it('should be disabled for non-stackable marks with at least of of the stack channel', () => {
     [undefined, StackOffset.CENTER, StackOffset.NONE, StackOffset.ZERO, StackOffset.NORMALIZE].forEach((stacked) => {
       NON_STACKABLE_MARKS.forEach((nonStackableMark) => {
-        const spec = {
+        const spec: ExtendedUnitSpec = {
           "data": {"url": "data/barley.json"},
           "mark": nonStackableMark,
           "encoding": {
@@ -29,8 +29,8 @@ describe('stack', () => {
             "mark": {"stacked": stacked}
           }
         };
-        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
-        assert.isFalse(isStacked(spec as any));
+        assert.isNull(stack(spec.mark, spec.encoding, spec.config.mark.stacked));
+        assert.isFalse(isStacked(spec));
       });
     });
   });
@@ -38,7 +38,7 @@ describe('stack', () => {
   it('should always be disabled for raw plot', () => {
     [undefined, StackOffset.CENTER, StackOffset.NONE, StackOffset.ZERO, StackOffset.NORMALIZE].forEach((stacked) => {
       PRIMITIVE_MARKS.forEach((mark) => {
-        const spec = {
+        const spec: ExtendedUnitSpec = {
           "data": {"url": "data/barley.json"},
           "mark": mark,
           "encoding": {
@@ -50,8 +50,8 @@ describe('stack', () => {
             "mark": {"stacked": stacked}
           }
         };
-        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
-        assert.isFalse(isStacked(spec as any));
+        assert.isNull(stack(spec.mark, spec.encoding, spec.config.mark.stacked));
+        assert.isFalse(isStacked(spec));
       });
     });
   });
@@ -59,7 +59,7 @@ describe('stack', () => {
   it('should always be disabled if there is no stackby channel', () => {
     [undefined, StackOffset.CENTER, StackOffset.NONE, StackOffset.ZERO, StackOffset.NORMALIZE].forEach((stacked) => {
       PRIMITIVE_MARKS.forEach((mark) => {
-        const spec = {
+        const spec: ExtendedUnitSpec = {
           "data": {"url": "data/barley.json"},
           "mark": mark,
           "encoding": {
@@ -70,8 +70,8 @@ describe('stack', () => {
             "mark": {"stacked": stacked}
           }
         };
-        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
-        assert.isFalse(isStacked(spec as any));
+        assert.isNull(stack(spec.mark, spec.encoding, spec.config.mark.stacked));
+        assert.isFalse(isStacked(spec));
       });
     });
   });
@@ -79,7 +79,7 @@ describe('stack', () => {
   it('should always be disabled if the stackby channel is aggregated', () => {
     [undefined, StackOffset.CENTER, StackOffset.NONE, StackOffset.ZERO, StackOffset.NORMALIZE].forEach((stacked) => {
       PRIMITIVE_MARKS.forEach((mark) => {
-        const spec = {
+        const spec: ExtendedUnitSpec = {
           "data": {"url": "data/barley.json"},
           "mark": mark,
           "encoding": {
@@ -91,8 +91,8 @@ describe('stack', () => {
             "mark": {"stacked": stacked}
           }
         };
-        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
-        assert.isFalse(isStacked(spec as any));
+        assert.isNull(stack(spec.mark, spec.encoding, spec.config.mark.stacked));
+        assert.isFalse(isStacked(spec));
       });
     });
   });
@@ -101,7 +101,7 @@ describe('stack', () => {
     [undefined, StackOffset.CENTER, StackOffset.ZERO, StackOffset.NORMALIZE].forEach((stacked) => {
       const marks = stacked === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
       marks.forEach((mark) => {
-        const spec = {
+        const spec: ExtendedUnitSpec = {
           "data": {"url": "data/barley.json"},
           "mark": mark,
           "encoding": {
@@ -114,9 +114,9 @@ describe('stack', () => {
             "mark": {"stacked": stacked}
           }
         };
-        const _stack = stack(spec.mark, spec.encoding as any, spec.config.mark.stacked);
+        const _stack = stack(spec.mark, spec.encoding, spec.config.mark.stacked);
         assert.isOk(_stack);
-        assert.isTrue(isStacked(spec as any));
+        assert.isTrue(isStacked(spec));
         assert.equal(_stack.stackByChannels[0], DETAIL);
       });
     });
@@ -125,7 +125,7 @@ describe('stack', () => {
   it('should always be disabled if both x and y are aggregate', () => {
     [undefined, StackOffset.CENTER, StackOffset.NONE, StackOffset.ZERO, StackOffset.NORMALIZE].forEach((stacked) => {
       PRIMITIVE_MARKS.forEach((mark) => {
-        const spec = {
+        const spec: ExtendedUnitSpec = {
           "data": {"url": "data/barley.json"},
           "mark": mark,
           "encoding": {
@@ -137,8 +137,8 @@ describe('stack', () => {
             "mark": {"stacked": stacked}
           }
         };
-        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
-        assert.isFalse(isStacked(spec as any));
+        assert.isNull(stack(spec.mark, spec.encoding, spec.config.mark.stacked));
+        assert.isFalse(isStacked(spec));
       });
     });
   });
@@ -146,7 +146,7 @@ describe('stack', () => {
   it('should always be disabled if neither x nor y is aggregate', () => {
     [undefined, StackOffset.CENTER, StackOffset.NONE, StackOffset.ZERO, StackOffset.NORMALIZE].forEach((stacked) => {
       PRIMITIVE_MARKS.forEach((mark) => {
-        const spec = {
+        const spec: ExtendedUnitSpec = {
           "data": {"url": "data/barley.json"},
           "mark": mark,
           "encoding": {
@@ -158,8 +158,8 @@ describe('stack', () => {
             "mark": {"stacked": stacked}
           }
         };
-        assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
-        assert.isFalse(isStacked(spec as any));
+        assert.isNull(stack(spec.mark, spec.encoding, spec.config.mark.stacked));
+        assert.isFalse(isStacked(spec));
       });
     });
   });
@@ -169,7 +169,7 @@ describe('stack', () => {
       const marks = stacked === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
       marks.forEach((mark) => {
         log.runLocalLogger((localLogger) => {
-          const spec = {
+          const spec: ExtendedUnitSpec = {
             "mark": mark,
             "encoding": {
               "x": {"field": "a", "type": "quantitative", "aggregate": "sum"},
@@ -181,8 +181,8 @@ describe('stack', () => {
               "mark": {"stacked": stacked}
             }
           };
-          assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
-          assert.isFalse(isStacked(spec as any));
+          assert.isNull(stack(spec.mark, spec.encoding, spec.config.mark.stacked));
+          assert.isFalse(isStacked(spec));
           assert.equal(localLogger.warns[0], log.message.cannotStackRangedMark(X),
             JSON.stringify({stacked: stacked, mark: mark})
           );
@@ -196,7 +196,7 @@ describe('stack', () => {
       const marks = stacked === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
       marks.forEach((mark) => {
         log.runLocalLogger((localLogger) => {
-          const spec = {
+          const spec: ExtendedUnitSpec = {
             "mark": mark,
             "encoding": {
               "y": {"field": "a", "type": "quantitative", "aggregate": "sum"},
@@ -208,8 +208,8 @@ describe('stack', () => {
               "mark": {"stacked": stacked}
             }
           };
-          assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
-          assert.isFalse(isStacked(spec as any));
+          assert.isNull(stack(spec.mark, spec.encoding, spec.config.mark.stacked));
+          assert.isFalse(isStacked(spec));
           assert.equal(localLogger.warns[0], log.message.cannotStackRangedMark(Y),
             JSON.stringify({stacked: stacked, mark: mark})
           );
@@ -224,7 +224,7 @@ describe('stack', () => {
         const marks = stacked === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
         marks.forEach((mark) => {
           log.runLocalLogger((localLogger) => {
-            const spec = {
+            const spec: ExtendedUnitSpec = {
               "data": {"url": "data/barley.json"},
               "mark": mark,
               "encoding": {
@@ -236,8 +236,8 @@ describe('stack', () => {
                 "mark": {"stacked": stacked}
               }
             };
-            assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
-            assert.isFalse(isStacked(spec as any));
+            assert.isNull(stack(spec.mark, spec.encoding, spec.config.mark.stacked));
+            assert.isFalse(isStacked(spec));
             assert.equal(localLogger.warns[0], log.message.cannotStackNonLinearScale(scaleType));
           });
         });
@@ -251,7 +251,7 @@ describe('stack', () => {
         const marks = stacked === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
         marks.forEach((mark) => {
           log.runLocalLogger((localLogger) => {
-            const spec = {
+            const spec: ExtendedUnitSpec = {
               "data": {"url": "data/barley.json"},
               "mark": mark,
               "encoding": {
@@ -263,8 +263,8 @@ describe('stack', () => {
                 "mark": {"stacked": stacked}
               }
             };
-            assert.isNull(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked));
-            assert.isFalse(isStacked(spec as any));
+            assert.isNull(stack(spec.mark, spec.encoding, spec.config.mark.stacked));
+            assert.isFalse(isStacked(spec));
             assert.equal(localLogger.warns[0], log.message.cannotStackNonSummativeAggregate(aggregate));
           });
         });
@@ -275,7 +275,7 @@ describe('stack', () => {
   describe('stack().groupbyChannel, .fieldChannel', () => {
     it('should be correct for horizontal', () => {
       [BAR, AREA].forEach((stackableMark) => {
-        const spec = {
+        const spec: ExtendedUnitSpec = {
           "data": {"url": "data/barley.json"},
           "mark": stackableMark,
           "encoding": {
@@ -284,16 +284,16 @@ describe('stack', () => {
             "color": {"field": "site", "type": "nominal"}
           }
         };
-        const _stack = stack(spec.mark, spec.encoding as any, undefined);
+        const _stack = stack(spec.mark, spec.encoding, undefined);
         assert.equal(_stack.fieldChannel, X);
         assert.equal(_stack.groupbyChannel, Y);
-        assert.isTrue(isStacked(spec as any));
+        assert.isTrue(isStacked(spec));
       });
     });
 
     it('should be correct for horizontal (single)', () => {
       [BAR, AREA].forEach((stackableMark) => {
-        const spec = {
+        const spec: ExtendedUnitSpec = {
           "data": {"url": "data/barley.json"},
           "mark": stackableMark,
           "encoding": {
@@ -301,16 +301,16 @@ describe('stack', () => {
             "color": {"field": "site", "type": "nominal"}
           }
         };
-        const _stack = stack(spec.mark, spec.encoding as any, undefined);
+        const _stack = stack(spec.mark, spec.encoding, undefined);
         assert.equal(_stack.fieldChannel, X);
         assert.equal(_stack.groupbyChannel, null);
-        assert.isTrue(isStacked(spec as any));
+        assert.isTrue(isStacked(spec));
       });
     });
 
     it('should be correct for vertical', () => {
       [BAR, AREA].forEach((stackableMark) => {
-        const spec = {
+        const spec: ExtendedUnitSpec = {
           "data": {"url": "data/barley.json"},
           "mark": stackableMark,
           "encoding": {
@@ -319,16 +319,16 @@ describe('stack', () => {
             "color": {"field": "site", "type": "nominal"}
           }
         };
-        const _stack = stack(spec.mark, spec.encoding as any, undefined);
+        const _stack = stack(spec.mark, spec.encoding, undefined);
         assert.equal(_stack.fieldChannel, Y);
         assert.equal(_stack.groupbyChannel, X);
-        assert.isTrue(isStacked(spec as any));
+        assert.isTrue(isStacked(spec));
       });
     });
 
     it('should be correct for vertical (single)', () => {
       [BAR, AREA].forEach((stackableMark) => {
-        const spec = {
+        const spec: ExtendedUnitSpec = {
           "data": {"url": "data/barley.json"},
           "mark": stackableMark,
           "encoding": {
@@ -336,10 +336,10 @@ describe('stack', () => {
             "color": {"field": "site", "type": "nominal"}
           }
         };
-        const _stack = stack(spec.mark, spec.encoding as any, undefined);
+        const _stack = stack(spec.mark, spec.encoding, undefined);
         assert.equal(_stack.fieldChannel, Y);
         assert.equal(_stack.groupbyChannel, null);
-        assert.isTrue(isStacked(spec as any));
+        assert.isTrue(isStacked(spec));
       });
     });
   });
@@ -347,7 +347,7 @@ describe('stack', () => {
   describe('stack().offset', () => {
     it('should be zero for stackable marks with at least of of the stack channel if stacked is unspecified', () => {
       [BAR, AREA].forEach((stackableMark) => {
-        const spec = {
+        const spec: ExtendedUnitSpec = {
           "data": {"url": "data/barley.json"},
           "mark": stackableMark,
           "encoding": {
@@ -356,15 +356,15 @@ describe('stack', () => {
             "color": {"field": "site", "type": "nominal"}
           }
         };
-        assert.equal(stack(spec.mark, spec.encoding as any, undefined).offset, StackOffset.ZERO);
-        assert.isTrue(isStacked(spec as any));
+        assert.equal(stack(spec.mark, spec.encoding, undefined).offset, StackOffset.ZERO);
+        assert.isTrue(isStacked(spec));
       });
     });
 
     it('should be the specified stacked for stackable marks with at least one of the stack channel', () => {
       [StackOffset.CENTER, StackOffset.ZERO, StackOffset.NORMALIZE].forEach((stacked) => {
         [BAR, AREA].forEach((stackableMark) => {
-          const spec = {
+          const spec: ExtendedUnitSpec = {
             "data": {"url": "data/barley.json"},
             "mark": stackableMark,
             "encoding": {
@@ -376,8 +376,8 @@ describe('stack', () => {
               "mark": {"stacked": stacked}
             }
           };
-          assert.equal(stack(spec.mark, spec.encoding as any, spec.config.mark.stacked).offset, stacked);
-          assert.equal(isStacked(spec as any), StackOffset.NONE !== stacked);
+          assert.equal(stack(spec.mark, spec.encoding, spec.config.mark.stacked).offset, stacked);
+          assert.equal(isStacked(spec), true);
         });
       });
     });

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,7 +1,7 @@
 import {buildModel} from '../src/compile/common';
 import {UnitModel} from '../src/compile/unit';
 import {FacetModel} from '../src/compile/facet';
-import {ExtendedUnitSpec, FacetSpec, normalize} from '../src/spec';
+import {ExtendedUnitSpec, FacetSpec, normalize, ExtendedSpec} from '../src/spec';
 import {contains} from '../src/util';
 import {Model} from '../src/compile/model';
 
@@ -9,7 +9,7 @@ import {Model} from '../src/compile/model';
  * Call new Model without worrying about types.
  * We use this in tests to allow using raw JSON.
  */
-export function parseModel(inputSpec): Model {
+export function parseModel(inputSpec: ExtendedSpec): Model {
   const spec = normalize(inputSpec);
   return buildModel(spec, null, '');
 }
@@ -18,9 +18,9 @@ export function parseModel(inputSpec): Model {
  * Call new UnitModel without worrying about types.
  * We use this in tests to allow using raw JSON.
  */
-export function parseUnitModel(spec) {
+export function parseUnitModel(spec: ExtendedUnitSpec) {
   // TODO: support other type of model as well
-  return new UnitModel(spec as ExtendedUnitSpec, null, '');
+  return new UnitModel(spec, null, '');
 }
 
 
@@ -28,18 +28,18 @@ export function parseUnitModel(spec) {
  * Call new FacetModel without worrying about types.
  * We use this in tests to allow using raw JSON.
  */
-export function parseFacetModel(spec) {
+export function parseFacetModel(spec: FacetSpec) {
   // TODO: support other type of model as well
   return new FacetModel(spec as FacetSpec, null, '');
 }
 
 export const zSchema = require('z-schema');
 
-zSchema.registerFormat('color', function (str) {
+zSchema.registerFormat('color', function (str: string) {
   // valid colors are in list or hex color
   return contains(['purple'], str) || /^#([0-9a-f]{3}){1,2}$/i.test(str);
 });
-zSchema.registerFormat('font', function (str) {
+zSchema.registerFormat('font', function (str: string) {
   // right now no fonts are valid
   return false;
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "declaration": true,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "removeComments": false,
     "noLib": false,
     "preserveConstEnums": true,

--- a/typings/datalib.d.ts
+++ b/typings/datalib.d.ts
@@ -1,15 +1,18 @@
 declare module 'datalib/src/util' {
-  export function keys(a): Array<string>;
-  export function extend(a, b, ...rest);
+  export function keys(a: any): Array<string>;
+  export function extend<T, U, V, W>(a: T, b: U, c: V, d: W): T & U & V & W;
+  export function extend<T, U, V>(a: T, b: U, c: V): T & U & V;
+  export function extend<T, U>(a: T, b: U): T & U;
+  export function extend(...all: any[]): any;
   export function duplicate<T>(a: T): T;
   export function isArray(a: any | any[]): a is any[];
-  export function vals(a);
+  export function vals(a: any): any;
   export function truncate(a: string, length: number): string;
-  export function toMap(a);
-  export function isObject(a): a is any;
-  export function isString(a): a is string;
-  export function isNumber(a): a is number;
-  export function isBoolean(a): a is boolean;
+  export function toMap(a: any): any;
+  export function isObject(a: any): a is any;
+  export function isString(a: any): a is string;
+  export function isNumber(a: any): a is number;
+  export function isBoolean(a: any): a is boolean;
 }
 
 interface BinFunc {

--- a/typings/vega-lite.d.ts
+++ b/typings/vega-lite.d.ts
@@ -1,3 +1,3 @@
 declare module vl {
-  export var version;
+  export var version: string;
 }

--- a/typings/vega-util.d.ts
+++ b/typings/vega-util.d.ts
@@ -1,9 +1,9 @@
 declare module 'vega-util' {
   export interface LoggerInterface {
     level: (_: number) => number | LoggerInterface;
-    warn(...args): LoggerInterface;
-    info(...args): LoggerInterface;
-    debug(...args): LoggerInterface;
+    warn(...args: any[]): LoggerInterface;
+    info(...args: any[]): LoggerInterface;
+    debug(...args: any[]): LoggerInterface;
   }
 
   export const None: number;
@@ -11,6 +11,6 @@ declare module 'vega-util' {
   export const Info: number;
   export const Debug: number;
 
-  export function log(...args);
+  export function log(...args: any[]): void;
   export function logger(_: number): LoggerInterface;
 }

--- a/typings/vega.d.ts
+++ b/typings/vega.d.ts
@@ -1,4 +1,4 @@
 declare module vg {
-  export var version;
-  export function embed(selector: any, spec: any, f?: any);
+  export var version: string;
+  export function embed(selector: any, spec: any, f?: any): void;
 }


### PR DESCRIPTION
And then fix all the resulting typescript compiler errors (usually just adding types to places). This identified a handful of typos, which were fixed, and necessitated swapping out the string enum hack with a real, correctly-typed namespace structure.

Without `noImplictAny` on in `vega-lite`, due to current limitations in the typescript compiler, it is almost impossible for a typescript consumer to use vega-lite with `noImplictAny` on, as all the implicit any errors which leak into the generated `.d.ts` API surface in consumers' projects.

And it's just a good idea to have this flag on, in general, as it helps identify many likely bugs. I'd also recommend enabling struct null checks in the future, which will hopefully be less work than this PR was.