### PR TITLE
Get rid of formula transform for `bin_mid` and use inline signal instead

### DIFF
--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -137,7 +137,7 @@ export function numberFormat(fieldDef: FieldDef, format: string, config: Config,
 /** Return field reference with potential "-" prefix for descending sort */
 export function sortField(orderChannelDef: OrderChannelDef) {
   return (orderChannelDef.sort === SortOrder.DESCENDING ? '-' : '') +
-    field(orderChannelDef, {binSuffix: 'mid'});
+    field(orderChannelDef, {binSuffix: 'start'});
 }
 
 /**

--- a/src/compile/data/bin.ts
+++ b/src/compile/data/bin.ts
@@ -32,15 +32,6 @@ export namespace bin {
         }
 
         const transform: VgTransform[] = [binTrans];
-        // Calculate mid bin
-        // TODO: consider removing this
-        transform.push({
-          type: 'formula',
-          as: field(fieldDef, { binSuffix: 'mid' }),
-          expr: '(' + field(fieldDef, { binSuffix: 'start', datum: true }) + '+' +
-            field(fieldDef, { binSuffix: 'end', datum: true }) + ')/2'
-        });
-
         // If color ramp has type linear or time, we have to create new bin_range field
         // with correct number format
         const isOrdinalColor = model.hasDiscreteScale(channel) || channel === COLOR;

--- a/src/compile/data/summary.ts
+++ b/src/compile/data/summary.ts
@@ -16,7 +16,6 @@ export namespace summary {
   function addDimension(dims: { [field: string]: boolean }, fieldDef: FieldDef) {
     if (fieldDef.bin) {
       dims[field(fieldDef, { binSuffix: 'start' })] = true;
-      dims[field(fieldDef, { binSuffix: 'mid' })] = true;
       dims[field(fieldDef, { binSuffix: 'end' })] = true;
 
       // const scale = model.scale(channel);

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -188,7 +188,7 @@ function sortPathBy(model: UnitModel): string | string[] {
         field: sort.field
       });
     } else {
-      return '-' + model.field(dimensionChannel, {binSuffix: 'mid'});
+      return '-' + model.field(dimensionChannel, {binSuffix: 'start'});
     }
   }
 }
@@ -205,7 +205,6 @@ function detailFields(model: UnitModel): string[] {
     return details;
   }, []);
 }
-
 
 function stackTransforms(model: UnitModel, impute: boolean): any[] {
   const stackByFields = getStackByFields(model);
@@ -249,7 +248,7 @@ function imputeTransform(model: UnitModel, stackFields: string[]) {
     type: 'impute',
     field: model.field(stack.fieldChannel),
     groupby: stackFields,
-    orderby: [model.field(stack.groupbyChannel, {binSuffix: 'mid'})],
+    orderby: [model.field(stack.groupbyChannel, {binSuffix: 'start'})],
     method: 'value',
     value: 0
   };
@@ -270,7 +269,7 @@ function stackTransform(model: UnitModel, stackFields: string[]) {
   // add stack transform to mark
   let transform: VgStackTransform = {
     type: 'stack',
-    groupby: [model.field(stack.groupbyChannel, {binSuffix: 'mid'}) || 'undefined'],
+    groupby: [model.field(stack.groupbyChannel, {binSuffix: 'start'}) || 'undefined'],
     field: model.field(stack.fieldChannel),
     sortby: sortby,
     as: [valName + '_start', valName + '_end']

--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -65,6 +65,13 @@ export function band(scaleName: string) {
   return ref;
 }
 
+export function binMidSignal(fieldDef: FieldDef, scaleName: string) {
+  return {
+    scale: scaleName,
+    signal: '(' + field(fieldDef, {binSuffix: 'start', datum: true}) + '+' +
+      field(fieldDef, {binSuffix: 'end', datum: true}) + ')/2'
+  };
+}
 
 export function normal(channel: Channel, fieldDef: FieldDef, scaleName: string, scale: Scale,
 defaultRef: VgValueRef | 'base' | 'baseOrMax'): VgValueRef {
@@ -76,7 +83,11 @@ defaultRef: VgValueRef | 'base' | 'baseOrMax'): VgValueRef {
       if (isDiscreteScale(scale.type)) {
         return fieldRef(fieldDef, scaleName, {binSuffix: 'range'});
       } else {
-        return fieldRef(fieldDef, scaleName, {binSuffix: 'mid'});
+        if (fieldDef.bin) {
+          return binMidSignal(fieldDef, scaleName);
+        } else {
+          return fieldRef(fieldDef, scaleName, {}); // no need for bin suffix
+        }
       }
     } else if (fieldDef.value) {
       return {

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -99,7 +99,7 @@ export interface FieldRefOption {
   /** prepend fn with custom function prefix */
   prefix?: string;
   /** append suffix to the field ref for bin (default='start') */
-  binSuffix?: 'start' | 'end' | 'mid' | 'range';
+  binSuffix?: 'start' | 'end' | 'range';
   /** append suffix to the field ref (general) */
   suffix?: string;
 }

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -32,6 +32,7 @@ export type VgValueRef = {
     group?: string,
     parent?: string
   },
+  signal?: string;
   template?: string,
   scale?: string, // TODO: object
   mult?: number,

--- a/test/compile/data/bin.test.ts
+++ b/test/compile/data/bin.test.ts
@@ -31,14 +31,6 @@ describe('compile/data/bin', function() {
         max: 100
       });
     });
-
-    it('should add formula transform to calculate bin mid', () => {
-      assert.deepEqual(transform[1], {
-        type: 'formula',
-        as: 'bin_Acceleration_mid',
-        expr: '(datum["bin_Acceleration_start"]+datum["bin_Acceleration_end"])/2'
-      });
-    });
   });
 
   describe('parseLayer', function() {

--- a/test/compile/mark/bar.test.ts
+++ b/test/compile/mark/bar.test.ts
@@ -7,7 +7,6 @@ import {defaultMarkConfig} from '../../../src/config';
 import {defaultScaleConfig} from '../../../src/scale';
 import {bar} from '../../../src/compile/mark/bar';
 
-
 describe('Mark: Bar', function() {
   it('should return the correct mark type', function() {
     assert.equal(bar.markType(), 'rect');
@@ -141,7 +140,7 @@ describe('Mark: Bar', function() {
     const props = bar.properties(model);
 
     it('should draw bar with y centered on bin_mid and height = size field', function() {
-      assert.deepEqual(props.yc, {scale: 'y', field: 'bin_Horsepower_mid'});
+      assert.deepEqual(props.yc, {scale: 'y', signal: '(datum["bin_Horsepower_start"]+datum["bin_Horsepower_end"])/2'});
       assert.deepEqual(props.height, {scale: 'size', field: 'mean_Acceleration'});
     });
   });
@@ -159,7 +158,7 @@ describe('Mark: Bar', function() {
     const props = bar.properties(model);
 
     it('should draw bar with x centered on bin_mid and width = size field', function() {
-      assert.deepEqual(props.xc, {scale: 'x', field: 'bin_Horsepower_mid'});
+      assert.deepEqual(props.xc, {scale: 'x', signal: '(datum["bin_Horsepower_start"]+datum["bin_Horsepower_end"])/2'});
       assert.deepEqual(props.width, {scale: 'size', field: 'mean_Acceleration'});
     });
   });

--- a/test/compile/mark/mark.test.ts
+++ b/test/compile/mark/mark.test.ts
@@ -20,7 +20,7 @@ describe('Mark', function() {
       const stackTransform = markGroup[0].from.transform[0];
       assert.equal(stackTransform.type, 'stack');
 
-      assert.deepEqual(stackTransform.groupby, ['bin_Cost__Total_$_mid']);
+      assert.deepEqual(stackTransform.groupby, ['bin_Cost__Total_$_start']);
       assert.deepEqual(stackTransform.field, 'sum_Cost__Other');
       assert.deepEqual(stackTransform.sortby, ['-Effect__Amount_of_damage']);
     });
@@ -38,7 +38,7 @@ describe('Mark', function() {
       const stackTransform = markGroup[0].from.transform[0];
       assert.equal(stackTransform.type, 'stack');
 
-      assert.deepEqual(stackTransform.groupby, ['bin_Cost__Total_$_mid']);
+      assert.deepEqual(stackTransform.groupby, ['bin_Cost__Total_$_start']);
       assert.deepEqual(stackTransform.field, 'sum_Cost__Other');
       assert.deepEqual(stackTransform.sortby, ['-Effect__Amount_of_damage']);
     });


### PR DESCRIPTION
Get rid of formula transform for `bin_mid` and use inline signal instead

Fix #1681 