### PR TITLE
Correct our reproduction of becker's barley

### DIFF
--- a/examples/specs/trellis_barley.vl.json
+++ b/examples/specs/trellis_barley.vl.json
@@ -3,11 +3,17 @@
   "data": {"url": "data/barley.json"},
   "mark": "point",
   "encoding": {
-    "row": {"field": "site", "type": "ordinal"},
-    "x": {"aggregate": "mean", "field": "yield", "type": "quantitative"},
+    "row": {
+      "field": "site", "type": "ordinal",
+      "sort": {"op": "median", "field": "yield", "order": "descending"}
+    },
+    "x": {
+      "aggregate": "median", "field": "yield", "type": "quantitative",
+      "scale": {"zero": false}
+    },
     "y": {
       "field": "variety", "type": "ordinal",
-      "sort": {"field": "yield","op": "mean"},
+      "sort": {"field": "yield","op": "median", "order": "descending"},
       "scale": {"bandSize": 12}
     },
     "color": {"field": "year", "type": "nominal"}


### PR DESCRIPTION
Now the aggregation function, sorting order, and scale (not starting from zero) are similar to the original plot!

cc: @jakevdp -- I saw that you use this example in Altair example too. You might want to consider updating.  (Btw, Happy Thanksgiving!)

![vega_editor_and_hci_stanford_edu_courses_cs448b_papers_becker-trellis-jcgs_pdf](https://cloud.githubusercontent.com/assets/111269/20583576/2dde0d02-b1a0-11e6-84f9-964cb99780b7.png)

We should cherry pick this to 1.x if we were to update the github pages too. 