### PR TITLE
Correctly generate source maps for minified file.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "build": "browserify src/vl.ts -p tsify -d -s vl | exorcist vega-lite.js.map > vega-lite.js ",
-    "postbuild": "uglifyjs vega-lite.js -cm --source-map vega-lite.min.js.map > vega-lite.min.js && npm run schema",
+    "postbuild": "uglifyjs vega-lite.js -cm --in-source-map vega-lite.js.map --source-map vega-lite.min.js.map > vega-lite.min.js && npm run schema",
     "build:all": "npm run clean && npm run data && npm run build && npm test && npm run lint && npm run build:images",
     "build:images": "npm run data && scripts/generate-images.sh",
     "build:toc": "bundle exec jekyll build --incremental -q && scripts/generate-toc",


### PR DESCRIPTION
See https://github.com/danvk/source-map-explorer/blob/master/README.md#generating-source-maps

Now we can generate

<img width="1676" alt="screen shot 2016-11-24 at 10 04 41" src="https://cloud.githubusercontent.com/assets/589034/20607477/9444d246-b22d-11e6-89ab-24d9f030e498.png">
