### PR TITLE
[WIP] Add rule for using quantitative field with size

### DIFF
--- a/src/scale.ts
+++ b/src/scale.ts
@@ -136,20 +136,67 @@ export interface ScaleConfig {
   /** Default range for shape */
   shapeRange?: string[];
 
-  /** Default range for bar size scale */
-  barSizeRange?: number[];
+  /**
+   * Default minimum range for bar size scale with zero=false.
+   * @minimum 1
+   */
+  minBarSize?: number;
 
-  /** Default range for font size scale */
-  fontSizeRange?: number[];
+  /**
+   * Default max range for bar size scale.
+   * If undefined (default), we will use bandSize - 1.
+   * @minimum 1
+   */
+  maxBarSize?: number;
 
-  /** Default range for rule stroke widths */
-  ruleSizeRange?: number[];
+  /**
+   * Default minimum range for tick size (tick span) scale with zero=false.
+   * @minimum 1
+   */
+  minTickSize?: number;
 
-  /** Default range for tick spans */
-  tickSizeRange?: number[];
+  /**
+   * Default max range for tick size (tick span) scale.
+   * If undefined (default), we will use bandSize - 1.
+   * @minimum 1
+   */
+  maxTickSize?: number;
 
-  /** Default range for bar size scale */
-  pointSizeRange?: number[];
+  /**
+   * Default minimum range for rule size (strokeWidth) scale with zero=false.
+   * @minimum 1
+   */
+  minRuleSize?: number;
+
+  /**
+   * Default max range for rule size (strokeWidth) scale.
+   * @minimum 1
+   */
+  maxRuleSize?: number;
+
+  /**
+   * Default minimum range for point size scale with zero=false.
+   * @minimum 1
+   */
+  minPointSize?: number;
+
+  /**
+   * Default max range for point size scale.
+   * @minimum 1
+   */
+  maxPointSize?: number;
+
+  /**
+   * Default minimum range for text size (fontSize) scale with zero=false.
+   * @minimum 1
+   */
+  minTextSize?: number;
+
+  /**
+   * Default max range for text size (fontSize) scale.
+   * @minimum 1
+   */
+  maxTextSize?: number;
 
   // nice should depends on type (quantitative or temporal), so
   // let's not make a config.
@@ -165,12 +212,23 @@ export const defaultScaleConfig = {
   useRawDomain: false,
   opacity: [0.3, 0.8],
 
+  // if tickSize = 1, it becomes a dot.
+  // To be consistent, we just use 3 to be somewhat consistent with point, which use area = 9.
+  minTickSize: 3,
+
+  minRuleSize: 1,
+  maxRuleSize: 5,
+
+  // TODO: revise if these *can* become ratios of rangeStep
+  minPointSize: 9, // Point size is area. For square point, 9 = 3 pixel ^ 2, not too small!
+
+  // QUESTION: should these be min/maxFontSize?
+  minTextSize: 8, // smaller than 8 would be illegible
+  maxTextSize: 40,
+
   nominalColorScheme: 'category10',
   sequentialColorScheme: 'Greens',
   shapeRange: ['circle', 'square', 'cross', 'diamond', 'triangle-up', 'triangle-down'],
-  fontSizeRange: [8, 40],
-  ruleSizeRange: [1, 5],
-  tickSizeRange: [1, 20]
 };
 
 export interface Scale {

--- a/test/compile/scale.test.ts
+++ b/test/compile/scale.test.ts
@@ -2,12 +2,12 @@
 
 import {assert} from 'chai';
 
-import {bandSize, type, domain, parseScaleComponent} from '../../src/compile/scale';
+import {bandSize, type, domain, parseScaleComponent, defaultProperty} from '../../src/compile/scale';
 import {SOURCE, SUMMARY} from '../../src/data';
 import {parseUnitModel} from '../util';
 
 import * as log from '../../src/log';
-import {X, Y, SHAPE, DETAIL, ROW, COLUMN} from '../../src/channel';
+import {X, Y, SHAPE, DETAIL, ROW, COLUMN, Channel} from '../../src/channel';
 import {BANDSIZE_FIT, ScaleType, defaultScaleConfig} from '../../src/scale';
 import {POINT, RECT, BAR, TEXT} from '../../src/mark';
 import {TimeUnit} from '../../src/timeunit';
@@ -160,6 +160,46 @@ describe('Scale', function() {
           assert.equal(type('ordinal', {field: 'a', type: ORDINAL}, channel, POINT, true), ScaleType.POINT);
           assert.equal(localLogger.warns[0], log.message.scaleTypeNotWorkWithChannel(channel, 'ordinal', 'point'));
         });
+      });
+    });
+  });
+
+  describe('defaultProperty', () => {
+    describe('nice', () => {
+      // TODO:
+    });
+
+    describe('padding', () => {
+      // TODO:
+    });
+
+    describe('zero', () => {
+      it('should return true when mapping a quantitative field to size', () => {
+        assert(defaultProperty.zero({}, 'size', {field: 'a', type: 'quantitative'}));
+      });
+
+      it('should return false when mapping a ordinal field to size', () => {
+        assert(!defaultProperty.zero({}, 'size', {field: 'a', type: 'ordinal'}));
+      });
+
+      it('should return true when mapping a non-binned quantitative field to x/y', () => {
+        for (let channel of ['x', 'y'] as Channel[]) {
+          assert(defaultProperty.zero({}, channel, {field: 'a', type: 'quantitative'}));
+        }
+      });
+
+      it('should return false when mapping a binned quantitative field to x/y', () => {
+        for (let channel of ['x', 'y'] as Channel[]) {
+          assert(!defaultProperty.zero({}, channel, {bin: true, field: 'a', type: 'quantitative'}));
+        }
+      });
+
+      it('should return false when mapping a non-binned quantitative field with custom domain to x/y', () => {
+        for (let channel of ['x', 'y'] as Channel[]) {
+          assert(!defaultProperty.zero({domain: [1, 5]}, channel, {
+            bin: true, field: 'a', type: 'quantitative'
+          }));
+        }
       });
     });
   });
@@ -700,14 +740,6 @@ describe('Scale', function() {
     describe('color', function() {
       // TODO:
     });
-  });
-
-  describe('bandSize()', function() {
-    // TODO:
-  });
-
-  describe('nice()', function() {
-    // FIXME
   });
 
   describe('reverse()', function() {

--- a/test/compile/scale.test.ts
+++ b/test/compile/scale.test.ts
@@ -658,15 +658,105 @@ describe('Scale', function() {
 
     describe('size', function() {
       describe('bar', function() {
-        // TODO:
+        it('should return [minBarSize, maxBarSize] if both are specified', () => {
+          const model = parseUnitModel({
+            "data": {"url": "data/cars.json"},
+            "mark": "bar",
+            "encoding": {
+              // not truly ordinal, just say ordinal for the sake of testing
+              "size": {"field": "Origin", "type": "ordinal"}
+            },
+            config: {
+              scale: {
+                minBarSize: 2,
+                maxBarSize: 9
+              }
+            }
+          });
+          const scales = parseScaleComponent(model)['size'];
+          assert.deepEqual(scales.main.range, [2, 9]);
+        });
+
+        it('should return [thinBarSize, bandWidth-1] if min/maxBarSize are not specified', () => {
+          const model = parseUnitModel({
+            "data": {"url": "data/cars.json"},
+            "mark": "bar",
+            "encoding": {
+              "y": {"field": "Acceleration", "type": "quantitative"},
+              "x": {"field": "Cylinders", "type": "ordinal", "scale": {"bandSize": 11}},
+              // not truly ordinal, just say ordinal for the sake of testing
+              "size": {"field": "Origin", "type": "ordinal"}
+            }
+          });
+          const scales = parseScaleComponent(model)['size'];
+          assert.deepEqual(scales.main.range, [2, 10]);
+        });
+      });
+
+      describe('tick', function() {
+        it('should return [minTickSize, maxTickSize] if both are specified', () => {
+          const model = parseUnitModel({
+            "data": {"url": "data/cars.json"},
+            "mark": "tick",
+            "encoding": {
+              // not truly ordinal, just say ordinal for the sake of testing
+              "size": {"field": "Origin", "type": "ordinal"}
+            },
+            config: {
+              scale: {
+                minTickSize: 4,
+                maxTickSize: 9
+              }
+            }
+          });
+          const scales = parseScaleComponent(model)['size'];
+          assert.deepEqual(scales.main.range, [4, 9]);
+        });
+
+        it('should return [minTickSize, bandWidth-1] if min/maxBarSize are not specified', () => {
+          const model = parseUnitModel({
+            "data": {"url": "data/cars.json"},
+            "mark": "tick",
+            "encoding": {
+              "y": {"field": "Acceleration", "type": "quantitative"},
+              "x": {"field": "Cylinders", "type": "ordinal", "scale": {"bandSize": 11}},
+              // not truly ordinal, just say ordinal for the sake of testing
+              "size": {"field": "Origin", "type": "ordinal"}
+            }
+          });
+          const scales = parseScaleComponent(model)['size'];
+          assert.deepEqual(scales.main.range, [3, 20]);
+        });
       });
 
       describe('text', function() {
-        // TODO:
+        it('should return [minTextSize, maxTextSize]', () => {
+          const model = parseUnitModel({
+            "data": {"url": "data/cars.json"},
+            "mark": "text",
+            "encoding": {
+              // not truly ordinal, just say ordinal for the sake of testing
+              "size": {"field": "Origin", "type": "ordinal"}
+            }
+          });
+          const scales = parseScaleComponent(model)['size'];
+          assert.deepEqual(scales.main.range, [defaultScaleConfig.minTextSize, defaultScaleConfig.maxTextSize]);
+        });
       });
 
       describe('rule', function() {
-        // TODO:
+        it('should return [minRuleSize, maxRuleSize]', () => {
+          const model = parseUnitModel({
+            "data": {"url": "data/cars.json"},
+            "mark": "rule",
+            "encoding": {
+              // not truly ordinal, just say ordinal for the sake of testing
+              "size": {"field": "Origin", "type": "ordinal"}
+            }
+          });
+          const scales = parseScaleComponent(model)['size'];
+          assert.deepEqual(scales.main.range, [defaultScaleConfig.minRuleSize, defaultScaleConfig.maxRuleSize]);
+        });
       });
 
       describe('point, square, circle', function() {
@@ -693,6 +783,7 @@ describe('Scale', function() {
             "encoding": {
               "y": {"field": "Origin", "type": "ordinal", "scale": {"bandSize": 11}},
               "x": {"field": "Cylinders", "type": "ordinal", "scale": {"bandSize": 13}},
+              // not truly ordinal, just say ordinal for the sake of testing
               "size": {"field": "Origin", "type": "ordinal"}
             }
           });
@@ -739,6 +830,7 @@ describe('Scale', function() {
             "encoding": {
               "y": {"field": "Acceleration", "type": "quantitative"},
               "x": {"field": "Cylinders", "type": "ordinal", "scale": {"bandSize": 11}},
+              // not truly ordinal, just say ordinal for the sake of testing
               "size": {"field": "Origin", "type": "ordinal"}
             }
           });

--- a/test/compile/scale.test.ts
+++ b/test/compile/scale.test.ts
@@ -670,7 +670,7 @@ describe('Scale', function() {
       });
 
       describe('point, square, circle', function() {
-        it('should return [9, (minBandSize-2)^2] if both x and y are discrete', () => {
+        it('should return [0, (minBandSize-2)^2] if both x and y are discrete and size is quantitative (thus use zero=true, by default)', () => {
           // TODO: replace this test with something more local
           const model = parseUnitModel({
             "data": {"url": "data/cars.json"},
@@ -682,10 +682,41 @@ describe('Scale', function() {
             }
           });
           const scales = parseScaleComponent(model)['size'];
+          assert.deepEqual(scales.main.range, [0, 81]);
+        });
+
+        it('should return [9, (minBandSize-2)^2] if both x and y are discrete and size is not quantitative (thus use zero=false, by default)', () => {
+          // TODO: replace this test with something more local
+          const model = parseUnitModel({
+            "data": {"url": "data/cars.json"},
+            "mark": "point",
+            "encoding": {
+              "y": {"field": "Origin", "type": "ordinal", "scale": {"bandSize": 11}},
+              "x": {"field": "Cylinders", "type": "ordinal", "scale": {"bandSize": 13}},
+              "size": {"field": "Origin", "type": "ordinal"}
+            }
+          });
+          const scales = parseScaleComponent(model)['size'];
           assert.deepEqual(scales.main.range, [9, 81]);
         });
 
-        it('should return [9, (xBandSize-2)^2] if x is discrete and y is continuous', () => {
+        it('should return [9, (minBandSize-2)^2] if both x and y are discrete and size is quantitative but use zero=false', () => {
+          // TODO: replace this test with something more local
+          const model = parseUnitModel({
+            "data": {"url": "data/cars.json"},
+            "mark": "point",
+            "encoding": {
+              "y": {"field": "Origin", "type": "ordinal", "scale": {"bandSize": 11}},
+              "x": {"field": "Cylinders", "type": "ordinal", "scale": {"bandSize": 13}},
+              "size": {"field": "Acceleration", "type": "quantitative", "scale": {"zero": false}}
+            }
+          });
+          const scales = parseScaleComponent(model)['size'];
+          assert.deepEqual(scales.main.range, [9, 81]);
+          // TODO: this actually should throw warning too.
+        });
+
+        it('should return [0, (xBandSize-2)^2] if x is discrete and y is continuous and size is quantitative (thus use zero=true, by default)', () => {
           // TODO: replace this test with something more local
           const model = parseUnitModel({
             "data": {"url": "data/cars.json"},
@@ -697,10 +728,25 @@ describe('Scale', function() {
             }
           });
           const scales = parseScaleComponent(model)['size'];
+          assert.deepEqual(scales.main.range, [0, 81]);
+        });
+
+        it('should return [9, (xBandSize-2)^2] if x is discrete and y is continuous and size is quantitative (thus use zero=false, by default)', () => {
+          // TODO: replace this test with something more local
+          const model = parseUnitModel({
+            "data": {"url": "data/cars.json"},
+            "mark": "point",
+            "encoding": {
+              "y": {"field": "Acceleration", "type": "quantitative"},
+              "x": {"field": "Cylinders", "type": "ordinal", "scale": {"bandSize": 11}},
+              "size": {"field": "Origin", "type": "ordinal"}
+            }
+          });
+          const scales = parseScaleComponent(model)['size'];
           assert.deepEqual(scales.main.range, [9, 81]);
         });
 
-        it('should return [9, (yBandSize-2)^2] if y is discrete and x is continuous', () => {
+        it('should return [0, (yBandSize-2)^2] if y is discrete and x is continuous and size is quantitative (thus use zero=true, by default)', () => {
           // TODO: replace this test with something more local
           const model = parseUnitModel({
             "data": {"url": "data/cars.json"},
@@ -712,10 +758,10 @@ describe('Scale', function() {
             }
           });
           const scales = parseScaleComponent(model)['size'];
-          assert.deepEqual(scales.main.range, [9, 81]);
+          assert.deepEqual(scales.main.range, [0, 81]);
         });
 
-        it('should return [9, (scaleConfig.BandSize-2)^2] if y is discrete and x is continuous', () => {
+        it('should return [0, (scaleConfig.BandSize-2)^2] if y is discrete and x is continuous and size is quantitative (thus use zero=true, by default)', () => {
           // TODO: replace this test with something more local
           const model = parseUnitModel({
             "data": {"url": "data/cars.json"},
@@ -728,7 +774,7 @@ describe('Scale', function() {
             "config": {"scale": {"bandSize": 11}}
           });
           const scales = parseScaleComponent(model)['size'];
-          assert.deepEqual(scales.main.range, [9, 81]);
+          assert.deepEqual(scales.main.range, [0, 81]);
         });
       });
     });

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -1917,13 +1917,6 @@
                     "description": "Default band size for (1) `y` ordinal scale,\n\nand (2) `x` ordinal scale when the mark is not `text`.",
                     "minimum": 0
                 },
-                "barSizeRange": {
-                    "description": "Default range for bar size scale",
-                    "items": {
-                        "type": "number"
-                    },
-                    "type": "array"
-                },
                 "clamp": {
                     "description": "If true, values that exceed the data domain are clamped to either the minimum or maximum range value",
                     "type": "boolean"
@@ -1933,12 +1926,55 @@
                     "minimum": 0,
                     "type": "number"
                 },
-                "fontSizeRange": {
-                    "description": "Default range for font size scale",
-                    "items": {
-                        "type": "number"
-                    },
-                    "type": "array"
+                "maxBarSize": {
+                    "description": "Default max range for bar size scale.\n\nIf undefined (default), we will use bandSize - 1.",
+                    "minimum": 1,
+                    "type": "number"
+                },
+                "maxPointSize": {
+                    "description": "Default max range for point size scale.",
+                    "minimum": 1,
+                    "type": "number"
+                },
+                "maxRuleSize": {
+                    "description": "Default max range for rule size (strokeWidth) scale.",
+                    "minimum": 1,
+                    "type": "number"
+                },
+                "maxTextSize": {
+                    "description": "Default max range for text size (fontSize) scale.",
+                    "minimum": 1,
+                    "type": "number"
+                },
+                "maxTickSize": {
+                    "description": "Default max range for tick size (tick span) scale.\n\nIf undefined (default), we will use bandSize - 1.",
+                    "minimum": 1,
+                    "type": "number"
+                },
+                "minBarSize": {
+                    "description": "Default minimum range for bar size scale with zero=false.",
+                    "minimum": 1,
+                    "type": "number"
+                },
+                "minPointSize": {
+                    "description": "Default minimum range for point size scale with zero=false.",
+                    "minimum": 1,
+                    "type": "number"
+                },
+                "minRuleSize": {
+                    "description": "Default minimum range for rule size (strokeWidth) scale with zero=false.",
+                    "minimum": 1,
+                    "type": "number"
+                },
+                "minTextSize": {
+                    "description": "Default minimum range for text size (fontSize) scale with zero=false.",
+                    "minimum": 1,
+                    "type": "number"
+                },
+                "minTickSize": {
+                    "description": "Default minimum range for tick size (tick span) scale with zero=false.",
+                    "minimum": 1,
+                    "type": "number"
                 },
                 "nominalColorScheme": {
                     "description": "Default color scheme for nominal (categorical) data",
@@ -1957,23 +1993,9 @@
                     "minimum": 0,
                     "type": "number"
                 },
-                "pointSizeRange": {
-                    "description": "Default range for bar size scale",
-                    "items": {
-                        "type": "number"
-                    },
-                    "type": "array"
-                },
                 "round": {
                     "description": "If true, rounds numeric output values to integers.\n\nThis can be helpful for snapping to the pixel grid.\n\n(Only available for `x`, `y`, `size`, `row`, and `column` scales.)",
                     "type": "boolean"
-                },
-                "ruleSizeRange": {
-                    "description": "Default range for rule stroke widths",
-                    "items": {
-                        "type": "number"
-                    },
-                    "type": "array"
                 },
                 "sequentialColorScheme": {
                     "description": "Default color scheme for ordinal, quantitative and temporal field",
@@ -1990,13 +2012,6 @@
                     "description": "Default band width for `x` ordinal scale when is mark is `text`.",
                     "minimum": 0,
                     "type": "number"
-                },
-                "tickSizeRange": {
-                    "description": "Default range for tick spans",
-                    "items": {
-                        "type": "number"
-                    },
-                    "type": "array"
                 },
                 "useRawDomain": {
                     "description": "Uses the source data range as scale domain instead of aggregated data for aggregate axis.\n\nThis property only works with aggregate functions that produce values within the raw data domain (`\"mean\"`, `\"average\"`, `\"stdev\"`, `\"stdevp\"`, `\"median\"`, `\"q1\"`, `\"q3\"`, `\"min\"`, `\"max\"`). For other aggregations that produce values outside of the raw data domain (e.g. `\"count\"`, `\"sum\"`), this property is ignored.",


### PR DESCRIPTION
Address part of #1711 (Still haven't test stuff related to legend, but it's not in the scope of this PR)

- Scale's `zero` should be true by default for `size`
- Break size's range calculation into sizeRangeMin and sizeRangeMax
  - `sizeRangeMin` depends on scale.zero
  - `sizeRangeMax` depends on scale.bandSize (rangeStep)
- Replace scale configs `bar/font/rule/tick/pointSizeRange` with `minBar/Tick/Rule/Point/TextSize` (and `max...`) such as `minBarSize`

Questions:
- I think we should consolidate mark-specific mark config `config.mark.barXXX,tickXXX` with the `config.scale.{min/max}{Bar/Tick/Rule/Point/Text}Size` above?
   - For example, we could have `config.bar.size` (if size is not mapped) and `config.bar.sizeRangeMin/Max` (or shorter `config.bar.min/maxSize`). This will make configs way more concise.  Plus, this way `config.mark.*`and `config.scale.*` can serve as generic mark and scale config, while mark-specific config can be `config.<markname>.*`.  By separating this, we can also have bar use blue color by default while line use grey color by default as well.  
  - If so, I can do that in a follow-up PR

- `minTextSize` or `minFontSize` ?
   - fontSize would be consistent with how people call textSize
   - minTextSize would be consistent with min<Channel>Size format
   - If we agree with the proposal above, this could become just `config.text.size(Range)Min` 

(What do you think?)

- [x] Need to update schema once @domoritz  update merge the schema in vg3 branch