### PR TITLE
Only apply `config.scale.round` for x, y, row, column

### DIFF
--- a/site/docs/scale.md
+++ b/site/docs/scale.md
@@ -194,7 +194,7 @@ We can also create diverging color graph by specify `range` with multiple elemen
 
 | Property      | Type          | Description    |
 | :------------ |:-------------:| :------------- |
-| round         | Boolean       | If `true`, rounds numeric output values to integers. This can be helpful for snapping to the pixel grid (only available for `x`, `y`, `size`, `row`, and `column` scales). <span class="note-line">__Default value:__ derived from [scale config](config.html#scale-config) (`true` by default).</span> |
+| round         | Boolean       | If `true`, rounds numeric output values to integers. This can be helpful for snapping to the pixel grid. <span class="note-line">__Default value:__ True for `"x"`, `"y"`, `"row"`, `"column"` channels if scale config's `round` is `true`; false otherwise.</span> |
 
 {:#quant-props}
 

--- a/src/compile/scale.ts
+++ b/src/compile/scale.ts
@@ -155,6 +155,8 @@ export function initScale(topLevelSize: number | undefined, mark: Mark | undefin
           value = defaultProperty.nice(scale.type, channel, fieldDef);
         } else if (property === 'padding') {
           value = defaultProperty.padding(scale.type, channel, scaleConfig);
+        } else if (property === 'round') {
+          value = defaultProperty.round(channel, scaleConfig);
         } else if (property === 'zero') {
           value = defaultProperty.zero(scale, channel, fieldDef);
         } else {
@@ -393,6 +395,13 @@ export namespace defaultProperty {
       } else if (scaleType === ScaleType.BAND) {
         return scaleConfig.bandPadding;
       }
+    }
+    return undefined;
+  }
+
+  export function round(channel: Channel, scaleConfig: ScaleConfig) {
+    if (contains(['x', 'y', 'row', 'column'], channel)) {
+      return scaleConfig.round;
     }
     return undefined;
   }

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -148,8 +148,11 @@ export interface Scale {
    * The range of the scale, representing the set of visual values. For numeric values, the range can take the form of a two-element array with minimum and maximum values. For ordinal or quantized data, the range may by an array of desired output values, which are mapped to elements in the specified domain. For ordinal scales only, the range can be defined using a DataRef: the range values are then drawn dynamically from a backing data set.
    */
   range?: number[] | string[]; // TODO: declare vgRangeDomain
+
   /**
    * If true, rounds numeric output values to integers. This can be helpful for snapping to the pixel grid.
+   *
+   * __Default Rule:__ `true` for `"x"`, `"y"`, `"row"`, `"column"` channels if scale config's `round` is `true`; `false` otherwise.
    */
   round?: boolean;
 

--- a/test/compile/scale.test.ts
+++ b/test/compile/scale.test.ts
@@ -7,7 +7,7 @@ import {SOURCE, SUMMARY} from '../../src/data';
 import {parseUnitModel} from '../util';
 
 import * as log from '../../src/log';
-import {X, Y, SHAPE, DETAIL, ROW, COLUMN, Channel} from '../../src/channel';
+import {X, Y, SHAPE, DETAIL, ROW, COLUMN, Channel, NONSPATIAL_SCALE_CHANNELS} from '../../src/channel';
 import {RANGESTEP_FIT, ScaleType, defaultScaleConfig} from '../../src/scale';
 import {Mark, POINT, RECT, BAR, TEXT} from '../../src/mark';
 import * as mark from '../../src/mark';
@@ -173,6 +173,22 @@ describe('Scale', function() {
 
     describe('padding', () => {
       // TODO:
+    });
+
+    describe('round', () => {
+      it('should return scaleConfig.round for x, y, row, column.', () => {
+        for (let c of ['x', 'y', 'row', 'column'] as Channel[]) {
+          assert(defaultProperty.round(c, {round: true}));
+          assert(!defaultProperty.round(c, {round: false}));
+        }
+      });
+
+      it('should return undefined other channels (not x, y, row, column).', () => {
+        for (let c of NONSPATIAL_SCALE_CHANNELS) {
+          assert.isUndefined(defaultProperty.round(c, {round: true}));
+          assert.isUndefined(defaultProperty.round(c, {round: false}));
+        }
+      });
     });
 
     describe('zero', () => {

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -2498,7 +2498,7 @@
                     "minimum": 0
                 },
                 "round": {
-                    "description": "If true, rounds numeric output values to integers. This can be helpful for snapping to the pixel grid.",
+                    "description": "If true, rounds numeric output values to integers. This can be helpful for snapping to the pixel grid.\n\n__Default Rule:__ `true` for `\"x\"`, `\"y\"`, `\"row\"`, `\"column\"` channels if scale config's `round` is `true`; `false` otherwise.",
                     "type": "boolean"
                 },
                 "scheme": {


### PR DESCRIPTION
Fix #1750