### PR TITLE
Distinguish between `isContinuousToContinuous()` and `hasContinuousDomain()` + rename `isDiscreteScale()` => `hasDiscreteDomain()`

### DIFF
--- a/src/compile/config.ts
+++ b/src/compile/config.ts
@@ -6,7 +6,7 @@ import {Encoding, isAggregate, has} from '../encoding';
 import {isMeasure} from '../fielddef';
 import {MarkConfig, TextConfig, Orient} from '../mark';
 import {BAR, AREA, POINT, LINE, TICK, CIRCLE, SQUARE, RECT, RULE, TEXT, Mark} from '../mark';
-import {Scale, isDiscreteScale} from '../scale';
+import {Scale, hasDiscreteDomain} from '../scale';
 import {StackProperties} from '../stack';
 import {TEMPORAL} from '../type';
 import {contains, extend, Dict} from '../util';
@@ -84,9 +84,9 @@ export function orient(mark: Mark, encoding: Encoding, scale: Dict<Scale>, markC
       const yScaleType = scale['y'] ? scale['y'].type : null;
 
       // Tick is opposite to bar, line, area and never have ranged mark.
-      if (!isDiscreteScale(xScaleType) && (
+      if (!hasDiscreteDomain(xScaleType) && (
             !encoding.y ||
-            isDiscreteScale(yScaleType) ||
+            hasDiscreteDomain(yScaleType) ||
             encoding.y.bin
         )) {
         return 'vertical';

--- a/src/compile/layout.ts
+++ b/src/compile/layout.ts
@@ -1,7 +1,7 @@
 
 import {Channel, X, Y, ROW, COLUMN} from '../channel';
 import {LAYOUT} from '../data';
-import {ScaleType, isDiscreteScale} from '../scale';
+import {ScaleType, hasDiscreteDomain} from '../scale';
 import {Formula} from '../transform';
 import {extend, keys, StringSet} from '../util';
 import {VgData} from '../vega.schema';
@@ -82,7 +82,7 @@ export function unitSizeExpr(model: UnitModel, channel: Channel): string {
   const scale = model.scale(channel);
   if (scale) {
 
-    if (isDiscreteScale(scale.type) && scale.rangeStep) {
+    if (hasDiscreteDomain(scale.type) && scale.rangeStep) {
       // If the spec has top level size or specified rangeStep = fit, it will be undefined here.
 
       let layoutOffset = scale.type === ScaleType.BAND ? 2 * scale.padding : 1;
@@ -169,7 +169,7 @@ function parseLayerSizeLayout(model: LayerModel, channel: Channel): SizeComponen
 function getDistinct(model: Model, channel: Channel): StringSet {
   if (model.has(channel) && model.hasDiscreteScale(channel)) {
     const scale = model.scale(channel);
-    if (isDiscreteScale(scale.type) && !(scale.domain instanceof Array)) {
+    if (hasDiscreteDomain(scale.type) && !(scale.domain instanceof Array)) {
       // if explicit domain is declared, use array length
       const distinctField = model.field(channel);
       let distinct: StringSet = {};

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -2,7 +2,7 @@ import {X, Y, COLOR, TEXT, SHAPE, PATH, ORDER, OPACITY, DETAIL, STACK_GROUP_CHAN
 import {has, isAggregate} from '../../encoding';
 import {OrderChannelDef, FieldDef, field} from '../../fielddef';
 import {AREA, LINE, TEXT as TEXTMARK} from '../../mark';
-import {isDiscreteScale} from '../../scale';
+import {hasDiscreteDomain} from '../../scale';
 import {isSortField} from '../../sort';
 import {contains, extend, isArray} from '../../util';
 import {VgStackTransform} from '../../vega.schema';
@@ -229,7 +229,7 @@ function getStackByFields(model: UnitModel) {
         const fieldDef: FieldDef = channelEncoding;
         const scale = model.scale(channel);
         const _field = field(fieldDef, {
-          binSuffix: scale && isDiscreteScale(scale.type) ? 'range' : 'start'
+          binSuffix: scale && hasDiscreteDomain(scale.type) ? 'range' : 'start'
         });
         if (!!_field) {
           fields.push(_field);

--- a/src/compile/mark/rect.ts
+++ b/src/compile/mark/rect.ts
@@ -1,5 +1,5 @@
 import {X, X2, Y, Y2} from '../../channel';
-import {ScaleType, isDiscreteScale} from '../../scale';
+import {ScaleType, hasDiscreteDomain} from '../../scale';
 import {RECT} from '../../mark';
 import {extend} from '../../util';
 import * as log from '../../log';
@@ -34,7 +34,7 @@ export namespace rect {
     if (xFieldDef && xFieldDef.bin && !x2FieldDef) { // TODO: better check for bin
       p.x2 = ref.bin(xFieldDef, xScaleName, 'start');
       p.x = ref.bin(xFieldDef, xScaleName, 'end');
-    } else if (xScale && isDiscreteScale(xScale.type)) {
+    } else if (xScale && hasDiscreteDomain(xScale.type)) {
       /* istanbul ignore else */
       if (xScale.type === ScaleType.BAND) {
         p.x = ref.fieldRef(xFieldDef, xScaleName, {});
@@ -62,7 +62,7 @@ export namespace rect {
     if (yFieldDef && yFieldDef.bin && !y2FieldDef) { // TODO: better check for bin
       p.y2 = ref.bin(yFieldDef, yScaleName, 'start');
       p.y = ref.bin(yFieldDef, yScaleName, 'end');
-    } else if (yScale && isDiscreteScale(yScale.type)) {
+    } else if (yScale && hasDiscreteDomain(yScale.type)) {
       /* istanbul ignore else */
       if (yScale.type === ScaleType.BAND) {
         p.y = ref.fieldRef(yFieldDef, yScaleName, {});

--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -5,7 +5,7 @@
 import {Channel, X, X2, Y, Y2} from '../../channel';
 import {Config} from '../../config';
 import {FieldDef, FieldRefOption, field} from '../../fielddef';
-import {Scale, ScaleType, isDiscreteScale} from '../../scale';
+import {Scale, ScaleType, hasDiscreteDomain} from '../../scale';
 import {StackProperties} from '../../stack';
 import {contains} from '../../util';
 import {VgValueRef} from '../../vega.schema';
@@ -82,7 +82,7 @@ export function midPoint(channel: Channel, fieldDef: FieldDef, scaleName: string
   if (fieldDef) {
     /* istanbul ignore else */
     if (fieldDef.field) {
-      if (isDiscreteScale(scale.type)) {
+      if (hasDiscreteDomain(scale.type)) {
         if (scale.type === 'band') {
           // For band, to get mid point, need to offset by half of the band
           return fieldRef(fieldDef, scaleName, {binSuffix: 'range'}, band(scaleName, 0.5));

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -7,7 +7,7 @@ import {Data, DataTable} from '../data';
 import {reduce, forEach} from '../encoding';
 import {FieldDef, FieldRefOption, field} from '../fielddef';
 import {Legend} from '../legend';
-import {Scale, isDiscreteScale} from '../scale';
+import {Scale, hasDiscreteDomain} from '../scale';
 import {SortField, SortOrder} from '../sort';
 import {BaseSpec} from '../spec';
 import {Transform} from '../transform';
@@ -313,7 +313,7 @@ export abstract class Model {
 
     if (fieldDef.bin) { // bin has default suffix that depends on scaleType
       opt = extend({
-        binSuffix: isDiscreteScale(this.scale(channel).type) ? 'range' : 'start'
+        binSuffix: hasDiscreteDomain(this.scale(channel).type) ? 'range' : 'start'
       }, opt);
     }
 
@@ -328,7 +328,7 @@ export abstract class Model {
 
   public hasDiscreteScale(channel: Channel) {
     const scale = this.scale(channel);
-    return scale && isDiscreteScale(scale.type);
+    return scale && hasDiscreteDomain(scale.type);
   }
 
   public renameScale(oldName: string, newName: string) {

--- a/src/compile/scale.ts
+++ b/src/compile/scale.ts
@@ -7,7 +7,7 @@ import {SOURCE, STACKED_SCALE} from '../data';
 import {DateTime, isDateTime, timestamp} from '../datetime';
 import {ChannelDefWithScale, FieldDef, field} from '../fielddef';
 import {Mark, BAR, TEXT as TEXTMARK, RECT, MarkConfig, PointConfig} from '../mark';
-import {Scale, ScaleConfig, ScaleType, NiceTime, RANGESTEP_FIT, RangeStep, isDiscreteScale, scaleTypeSupportProperty} from '../scale';
+import {Scale, ScaleConfig, ScaleType, NiceTime, RANGESTEP_FIT, RangeStep, hasDiscreteDomain, scaleTypeSupportProperty} from '../scale';
 import {isSortField, SortOrder} from '../sort';
 import {StackOffset} from '../stack';
 import {TimeUnit} from '../timeunit';
@@ -497,7 +497,7 @@ export function domain(scale: Scale, model: Model, channel:Channel): any {
       })
     };
   } else if (fieldDef.bin) { // bin
-    if (isDiscreteScale(scale.type)) {
+    if (hasDiscreteDomain(scale.type)) {
       // ordinal bin scale takes domain from bin_range, ordered by bin_start
       return {
         data: model.dataTable(),
@@ -540,7 +540,7 @@ export function domain(scale: Scale, model: Model, channel:Channel): any {
 }
 
 export function domainSort(model: Model, channel: Channel, scaleType: ScaleType): any {
-  if (!isDiscreteScale(scaleType)) {
+  if (!hasDiscreteDomain(scaleType)) {
     return undefined;
   }
 

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -10,7 +10,7 @@ import * as vlEncoding from '../encoding'; // TODO: remove
 import {FieldDef, FieldRefOption, field} from '../fielddef';
 import {Legend} from '../legend';
 import {Mark, TEXT as TEXTMARK} from '../mark';
-import {Scale, ScaleConfig, isDiscreteScale} from '../scale';
+import {Scale, ScaleConfig, hasDiscreteDomain} from '../scale';
 import {ExtendedUnitSpec} from '../spec';
 import {getFullName, QUANTITATIVE} from '../type';
 import {duplicate, extend, isArray, mergeDeep, Dict} from '../util';
@@ -179,7 +179,7 @@ export class UnitModel extends Model {
     if (width !== undefined) {
       this._width = width;
     } else if (scale[X]) {
-      if (!isDiscreteScale(scale[X].type) || !scale[X].rangeStep) {
+      if (!hasDiscreteDomain(scale[X].type) || !scale[X].rangeStep) {
         this._width = cellConfig.width;
       } // else: Do nothing, use dynamic width.
     } else { // No scale X
@@ -197,7 +197,7 @@ export class UnitModel extends Model {
     if (height !== undefined) {
       this._height = height;
     } else if (scale[Y]) {
-      if (!isDiscreteScale(scale[Y].type) || !scale[Y].rangeStep) {
+      if (!hasDiscreteDomain(scale[Y].type) || !scale[Y].rangeStep) {
         this._height = cellConfig.height;
       } // else: Do nothing, use dynamic height .
     } else {
@@ -362,7 +362,7 @@ export class UnitModel extends Model {
 
     if (fieldDef.bin) { // bin has default suffix that depends on scaleType
       opt = extend({
-        binSuffix: isDiscreteScale(this.scale(channel).type) ? 'range' : 'start'
+        binSuffix: hasDiscreteDomain(this.scale(channel).type) ? 'range' : 'start'
       }, opt);
     }
 

--- a/test/scale.test.ts
+++ b/test/scale.test.ts
@@ -1,4 +1,4 @@
-import {scaleTypeSupportProperty, SCALE_TYPES, SCALE_PROPERTIES} from '../src/scale';
+import * as scale from '../src/scale';
 import {assert} from 'chai';
 import {some} from '../src/util';
 
@@ -6,13 +6,21 @@ describe('scale', () => {
   describe('scaleTypeSupportProperty', () => {
     // Make sure we always edit this when we add new channel
     it('should have at least one supported scale types for all scale properties', () => {
-      for (let prop of SCALE_PROPERTIES) {
-        assert(some(SCALE_TYPES, (scaleType) => {
-          return scaleTypeSupportProperty(scaleType, prop);
+      for (let prop of scale.SCALE_PROPERTIES) {
+        assert(some(scale.SCALE_TYPES, (scaleType) => {
+          return scale.scaleTypeSupportProperty(scaleType, prop);
         }));
       }
     });
 
     // TODO: write more test blindly (Don't look at our code, just look at D3 code.)
+  });
+
+  describe('scaleTypes', () => {
+    it('should either hasContinuousDomain or hasDiscreteDomain', () => {
+      for (let scaleType of scale.SCALE_TYPES) {
+        assert(scale.hasContinuousDomain(scaleType) !== scale.hasDiscreteDomain(scaleType));
+      }
+    });
   });
 });


### PR DESCRIPTION
Fix #1753. 

The current way we change `isContinuous()` in #1746 will cause bug due to terminology mismatch as described in #1753.  This will make things correct and you can use `hasContinuousDomain()` in #1746 instead of `isContinuous()`. 

- Add test that a scale should either hasContinuousDomain or hasDiscreteDomain.

Please merge this and I'm happy to resolve conflicts in #1746 for you. 