### PR TITLE
Facet clean up and a few more fixes 

### DIFF
--- a/examples/specs/bar_filter_calc.vl.json
+++ b/examples/specs/bar_filter_calc.vl.json
@@ -14,7 +14,7 @@
     ]
   },
   "transform": {
-    "calculate": [{"field": "b2","expr": "2*datum.b"}],
+    "calculate": [{"as": "b2","expr": "2*datum.b"}],
     "filter": "datum.b2 > 60"
   },
   "mark": "bar",

--- a/examples/specs/bar_grouped.vl.json
+++ b/examples/specs/bar_grouped.vl.json
@@ -2,7 +2,7 @@
   "data": { "url": "data/population.json"},
   "transform": {
     "filter": "datum.year == 2000",
-    "calculate": [{"field": "gender", "expr": "datum.sex == 2 ? \"Female\" : \"Male\""}]
+    "calculate": [{"as": "gender", "expr": "datum.sex == 2 ? \"Female\" : \"Male\""}]
   },
   "mark": "bar",
   "encoding": {

--- a/examples/specs/bar_grouped_horizontal.vl.json
+++ b/examples/specs/bar_grouped_horizontal.vl.json
@@ -2,7 +2,7 @@
   "data": { "url": "data/population.json"},
   "transform": {
     "filter": "datum.year == 2000",
-    "calculate": [{"field": "gender", "expr": "datum.sex == 2 ? \"Female\" : \"Male\""}]
+    "calculate": [{"as": "gender", "expr": "datum.sex == 2 ? \"Female\" : \"Male\""}]
   },
   "mark": "bar",
   "encoding": {

--- a/examples/specs/bar_layered_transparent.vl.json
+++ b/examples/specs/bar_layered_transparent.vl.json
@@ -3,7 +3,7 @@
   "data": { "url": "data/population.json"},
   "transform": {
     "filter": "datum.year == 2000",
-    "calculate": [{"field": "gender", "expr": "datum.sex == 2 ? \"Female\" : \"Male\""}]
+    "calculate": [{"as": "gender", "expr": "datum.sex == 2 ? \"Female\" : \"Male\""}]
   },
   "mark": "bar",
   "encoding": {

--- a/examples/specs/stacked_bar_normalize.vl.json
+++ b/examples/specs/stacked_bar_normalize.vl.json
@@ -2,7 +2,7 @@
   "data": { "url": "data/population.json"},
   "transform": {
     "filter": "datum.year == 2000",
-    "calculate": [{"field": "gender", "expr": "datum.sex == 2 ? \"Female\" : \"Male\""}]
+    "calculate": [{"as": "gender", "expr": "datum.sex == 2 ? \"Female\" : \"Male\""}]
   },
   "mark": "bar",
   "encoding": {

--- a/examples/specs/stacked_bar_population.vl.json
+++ b/examples/specs/stacked_bar_population.vl.json
@@ -3,7 +3,7 @@
   "data": { "url": "data/population.json"},
   "transform": {
     "filter": "datum.year == 2000",
-    "calculate": [{"field": "gender", "expr": "datum.sex == 2 ? \"Female\" : \"Male\""}]
+    "calculate": [{"as": "gender", "expr": "datum.sex == 2 ? \"Female\" : \"Male\""}]
   },
   "mark": "bar",
   "encoding": {

--- a/examples/specs/stacked_bar_sum_opacity.vl.json
+++ b/examples/specs/stacked_bar_sum_opacity.vl.json
@@ -5,7 +5,7 @@
     "filter": "datum.year == 2000",
     "calculate": [
       {
-        "field": "gender",
+        "as": "gender",
         "expr": "datum.sex == 2 ? \"Female\" : \"Male\""
       }
     ]

--- a/examples/specs/text_scatter_colored.vl.json
+++ b/examples/specs/text_scatter_colored.vl.json
@@ -2,7 +2,7 @@
   "data": {"url": "data/cars.json"},
   "transform": {
     "calculate": [{
-      "field": "OriginInitial",
+      "as": "OriginInitial",
       "expr": "datum.Origin[0]"
     }]
   },

--- a/examples/specs/trellis_bar.vl.json
+++ b/examples/specs/trellis_bar.vl.json
@@ -3,7 +3,7 @@
   "data": { "url": "data/population.json"},
   "transform": {
     "filter": "datum.year == 2000",
-    "calculate": [{"field": "gender", "expr": "datum.sex == 2 ? \"Female\" : \"Male\""}]
+    "calculate": [{"as": "gender", "expr": "datum.sex == 2 ? \"Female\" : \"Male\""}]
   },
   "mark": "bar",
   "encoding": {

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -33,6 +33,11 @@ export interface AxisConfig {
    */
   axisColor?: string;
 
+  /**
+   * Whether to include the axis domain line.
+   */
+  domain?: boolean;
+
   // ---------- Grid ----------
   /**
    * A flag indicate if gridlines should be created in addition to ticks. If `grid` is unspecified, the default value is `true` for ROW and COL. For X and Y, the default value is `true` for quantitative and time fields and `false` otherwise.
@@ -98,6 +103,12 @@ export interface AxisConfig {
    * @minimum 0
    */
   subdivide?: number;
+
+  /**
+   * Whether the axis should include ticks.
+   */
+  tick?: boolean;
+
   /**
    * A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are "nice" (multiples of 2, 5, 10) and lie within the underlying scale's range.
    * @minimum 0
@@ -208,15 +219,16 @@ export const defaultAxisConfig: AxisConfig = {
   grid: undefined, // automatically determined
   label: true,
   labelMaxLength: 25,
-  tickSize: undefined, // implicitly 6
+  tickSize: undefined, // implicitly 6 (by Vega) // FIXME check if this is still true
   characterWidth: 6
 };
 
 export const defaultFacetAxisConfig: AxisConfig = {
   axisWidth: 0,
+  domain: false,
   label: true,
   grid: false,
-  tickSize: 0
+  tick: false
 };
 
 export interface Axis extends AxisConfig {

--- a/src/compile/axis.ts
+++ b/src/compile/axis.ts
@@ -31,6 +31,7 @@ export function parseInnerAxis(channel: Channel, model: Model): VgAxis {
     orient: channel === 'x' ? 'bottom' : 'left',
     scale: model.scaleName(channel),
     grid: true,
+    domain: false,
     tick: false,
     label: false
   };
@@ -78,7 +79,7 @@ export function parseAxis(channel: Channel, model: Model): VgAxis {
     // a) properties with special rules (so it has axis[property] methods) -- call rule functions
     'format', 'grid', 'offset', 'orient', 'tickSize', 'tickCount', 'tickSizeEnd', 'title', 'titleOffset', 'values', 'zindex',
     // b) properties without rules, only produce default values in the schema, or explicit value if specified
-    'tickPadding', 'tickSize', 'tickSizeMajor', 'tickSizeMinor','subdivide'
+    'domain', 'tick', 'tickPadding', 'tickSize', 'tickSizeMajor', 'tickSizeMinor','subdivide'
   ].forEach(function(property) {
     let method: (model: Model, channel: Channel, def:any)=>any;
 

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -164,10 +164,12 @@ export interface Scale {
    * The domain of the scale, representing the set of data values. For quantitative data, this can take the form of a two-element array with minimum and maximum values. For ordinal/categorical data, this may be an array of valid input values.
    */
   domain?: number[] | string[] | DateTime[];
+
   /**
-   * The range of the scale, representing the set of visual values. For numeric values, the range can take the form of a two-element array with minimum and maximum values. For ordinal or quantized data, the range may by an array of desired output values, which are mapped to elements in the specified domain. For ordinal scales only, the range can be defined using a DataRef: the range values are then drawn dynamically from a backing data set.
+   * The range of the scale, representing the set of visual values. For numeric values, the range can take the form of a two-element array with minimum and maximum values. For ordinal or quantized data, the range may by an array of desired output values, which are mapped to elements in the specified domain.
    */
   range?: number[] | string[]; // TODO: declare vgRangeDomain
+
 
   /**
    * If true, rounds numeric output values to integers. This can be helpful for snapping to the pixel grid.
@@ -190,7 +192,7 @@ export interface Scale {
   rangeStep?: number | null;
 
   /**
-   * Color scheme that determines output color of a color scale.
+   * Color scheme that determines output color of an index/ordinal/sequential color scale.
    */
   scheme?: string;
 

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -161,4 +161,105 @@ describe('compile/facet', () => {
       );
     });
   });
+
+  describe('getSharedAxisGroup', () => {
+    describe('column-only', () => {
+      const model = parseFacetModel({
+        facet: {
+          column: {field: 'a', type: 'ordinal'}
+        },
+        spec: {
+          mark: 'point',
+          encoding: {
+            x: {field: 'b', type: 'quantitative'},
+            y: {field: 'c', type: 'quantitative'}
+          }
+        }
+      });
+
+      // HACK: mock that we have parsed its data and there is not summary
+      // This way, we won't have surge in test coverage for the parse methods.
+      model['hasSummary'] = () => false;
+
+      describe('xAxisGroup', () => {
+        const xSharedAxisGroup = facet.getSharedAxisGroup(model, 'x');
+        it('should have correct type, name, and data source', () => {
+          assert.equal(xSharedAxisGroup.name, 'x-axes');
+          assert.equal(xSharedAxisGroup.type, 'group');
+          assert.deepEqual(xSharedAxisGroup.from, {data: 'column-source'});
+        });
+
+        it('should have width = child width, height = group height, x = column field', () => {
+          assert.deepEqual(xSharedAxisGroup.encode.update.width, {field: {parent: 'child_width'}});
+          assert.deepEqual(xSharedAxisGroup.encode.update.height, {field: {group: 'height'}});
+          assert.deepEqual(xSharedAxisGroup.encode.update.x, {scale: 'column', field: 'a', offset: 8});
+        });
+      });
+
+      describe('yAxisGroup', () => {
+        const ySharedAxisGroup = facet.getSharedAxisGroup(model, 'y');
+        it('should have correct type, name, and data source', () => {
+          assert.equal(ySharedAxisGroup.name, 'y-axes');
+          assert.equal(ySharedAxisGroup.type, 'group');
+          assert.equal(ySharedAxisGroup.from, undefined);
+        });
+
+        it('should have height = child height, width = group width, y = defaultFacetSpacing / 2.', () => {
+          assert.deepEqual(ySharedAxisGroup.encode.update.height, {field: {parent: 'child_height'}});
+          assert.deepEqual(ySharedAxisGroup.encode.update.width, {field: {group: 'width'}});
+          assert.deepEqual(ySharedAxisGroup.encode.update.y, {value: 8});
+        });
+      });
+    });
+
+    describe('row-only', () => {
+      const model = parseFacetModel({
+        facet: {
+          row: {field: 'a', type: 'ordinal'}
+        },
+        spec: {
+          mark: 'point',
+          encoding: {
+            x: {field: 'b', type: 'quantitative'},
+            y: {field: 'c', type: 'quantitative'}
+          }
+        }
+      });
+
+      // HACK: mock that we have parsed its data and there is not summary
+      // This way, we won't have surge in test coverage for the parse methods.
+      model['hasSummary'] = () => false;
+
+      describe('yAxisGroup', () => {
+        const ySharedAxisGroup = facet.getSharedAxisGroup(model, 'y');
+        it('should have correct type, name, and data source', () => {
+          assert.equal(ySharedAxisGroup.name, 'y-axes');
+          assert.equal(ySharedAxisGroup.type, 'group');
+          assert.deepEqual(ySharedAxisGroup.from, {data: 'row-source'});
+        });
+
+        it('should have height = child height, width = group width, y= row field', () => {
+          assert.deepEqual(ySharedAxisGroup.encode.update.height, {field: {parent: 'child_height'}});
+          assert.deepEqual(ySharedAxisGroup.encode.update.width, {field: {group: 'width'}});
+          assert.deepEqual(ySharedAxisGroup.encode.update.y, {scale: 'row', field: 'a', offset: 8});
+        });
+      });
+
+      describe('xAxisGroup', () => {
+        const xSharedAxisGroup = facet.getSharedAxisGroup(model, 'x');
+        it('should have correct type, name, and data source', () => {
+          assert.equal(xSharedAxisGroup.name, 'x-axes');
+          assert.equal(xSharedAxisGroup.type, 'group');
+          assert.equal(xSharedAxisGroup.from, undefined);
+        });
+
+        it('should have width = child width, height = group height, x, x = defaultFacetSpacing / 2.', () => {
+          assert.deepEqual(xSharedAxisGroup.encode.update.width, {field: {parent: 'child_width'}});
+          assert.deepEqual(xSharedAxisGroup.encode.update.height, {field: {group: 'height'}});
+          assert.deepEqual(xSharedAxisGroup.encode.update.x, {value: 8});
+        });
+      });
+    });
+  });
 });
+

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -158,6 +158,10 @@
                     "minimum": 0,
                     "type": "number"
                 },
+                "domain": {
+                    "description": "Whether to include the axis domain line.",
+                    "type": "boolean"
+                },
                 "format": {
                     "description": "The formatting pattern for axis labels.",
                     "type": "string"
@@ -231,6 +235,10 @@
                     "description": "If provided, sets the number of minor ticks between major ticks (the value 9 results in decimal subdivision). Only applicable for axes visualizing quantitative scales.",
                     "minimum": 0,
                     "type": "number"
+                },
+                "tick": {
+                    "description": "Whether the axis should include ticks.",
+                    "type": "boolean"
                 },
                 "tickColor": {
                     "description": "The color of the axis's tick.",
@@ -355,6 +363,10 @@
                     "minimum": 0,
                     "type": "number"
                 },
+                "domain": {
+                    "description": "Whether to include the axis domain line.",
+                    "type": "boolean"
+                },
                 "grid": {
                     "description": "A flag indicate if gridlines should be created in addition to ticks. If `grid` is unspecified, the default value is `true` for ROW and COL. For X and Y, the default value is `true` for quantitative and time fields and `false` otherwise.",
                     "type": "boolean"
@@ -419,6 +431,10 @@
                     "description": "If provided, sets the number of minor ticks between major ticks (the value 9 results in decimal subdivision). Only applicable for axes visualizing quantitative scales.",
                     "minimum": 0,
                     "type": "number"
+                },
+                "tick": {
+                    "description": "Whether the axis should include ticks.",
+                    "type": "boolean"
                 },
                 "tickColor": {
                     "description": "The color of the axis's tick.",

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -2519,7 +2519,7 @@
                             "type": "array"
                         }
                     ],
-                    "description": "The range of the scale, representing the set of visual values. For numeric values, the range can take the form of a two-element array with minimum and maximum values. For ordinal or quantized data, the range may by an array of desired output values, which are mapped to elements in the specified domain. For ordinal scales only, the range can be defined using a DataRef: the range values are then drawn dynamically from a backing data set."
+                    "description": "The range of the scale, representing the set of visual values. For numeric values, the range can take the form of a two-element array with minimum and maximum values. For ordinal or quantized data, the range may by an array of desired output values, which are mapped to elements in the specified domain."
                 },
                 "rangeStep": {
                     "anyOf": [
@@ -2538,7 +2538,7 @@
                     "type": "boolean"
                 },
                 "scheme": {
-                    "description": "Color scheme that determines output color of a color scale.",
+                    "description": "Color scheme that determines output color of an index/ordinal/sequential color scale.",
                     "type": "string"
                 },
                 "spacing": {


### PR DESCRIPTION
Now we can get reasonable facet.

Note that we will to handle the following issues later:
- `paddingOuter` for point doesn't make (may need to just output `padding` if we don't wanna change vega https://github.com/vega/vega/issues/679
- The grid line is too long.
- Need to deal with axis grid layer
- If there is null value, the layout is still incorrect for both facet and non-facet plot. (This should be fixed in Vega https://github.com/vega/vega/issues/678)

![vega_editor](https://cloud.githubusercontent.com/assets/111269/21109979/4543579a-c050-11e6-8215-b3cea442a823.png)

cc: @domoritz 