### PR TITLE
Add warning if type is missing and augment default type

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -148,6 +148,7 @@ export function getSupportedRole(channel: Channel): SupportedRole {
     case COLOR:
     case OPACITY:
     case LABEL:
+    case ORDER:
     case DETAIL:
       return {
         measure: true,
@@ -169,7 +170,7 @@ export function getSupportedRole(channel: Channel): SupportedRole {
         dimension: false
       };
   }
-  throw new Error('Invalid encoding channel' + channel);
+  throw new Error('Invalid encoding channel ' + channel);
 }
 
 export function hasScale(channel: Channel) {

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -5,10 +5,9 @@ import {COLUMN, ROW, X, Y, Channel} from '../channel';
 import {defaultConfig, Config} from '../config';
 import {Facet} from '../facet';
 import {forEach} from '../encoding';
-import {FieldDef, isDimension} from '../fielddef';
+import {FieldDef, isDimension, normalize} from '../fielddef';
 import {Scale} from '../scale';
 import {FacetSpec} from '../spec';
-import {getFullName} from '../type';
 import {contains, extend, keys, vals, flatten, duplicate, mergeDeep, Dict} from '../util';
 import {VgData, VgMarkGroup} from '../vega.schema';
 import {StackProperties} from '../stack';
@@ -81,12 +80,10 @@ export class FacetModel extends Model {
         return;
       }
 
-      // TODO: if has no field / datum, then drop the field
-      if (fieldDef.type) {
-        // convert short type to full type
-        fieldDef.type = getFullName(fieldDef.type);
-      }
+      // Convert type to full, lowercase type, or augment the fieldDef with a default type if missing.
+      normalize(fieldDef, channel);
 
+      // TODO: move this warning into normalize
       if (!isDimension(fieldDef)) {
         log.warn(log.message.facetChannelShouldBeDiscrete(channel));
       }

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -1,18 +1,16 @@
 import * as log from '../log';
 
-import {AggregateOp} from '../aggregate';
 import {Axis} from '../axis';
-import {X, Y, X2, Y2, TEXT, ORDER, Channel, UNIT_CHANNELS,  UNIT_SCALE_CHANNELS, NONSPATIAL_SCALE_CHANNELS, supportMark} from '../channel';
+import {X, Y, X2, Y2, TEXT, Channel, UNIT_CHANNELS,  UNIT_SCALE_CHANNELS, NONSPATIAL_SCALE_CHANNELS, supportMark} from '../channel';
 import {defaultConfig, Config, CellConfig} from '../config';
 import {SOURCE, SUMMARY} from '../data';
 import {Encoding} from '../encoding';
 import * as vlEncoding from '../encoding'; // TODO: remove
-import {FieldDef, FieldRefOption, field} from '../fielddef';
+import {FieldDef, FieldRefOption, field, normalize} from '../fielddef';
 import {Legend} from '../legend';
 import {Mark, TEXT as TEXTMARK} from '../mark';
 import {Scale, ScaleConfig, hasDiscreteDomain} from '../scale';
 import {ExtendedUnitSpec} from '../spec';
-import {getFullName, QUANTITATIVE} from '../type';
 import {duplicate, extend, isArray, mergeDeep, Dict} from '../util';
 import {VgData} from '../vega.schema';
 
@@ -27,18 +25,6 @@ import {parseMark} from './mark/mark';
 import initScale from './scale/init';
 import parseScaleComponent from './scale/parse';
 import {stack, StackProperties} from '../stack';
-
-function normalizeFieldDef(fieldDef: FieldDef, channel: Channel) {
-  if (fieldDef.type) {
-    // convert short type to full type
-    fieldDef.type = getFullName(fieldDef.type);
-  }
-
-  if ((channel === ORDER) && !fieldDef.aggregate && fieldDef.type === QUANTITATIVE) {
-    fieldDef.aggregate = AggregateOp.MIN;
-  }
-  return fieldDef;
-}
 
 /**
  * Internal model of Vega-Lite specification for the compiler.
@@ -121,7 +107,7 @@ export class UnitModel extends Model {
           if (fieldDef.field === undefined && fieldDef.value === undefined) { // TODO: datum
             log.warn(log.message.emptyFieldDef(fieldDef, channel));
           } else {
-            fieldDefs.push(normalizeFieldDef(fieldDef, channel));
+            fieldDefs.push(normalize(fieldDef, channel));
           }
           return fieldDefs;
         }, []);
@@ -132,7 +118,7 @@ export class UnitModel extends Model {
           delete encoding[channel];
           return;
         }
-        normalizeFieldDef(fieldDef, channel);
+        normalize(fieldDef, channel);
       }
     });
     return encoding;

--- a/src/log.ts
+++ b/src/log.ts
@@ -107,6 +107,10 @@ export namespace message {
     return `Invalid field type "${type}"`;
   }
 
+  export function emptyOrInvalidFieldType(type: Type | string, channel: Channel, newType: Type) {
+    return `Invalid field type (${type}) for channel ${channel}, using ${newType} instead.`;
+  }
+
   export function emptyFieldDef(fieldDef: FieldDef, channel: Channel) {
     return `Dropping ${JSON.stringify(fieldDef)} from channel ${channel} since it does not contain data field or value.`;
   }

--- a/src/type.ts
+++ b/src/type.ts
@@ -14,33 +14,28 @@ export const TEMPORAL = Type.TEMPORAL;
 export const NOMINAL = Type.NOMINAL;
 
 /**
- * Mapping from full type names to short type names.
- * @type {Object}
- */
-export const SHORT_TYPE = {
-  quantitative: 'Q',
-  temporal: 'T',
-  nominal: 'N',
-  ordinal: 'O'
-};
-/**
- * Mapping from short type names to full type names.
- * @type {Object}
- */
-export const TYPE_FROM_SHORT_TYPE = {
-  Q: QUANTITATIVE,
-  T: TEMPORAL,
-  O: ORDINAL,
-  N: NOMINAL
-};
-
-/**
  * Get full, lowercase type name for a given type.
  * @param  type
  * @return Full type name.
  */
-export function getFullName(type: Type): Type {
-  const typeString = <any>type;  // force type as string so we can translate short types
-  return TYPE_FROM_SHORT_TYPE[typeString.toUpperCase()] || // short type is uppercase by default
-         typeString.toLowerCase();
+export function getFullName(type: Type|string): Type {
+  if (type) {
+    type = type.toLowerCase();
+    switch (type) {
+      case 'q':
+      case QUANTITATIVE:
+        return 'quantitative';
+      case 't':
+      case TEMPORAL:
+        return 'temporal';
+      case 'o':
+      case ORDINAL:
+        return 'ordinal';
+      case 'n':
+      case NOMINAL:
+        return 'nominal';
+    }
+  }
+  // If we get invalid input, return undefined type.
+  return undefined;
 }

--- a/test/fielddef.test.ts
+++ b/test/fielddef.test.ts
@@ -1,11 +1,48 @@
 import {assert} from 'chai';
 
 import {AggregateOp} from '../src/aggregate';
-import {title} from '../src/fielddef';
+import {Channel} from '../src/channel';
+import {defaultType, normalize, title} from '../src/fielddef';
+import * as log from '../src/log';
 import {TimeUnit} from '../src/timeunit';
 import {QUANTITATIVE, TEMPORAL} from '../src/type';
 
 describe('fieldDef', () => {
+  describe('defaultType()', () => {
+    it('should return temporal if there is timeUnit', () => {
+      assert.equal(defaultType({timeUnit: 'month', field: 'a'}, 'x'), 'temporal');
+    });
+
+    it('should return quantitative if there is bin', () => {
+      assert.equal(defaultType({bin: 'true', field: 'a'}, 'x'), 'quantitative');
+    });
+
+    it('should return quantitative for a channel that supports measure', () => {
+      for (let c of ['x', 'y', 'color', 'size', 'opacity', 'order'] as Channel[]) {
+        assert.equal(defaultType({field: 'a'}, c), 'quantitative');
+      }
+    });
+
+    it('should return nominal for a channel that does not support measure', () => {
+      for (let c of ['shape', 'row', 'column'] as Channel[]) {
+        assert.equal(defaultType({field: 'a'}, c), 'nominal');
+      }
+    });
+  });
+
+  describe('normalize()', () => {
+    it('should return fieldDef with full type name.', () => {
+      const fieldDef = {field: 'a', type: 'q' as any};
+      assert.deepEqual(normalize(fieldDef, 'x'), {field: 'a', type: 'quantitative'});
+    });
+
+    it('should return fieldDef with default type and throw warning if type is missing.', log.wrap((localLogger) => {
+      const fieldDef = {field: 'a'};
+      assert.deepEqual(normalize(fieldDef, 'x'), {field: 'a', type: 'quantitative'});
+      assert.equal(localLogger.warns[0], log.message.emptyOrInvalidFieldType(undefined, 'x', 'quantitative'));
+    }));
+  });
+
   describe('title()', () => {
     it('should return title if the fieldDef has title', () => {
       const fieldDef = {field: '2', type: QUANTITATIVE, title: 'baz'};

--- a/test/type.test.ts
+++ b/test/type.test.ts
@@ -1,17 +1,26 @@
 import {assert} from 'chai';
 
-import {getFullName, QUANTITATIVE} from '../src/type';
+import * as type from '../src/type';
 
-describe('vl.type.getFullName()', function () {
-  it('translates short type', function() {
-    assert.equal(getFullName(<any>'Q'), QUANTITATIVE);
-  });
+describe('type', function () {
+  describe('getFullName()', () => {
+    it('should return correct lowercase, full type names.', () => {
+      for (let t of ['q', 'Q', 'quantitative', 'QUANTITATIVE']) {
+        assert.equal(type.getFullName(t), 'quantitative');
+      }
+      for (let t of ['t', 'T', 'temporal', 'TEMPORAL']) {
+        assert.equal(type.getFullName(t), 'temporal');
+      }
+      for (let t of ['o', 'O', 'ordinal', 'ORDINAL']) {
+        assert.equal(type.getFullName(t), 'ordinal');
+      }
+      for (let t of ['n', 'N', 'nominal', 'NOMINAL']) {
+        assert.equal(type.getFullName(t), 'nominal');
+      }
+    });
 
-  it('translates long type', function() {
-    assert.equal(getFullName(<any>'quantitative'), QUANTITATIVE);
-  });
-
-  it('translates enum', function() {
-    assert.equal(getFullName(QUANTITATIVE), QUANTITATIVE);
+    it('should return undefined for invalid type', () => {
+      assert.equal(type.getFullName('haha'), undefined);
+    });
   });
 });


### PR DESCRIPTION
- Consolidate `fieldDef.normalize(), defaultType()`
  - No longer automatically adding `aggregate: 'min'` to order and path (I don't think it's a good default anymore, not sure why I added it back then.
- Make `type.getFullName()` return undefined if the input type is invalid + add more tests
- Remove unnecessary `SHORT_TYPE` and `TYPE_FROM_SHORT_TYPE` dictionary in `type.ts`

Fix #1651