### PR TITLE
Remove `path` channel as we can use `order` channel for sorting line order instead

### DIFF
--- a/examples/specs/scatter_color_zindex.vl.json
+++ b/examples/specs/scatter_color_zindex.vl.json
@@ -5,6 +5,6 @@
     "x": {"field": "Horsepower", "type": "quantitative"},
     "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
     "color": {"field": "Origin", "type": "nominal"},
-    "order": {"field": "Origin", "type": "ordinal", "sort": "descending"}
+    "zindex": {"field": "Origin", "type": "ordinal", "sort": "descending"}
   }
 }

--- a/examples/specs/scatter_connected.vl.json
+++ b/examples/specs/scatter_connected.vl.json
@@ -4,7 +4,7 @@
   "encoding": {
     "x": {"field": "miles","type": "quantitative", "scale": {"zero": false}},
     "y": {"field": "gas","type": "quantitative", "scale": {"zero": false}},
-    "path": {"field": "year","type": "temporal"}
+    "order": {"field": "year","type": "temporal"}
   },
   "config": {"overlay": {"line": true}}
 }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -27,13 +27,13 @@ export namespace Channel {
   // Non-scale channel
   export const TEXT: 'text' = 'text';
   export const LABEL: 'label' = 'label';
-  export const PATH: 'path' = 'path';
   export const ORDER: 'order' = 'order';
   export const DETAIL: 'detail' = 'detail';
 }
+
 export type Channel = typeof Channel.X | typeof Channel.Y | typeof Channel.X2 | typeof Channel.Y2 | typeof Channel.ROW
   | typeof Channel.COLUMN | typeof Channel.SHAPE | typeof Channel.SIZE | typeof Channel.COLOR
-  | typeof Channel.TEXT | typeof Channel.DETAIL | typeof Channel.LABEL | typeof Channel.PATH
+  | typeof Channel.TEXT | typeof Channel.DETAIL | typeof Channel.LABEL
   | typeof Channel.ORDER | typeof Channel.OPACITY;
 
 export const X = Channel.X;
@@ -48,14 +48,13 @@ export const COLOR = Channel.COLOR;
 export const TEXT = Channel.TEXT;
 export const DETAIL = Channel.DETAIL;
 export const LABEL = Channel.LABEL;
-export const PATH = Channel.PATH;
 export const ORDER = Channel.ORDER;
 export const OPACITY = Channel.OPACITY;
 
-export const CHANNELS = [X, Y, X2, Y2, ROW, COLUMN, SIZE, SHAPE, COLOR, PATH, ORDER, OPACITY, TEXT, DETAIL, LABEL];
+export const CHANNELS = [X, Y, X2, Y2, ROW, COLUMN, SIZE, SHAPE, COLOR, ORDER, OPACITY, TEXT, DETAIL, LABEL];
 
 export const UNIT_CHANNELS = without(CHANNELS, [ROW, COLUMN]);
-export const UNIT_SCALE_CHANNELS = without(UNIT_CHANNELS, [X2, Y2, PATH, ORDER, DETAIL, TEXT, LABEL, X2, Y2]);
+export const UNIT_SCALE_CHANNELS = without(UNIT_CHANNELS, [X2, Y2, ORDER, DETAIL, TEXT, LABEL, X2, Y2]);
 export const SCALE_CHANNELS = UNIT_SCALE_CHANNELS.concat([ROW, COLUMN]);
 export const NONSPATIAL_CHANNELS = without(UNIT_CHANNELS, [X, Y, X2, Y2]);
 export const NONSPATIAL_SCALE_CHANNELS = without(UNIT_SCALE_CHANNELS, [X, Y]);
@@ -97,7 +96,7 @@ export function getSupportedMark(channel: Channel): SupportedMark {
     case Y:
     case COLOR:
     case DETAIL:
-    case ORDER:
+    case ORDER:    // TODO: revise (order might not support rect, which is not stackable?)
     case OPACITY:
     case ROW:
     case COLUMN:
@@ -119,8 +118,6 @@ export function getSupportedMark(channel: Channel): SupportedMark {
       return {point: true};
     case TEXT:
       return {text: true};
-    case PATH:
-      return {line: true};
   }
   return {};
 }
@@ -162,17 +159,12 @@ export function getSupportedRole(channel: Channel): SupportedRole {
         measure: true,
         dimension: false
       };
-    case PATH:
-      return {
-        measure: false,
-        dimension: true
-      };
   }
   throw new Error('Invalid encoding channel' + channel);
 }
 
 export function hasScale(channel: Channel) {
-  return !contains([DETAIL, PATH, TEXT, LABEL, ORDER], channel);
+  return !contains([DETAIL, TEXT, LABEL, ORDER], channel);
 }
 
 // Position does not work with ordinal (lookup) scale and sequential (which is only for color)

--- a/src/compile/config.ts
+++ b/src/compile/config.ts
@@ -132,7 +132,7 @@ export function orient(mark: Mark, encoding: Encoding, scale: Dict<Scale>, markC
           return markConfig.orient;
         }
 
-        if (!(mark === LINE &&  encoding.path)) {
+        if (!(mark === LINE && encoding.order)) {
           // Except for connected scatterplot, we should log warning for unclear orientation of QxQ plots.
           log.warn(log.message.unclearOrientContinuous(mark));
         }

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -2,7 +2,7 @@ import * as log from '../log';
 
 import {AggregateOp} from '../aggregate';
 import {Axis} from '../axis';
-import {X, Y, X2, Y2, TEXT, PATH, ORDER, Channel, UNIT_CHANNELS,  UNIT_SCALE_CHANNELS, NONSPATIAL_SCALE_CHANNELS, supportMark} from '../channel';
+import {X, Y, X2, Y2, TEXT, ORDER, Channel, UNIT_CHANNELS,  UNIT_SCALE_CHANNELS, NONSPATIAL_SCALE_CHANNELS, supportMark} from '../channel';
 import {defaultConfig, Config, CellConfig} from '../config';
 import {SOURCE, SUMMARY} from '../data';
 import {Encoding} from '../encoding';
@@ -34,7 +34,7 @@ function normalizeFieldDef(fieldDef: FieldDef, channel: Channel) {
     fieldDef.type = getFullName(fieldDef.type);
   }
 
-  if ((channel === PATH || channel === ORDER) && !fieldDef.aggregate && fieldDef.type === QUANTITATIVE) {
+  if ((channel === ORDER) && !fieldDef.aggregate && fieldDef.type === QUANTITATIVE) {
     fieldDef.aggregate = AggregateOp.MIN;
   }
   return fieldDef;

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -71,12 +71,7 @@ export interface UnitEncoding {
   label?: FieldDef;
 
   /**
-   * Order of data points in line marks.
-   */
-  path?: OrderChannelDef | OrderChannelDef[];
-
-  /**
-   * Layer order for non-stacked marks, or stack order for stacked marks.
+   * stack order for stacked marks or order of data points in line marks.
    */
   order?: OrderChannelDef | OrderChannelDef[];
 }

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -332,11 +332,6 @@ export function normalizeOverlay(spec: UnitSpec, overlayWithPoint: boolean, over
     let pointSpec = duplicate(baseSpec);
     pointSpec.mark = POINT;
 
-    // Do not include path for point
-    if (pointSpec.encoding.path) {
-      delete pointSpec.encoding.path;
-    }
-
     let markConfig = extend({},
       defaultOverlayConfig.pointStyle,
       spec.config.overlay.pointStyle,

--- a/test/spec.test.ts
+++ b/test/spec.test.ts
@@ -107,45 +107,6 @@ describe('normalize()', function () {
           ]
         });
       });
-
-      it('should not include path for line\'s point marker', () => {
-        const spec: any = {
-          "description": "Google's stock price over time.",
-          "data": {"url": "data/stocks.csv", "format": {"type": "csv"}},
-          "transform": {"filter": "datum[\"symbol\"]==='GOOG'"},
-          "mark": "line",
-          "encoding": {
-            "path": {"field": "date", "type": "temporal"},
-            "y": {"field": "price", "type": "quantitative"},
-            "x": {"field": "price", "type": "quantitative"}
-          },
-          "config": {"overlay": {"line": true}}
-        };
-        const normalizedSpec = normalize(spec);
-        assert.deepEqual(normalizedSpec, {
-          "description": "Google's stock price over time.",
-          "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
-          "transform": {"filter": "datum[\"symbol\"]==='GOOG'"},
-          "layers": [
-            {
-              "mark": "line",
-              "encoding": {
-                "path": {"field": "date", "type": "temporal"},
-                "y": {"field": "price", "type": "quantitative"},
-                "x": {"field": "price", "type": "quantitative"}
-              }
-            },
-            {
-              "mark": "point",
-              "encoding": {
-                "y": {"field": "price", "type": "quantitative"},
-                "x": {"field": "price", "type": "quantitative"}
-              },
-              "config": {"mark": {"filled": true}}
-            }
-          ]
-        });
-      });
     });
 
     describe('area', () => {

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -1068,21 +1068,7 @@
                             "type": "array"
                         }
                     ],
-                    "description": "Layer order for non-stacked marks, or stack order for stacked marks."
-                },
-                "path": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/OrderChannelDef"
-                        },
-                        {
-                            "items": {
-                                "$ref": "#/definitions/OrderChannelDef"
-                            },
-                            "type": "array"
-                        }
-                    ],
-                    "description": "Order of data points in line marks."
+                    "description": "stack order for stacked marks or order of data points in line marks."
                 },
                 "row": {
                     "$ref": "#/definitions/PositionChannelDef",
@@ -3106,21 +3092,7 @@
                             "type": "array"
                         }
                     ],
-                    "description": "Layer order for non-stacked marks, or stack order for stacked marks."
-                },
-                "path": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/OrderChannelDef"
-                        },
-                        {
-                            "items": {
-                                "$ref": "#/definitions/OrderChannelDef"
-                            },
-                            "type": "array"
-                        }
-                    ],
-                    "description": "Order of data points in line marks."
+                    "description": "stack order for stacked marks or order of data points in line marks."
                 },
                 "shape": {
                     "$ref": "#/definitions/ChannelDefWithLegend",


### PR DESCRIPTION
Note that unlike VL1, now Vega 3 has zindex properties. Thus layer order can be mapped to a scale (haven't implemented yet) while stack order and path order cannot.
Thus, I think it makes sense to consolidate  `order` channel for sorting line order / stack order and have zindex as a separate channel that supports scale. As a result, we can free up `path` for geopath.

(Forked from #1776 -- Please merge #1776 first.)