### PR TITLE
Add pathOrder data component to support sorting line

### DIFF
--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -4,10 +4,10 @@ import {BAR, POINT, CIRCLE, SQUARE} from '../mark';
 import {AggregateOp} from '../aggregate';
 import {COLOR, OPACITY, TEXT, Channel} from '../channel';
 import {Config} from '../config';
-import {FieldDef} from '../fielddef';
+import {FieldDef, OrderChannelDef, field} from '../fielddef';
 import {TimeUnit} from '../timeunit';
 import {QUANTITATIVE} from '../type';
-import {contains, union, Dict} from '../util';
+import {contains, isArray, union, Dict} from '../util';
 
 import {FacetModel} from './facet';
 import {LayerModel} from './layer';
@@ -15,7 +15,7 @@ import {Model} from './model';
 import {formatExpression} from '../timeunit';
 import {UnitModel} from './unit';
 import {Spec, isUnitSpec, isSomeFacetSpec, isLayerSpec} from '../spec';
-import {VgValueRef} from '../vega.schema';
+import {VgValueRef, VgSort} from '../vega.schema';
 
 export function buildModel(spec: Spec, parent: Model, parentGivenName: string): Model {
   if (isSomeFacetSpec(spec)) {
@@ -144,4 +144,15 @@ export function timeFormatExpression(field: string, timeUnit: TimeUnit, format: 
   } else {
     return formatExpression(timeUnit, field, shortTimeLabels);
   }
+}
+
+/**
+ * Return Vega sort parameters (tuple of field and order).
+ */
+export function sortParams(orderDef: OrderChannelDef | OrderChannelDef[]): VgSort {
+  return (isArray(orderDef) ? orderDef : [orderDef]).reduce((s, orderChannelDef) => {
+    s.field.push(field(orderChannelDef, {binSuffix: 'start'}));
+    s.order.push(orderChannelDef.sort || 'ascending');
+    return s;
+  }, {field:[], order: []});
 }

--- a/src/compile/data/pathorder.ts
+++ b/src/compile/data/pathorder.ts
@@ -1,0 +1,95 @@
+import * as stringify from 'json-stable-stringify';
+
+import {DataComponentCompiler} from './base';
+
+import {isAggregate} from '../../encoding';
+import {field} from '../../fielddef';
+import {isSortField} from '../../sort';
+import {VgSort} from '../../vega.schema';
+import {contains} from '../../util';
+
+import {sortParams} from '../common';
+import {FacetModel} from '../facet';
+import {LayerModel} from '../layer';
+import {UnitModel} from '../unit';
+
+export const pathOrder: DataComponentCompiler<VgSort> = {
+  parseUnit: function(model: UnitModel): VgSort {
+    if (contains(['line', 'area'], model.mark())) {
+      if (model.mark() === 'line' && model.has('order')) {
+        // For only line, sort by the order field if it is specified.
+        return sortParams(model.encoding().order);
+      } else {
+        // For both line and area, we sort values based on dimension by default
+        const dimensionChannel: 'x' | 'y' = model.config().mark.orient === 'horizontal' ? 'y' : 'x';
+        const sort = model.sort(dimensionChannel);
+        const sortField = isSortField(sort) ?
+          field({
+            // FIXME: this op might not already exist?
+            // FIXME: what if dimensionChannel (x or y) contains custom domain?
+            aggregate: isAggregate(model.encoding()) ? sort.op : undefined,
+            field: sort.field
+          }) :
+          model.field(dimensionChannel, {binSuffix: 'start'});
+
+        return {
+          field: sortField,
+          order: 'descending'
+        };
+      }
+
+    }
+    return null;
+  },
+
+  parseFacet: function(model: FacetModel) {
+    const childDataComponent = model.child().component.data;
+
+    // If child doesn't have its own data source, then consider merging
+    if (!childDataComponent.source) {
+      // For now, let's assume it always has union scale
+      const pathOrderComponent = childDataComponent.pathOrder;
+      delete childDataComponent.pathOrder;
+      return pathOrderComponent;
+    }
+    return null;
+  },
+
+  parseLayer: function(model: LayerModel) {
+    // note that we run this before source.parseLayer
+    let pathOrderComponent: VgSort = null;
+    let stringifiedPathOrder: string = null;
+
+    for (let child of model.children()) {
+      const childDataComponent = child.component.data;
+      if (model.compatibleSource(child) && childDataComponent.pathOrder !== null) {
+        if (pathOrderComponent === null) {
+          pathOrderComponent = childDataComponent.pathOrder;
+          stringifiedPathOrder = stringify(pathOrderComponent);
+        } else if (stringifiedPathOrder !== stringify(childDataComponent.pathOrder)) {
+          pathOrderComponent = null;
+          break;
+        }
+      }
+    }
+
+    if (pathOrderComponent !== null) {
+      // If we merge pathOrderComponent, remove them from children.
+      for (let child of model.children()) {
+        delete child.component.data.pathOrder;
+      }
+    }
+
+    return pathOrderComponent;
+  },
+
+  assemble: function(pathOrderComponent: VgSort) {
+    if (pathOrderComponent) {
+      return {
+        type: 'collect',
+        sort: pathOrderComponent
+      };
+    }
+    return null;
+  }
+};

--- a/src/compile/data/stack.ts
+++ b/src/compile/data/stack.ts
@@ -4,6 +4,7 @@ import {FacetModel} from './../facet';
 import {LayerModel} from './../layer';
 import {UnitModel} from './../unit';
 
+import {sortParams} from '../common';
 import {STACKED, SUMMARY} from '../../data';
 import {has} from '../../encoding';
 import {FieldDef, field} from '../../fielddef';
@@ -91,17 +92,12 @@ export const stack: DataComponentCompiler<StackComponent> = {
     }
 
     const groupby = model.field(stackProperties.groupbyChannel, {binSuffix: 'start'});
-
     const stackby = getStackByFields(model);
     const orderDef = model.encoding().order;
 
     let sort: VgSort;
     if (orderDef) {
-      sort = (isArray(orderDef) ? orderDef : [orderDef]).reduce((s, orderChannelDef) => {
-        s.field.push(field(orderChannelDef, {binSuffix: 'start'}));
-        s.order.push(orderChannelDef.sort || 'ascending');
-        return s;
-      }, {field:[], order: []});
+      sort = sortParams(orderDef);
     } else {
       // default = descending by stackFields
       // FIXME is the default here correct for binned fields?

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -136,10 +136,13 @@ export interface VgStackTransform {
   as: string[];
 }
 
-export interface VgSort {
-  field: string | string[];
-  order: SortOrder | SortOrder[];
-}
+export type VgSort = {
+  field: string;
+  order: 'ascending' | 'descending';
+} | {
+  field: string[];
+  order: ('ascending' | 'descending')[];
+};
 
 export interface VgImputeTransform {
   type: 'impute';

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -1,8 +1,6 @@
 import {StackOffset} from './stack';
 import {ScaleType, NiceTime} from './scale';
-import {SortOrder} from './sort';
 import {isArray} from './util';
-
 
 export interface VgData {
   name: string;

--- a/test/compile/data/datatestutil.ts
+++ b/test/compile/data/datatestutil.ts
@@ -8,6 +8,7 @@ export function mockDataComponent(): DataComponent {
     nullFilter: null,
     filter: null,
     nonPositiveFilter: null,
+    pathOrder: null,
 
     source: null,
     bin: null,

--- a/test/compile/data/pathorder.test.ts
+++ b/test/compile/data/pathorder.test.ts
@@ -1,0 +1,176 @@
+/* tslint:disable:quotemark */
+
+import {assert} from 'chai';
+
+import {pathOrder} from '../../../src/compile/data/pathorder';
+import {LayerModel} from '../../../src/compile/layer';
+import {parseUnitModel, parseModel, parseFacetModel} from '../../util';
+
+describe('compile/data/pathorder', function() {
+  describe('compileUnit', function() {
+    it('should order by order field for line with order (connected scatterplot)', function () {
+      const model = parseUnitModel({
+        "data": {"url": "data/driving.json"},
+        "mark": "line",
+        "encoding": {
+          "x": {"field": "miles","type": "quantitative", "scale": {"zero": false}},
+          "y": {"field": "gas","type": "quantitative", "scale": {"zero": false}},
+          "order": {"field": "year","type": "temporal"}
+        }
+      });
+      assert.deepEqual(pathOrder.parseUnit(model), {
+        field: ['year'],
+        order: ['ascending']
+      });
+    });
+
+    it('should order by x by default if x is the dimension', function () {
+      const model = parseUnitModel({
+        "data": {"url": "data/movies.json"},
+        "mark": "line",
+        "encoding": {
+          "x": {
+            "bin": {"maxbins": 10},
+            "field": "IMDB_Rating",
+            "type": "quantitative"
+          },
+          "color": {
+            "field": "Source",
+            "type": "nominal"
+          },
+          "y": {
+            "aggregate": "count",
+            "field": "*",
+            "type": "quantitative"
+          }
+        }
+      });
+      assert.deepEqual(pathOrder.parseUnit(model), {
+        field: 'bin_IMDB_Rating_start',
+        order: 'descending'
+      });
+    });
+
+    it('should order by x by default if y is the dimension', function () {
+      const model = parseUnitModel({
+        "data": {"url": "data/movies.json"},
+        "mark": "line",
+        "encoding": {
+          "y": {
+            "bin": {"maxbins": 10},
+            "field": "IMDB_Rating",
+            "type": "quantitative"
+          },
+          "color": {
+            "field": "Source",
+            "type": "nominal"
+          },
+          "x": {
+            "aggregate": "count",
+            "field": "*",
+            "type": "quantitative"
+          }
+        }
+      });
+      assert.deepEqual(pathOrder.parseUnit(model), {
+        field: 'bin_IMDB_Rating_start',
+        order: 'descending'
+      });
+    });
+  });
+
+  describe('parseLayer', function() {
+    it('should return line order for line when merging line and point', () => {
+      const model = parseFacetModel({
+        "data": {"url": "data/movies.json"},
+        "facet": {
+          "column": {
+            "field": "Source",
+            "type": "nominal"
+          }
+        },
+        "spec": {
+          "mark": "line",
+          "encoding": {
+            "y": {
+              "bin": {"maxbins": 10},
+              "field": "IMDB_Rating",
+              "type": "quantitative"
+            },
+            "x": {
+              "aggregate": "count",
+              "field": "*",
+              "type": "quantitative"
+            }
+          }
+        }
+      });
+      const child = model.child();
+      child.component.data = {
+        pathOrder: pathOrder.parseUnit(child as any)
+      } as any;
+
+      assert.deepEqual(pathOrder.parseFacet(model), {
+        field: 'bin_IMDB_Rating_start',
+        order: 'descending'
+      });
+    });
+  });
+
+  describe('parseFacet', function() {
+    it('should return line order for line for faceted line', () => {
+      const model = parseModel({
+        "data": {"url": "data/movies.json"},
+        "mark": "line",
+        "encoding": {
+          "y": {
+            "bin": {"maxbins": 10},
+            "field": "IMDB_Rating",
+            "type": "quantitative"
+          },
+          "color": {
+            "field": "Source",
+            "type": "nominal"
+          },
+          "x": {
+            "aggregate": "count",
+            "field": "*",
+            "type": "quantitative"
+          }
+        },
+        "config": {
+          "overlay": {
+            "line": true
+          }
+        }
+      }) as LayerModel;
+      const children = model.children();
+      children[0].component.data = {
+        pathOrder: pathOrder.parseUnit(children[0])
+      } as any;
+      children[1].component.data = {
+        pathOrder: pathOrder.parseUnit(children[1])
+      } as any;
+
+      assert.deepEqual(pathOrder.parseLayer(model), {
+        field: 'bin_IMDB_Rating_start',
+        order: 'descending'
+      });
+    });
+  });
+
+  describe('assemble', function() {
+    it('should correctly assemble a collect transform', () => {
+      assert.deepEqual(pathOrder.assemble({
+        field: 'a',
+        order: 'ascending'
+      }), {
+        type: 'collect',
+        sort: {
+          field: 'a',
+          order: 'ascending'
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
(Replacing the original inline sort transform that serves the same purpose)


Before:

![vega_editor](https://cloud.githubusercontent.com/assets/111269/21830280/8616c696-d750-11e6-8e7b-f0c029430ede.png)

![vega_editor](https://cloud.githubusercontent.com/assets/111269/21830273/79aea590-d750-11e6-8189-519911623e11.png)

After: 

![vega_editor](https://cloud.githubusercontent.com/assets/111269/21830380/216ba530-d751-11e6-8a4f-f8710dfb2e9d.png)

![vega_editor](https://cloud.githubusercontent.com/assets/111269/21830387/2b44b632-d751-11e6-8670-7f11fcdb8af8.png)

