### PR TITLE
Make stacked area chart with imputation render correctly.

### DIFF
--- a/src/compile/data/data.ts
+++ b/src/compile/data/data.ts
@@ -1,7 +1,7 @@
 import {SOURCE} from '../../data';
 import {FieldDef} from '../../fielddef';
 import {Formula} from '../../transform';
-import {keys, Dict, StringSet} from '../../util';
+import {Dict, StringSet} from '../../util';
 import {VgData, VgSort, VgTransform} from '../../vega.schema';
 
 import {FacetModel} from './../facet';
@@ -152,22 +152,13 @@ export function assembleData(model: Model, data: VgData[]) {
     data.push(summaryData);
   });
 
-  if (data.length > 0) {
-    const dataTable = data[data.length - 1];
-
-    // nonPositiveFilter
-    const nonPositiveFilterTransform = nonPositiveFilter.assemble(component.nonPositiveFilter);
-    if (nonPositiveFilterTransform.length > 0) {
+  // nonPositiveFilter
+  const nonPositiveFilterTransform = nonPositiveFilter.assemble(component.nonPositiveFilter);
+  if (nonPositiveFilterTransform.length > 0) {
+    if (data.length > 0) {
+      const dataTable = data[data.length - 1];
       dataTable.transform = (dataTable.transform || []).concat(nonPositiveFilterTransform);
-    }
-
-    // Path Order
-    const pathOrderCollectTransform = pathOrder.assemble(component.pathOrder);
-    if (pathOrderCollectTransform) {
-      dataTable.transform = (dataTable.transform || []).concat([pathOrderCollectTransform]);
-    }
-  } else {
-    if (keys(component.nonPositiveFilter).length > 0) {
+    } else { /* istanbul ignore else: should never reach here */
       throw new Error('Invalid nonPositiveFilter not merged');
     }
   }
@@ -177,5 +168,17 @@ export function assembleData(model: Model, data: VgData[]) {
   if (stackData) {
     data.push(stackData);
   }
+
+  // Path Order
+  const pathOrderCollectTransform = pathOrder.assemble(component.pathOrder);
+  if (pathOrderCollectTransform) {
+    const dataTable = data[data.length - 1];
+    if (data.length > 0) {
+      dataTable.transform = (dataTable.transform || []).concat([pathOrderCollectTransform]);
+    } else { /* istanbul ignore else: should never reach here */
+      throw new Error('Invalid path order collect transform not added');
+    }
+  }
+
   return data;
 }

--- a/test/compile/data/data.test.ts
+++ b/test/compile/data/data.test.ts
@@ -48,6 +48,44 @@ describe('data', function () {
         });
       });
     });
+
+    describe('stacked bar chart with binned dimension', () => {
+      const model = parseUnitModel({
+        "mark": "area",
+        "encoding": {
+          "x": {
+            "bin": {"maxbins": 10},
+            "field": "IMDB_Rating",
+            "type": "quantitative"
+          },
+          "color": {
+            "field": "Source",
+            "type": "nominal"
+          },
+          "y": {
+            "aggregate": "count",
+            "field": "*",
+            "type": "quantitative"
+          }
+        }
+      });
+
+      const data = compileAssembleData(model);
+      it('should contains 3 tables', function() {
+        assert.equal(data.length, 3);
+      });
+
+      it('should have collect transform as the last transform in stacked', function() {
+        const stackedTransform = data[2].transform;
+        assert.deepEqual(stackedTransform[stackedTransform.length - 1], {
+          type: 'collect',
+          sort: {
+            "field": "bin_IMDB_Rating_start",
+            "order": "descending"
+          }
+        });
+      });
+    });
   });
 
   describe('assemble', function () {

--- a/test/compile/data/stack.test.ts
+++ b/test/compile/data/stack.test.ts
@@ -20,7 +20,33 @@ describe('compile/data/stack', () => {
     });
   });
 
-  it('should produce correct stack component for bar with color and binned x', () => {
+  it('should produce correct stack component for bar with color', () => {
+    const model = parseUnitModel({
+      "mark": "bar",
+      "encoding": {
+        "x": {"aggregate": "sum", "field": "a", "type": "quantitative"},
+        "y": {"field": "b", "type": "nominal"},
+        "color": {"field": "c", "type": "ordinal", }
+      }
+    });
+
+    const stackComponent = stack.parseUnit(model);
+    assert.deepEqual(stackComponent, {
+      name: 'stacked',
+      source: 'summary',
+      groupby: ['b'],
+      field: 'sum_a',
+      stackby: ['c'],
+      sort: {
+        field: ['c'],
+        order: ['descending']
+      },
+      offset: 'zero',
+      impute: false
+    });
+  });
+
+  it('should produce correct stack component with both start and end of the binned field for bar with color and binned y', () => {
     const model = parseUnitModel({
       "mark": "bar",
       "encoding": {
@@ -34,7 +60,7 @@ describe('compile/data/stack', () => {
     assert.deepEqual(stackComponent, {
       name: 'stacked',
       source: 'summary',
-      groupby: ['bin_b_start'],
+      groupby: ['bin_b_start', 'bin_b_end'],
       field: 'sum_a',
       stackby: ['c'],
       sort: {


### PR DESCRIPTION
1. Make pathOrder's collect transform always included in the last data source (can be raw/summary/stacked)
2. Make stack's `impute` and `stack` transforms always include both binned field's start and end

<img width="1014" alt="vega_editor" src="https://cloud.githubusercontent.com/assets/111269/21876341/ffc6ab1e-d836-11e6-956f-361b4c96ac23.png">

Fix #1805 