### PR TITLE
Add top-level `padding` and make it = 5 by default

### DIFF
--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -76,6 +76,7 @@ export function topLevelBasicProperties(model: Model) {
   const config = model.config();
   return extend(
     // TODO: Add other top-level basic properties (#1778)
+    {padding: model.padding() || config.padding},
     {autosize: 'pad'},
     config.viewport ? { viewport: config.viewport } : {},
     config.background ? { background: config.background } : {}

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -9,7 +9,7 @@ import {FieldDef, FieldRefOption, field} from '../fielddef';
 import {Legend} from '../legend';
 import {Scale, hasDiscreteDomain} from '../scale';
 import {SortField, SortOrder} from '../sort';
-import {BaseSpec} from '../spec';
+import {BaseSpec, Padding} from '../spec';
 import {Transform} from '../transform';
 import {extend, flatten, vals, Dict} from '../util';
 import {VgData, VgMarkGroup, VgScale, VgAxis, VgLegend} from '../vega.schema';
@@ -90,6 +90,7 @@ export abstract class Model {
   protected _parent: Model;
   protected _name: string;
   protected _description: string;
+  protected _padding: Padding;
 
   protected _data: Data;
 
@@ -127,6 +128,7 @@ export abstract class Model {
     this._data = spec.data;
 
     this._description = spec.description;
+    this._padding = spec.padding;
     this._transform = spec.transform;
 
     if (spec.transform) {
@@ -255,6 +257,10 @@ export abstract class Model {
 
   public description() {
     return this._description;
+  }
+
+  public padding() {
+    return this._padding;
   }
 
   public data() {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ import {LegendConfig, defaultLegendConfig} from './legend';
 import {MarkConfig, AreaConfig, BarConfig, LineConfig, PointConfig, TextConfig, TickConfig, RectConfig, RuleConfig} from './mark';
 import * as mark from './mark';
 import {ScaleConfig, defaultScaleConfig} from './scale';
-
+import {Padding} from './spec';
 
 export interface CellConfig {
   width?: number;
@@ -126,6 +126,15 @@ export interface Config {
   background?: string;
 
   /**
+   * The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `"top"`, `"left"`, `"right"`, `"bottom"` properties.
+   *
+   * __Default value__: `5`
+   *
+   * * @minimum 0
+   */
+  padding?: Padding;
+
+  /**
    * D3 Number format for axis labels and text tables. For example "s" for SI units.
    */
   numberFormat?: string;
@@ -198,6 +207,7 @@ export interface Config {
 }
 
 export const defaultConfig: Config = {
+  padding: 5,
   numberFormat: 's',
   timeFormat: '%b %d, %Y',
   countTitle: 'Number of Records',

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -12,6 +12,8 @@ import {ROW, COLUMN, X, Y, X2, Y2} from './channel';
 import * as vlEncoding from './encoding';
 import {contains, duplicate, extend, hash, keys, omit, pick, vals} from './util';
 
+export type Padding = number | {top?: number, bottom?: number, left?: number, right?: number};
+
 export interface BaseSpec {
   /**
    * URL to JSON schema for this Vega-Lite specification.
@@ -29,6 +31,15 @@ export interface BaseSpec {
    * This property has no effect on the output visualization.
    */
   description?: string;
+
+  /**
+   * The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `"top"`, `"left"`, `"right"`, `"bottom"` properties.
+   *
+   * __Default value__: `5`
+   *
+   * @minimum 0
+   */
+  padding?: Padding;
 
   /**
    * An object describing the data source

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -24,6 +24,7 @@ describe('Compile', function() {
         "mark": "point"
       }).spec;
 
+      assert.equal(spec.padding, 5);
       assert.equal(spec.autosize, 'pad');
       assert.deepEqual(spec.signals, [
         {

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -866,6 +866,31 @@
                     "$ref": "#/definitions/OverlayConfig",
                     "description": "Mark Overlay Config"
                 },
+                "padding": {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "bottom": {
+                                    "type": "number"
+                                },
+                                "left": {
+                                    "type": "number"
+                                },
+                                "right": {
+                                    "type": "number"
+                                },
+                                "top": {
+                                    "type": "number"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `\"top\"`, `\"left\"`, `\"right\"`, `\"bottom\"` properties.\n\n__Default value__: `5`\n\n* @minimum 0"
+                },
                 "point": {
                     "$ref": "#/definitions/PointConfig",
                     "description": "Point-Specific Config"
@@ -1164,6 +1189,32 @@
                     "description": "Name of the visualization for later reference.",
                     "type": "string"
                 },
+                "padding": {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "bottom": {
+                                    "type": "number"
+                                },
+                                "left": {
+                                    "type": "number"
+                                },
+                                "right": {
+                                    "type": "number"
+                                },
+                                "top": {
+                                    "type": "number"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `\"top\"`, `\"left\"`, `\"right\"`, `\"bottom\"` properties.\n\n__Default value__: `5`",
+                    "minimum": 0
+                },
                 "transform": {
                     "$ref": "#/definitions/Transform",
                     "description": "An object describing filter and new field calculation."
@@ -1241,6 +1292,32 @@
                 "name": {
                     "description": "Name of the visualization for later reference.",
                     "type": "string"
+                },
+                "padding": {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "bottom": {
+                                    "type": "number"
+                                },
+                                "left": {
+                                    "type": "number"
+                                },
+                                "right": {
+                                    "type": "number"
+                                },
+                                "top": {
+                                    "type": "number"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `\"top\"`, `\"left\"`, `\"right\"`, `\"bottom\"` properties.\n\n__Default value__: `5`",
+                    "minimum": 0
                 },
                 "spec": {
                     "anyOf": [
@@ -1390,6 +1467,32 @@
                 "name": {
                     "description": "Name of the visualization for later reference.",
                     "type": "string"
+                },
+                "padding": {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "bottom": {
+                                    "type": "number"
+                                },
+                                "left": {
+                                    "type": "number"
+                                },
+                                "right": {
+                                    "type": "number"
+                                },
+                                "top": {
+                                    "type": "number"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `\"top\"`, `\"left\"`, `\"right\"`, `\"bottom\"` properties.\n\n__Default value__: `5`",
+                    "minimum": 0
                 },
                 "transform": {
                     "$ref": "#/definitions/Transform",
@@ -3137,6 +3240,32 @@
                 "name": {
                     "description": "Name of the visualization for later reference.",
                     "type": "string"
+                },
+                "padding": {
+                    "anyOf": [
+                        {
+                            "properties": {
+                                "bottom": {
+                                    "type": "number"
+                                },
+                                "left": {
+                                    "type": "number"
+                                },
+                                "right": {
+                                    "type": "number"
+                                },
+                                "top": {
+                                    "type": "number"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `\"top\"`, `\"left\"`, `\"right\"`, `\"bottom\"` properties.\n\n__Default value__: `5`",
+                    "minimum": 0
                 },
                 "transform": {
                     "$ref": "#/definitions/Transform",


### PR DESCRIPTION
(as suggested by Jeff)

Fix #1822
