### PR TITLE
Distinguish between PointConfig and SymbolConfig.

### DIFF
--- a/src/compile/mark/point.ts
+++ b/src/compile/mark/point.ts
@@ -1,6 +1,6 @@
 import {X, Y, SHAPE, SIZE} from '../../channel';
 import {ChannelDefWithLegend} from '../../fielddef';
-import {PointConfig} from '../../mark';
+import {SymbolConfig, PointConfig} from '../../mark';
 import {Scale} from '../../scale';
 import {VgValueRef} from '../../vega.schema';
 
@@ -14,7 +14,7 @@ function encodeEntry(model: UnitModel, fixedShape?: string) {
   // TODO Use Vega's marks properties interface
   let p: any = {};
   const config = model.config();
-  const markSpecificConfig: PointConfig = fixedShape ? config[fixedShape] : config.point;
+  const markSpecificConfig: SymbolConfig = fixedShape ? config[fixedShape] : config.point;
   const stack = model.stack();
 
   // TODO: refactor how refer to scale as discussed in https://github.com/vega/vega-lite/pull/1613
@@ -26,18 +26,18 @@ function encodeEntry(model: UnitModel, fixedShape?: string) {
     {value: markSpecificConfig.size}
   );
 
-  p.shape = shape(model.encoding().shape, model.scaleName(SHAPE), model.scale(SHAPE), markSpecificConfig, fixedShape);
+  p.shape = shape(model.encoding().shape, model.scaleName(SHAPE), model.scale(SHAPE), config.point, fixedShape);
 
   applyColorAndOpacity(p, model);
   return p;
 }
 
-function shape(fieldDef: ChannelDefWithLegend, scaleName: string, scale: Scale, markSpecificConfig: PointConfig, fixedShape?: string): VgValueRef {
+function shape(fieldDef: ChannelDefWithLegend, scaleName: string, scale: Scale, pointConfig: PointConfig, fixedShape?: string): VgValueRef {
   // shape
   if (fixedShape) { // square and circle marks
     return { value: fixedShape };
   }
-  return ref.midPoint(SHAPE, fieldDef, scaleName, scale, {value: markSpecificConfig.shape});
+  return ref.midPoint(SHAPE, fieldDef, scaleName, scale, {value: pointConfig.shape});
 }
 
 export const point: MarkCompiler = {

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -2,7 +2,7 @@ import * as log from '../../log';
 
 import {COLUMN, ROW, X, Y, SHAPE, SIZE, COLOR, OPACITY, Channel} from '../../channel';
 import {Config} from '../../config';
-import {Mark, PointConfig} from '../../mark';
+import {Mark} from '../../mark';
 import {Scale, ScaleConfig, ScaleType, scaleTypeSupportProperty} from '../../scale';
 import * as util from '../../util';
 
@@ -150,8 +150,8 @@ function sizeRangeMax(mark: Mark, xyRangeSteps: number[], config: Config) {
     case 'point':
     case 'square':
     case 'circle':
-      if ((config[mark] as PointConfig).maxSize) {
-        return (config[mark] as PointConfig).maxSize;
+      if (config[mark].maxSize) {
+        return config[mark].maxSize;
       }
 
       // FIXME this case totally should be refactored

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import {AxisConfig, defaultAxisConfig, defaultFacetAxisConfig} from './axis';
 import {LegendConfig, defaultLegendConfig} from './legend';
-import {MarkConfig, AreaConfig, BarConfig, LineConfig, PointConfig, TextConfig, TickConfig, RectConfig, RuleConfig} from './mark';
+import {MarkConfig, AreaConfig, BarConfig, LineConfig, PointConfig, RectConfig, RuleConfig, SymbolConfig, TextConfig, TickConfig} from './mark';
 import * as mark from './mark';
 import {ScaleConfig, defaultScaleConfig} from './scale';
 import {Padding} from './spec';
@@ -164,7 +164,7 @@ export interface Config {
   bar?: BarConfig;
 
   /** Circle-Specific Config */
-  circle?: PointConfig;
+  circle?: SymbolConfig;
 
   /** Line-Specific Config */
   line?: LineConfig;
@@ -179,7 +179,7 @@ export interface Config {
   rule?: RuleConfig;
 
   /** Square-Specific Config */
-  square?: PointConfig;
+  square?: SymbolConfig;
 
   /** Text-Specific Config */
   text?: TextConfig;

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -250,17 +250,7 @@ export const defaultLineConfig: LineConfig = {
   strokeWidth: 2
 };
 
-export interface PointConfig extends MarkConfig {
-  /**
-   * The default symbol shape to use. One of: `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
-   */
-  shape?: Shape | string;
-
-  /**
-   * The default collection of symbol shapes for mapping nominal fields to shapes of point marks (i.e., range of a `shape` scale).
-   * Each value should be one of: `"circle"`, `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
-   */
-  shapes?: (Shape|string)[];
+export interface SymbolConfig extends MarkConfig {
 
   /**
    * The pixel area each the point/circle/square.
@@ -282,9 +272,20 @@ export interface PointConfig extends MarkConfig {
   maxSize?: number;
 }
 
-export const defaultPointConfig: PointConfig = {
-  shape: 'circle',
-  shapes: ['circle', 'square', 'cross', 'diamond', 'triangle-up', 'triangle-down'],
+export interface PointConfig extends SymbolConfig {
+  /**
+   * The default symbol shape to use. One of: `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
+   */
+  shape?: Shape | string;
+
+  /**
+   * The default collection of symbol shapes for mapping nominal fields to shapes of point marks (i.e., range of a `shape` scale).
+   * Each value should be one of: `"circle"`, `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
+   */
+  shapes?: (Shape|string)[];
+}
+
+export const defaultSymbolConfig: PointConfig = {
   size: 30,
 
   // FIXME: revise if these *can* become ratios of rangeStep
@@ -292,10 +293,13 @@ export const defaultPointConfig: PointConfig = {
   strokeWidth: 2
 };
 
-export const defaultCircleConfig: PointConfig = defaultPointConfig;
-export const defaultSquareConfig: PointConfig = extend({}, defaultPointConfig, {
-  shape: 'square'
+export const defaultPointConfig = extend({}, defaultSymbolConfig, {
+  shape: 'circle',
+  shapes: ['circle', 'square', 'cross', 'diamond', 'triangle-up', 'triangle-down'],
 });
+
+export const defaultCircleConfig: SymbolConfig = defaultSymbolConfig;
+export const defaultSquareConfig: SymbolConfig = defaultSymbolConfig;
 
 export interface RectConfig extends MarkConfig {}
 

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -835,7 +835,7 @@
                     "description": "Cell Config"
                 },
                 "circle": {
-                    "$ref": "#/definitions/PointConfig",
+                    "$ref": "#/definitions/SymbolConfig",
                     "description": "Circle-Specific Config"
                 },
                 "countTitle": {
@@ -908,7 +908,7 @@
                     "description": "Scale Config"
                 },
                 "square": {
-                    "$ref": "#/definitions/PointConfig",
+                    "$ref": "#/definitions/SymbolConfig",
                     "description": "Square-Specific Config"
                 },
                 "text": {
@@ -2744,6 +2744,119 @@
                 "zero"
             ],
             "type": "string"
+        },
+        "SymbolConfig": {
+            "properties": {
+                "color": {
+                    "description": "Default color.",
+                    "type": "string"
+                },
+                "fill": {
+                    "description": "Default Fill Color.  This has higher precedence than config.color",
+                    "type": "string"
+                },
+                "fillOpacity": {
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "filled": {
+                    "description": "Whether the shape\\'s color should be used as fill color instead of stroke color.\nThis is only applicable for \"bar\", \"point\", and \"area\".\nAll marks except \"point\" marks are filled by default.\nSee Mark Documentation (http://vega.github.io/vega-lite/docs/marks.html)\nfor usage example.",
+                    "type": "boolean"
+                },
+                "interpolate": {
+                    "$ref": "#/definitions/Interpolate",
+                    "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+                },
+                "maxOpacity": {
+                    "description": "Default max opacity for mapping a field to opacity.",
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "maxSize": {
+                    "description": "Default max value for point size scale.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "maxStrokeWidth": {
+                    "description": "Default max strokeWidth for strokeWidth  (or rule/line's size) scale.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "minOpacity": {
+                    "description": "Default minimum opacity for mapping a field to opacity.",
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "minSize": {
+                    "description": "Default minimum value for point size scale with zero=false.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "minStrokeWidth": {
+                    "description": "Default minimum strokeWidth for strokeWidth (or rule/line's size) scale with zero=false.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "nominalColorScheme": {
+                    "description": "Default color scheme for nominal (categorical) data",
+                    "type": "string"
+                },
+                "opacity": {
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "orient": {
+                    "$ref": "#/definitions/Orient",
+                    "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
+                },
+                "sequentialColorScheme": {
+                    "description": "Default color scheme for ordinal, quantitative and temporal field",
+                    "type": "string"
+                },
+                "size": {
+                    "description": "The pixel area each the point/circle/square.\nFor example: in the case of circles, the radius is determined in part by the square root of the size value.",
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "stacked": {
+                    "$ref": "#/definitions/StackOffset"
+                },
+                "stroke": {
+                    "description": "Default Stroke Color.  This has higher precedence than config.color",
+                    "type": "string"
+                },
+                "strokeDash": {
+                    "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.",
+                    "items": {
+                        "type": "number"
+                    },
+                    "type": "array"
+                },
+                "strokeDashOffset": {
+                    "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
+                    "type": "number"
+                },
+                "strokeOpacity": {
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "strokeWidth": {
+                    "minimum": 0,
+                    "type": "number"
+                },
+                "tension": {
+                    "description": "Depending on the interpolation type, sets the tension parameter (for line and area marks).",
+                    "maximum": 1,
+                    "minimum": 0,
+                    "type": "number"
+                }
+            },
+            "type": "object"
         },
         "TextConfig": {
             "properties": {


### PR DESCRIPTION
(Config for `circle` and `square` should not include `shape` and `shapes` properties)
