### PR TITLE
[Obsolete] Remove the unnecessary bin_legend scale

### DIFF
--- a/examples/specs/point_1d_bin_color_legend.vl.json
+++ b/examples/specs/point_1d_bin_color_legend.vl.json
@@ -1,0 +1,9 @@
+{
+  "description": "Demonstrate color legend with binned data.",
+  "data": {"url": "data/cars.json"},
+  "mark": "point",
+  "encoding": {
+    "x": {"field": "Acceleration", "type": "quantitative"},
+    "color": {"bin": true, "field": "Acceleration", "type": "quantitative"}
+  }
+}

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -155,7 +155,6 @@ export class LayerModel extends Model {
               }
             }
 
-            modelScales.binLegend = modelScales.binLegend ? modelScales.binLegend : childScales.binLegend;
             modelScales.binLegendLabel = modelScales.binLegendLabel ? modelScales.binLegendLabel : childScales.binLegendLabel;
           } else {
             scaleComponent[channel] = childScales;

--- a/src/compile/legend/parse.ts
+++ b/src/compile/legend/parse.ts
@@ -4,7 +4,7 @@ import {keys, Dict} from '../../util';
 import {VgLegend} from '../../vega.schema';
 
 import {numberFormat} from '../common';
-import {BIN_LEGEND_SUFFIX} from '../scale/scale';
+import {BIN_LEGEND_LABEL_SUFFIX} from '../scale/scale';
 import {UnitModel} from '../unit';
 
 import * as encode from './encode';
@@ -27,7 +27,7 @@ export function parseLegendComponent(model: UnitModel): Dict<VgLegend> {
 
 function getLegendDefWithScale(model: UnitModel, channel: Channel): VgLegend {
   // For binned field with continuous scale, use a special scale so we can overrride the mark props and labels
-  const suffix = model.fieldDef(channel).bin && hasContinuousDomain(model.scale(channel).type) ? BIN_LEGEND_SUFFIX : '';
+  const suffix = model.fieldDef(channel).bin && hasContinuousDomain(model.scale(channel).type) ? BIN_LEGEND_LABEL_SUFFIX : '';
   switch (channel) {
     case COLOR:
       const scale = model.scaleName(COLOR) + suffix;

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -16,7 +16,7 @@ import {VgData, VgMarkGroup, VgScale, VgAxis, VgLegend} from '../vega.schema';
 
 import {DataComponent} from './data/data';
 import {LayoutComponent} from './layout';
-import {ScaleComponents, BIN_LEGEND_SUFFIX, BIN_LEGEND_LABEL_SUFFIX} from './scale/scale';
+import {ScaleComponents, BIN_LEGEND_LABEL_SUFFIX} from './scale/scale';
 import {StackProperties} from '../stack';
 
 /* tslint:disable:no-unused-variable */
@@ -186,9 +186,6 @@ export abstract class Model {
     // help assemble scale domains with scale signature as well
     return flatten(vals(this.component.scale).map((scales: ScaleComponents) => {
       let arr = [scales.main];
-      if (scales.binLegend) {
-        arr.push(scales.binLegend);
-      }
       if (scales.binLegendLabel) {
         arr.push(scales.binLegendLabel);
       }
@@ -362,7 +359,7 @@ export abstract class Model {
    * (DO NOT USE THIS METHOD DURING SCALE PARSING, use model.name() instead)
    */
   public scaleName(originalScaleName: Channel|string, parse?: boolean): string {
-    const channel = originalScaleName.replace(BIN_LEGEND_SUFFIX, '').replace(BIN_LEGEND_LABEL_SUFFIX, '');
+    const channel = originalScaleName.replace(BIN_LEGEND_LABEL_SUFFIX, '');
 
     if (parse) {
       // During the parse phase always return a value

--- a/src/compile/scale/parse.ts
+++ b/src/compile/scale/parse.ts
@@ -6,7 +6,7 @@ import {extend, Dict} from '../../util';
 
 import {Model} from '../model';
 
-import {ScaleComponent, ScaleComponents, BIN_LEGEND_SUFFIX, BIN_LEGEND_LABEL_SUFFIX} from './scale';
+import {ScaleComponent, ScaleComponents, BIN_LEGEND_LABEL_SUFFIX} from './scale';
 import domain from './domain';
 
 /**
@@ -35,7 +35,6 @@ export function parseScale(model: Model, channel: Channel) {
 
     // Add additional scale needed for the labels in the binned legend.
     if (model.legend(channel) && fieldDef.bin && hasContinuousDomain(model.scale(channel).type)) {
-      scales.binLegend = parseBinLegend(channel, model, fieldDef);
       scales.binLegendLabel = parseBinLegendLabel(channel, model, fieldDef);
     }
 
@@ -84,22 +83,6 @@ function parseMainScale(model: Model, fieldDef: FieldDef, channel: Channel) {
   }
 
   return scaleDef;
-}
-
-/**
- * Return additional scale to drive legend when we use a continuous scale and binning.
- */
-function parseBinLegend(channel: Channel, model: Model, fieldDef: FieldDef): ScaleComponent {
-  return {
-    name: model.scaleName(channel, true) + BIN_LEGEND_SUFFIX,
-    type: ScaleType.POINT,
-    domain: {
-      data: model.dataTable(),
-      field: model.field(channel),
-      sort: true
-    },
-    range: [0,1] // doesn't matter because we override it
-  };
 }
 
 /**

--- a/src/compile/scale/scale.ts
+++ b/src/compile/scale/scale.ts
@@ -4,9 +4,6 @@ import {Channel} from '../../channel';
 import * as log from '../../log';
 
 
-
-/** Scale suffix for scale used to get drive binned legends. */
-export const BIN_LEGEND_SUFFIX = '_bin_legend';
 /** Scale suffix for scale for binned field's legend labels, which maps a binned field's quantitative values to range strings. */
 export const BIN_LEGEND_LABEL_SUFFIX = '_bin_legend_label';
 
@@ -18,7 +15,6 @@ export type ScaleComponent = VgScale;
 
 export type ScaleComponents = {
   main: ScaleComponent;
-  binLegend?: ScaleComponent;
   binLegendLabel?: ScaleComponent;
 }
 

--- a/test/compile/scale/parse.test.ts
+++ b/test/compile/scale/parse.test.ts
@@ -81,9 +81,6 @@ describe('src/compile', function() {
         assert.equal(scales.main.name, 'color');
         assert.equal(scales.main.type, 'sequential');
 
-        assert.equal(scales.binLegend.name, 'color_bin_legend');
-        assert.equal(scales.binLegend.type, 'point');
-
         assert.equal(scales.binLegendLabel.name, 'color_bin_legend_label');
         assert.equal(scales.binLegendLabel.type, 'ordinal');
       });
@@ -115,7 +112,6 @@ describe('src/compile', function() {
       it('should add correct scales', function() {
         assert.equal(scales.main.name, 'color');
         assert.equal(scales.main.type, 'sequential');
-        assert.equal(scales.binLegend, undefined);
         assert.equal(scales.binLegendLabel, undefined);
       });
     });


### PR DESCRIPTION
This was a hack to make legend work, but it seems we no longer need it.

```
{
  "description": "A scatterplot showing horsepower and miles per gallons.",
  "data": {"url": "data/cars.json"},
  "mark": "point",
  "encoding": {
    "x": {"field": "Acceleration", "type": "quantitative"},
    "color": {"bin": true, "field": "Acceleration", "type": "quantitative"}
  },
  "config": {"numberFormat": "d"}
}
```

![pasted_image_1_17_17__9_30_pm](https://cloud.githubusercontent.com/assets/111269/22052012/3adb62d4-dcfc-11e6-88b6-58f601601bde.png)

changing to opacity also works 

![pasted_image_1_17_17__9_31_pm](https://cloud.githubusercontent.com/assets/111269/22052019/47b75d32-dcfc-11e6-8353-425b10a8af18.png)
