### PR TITLE
Refactor Axis

### DIFF
--- a/src/axis.ts
+++ b/src/axis.ts
@@ -215,17 +215,13 @@ export interface AxisConfig {
 // more concise Vega output.
 
 export const defaultAxisConfig: AxisConfig = {
-  offset: undefined, // implicitly 0
-  grid: undefined, // automatically determined
-  label: true,
   labelMaxLength: 25,
-  tickSize: undefined, // implicitly 6 (by Vega) // FIXME check if this is still true
 };
 
 export const defaultFacetAxisConfig: AxisConfig = {
   axisWidth: 0,
+  // TODO: remove these
   domain: false,
-  label: true,
   grid: false,
   tick: false
 };

--- a/src/compile/axis/encode.ts
+++ b/src/compile/axis/encode.ts
@@ -6,7 +6,8 @@ import {VgAxis} from '../../vega.schema';
 import {timeFormatExpression} from '../common';
 import {Model} from '../model';
 
-export function domain(model: Model, channel: Channel, domainPropsSpec: any) {
+// TODO: @yuhanlu -- please change method signature to require only what are really needed
+export function domain(model: Model, channel: Channel, domainPropsSpec: any, def?: VgAxis) {
   const axis = model.axis(channel);
 
   return extend(
@@ -20,7 +21,8 @@ export function domain(model: Model, channel: Channel, domainPropsSpec: any) {
   );
 }
 
-export function grid(model: Model, channel: Channel, gridPropsSpec: any) {
+// TODO: @yuhanlu -- please change method signature to require only what are really needed
+export function grid(model: Model, channel: Channel, gridPropsSpec: any, def?: VgAxis) {
   const axis = model.axis(channel);
 
   return extend(
@@ -32,16 +34,11 @@ export function grid(model: Model, channel: Channel, gridPropsSpec: any) {
   );
 }
 
+// TODO: @yuhanlu -- please change method signature to require only what are really needed
 export function labels(model: Model, channel: Channel, labelsSpec: any, def: VgAxis) {
   const fieldDef = model.fieldDef(channel);
   const axis = model.axis(channel);
   const config = model.config();
-
-  if (!axis.label) {
-    return extend({
-      text: ''
-    }, labelsSpec);
-  }
 
   // Text
   if (contains([NOMINAL, ORDINAL], fieldDef.type) && axis.labelMaxLength) {
@@ -116,7 +113,8 @@ export function labels(model: Model, channel: Channel, labelsSpec: any, def: VgA
   return keys(labelsSpec).length === 0 ? undefined : labelsSpec;
 }
 
-export function ticks(model: Model, channel: Channel, ticksPropsSpec: any) {
+// TODO: @yuhanlu -- please change method signature to require only what are really needed
+export function ticks(model: Model, channel: Channel, ticksPropsSpec: any, def?: VgAxis) {
   const axis = model.axis(channel);
 
   return extend(
@@ -126,7 +124,8 @@ export function ticks(model: Model, channel: Channel, ticksPropsSpec: any) {
   );
 }
 
-export function title(model: Model, channel: Channel, titlePropsSpec: any) {
+// TODO: @yuhanlu -- please change method signature to require only what are really needed
+export function title(model: Model, channel: Channel, titlePropsSpec: any, def?: VgAxis) {
   const axis = model.axis(channel);
 
   return extend(

--- a/test/compile/axis/encode.test.ts
+++ b/test/compile/axis/encode.test.ts
@@ -78,7 +78,7 @@ describe('compile/axis', () => {
   });
 
   describe('encode.labels()', function () {
-    it('should show labels by default', function () {
+    it('should show truncated labels by default', function () {
       const labels = encode.labels(parseUnitModel({
           mark: "point",
           encoding: {
@@ -86,16 +86,6 @@ describe('compile/axis', () => {
           }
         }), 'x', {}, {orient: 'top'});
       assert.deepEqual(labels.text.signal, 'truncate(datum.value, 25)');
-    });
-
-    it('should hide labels if labels are set to false', function () {
-      const labels = encode.labels(parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: 'a', type: "ordinal", axis: {label: false}}
-          }
-        }), 'x', {}, null);
-      assert.deepEqual(labels.text, '');
     });
 
     it('should rotate labels if labelAngle is defined', function() {


### PR DESCRIPTION
- Remove unnecessary default config
- Don't output labels.text = ''  simply use `label` flag
- Correct the code for checking if part of axis is enabled. 

cc: @YuhanLu this refactor will simply your task a bit :) 