### PR TITLE
Make interfaces and schema for `FieldDef`, `ValueDef` more precise

### DIFF
--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -4,7 +4,7 @@ import {BAR, POINT, CIRCLE, SQUARE} from '../mark';
 import {AggregateOp} from '../aggregate';
 import {COLOR, OPACITY, TEXT, Channel} from '../channel';
 import {Config, CellConfig} from '../config';
-import {FieldDef, OrderChannelDef, field} from '../fielddef';
+import {FieldDef, OrderFieldDef, field, isFieldDef} from '../fielddef';
 import {MarkConfig, TextConfig} from '../mark';
 import {TimeUnit} from '../timeunit';
 import {QUANTITATIVE} from '../type';
@@ -45,8 +45,8 @@ export const FILL_STROKE_CONFIG = union(STROKE_CONFIG, FILL_CONFIG);
 
 export function applyColorAndOpacity(e: VgEncodeEntry, model: UnitModel) {
   const filled = model.config().mark.filled;
-  const colorFieldDef = model.encoding().color;
-  const opacityFieldDef = model.encoding().opacity;
+  const colorDef = model.encoding().color;
+
 
   // Apply fill stroke config first so that color field / value can override
   // fill / stroke
@@ -58,22 +58,23 @@ export function applyColorAndOpacity(e: VgEncodeEntry, model: UnitModel) {
 
   let colorValue: VgValueRef;
   let opacityValue: VgValueRef;
-  if (model.channelHasField(COLOR)) {
+  if (isFieldDef(colorDef)) {
     colorValue = {
       scale: model.scaleName(COLOR),
-      field: model.field(COLOR)
+      field: field(colorDef)
     };
-  } else if (colorFieldDef && colorFieldDef.value) {
-    colorValue = { value: colorFieldDef.value };
+  } else if (colorDef && colorDef.value) {
+    colorValue = { value: colorDef.value };
   }
 
-  if (model.channelHasField(OPACITY)) {
+  const opacityDef = model.encoding().opacity;
+  if (isFieldDef(opacityDef)) {
     opacityValue = {
       scale: model.scaleName(OPACITY),
-      field: model.field(OPACITY)
+      field: field(opacityDef)
     };
-  } else if (opacityFieldDef && opacityFieldDef.value) {
-    opacityValue = { value: opacityFieldDef.value };
+  } else if (opacityDef && opacityDef.value) {
+    opacityValue = { value: opacityDef.value };
   }
 
   if (colorValue !== undefined) {
@@ -152,7 +153,7 @@ export function timeFormatExpression(field: string, timeUnit: TimeUnit, format: 
 /**
  * Return Vega sort parameters (tuple of field and order).
  */
-export function sortParams(orderDef: OrderChannelDef | OrderChannelDef[]): VgSort {
+export function sortParams(orderDef: OrderFieldDef | OrderFieldDef[]): VgSort {
   return (isArray(orderDef) ? orderDef : [orderDef]).reduce((s, orderChannelDef) => {
     s.field.push(field(orderChannelDef, {binSuffix: 'start'}));
     s.order.push(orderChannelDef.sort || 'ascending');

--- a/src/compile/config.ts
+++ b/src/compile/config.ts
@@ -3,7 +3,7 @@ import * as log from '../log';
 import {X, COLOR, SIZE, DETAIL} from '../channel';
 import {Config} from '../config';
 import {Encoding, isAggregate, channelHasField} from '../encoding';
-import {isMeasure, FieldDef} from '../fielddef';
+import {isMeasure, isFieldDef, FieldDef} from '../fielddef';
 import {MarkConfig, TextConfig, Orient} from '../mark';
 import {BAR, AREA, POINT, LINE, TICK, CIRCLE, SQUARE, RECT, RULE, TEXT, Mark} from '../mark';
 import {Scale, hasDiscreteDomain} from '../scale';
@@ -87,7 +87,7 @@ export function orient(mark: Mark, encoding: Encoding, scale: Dict<Scale>, markC
       if (!hasDiscreteDomain(xScaleType) && (
             !encoding.y ||
             hasDiscreteDomain(yScaleType) ||
-            (encoding.y as FieldDef).bin
+            (isFieldDef(encoding.y) && encoding.y.bin)
         )) {
         return 'vertical';
       }

--- a/src/compile/config.ts
+++ b/src/compile/config.ts
@@ -3,7 +3,7 @@ import * as log from '../log';
 import {X, COLOR, SIZE, DETAIL} from '../channel';
 import {Config} from '../config';
 import {Encoding, isAggregate, channelHasField} from '../encoding';
-import {isMeasure} from '../fielddef';
+import {isMeasure, FieldDef} from '../fielddef';
 import {MarkConfig, TextConfig, Orient} from '../mark';
 import {BAR, AREA, POINT, LINE, TICK, CIRCLE, SQUARE, RECT, RULE, TEXT, Mark} from '../mark';
 import {Scale, hasDiscreteDomain} from '../scale';
@@ -87,7 +87,7 @@ export function orient(mark: Mark, encoding: Encoding, scale: Dict<Scale>, markC
       if (!hasDiscreteDomain(xScaleType) && (
             !encoding.y ||
             hasDiscreteDomain(yScaleType) ||
-            encoding.y.bin
+            (encoding.y as FieldDef).bin
         )) {
         return 'vertical';
       }
@@ -120,10 +120,12 @@ export function orient(mark: Mark, encoding: Encoding, scale: Dict<Scale>, markC
       } else if (!xIsMeasure && yIsMeasure) {
         return 'vertical';
       } else if (xIsMeasure && yIsMeasure) {
+        const xDef = encoding.x as FieldDef;
+        const yDef = encoding.y as FieldDef;
         // temporal without timeUnit is considered continuous, but better serves as dimension
-        if (encoding.x.type === TEMPORAL) {
+        if (xDef.type === TEMPORAL) {
           return 'vertical';
-        } else if (encoding.y.type === TEMPORAL) {
+        } else if (yDef.type === TEMPORAL) {
           return 'horizontal';
         }
 

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -74,7 +74,7 @@ export class FacetModel extends Model {
       }
 
       // TODO: array of row / column ?
-      if (fieldDef.field === undefined && fieldDef.value === undefined) { // TODO: datum
+      if (fieldDef.field === undefined) { // TODO: datum
         log.warn(log.message.emptyFieldDef(fieldDef, channel));
         delete facet[channel];
         return;

--- a/src/compile/legend/encode.ts
+++ b/src/compile/legend/encode.ts
@@ -1,5 +1,5 @@
 import {COLOR, SIZE, SHAPE, OPACITY, Channel} from '../../channel';
-import {FieldDef} from '../../fielddef';
+import {FieldDef, isValueDef} from '../../fielddef';
 import {AREA, BAR, TICK, TEXT, LINE, POINT, CIRCLE, SQUARE} from '../../mark';
 import {hasContinuousDomain} from '../../scale';
 import {TEMPORAL} from '../../type';
@@ -56,8 +56,9 @@ export function symbols(fieldDef: FieldDef, symbolsSpec: any, model: UnitModel, 
   }
 
   let value: VgValueRef;
-  if (model.encoding().color && model.encoding().color.value) {
-    value = { value: model.encoding().color.value };
+  const colorDef = model.encoding().color;
+  if (isValueDef(colorDef)) {
+    value = { value: colorDef.value };
   }
 
   if (value !== undefined) {

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -1,5 +1,6 @@
 import {X, Y, X2, Y2, SIZE} from '../../channel';
 import {Config} from '../../config';
+import {isFieldDef} from '../../fielddef';
 import {Scale, ScaleType} from '../../scale';
 import {StackProperties} from '../../stack';
 import {extend} from '../../util';
@@ -32,33 +33,33 @@ function x(model: UnitModel, stack: StackProperties) {
   let e: VgEncodeEntry = {};
   const config = model.config();
   const orient = model.config().mark.orient;
-  const sizeFieldDef = model.encoding().size;
+  const sizeDef = model.encoding().size;
 
-  const xFieldDef = model.encoding().x;
+  const xDef = model.encoding().x;
   const xScaleName = model.scaleName(X);
   const xScale = model.scale(X);
   // x, x2, and width -- we must specify two of these in all conditions
   if (orient === 'horizontal') {
-    e.x = ref.stackable(X, xFieldDef, xScaleName, model.scale(X), stack, 'base');
-    e.x2 = ref.stackable2(X2, xFieldDef, model.encoding().x2, xScaleName, model.scale(X), stack, 'base');
+    e.x = ref.stackable(X, xDef, xScaleName, model.scale(X), stack, 'base');
+    e.x2 = ref.stackable2(X2, xDef, model.encoding().x2, xScaleName, model.scale(X), stack, 'base');
     return e;
   } else { // vertical
-    if (xFieldDef && xFieldDef.field) {
-      if (xFieldDef.bin && !sizeFieldDef) {
+    if (isFieldDef(xDef)) {
+      if (xDef.bin && !sizeDef) {
         // TODO: check scale type = linear
 
-        e.x2 = ref.bin(xFieldDef, xScaleName, 'start', config.bar.binSpacing);
-        e.x = ref.bin(xFieldDef, xScaleName, 'end');
+        e.x2 = ref.bin(xDef, xScaleName, 'start', config.bar.binSpacing);
+        e.x = ref.bin(xDef, xScaleName, 'end');
         return e;
       } else if (xScale.type === ScaleType.BAND) {
         // TODO: band scale doesn't support size yet
-        e.x = ref.fieldRef(xFieldDef, xScaleName, {});
+        e.x = ref.fieldRef(xDef, xScaleName, {});
         e.width = ref.band(xScaleName);
         return e;
       }
     }
     // sized bin, normal point-ordinal axis, quantitative x-axis, or no x
-    e.xc = ref.midPoint(X, xFieldDef, xScaleName, model.scale(X),
+    e.xc = ref.midPoint(X, xDef, xScaleName, model.scale(X),
       extend(ref.midX(config), {offset: 1}) // TODO: config.singleBarOffset
     );
     e.width = ref.midPoint(SIZE, model.encoding().size, model.scaleName(SIZE), model.scale(SIZE),
@@ -72,9 +73,9 @@ function y(model: UnitModel, stack: StackProperties) {
   let e: VgEncodeEntry = {};
   const config = model.config();
   const orient = model.config().mark.orient;
-  const sizeFieldDef = model.encoding().size;
+  const sizeDef = model.encoding().size;
 
-  const yFieldDef = model.encoding().y;
+  const yDef = model.encoding().y;
   const yScaleName = model.scaleName(Y);
   const yScale = model.scale(Y);
   // y, y2 & height -- we must specify two of these in all conditions
@@ -83,19 +84,19 @@ function y(model: UnitModel, stack: StackProperties) {
     e.y2 = ref.stackable2(Y2, model.encoding().y, model.encoding().y2, yScaleName, model.scale(Y), stack, 'base');
     return e;
   } else {
-    if (yFieldDef && yFieldDef.field) {
-      if (yFieldDef.bin && !sizeFieldDef) {
-        e.y2 = ref.bin(yFieldDef, yScaleName, 'start');
-        e.y = ref.bin(yFieldDef, yScaleName, 'end', config.bar.binSpacing);
+    if (isFieldDef(yDef)) {
+      if (yDef.bin && !sizeDef) {
+        e.y2 = ref.bin(yDef, yScaleName, 'start');
+        e.y = ref.bin(yDef, yScaleName, 'end', config.bar.binSpacing);
         return e;
       } else if (yScale.type === ScaleType.BAND) {
         // TODO: band scale doesn't support size yet
-        e.y = ref.fieldRef(yFieldDef, yScaleName, {});
+        e.y = ref.fieldRef(yDef, yScaleName, {});
         e.height = ref.band(yScaleName);
         return e;
       }
     }
-    e.yc = ref.midPoint(Y, yFieldDef, yScaleName, model.scale(Y),
+    e.yc = ref.midPoint(Y, yDef, yScaleName, model.scale(Y),
       ref.midY(config)
     );
     e.height = ref.midPoint(SIZE, model.encoding().size, model.scaleName(SIZE), model.scale(SIZE),

--- a/src/compile/mark/line.ts
+++ b/src/compile/mark/line.ts
@@ -1,6 +1,6 @@
 import {X, Y} from '../../channel';
 import {Config} from '../../config';
-import {FieldDef} from '../../fielddef';
+import {ChannelDef, isValueDef} from '../../fielddef';
 import {VgEncodeEntry} from '../../vega.schema';
 
 import {applyColorAndOpacity, applyMarkConfig} from '../common';
@@ -35,9 +35,9 @@ export const line: MarkCompiler = {
 // FIXME: replace this with normal size and throw warning if the size field is not the grouping field instead?
 // NOTE: This is different from other size because
 // Vega does not support variable line size.
-function size(fieldDef: FieldDef, config: Config) {
-  if (fieldDef && fieldDef.value !== undefined) {
-      return { value: fieldDef.value};
+function size(sizeDef: ChannelDef, config: Config) {
+  if (isValueDef(sizeDef)) {
+      return { value: sizeDef.value};
   }
   // FIXME: We should not need this line since this should be taken care by applyColorAndOpacity
   // but we have to refactor \ first

--- a/src/compile/mark/point.ts
+++ b/src/compile/mark/point.ts
@@ -1,5 +1,5 @@
 import {X, Y, SHAPE, SIZE} from '../../channel';
-import {ChannelDefWithLegend} from '../../fielddef';
+import {LegendFieldDef} from '../../fielddef';
 import {SymbolConfig, PointConfig} from '../../mark';
 import {Scale} from '../../scale';
 import {VgEncodeEntry, VgValueRef} from '../../vega.schema';
@@ -31,12 +31,12 @@ function encodeEntry(model: UnitModel, fixedShape?: string) {
   return e;
 }
 
-function shape(fieldDef: ChannelDefWithLegend, scaleName: string, scale: Scale, pointConfig: PointConfig, fixedShape?: string): VgValueRef {
+function shape(shapeDef: LegendFieldDef, scaleName: string, scale: Scale, pointConfig: PointConfig, fixedShape?: string): VgValueRef {
   // shape
   if (fixedShape) { // square and circle marks
     return { value: fixedShape };
   }
-  return ref.midPoint(SHAPE, fieldDef, scaleName, scale, {value: pointConfig.shape});
+  return ref.midPoint(SHAPE, shapeDef, scaleName, scale, {value: pointConfig.shape});
 }
 
 export const point: MarkCompiler = {

--- a/src/compile/mark/rect.ts
+++ b/src/compile/mark/rect.ts
@@ -1,4 +1,5 @@
 import {X, X2, Y, Y2} from '../../channel';
+import {isFieldDef} from '../../fielddef';
 import {ScaleType, hasDiscreteDomain} from '../../scale';
 import {RECT} from '../../mark';
 import {extend} from '../../util';
@@ -28,18 +29,18 @@ export const rect: MarkCompiler = {
 function x(model: UnitModel) {
   let e: VgEncodeEntry = {};
 
-  const xFieldDef = model.encoding().x;
-  const x2FieldDef = model.encoding().x2;
+  const xDef = model.encoding().x;
+  const x2Def = model.encoding().x2;
   const xScaleName = model.scaleName(X);
   const xScale = model.scale(X);
 
-  if (xFieldDef && xFieldDef.bin && !x2FieldDef) { // TODO: better check for bin
-    e.x2 = ref.bin(xFieldDef, xScaleName, 'start');
-    e.x = ref.bin(xFieldDef, xScaleName, 'end');
+  if (isFieldDef(xDef) && xDef.bin && !x2Def) { // TODO: better check for bin
+    e.x2 = ref.bin(xDef, xScaleName, 'start');
+    e.x = ref.bin(xDef, xScaleName, 'end');
   } else if (xScale && hasDiscreteDomain(xScale.type)) {
     /* istanbul ignore else */
     if (xScale.type === ScaleType.BAND) {
-      e.x = ref.fieldRef(xFieldDef, xScaleName, {});
+      e.x = ref.fieldRef(xDef, xScaleName, {});
       e.width = ref.band(xScaleName);
     } else {
       // We don't support rect mark with point/ordinal scale
@@ -47,8 +48,8 @@ function x(model: UnitModel) {
     }
     // TODO: Currently we only support band scale for rect -- support point-ordinal axis case (if we support arbitrary scale type)
   } else { // continuous scale or no scale
-    e.x = ref.midPoint(X, xFieldDef, xScaleName, xScale, 'baseOrMax');
-    e.x2 = ref.midPoint(X2, x2FieldDef, xScaleName, xScale, 'base');
+    e.x = ref.midPoint(X, xDef, xScaleName, xScale, 'baseOrMax');
+    e.x2 = ref.midPoint(X2, x2Def, xScaleName, xScale, 'base');
   }
   return e;
 }
@@ -56,26 +57,26 @@ function x(model: UnitModel) {
 function y(model: UnitModel) {
   let e: VgEncodeEntry = {};
 
-  const yFieldDef = model.encoding().y;
-  const y2FieldDef = model.encoding().y2;
+  const yDef = model.encoding().y;
+  const y2Def = model.encoding().y2;
   const yScaleName = model.scaleName(Y);
   const yScale = model.scale(Y);
 
-  if (yFieldDef && yFieldDef.bin && !y2FieldDef) { // TODO: better check for bin
-    e.y2 = ref.bin(yFieldDef, yScaleName, 'start');
-    e.y = ref.bin(yFieldDef, yScaleName, 'end');
+  if (isFieldDef(yDef) && yDef.bin && !y2Def) { // TODO: better check for bin
+    e.y2 = ref.bin(yDef, yScaleName, 'start');
+    e.y = ref.bin(yDef, yScaleName, 'end');
   } else if (yScale && hasDiscreteDomain(yScale.type)) {
     /* istanbul ignore else */
     if (yScale.type === ScaleType.BAND) {
-      e.y = ref.fieldRef(yFieldDef, yScaleName, {});
+      e.y = ref.fieldRef(yDef, yScaleName, {});
       e.height = ref.band(yScaleName);
     } else {
       // We don't support rect mark with point/ordinal scale
       throw new Error(log.message.scaleTypeNotWorkWithMark(RECT, yScale.type));
     }
   } else { // continuous scale or no scale
-    e.y = ref.midPoint(Y, yFieldDef, yScaleName, yScale, 'baseOrMax');
-    e.y2 = ref.midPoint(Y2, y2FieldDef, yScaleName, yScale, 'base');
+    e.y = ref.midPoint(Y, yDef, yScaleName, yScale, 'baseOrMax');
+    e.y2 = ref.midPoint(Y2, y2Def, yScaleName, yScale, 'base');
   }
   return e;
 }

--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -4,7 +4,7 @@
 
 import {Channel, X, X2, Y, Y2} from '../../channel';
 import {Config} from '../../config';
-import {FieldDef, FieldRefOption, field} from '../../fielddef';
+import {ChannelDef, FieldDef, FieldRefOption, field, isFieldDef} from '../../fielddef';
 import {Scale, ScaleType, hasDiscreteDomain} from '../../scale';
 import {StackProperties} from '../../stack';
 import {contains} from '../../util';
@@ -16,13 +16,13 @@ import {VgValueRef} from '../../vega.schema';
 /**
  * @return Vega ValueRef for stackable x or y
  */
-export function stackable(channel: Channel, fieldDef: FieldDef, scaleName: string, scale: Scale,
+export function stackable(channel: Channel, channelDef: ChannelDef, scaleName: string, scale: Scale,
     stack: StackProperties, defaultRef: VgValueRef): VgValueRef {
-  if (fieldDef && stack && channel === stack.fieldChannel) {
+  if (channelDef && stack && channel === stack.fieldChannel) {
     // x or y use stack_end so that stacked line's point mark use stack_end too.
-    return fieldRef(fieldDef, scaleName, {suffix: 'end'});
+    return fieldRef(channelDef, scaleName, {suffix: 'end'});
   }
-  return midPoint(channel, fieldDef, scaleName, scale, defaultRef);
+  return midPoint(channel, channelDef, scaleName, scale, defaultRef);
 }
 
 /**
@@ -75,29 +75,29 @@ export function binMidSignal(fieldDef: FieldDef, scaleName: string) {
 /**
  * @returns {VgValueRef} Value Ref for xc / yc or mid point for other channels.
  */
-export function midPoint(channel: Channel, fieldDef: FieldDef, scaleName: string, scale: Scale,
+export function midPoint(channel: Channel, channelDef: ChannelDef, scaleName: string, scale: Scale,
   defaultRef: VgValueRef | 'base' | 'baseOrMax'): VgValueRef {
   // TODO: datum support
 
-  if (fieldDef) {
+  if (channelDef) {
     /* istanbul ignore else */
-    if (fieldDef.field) {
+    if (isFieldDef(channelDef)) {
       if (hasDiscreteDomain(scale.type)) {
         if (scale.type === 'band') {
           // For band, to get mid point, need to offset by half of the band
-          return fieldRef(fieldDef, scaleName, {binSuffix: 'range'}, band(scaleName, 0.5));
+          return fieldRef(channelDef, scaleName, {binSuffix: 'range'}, band(scaleName, 0.5));
         }
-        return fieldRef(fieldDef, scaleName, {binSuffix: 'range'});
+        return fieldRef(channelDef, scaleName, {binSuffix: 'range'});
       } else {
-        if (fieldDef.bin) {
-          return binMidSignal(fieldDef, scaleName);
+        if (channelDef.bin) {
+          return binMidSignal(channelDef, scaleName);
         } else {
-          return fieldRef(fieldDef, scaleName, {}); // no need for bin suffix
+          return fieldRef(channelDef, scaleName, {}); // no need for bin suffix
         }
       }
-    } else if (fieldDef.value) {
+    } else if (channelDef.value) {
       return {
-        value: fieldDef.value
+        value: channelDef.value
       };
     } else {
       throw new Error('FieldDef without field or value.'); // FIXME add this to log.message

--- a/src/compile/scale/init.ts
+++ b/src/compile/scale/init.ts
@@ -2,7 +2,7 @@ import * as log from '../../log';
 
 import {Config} from '../../config';
 import {Channel} from '../../channel';
-import {ChannelDefWithScale, FieldDef} from '../../fielddef';
+import {ScaleFieldDef, FieldDef} from '../../fielddef';
 import {Mark} from '../../mark';
 import {Scale, ScaleConfig, scaleTypeSupportProperty} from '../../scale';
 
@@ -13,7 +13,7 @@ import scaleType from './type';
 import * as util from '../../util';
 
 export default function init(
-    channel: Channel, fieldDef: ChannelDefWithScale, config: Config,
+    channel: Channel, fieldDef: ScaleFieldDef, config: Config,
     mark: Mark | undefined, topLevelSize: number | undefined, xyRangeSteps: number[]): Scale {
   let specifiedScale = (fieldDef || {}).scale || {};
 

--- a/src/compile/scale/type.ts
+++ b/src/compile/scale/type.ts
@@ -2,7 +2,7 @@ import * as log from '../../log';
 
 import {Config} from '../../config';
 import {hasScale, supportScaleType, Channel} from '../../channel';
-import {FieldDef, ChannelDefWithScale} from '../../fielddef';
+import {FieldDef, ScaleFieldDef} from '../../fielddef';
 import {Mark} from '../../mark';
 import {Scale, ScaleType} from '../../scale';
 
@@ -12,7 +12,7 @@ import * as util from '../../util';
  * Determine if there is a specified scale type and if it is appropriate,
  * or determine default type if type is unspecified or inappropriate.
  */
-export default function type(fieldDef: ChannelDefWithScale, channel: Channel,
+export default function type(fieldDef: ScaleFieldDef, channel: Channel,
   mark: Mark, topLevelSize: number | undefined, config: Config): ScaleType {
 
   if (!hasScale(channel)) {

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -10,35 +10,36 @@ export interface UnitEncoding {
    * `line`, `rule`, `text`, and `tick`
    * (or to width and height for `bar` and `area` marks).
    */
-  x?: PositionFieldDef | ValueDef;
+  x?: PositionFieldDef | ValueDef<number>;
 
   /**
    * Y coordinates for `point`, `circle`, `square`,
    * `line`, `rule`, `text`, and `tick`
    * (or to width and height for `bar` and `area` marks).
    */
-  y?: PositionFieldDef | ValueDef;
+  y?: PositionFieldDef | ValueDef<number>;
 
   /**
    * X2 coordinates for ranged `bar`, `rule`, `area`
    */
-  x2?: FieldDef | ValueDef;
+  x2?: FieldDef | ValueDef<number>;
 
   /**
    * Y2 coordinates for ranged `bar`, `rule`, `area`
    */
-  y2?: FieldDef | ValueDef;
+  y2?: FieldDef | ValueDef<number>;
 
   /**
    * Color of the marks – either fill or stroke color based on mark type.
    * (By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /
    * stroke color for `line` and `point`.)
    */
-  color?: LegendFieldDef | ValueDef;
+  color?: LegendFieldDef | ValueDef<string>;
+
   /**
    * Opacity of the marks – either can be a value or in a range.
    */
-  opacity?: LegendFieldDef | ValueDef;
+  opacity?: LegendFieldDef | ValueDef<number>;
 
   /**
    * Size of the mark.
@@ -48,14 +49,14 @@ export interface UnitEncoding {
    * - For `text` – the text's font size.
    * - Size is currently unsupported for `line` and `area`.
    */
-  size?: LegendFieldDef | ValueDef;
+  size?: LegendFieldDef | ValueDef<number>;
 
   /**
    * The symbol's shape (only for `point` marks). The supported values are
    * `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,
    * or `"triangle-down"`, or else a custom SVG path string.
    */
-  shape?: LegendFieldDef | ValueDef; // TODO: maybe distinguish ordinal-only
+  shape?: LegendFieldDef | ValueDef<string>; // TODO: maybe distinguish ordinal-only
 
   /**
    * Additional levels of detail for grouping data in aggregate views and
@@ -66,7 +67,7 @@ export interface UnitEncoding {
   /**
    * Text of the `text` mark.
    */
-  text?: FieldDef | ValueDef;
+  text?: FieldDef | ValueDef<string|number>;
 
   /**
    * stack order for stacked marks or order of data points in line marks.

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,5 +1,5 @@
 // utility for encoding mapping
-import {FieldDef, PositionChannelDef, FacetChannelDef, ChannelDefWithLegend, OrderChannelDef} from './fielddef';
+import {FieldDef, PositionFieldDef, FacetFieldDef, LegendFieldDef, OrderFieldDef, ValueDef} from './fielddef';
 import {Channel, CHANNELS} from './channel';
 import {isArray, some} from './util';
 
@@ -10,35 +10,35 @@ export interface UnitEncoding {
    * `line`, `rule`, `text`, and `tick`
    * (or to width and height for `bar` and `area` marks).
    */
-  x?: PositionChannelDef;
+  x?: PositionFieldDef | ValueDef;
 
   /**
    * Y coordinates for `point`, `circle`, `square`,
    * `line`, `rule`, `text`, and `tick`
    * (or to width and height for `bar` and `area` marks).
    */
-  y?: PositionChannelDef;
+  y?: PositionFieldDef | ValueDef;
 
   /**
    * X2 coordinates for ranged `bar`, `rule`, `area`
    */
-  x2?: FieldDef;
+  x2?: FieldDef | ValueDef;
 
   /**
    * Y2 coordinates for ranged `bar`, `rule`, `area`
    */
-  y2?: FieldDef;
+  y2?: FieldDef | ValueDef;
 
   /**
    * Color of the marks – either fill or stroke color based on mark type.
    * (By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /
    * stroke color for `line` and `point`.)
    */
-  color?: ChannelDefWithLegend;
+  color?: LegendFieldDef | ValueDef;
   /**
    * Opacity of the marks – either can be a value or in a range.
    */
-  opacity?: ChannelDefWithLegend;
+  opacity?: LegendFieldDef | ValueDef;
 
   /**
    * Size of the mark.
@@ -48,14 +48,14 @@ export interface UnitEncoding {
    * - For `text` – the text's font size.
    * - Size is currently unsupported for `line` and `area`.
    */
-  size?: ChannelDefWithLegend;
+  size?: LegendFieldDef | ValueDef;
 
   /**
    * The symbol's shape (only for `point` marks). The supported values are
    * `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,
    * or `"triangle-down"`, or else a custom SVG path string.
    */
-  shape?: ChannelDefWithLegend; // TODO: maybe distinguish ordinal-only
+  shape?: LegendFieldDef | ValueDef; // TODO: maybe distinguish ordinal-only
 
   /**
    * Additional levels of detail for grouping data in aggregate views and
@@ -66,14 +66,12 @@ export interface UnitEncoding {
   /**
    * Text of the `text` mark.
    */
-  text?: FieldDef;
-
-  label?: FieldDef;
+  text?: FieldDef | ValueDef;
 
   /**
    * stack order for stacked marks or order of data points in line marks.
    */
-  order?: OrderChannelDef | OrderChannelDef[];
+  order?: OrderFieldDef | OrderFieldDef[];
 }
 
 // TODO: once we decompose facet, rename this to ExtendedEncoding
@@ -81,12 +79,12 @@ export interface Encoding extends UnitEncoding {
   /**
    * Vertical facets for trellis plots.
    */
-  row?: FacetChannelDef;
+  row?: FacetFieldDef;
 
   /**
    * Horizontal facets for trellis plots.
    */
-  column?: FacetChannelDef;
+  column?: FacetFieldDef;
 }
 
 export function channelHasField(encoding: Encoding, channel: Channel): boolean {

--- a/src/facet.ts
+++ b/src/facet.ts
@@ -1,6 +1,6 @@
-import {FacetChannelDef} from './fielddef';
+import {FacetFieldDef} from './fielddef';
 
 export interface Facet {
-  row?: FacetChannelDef;
-  column?: FacetChannelDef;
+  row?: FacetFieldDef;
+  column?: FacetFieldDef;
 }

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -14,9 +14,17 @@ import {Type, NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL, getFullName} from './typ
 import {contains} from './util';
 
 /**
- *  Interface for any kind of FieldDef;
- *  For simplicity, we do not declare multiple interfaces of FieldDef like
- *  we do for JSON schema.
+ * Definition object for a constant value of an encoding channel.
+ */
+export interface ValueDef {
+  /**
+   * A constant value in visual domain.
+   */
+  value?: number | string | boolean;
+}
+
+/**
+ *  Definition object for a data field, its type and transformation of an encoding channel.
  */
 export interface FieldDef {
   /**
@@ -32,10 +40,6 @@ export interface FieldDef {
    */
   type?: Type;
 
-  /**
-   * A constant value in visual domain.
-   */
-  value?: number | string | boolean;
 
   // function
 
@@ -62,18 +66,18 @@ export interface FieldDef {
   title?: string;
 }
 
-export interface ChannelDefWithScale extends FieldDef {
+export interface ScaleFieldDef extends FieldDef {
   scale?: Scale;
   sort?: SortField | SortOrder;
 }
 
-export interface PositionChannelDef extends ChannelDefWithScale {
+export interface PositionFieldDef extends ScaleFieldDef {
   /**
    * @nullable
    */
   axis?: Axis;
 }
-export interface ChannelDefWithLegend extends ChannelDefWithScale {
+export interface LegendFieldDef extends ScaleFieldDef {
    /**
     * @nullable
     */
@@ -84,12 +88,22 @@ export interface ChannelDefWithLegend extends ChannelDefWithScale {
 
 // Order Path have no scale
 
-export interface OrderChannelDef extends FieldDef {
+export interface OrderFieldDef extends FieldDef {
   sort?: SortOrder;
 }
 
+export type ChannelDef = FieldDef | ValueDef;
+
+export function isFieldDef(channelDef: ChannelDef): channelDef is FieldDef | PositionFieldDef | LegendFieldDef | OrderFieldDef  {
+  return channelDef && !!channelDef['field'];
+}
+
+export function isValueDef(channelDef: ChannelDef): channelDef is ValueDef {
+  return channelDef && !!channelDef['value'];
+}
+
 // TODO: consider if we want to distinguish ordinalOnlyScale from scale
-export type FacetChannelDef = PositionChannelDef;
+export type FacetFieldDef = PositionFieldDef;
 
 export interface FieldRefOption {
   /** exclude bin, aggregate, timeUnit */
@@ -159,11 +173,11 @@ function _isFieldDimension(fieldDef: FieldDef) {
 }
 
 export function isDimension(fieldDef: FieldDef) {
-  return fieldDef && fieldDef.field && _isFieldDimension(fieldDef);
+  return fieldDef && isFieldDef(fieldDef) && _isFieldDimension(fieldDef);
 }
 
 export function isMeasure(fieldDef: FieldDef) {
-  return fieldDef && fieldDef.field && !_isFieldDimension(fieldDef);
+  return fieldDef && isFieldDef(fieldDef) && !_isFieldDimension(fieldDef);
 }
 
 export function count(): FieldDef {

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -16,11 +16,11 @@ import {contains} from './util';
 /**
  * Definition object for a constant value of an encoding channel.
  */
-export interface ValueDef {
+export interface ValueDef<T> {
   /**
    * A constant value in visual domain.
    */
-  value?: number | string | boolean;
+  value?: T;
 }
 
 /**
@@ -92,14 +92,14 @@ export interface OrderFieldDef extends FieldDef {
   sort?: SortOrder;
 }
 
-export type ChannelDef = FieldDef | ValueDef;
+export type ChannelDef = FieldDef | ValueDef<any>;
 
 export function isFieldDef(channelDef: ChannelDef): channelDef is FieldDef | PositionFieldDef | LegendFieldDef | OrderFieldDef  {
   return channelDef && !!channelDef['field'];
 }
 
-export function isValueDef(channelDef: ChannelDef): channelDef is ValueDef {
-  return channelDef && !!channelDef['value'];
+export function isValueDef(channelDef: ChannelDef): channelDef is ValueDef<any> {
+  return channelDef && 'value' in channelDef && channelDef['value'] !== undefined;
 }
 
 // TODO: consider if we want to distinguish ordinalOnlyScale from scale

--- a/src/legend.ts
+++ b/src/legend.ts
@@ -1,5 +1,4 @@
 import {DateTime} from './datetime';
-import {Shape} from './mark';
 import {VgLegendEncode} from './vega.schema';
 
 export interface LegendConfig {
@@ -76,7 +75,7 @@ export interface LegendConfig {
    * The shape of the legend symbol, can be the 'circle', 'square', 'cross', 'diamond',
    * 'triangle-up', 'triangle-down', or else a custom SVG path string.
    */
-  symbolShape?: Shape;
+  symbolShape?: string;
   /**
    * The size of the legend symbol, in pixels.
    * @mimimum 0
@@ -129,7 +128,7 @@ export interface Legend extends LegendConfig {
    */
   values?: number[] | string[] | DateTime[];
 
-  shape?: Shape;
+  shape?: string;
 
   /**
    * The type of the legend. Use `symbol` to create a discrete legend and `gradient` for a continuous color gradient.

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -276,13 +276,13 @@ export interface PointConfig extends SymbolConfig {
   /**
    * The default symbol shape to use. One of: `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
    */
-  shape?: Shape | string;
+  shape?: string;
 
   /**
    * The default collection of symbol shapes for mapping nominal fields to shapes of point marks (i.e., range of a `shape` scale).
    * Each value should be one of: `"circle"`, `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
    */
-  shapes?: (Shape|string)[];
+  shapes?: string[];
 }
 
 export const defaultSymbolConfig: PointConfig = {

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -3,7 +3,7 @@ import * as log from './log';
 import {SUM_OPS} from './aggregate';
 import {Channel, STACK_GROUP_CHANNELS, X, Y, X2, Y2} from './channel';
 import {Encoding, channelHasField, isAggregate} from './encoding';
-import {FieldDef} from './fielddef';
+import {FieldDef, PositionFieldDef, isFieldDef} from './fielddef';
 import {Mark, BAR, AREA, POINT, CIRCLE, SQUARE, LINE, RULE, TEXT, TICK} from './mark';
 import {ScaleType} from './scale';
 import {contains, isArray} from './util';
@@ -66,7 +66,7 @@ export function stack(mark: Mark, encoding: Encoding, stacked: StackOffset): Sta
     if (channelHasField(encoding, channel)) {
       const channelDef = encoding[channel];
       (isArray(channelDef) ? channelDef : [channelDef]).forEach((fieldDef) => {
-        if (!fieldDef.aggregate) {
+        if (isFieldDef(fieldDef) && !fieldDef.aggregate) {
           sc.push({
             channel: channel,
             fieldDef: fieldDef
@@ -82,15 +82,16 @@ export function stack(mark: Mark, encoding: Encoding, stacked: StackOffset): Sta
   }
 
   // Has only one aggregate axis
-  const hasXField = channelHasField(encoding, X);
-  const hasYField = channelHasField(encoding, Y);
-  const xIsAggregate = hasXField && !!encoding.x.aggregate;
-  const yIsAggregate = hasYField && !!encoding.y.aggregate;
+  const hasXField = isFieldDef(encoding.x);
+  const hasYField = isFieldDef(encoding.y);
+  const xIsAggregate = isFieldDef(encoding.x) && !!encoding.x.aggregate;
+  const yIsAggregate = isFieldDef(encoding.y) && !!encoding.y.aggregate;
 
   if (xIsAggregate !== yIsAggregate) {
     const fieldChannel = xIsAggregate ? X : Y;
-    const fieldChannelAggregate = encoding[fieldChannel].aggregate;
-    const fieldChannelScale = encoding[fieldChannel].scale;
+    const fieldDef = encoding[fieldChannel] as PositionFieldDef;
+    const fieldChannelAggregate = fieldDef.aggregate;
+    const fieldChannelScale = fieldDef.scale;
 
     if (contains(STACK_BY_DEFAULT_MARKS, mark)) {
       // Bar and Area with sum ops are automatically stacked by default

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -976,10 +976,10 @@
                 "color": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/LegendFieldDef"
                         },
                         {
-                            "$ref": "#/definitions/LegendFieldDef"
+                            "$ref": "#/definitions/ValueDef<string>"
                         }
                     ],
                     "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
@@ -1005,10 +1005,10 @@
                 "opacity": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/LegendFieldDef"
                         },
                         {
-                            "$ref": "#/definitions/LegendFieldDef"
+                            "$ref": "#/definitions/ValueDef<number>"
                         }
                     ],
                     "description": "Opacity of the marks – either can be a value or in a range."
@@ -1034,10 +1034,10 @@
                 "shape": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/LegendFieldDef"
                         },
                         {
-                            "$ref": "#/definitions/LegendFieldDef"
+                            "$ref": "#/definitions/ValueDef<string>"
                         }
                     ],
                     "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
@@ -1045,10 +1045,10 @@
                 "size": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/LegendFieldDef"
                         },
                         {
-                            "$ref": "#/definitions/LegendFieldDef"
+                            "$ref": "#/definitions/ValueDef<number>"
                         }
                     ],
                     "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
@@ -1056,10 +1056,10 @@
                 "text": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/FieldDef"
                         },
                         {
-                            "$ref": "#/definitions/FieldDef"
+                            "$ref": "#/definitions/ValueDef<string | number>"
                         }
                     ],
                     "description": "Text of the `text` mark."
@@ -1067,10 +1067,10 @@
                 "x": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/PositionFieldDef"
                         },
                         {
-                            "$ref": "#/definitions/PositionFieldDef"
+                            "$ref": "#/definitions/ValueDef<number>"
                         }
                     ],
                     "description": "X coordinates for `point`, `circle`, `square`,\n`line`, `rule`, `text`, and `tick`\n(or to width and height for `bar` and `area` marks)."
@@ -1078,10 +1078,10 @@
                 "x2": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/FieldDef"
                         },
                         {
-                            "$ref": "#/definitions/FieldDef"
+                            "$ref": "#/definitions/ValueDef<number>"
                         }
                     ],
                     "description": "X2 coordinates for ranged `bar`, `rule`, `area`"
@@ -1089,10 +1089,10 @@
                 "y": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/PositionFieldDef"
                         },
                         {
-                            "$ref": "#/definitions/PositionFieldDef"
+                            "$ref": "#/definitions/ValueDef<number>"
                         }
                     ],
                     "description": "Y coordinates for `point`, `circle`, `square`,\n`line`, `rule`, `text`, and `tick`\n(or to width and height for `bar` and `area` marks)."
@@ -1100,10 +1100,10 @@
                 "y2": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/FieldDef"
                         },
                         {
-                            "$ref": "#/definitions/FieldDef"
+                            "$ref": "#/definitions/ValueDef<number>"
                         }
                     ],
                     "description": "Y2 coordinates for ranged `bar`, `rule`, `area`"
@@ -3282,10 +3282,10 @@
                 "color": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/LegendFieldDef"
                         },
                         {
-                            "$ref": "#/definitions/LegendFieldDef"
+                            "$ref": "#/definitions/ValueDef<string>"
                         }
                     ],
                     "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
@@ -3307,10 +3307,10 @@
                 "opacity": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/LegendFieldDef"
                         },
                         {
-                            "$ref": "#/definitions/LegendFieldDef"
+                            "$ref": "#/definitions/ValueDef<number>"
                         }
                     ],
                     "description": "Opacity of the marks – either can be a value or in a range."
@@ -3332,10 +3332,10 @@
                 "shape": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/LegendFieldDef"
                         },
                         {
-                            "$ref": "#/definitions/LegendFieldDef"
+                            "$ref": "#/definitions/ValueDef<string>"
                         }
                     ],
                     "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
@@ -3343,10 +3343,10 @@
                 "size": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/LegendFieldDef"
                         },
                         {
-                            "$ref": "#/definitions/LegendFieldDef"
+                            "$ref": "#/definitions/ValueDef<number>"
                         }
                     ],
                     "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
@@ -3354,10 +3354,10 @@
                 "text": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/FieldDef"
                         },
                         {
-                            "$ref": "#/definitions/FieldDef"
+                            "$ref": "#/definitions/ValueDef<string | number>"
                         }
                     ],
                     "description": "Text of the `text` mark."
@@ -3365,10 +3365,10 @@
                 "x": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/PositionFieldDef"
                         },
                         {
-                            "$ref": "#/definitions/PositionFieldDef"
+                            "$ref": "#/definitions/ValueDef<number>"
                         }
                     ],
                     "description": "X coordinates for `point`, `circle`, `square`,\n`line`, `rule`, `text`, and `tick`\n(or to width and height for `bar` and `area` marks)."
@@ -3376,10 +3376,10 @@
                 "x2": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/FieldDef"
                         },
                         {
-                            "$ref": "#/definitions/FieldDef"
+                            "$ref": "#/definitions/ValueDef<number>"
                         }
                     ],
                     "description": "X2 coordinates for ranged `bar`, `rule`, `area`"
@@ -3387,10 +3387,10 @@
                 "y": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/PositionFieldDef"
                         },
                         {
-                            "$ref": "#/definitions/PositionFieldDef"
+                            "$ref": "#/definitions/ValueDef<number>"
                         }
                     ],
                     "description": "Y coordinates for `point`, `circle`, `square`,\n`line`, `rule`, `text`, and `tick`\n(or to width and height for `bar` and `area` marks)."
@@ -3398,10 +3398,10 @@
                 "y2": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/ValueDef"
+                            "$ref": "#/definitions/FieldDef"
                         },
                         {
-                            "$ref": "#/definitions/FieldDef"
+                            "$ref": "#/definitions/ValueDef<number>"
                         }
                     ],
                     "description": "Y2 coordinates for ranged `bar`, `rule`, `area`"
@@ -3482,16 +3482,35 @@
             ],
             "type": "object"
         },
-        "ValueDef": {
+        "ValueDef<number>": {
+            "description": "Definition object for a constant value of an encoding channel.",
+            "properties": {
+                "value": {
+                    "description": "A constant value in visual domain.",
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "ValueDef<string | number>": {
             "description": "Definition object for a constant value of an encoding channel.",
             "properties": {
                 "value": {
                     "description": "A constant value in visual domain.",
                     "type": [
                         "string",
-                        "number",
-                        "boolean"
+                        "number"
                     ]
+                }
+            },
+            "type": "object"
+        },
+        "ValueDef<string>": {
+            "description": "Definition object for a constant value of an encoding channel.",
+            "properties": {
+                "value": {
+                    "description": "A constant value in visual domain.",
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -741,77 +741,6 @@
             },
             "type": "object"
         },
-        "ChannelDefWithLegend": {
-            "properties": {
-                "aggregate": {
-                    "$ref": "#/definitions/AggregateOp",
-                    "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`)."
-                },
-                "bin": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/Bin"
-                        },
-                        {
-                            "type": "boolean"
-                        }
-                    ],
-                    "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
-                },
-                "field": {
-                    "description": "Name of the field from which to pull a data value.",
-                    "type": "string"
-                },
-                "legend": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/Legend"
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "scale": {
-                    "$ref": "#/definitions/Scale"
-                },
-                "sort": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/SortField"
-                        },
-                        {
-                            "enum": [
-                                "ascending",
-                                "descending"
-                            ],
-                            "type": "string"
-                        }
-                    ]
-                },
-                "timeUnit": {
-                    "$ref": "#/definitions/TimeUnit",
-                    "description": "Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`)."
-                },
-                "title": {
-                    "description": "Title for axis or legend.",
-                    "type": "string"
-                },
-                "type": {
-                    "$ref": "#/definitions/Type",
-                    "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case insensitive."
-                },
-                "value": {
-                    "description": "A constant value in visual domain.",
-                    "type": [
-                        "string",
-                        "number",
-                        "boolean"
-                    ]
-                }
-            },
-            "type": "object"
-        },
         "Config": {
             "properties": {
                 "area": {
@@ -1045,11 +974,18 @@
         "Encoding": {
             "properties": {
                 "color": {
-                    "$ref": "#/definitions/ChannelDefWithLegend",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/LegendFieldDef"
+                        }
+                    ],
                     "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
                 },
                 "column": {
-                    "$ref": "#/definitions/PositionChannelDef",
+                    "$ref": "#/definitions/PositionFieldDef",
                     "description": "Horizontal facets for trellis plots."
                 },
                 "detail": {
@@ -1066,21 +1002,25 @@
                     ],
                     "description": "Additional levels of detail for grouping data in aggregate views and\nin line and area marks without mapping data to a specific visual channel."
                 },
-                "label": {
-                    "$ref": "#/definitions/FieldDef"
-                },
                 "opacity": {
-                    "$ref": "#/definitions/ChannelDefWithLegend",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/LegendFieldDef"
+                        }
+                    ],
                     "description": "Opacity of the marks – either can be a value or in a range."
                 },
                 "order": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/OrderChannelDef"
+                            "$ref": "#/definitions/OrderFieldDef"
                         },
                         {
                             "items": {
-                                "$ref": "#/definitions/OrderChannelDef"
+                                "$ref": "#/definitions/OrderFieldDef"
                             },
                             "type": "array"
                         }
@@ -1088,35 +1028,84 @@
                     "description": "stack order for stacked marks or order of data points in line marks."
                 },
                 "row": {
-                    "$ref": "#/definitions/PositionChannelDef",
+                    "$ref": "#/definitions/PositionFieldDef",
                     "description": "Vertical facets for trellis plots."
                 },
                 "shape": {
-                    "$ref": "#/definitions/ChannelDefWithLegend",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/LegendFieldDef"
+                        }
+                    ],
                     "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
                 },
                 "size": {
-                    "$ref": "#/definitions/ChannelDefWithLegend",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/LegendFieldDef"
+                        }
+                    ],
                     "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
                 },
                 "text": {
-                    "$ref": "#/definitions/FieldDef",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/FieldDef"
+                        }
+                    ],
                     "description": "Text of the `text` mark."
                 },
                 "x": {
-                    "$ref": "#/definitions/PositionChannelDef",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/PositionFieldDef"
+                        }
+                    ],
                     "description": "X coordinates for `point`, `circle`, `square`,\n`line`, `rule`, `text`, and `tick`\n(or to width and height for `bar` and `area` marks)."
                 },
                 "x2": {
-                    "$ref": "#/definitions/FieldDef",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/FieldDef"
+                        }
+                    ],
                     "description": "X2 coordinates for ranged `bar`, `rule`, `area`"
                 },
                 "y": {
-                    "$ref": "#/definitions/PositionChannelDef",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/PositionFieldDef"
+                        }
+                    ],
                     "description": "Y coordinates for `point`, `circle`, `square`,\n`line`, `rule`, `text`, and `tick`\n(or to width and height for `bar` and `area` marks)."
                 },
                 "y2": {
-                    "$ref": "#/definitions/FieldDef",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/FieldDef"
+                        }
+                    ],
                     "description": "Y2 coordinates for ranged `bar`, `rule`, `area`"
                 }
             },
@@ -1228,10 +1217,10 @@
         "Facet": {
             "properties": {
                 "column": {
-                    "$ref": "#/definitions/PositionChannelDef"
+                    "$ref": "#/definitions/PositionFieldDef"
                 },
                 "row": {
-                    "$ref": "#/definitions/PositionChannelDef"
+                    "$ref": "#/definitions/PositionFieldDef"
                 }
             },
             "type": "object"
@@ -1341,6 +1330,7 @@
             "type": "object"
         },
         "FieldDef": {
+            "description": "Definition object for a data field, its type and transformation of an encoding channel.",
             "properties": {
                 "aggregate": {
                     "$ref": "#/definitions/AggregateOp",
@@ -1372,14 +1362,6 @@
                 "type": {
                     "$ref": "#/definitions/Type",
                     "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case insensitive."
-                },
-                "value": {
-                    "description": "A constant value in visual domain.",
-                    "type": [
-                        "string",
-                        "number",
-                        "boolean"
-                    ]
                 }
             },
             "type": "object"
@@ -1759,6 +1741,69 @@
             },
             "type": "object"
         },
+        "LegendFieldDef": {
+            "properties": {
+                "aggregate": {
+                    "$ref": "#/definitions/AggregateOp",
+                    "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`)."
+                },
+                "bin": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Bin"
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ],
+                    "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
+                },
+                "field": {
+                    "description": "Name of the field from which to pull a data value.",
+                    "type": "string"
+                },
+                "legend": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Legend"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "scale": {
+                    "$ref": "#/definitions/Scale"
+                },
+                "sort": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SortField"
+                        },
+                        {
+                            "enum": [
+                                "ascending",
+                                "descending"
+                            ],
+                            "type": "string"
+                        }
+                    ]
+                },
+                "timeUnit": {
+                    "$ref": "#/definitions/TimeUnit",
+                    "description": "Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`)."
+                },
+                "title": {
+                    "description": "Title for axis or legend.",
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/Type",
+                    "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case insensitive."
+                }
+            },
+            "type": "object"
+        },
         "LineConfig": {
             "properties": {
                 "color": {
@@ -2006,7 +2051,7 @@
             ],
             "type": "object"
         },
-        "OrderChannelDef": {
+        "OrderFieldDef": {
             "properties": {
                 "aggregate": {
                     "$ref": "#/definitions/AggregateOp",
@@ -2041,14 +2086,6 @@
                 "type": {
                     "$ref": "#/definitions/Type",
                     "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case insensitive."
-                },
-                "value": {
-                    "description": "A constant value in visual domain.",
-                    "type": [
-                        "string",
-                        "number",
-                        "boolean"
-                    ]
                 }
             },
             "type": "object"
@@ -2205,7 +2242,7 @@
             },
             "type": "object"
         },
-        "PositionChannelDef": {
+        "PositionFieldDef": {
             "properties": {
                 "aggregate": {
                     "$ref": "#/definitions/AggregateOp",
@@ -2264,14 +2301,6 @@
                 "type": {
                     "$ref": "#/definitions/Type",
                     "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case insensitive."
-                },
-                "value": {
-                    "description": "A constant value in visual domain.",
-                    "type": [
-                        "string",
-                        "number",
-                        "boolean"
-                    ]
                 }
             },
             "type": "object"
@@ -3251,7 +3280,14 @@
         "UnitEncoding": {
             "properties": {
                 "color": {
-                    "$ref": "#/definitions/ChannelDefWithLegend",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/LegendFieldDef"
+                        }
+                    ],
                     "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
                 },
                 "detail": {
@@ -3268,21 +3304,25 @@
                     ],
                     "description": "Additional levels of detail for grouping data in aggregate views and\nin line and area marks without mapping data to a specific visual channel."
                 },
-                "label": {
-                    "$ref": "#/definitions/FieldDef"
-                },
                 "opacity": {
-                    "$ref": "#/definitions/ChannelDefWithLegend",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/LegendFieldDef"
+                        }
+                    ],
                     "description": "Opacity of the marks – either can be a value or in a range."
                 },
                 "order": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/OrderChannelDef"
+                            "$ref": "#/definitions/OrderFieldDef"
                         },
                         {
                             "items": {
-                                "$ref": "#/definitions/OrderChannelDef"
+                                "$ref": "#/definitions/OrderFieldDef"
                             },
                             "type": "array"
                         }
@@ -3290,31 +3330,80 @@
                     "description": "stack order for stacked marks or order of data points in line marks."
                 },
                 "shape": {
-                    "$ref": "#/definitions/ChannelDefWithLegend",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/LegendFieldDef"
+                        }
+                    ],
                     "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
                 },
                 "size": {
-                    "$ref": "#/definitions/ChannelDefWithLegend",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/LegendFieldDef"
+                        }
+                    ],
                     "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
                 },
                 "text": {
-                    "$ref": "#/definitions/FieldDef",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/FieldDef"
+                        }
+                    ],
                     "description": "Text of the `text` mark."
                 },
                 "x": {
-                    "$ref": "#/definitions/PositionChannelDef",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/PositionFieldDef"
+                        }
+                    ],
                     "description": "X coordinates for `point`, `circle`, `square`,\n`line`, `rule`, `text`, and `tick`\n(or to width and height for `bar` and `area` marks)."
                 },
                 "x2": {
-                    "$ref": "#/definitions/FieldDef",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/FieldDef"
+                        }
+                    ],
                     "description": "X2 coordinates for ranged `bar`, `rule`, `area`"
                 },
                 "y": {
-                    "$ref": "#/definitions/PositionChannelDef",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/PositionFieldDef"
+                        }
+                    ],
                     "description": "Y coordinates for `point`, `circle`, `square`,\n`line`, `rule`, `text`, and `tick`\n(or to width and height for `bar` and `area` marks)."
                 },
                 "y2": {
-                    "$ref": "#/definitions/FieldDef",
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/ValueDef"
+                        },
+                        {
+                            "$ref": "#/definitions/FieldDef"
+                        }
+                    ],
                     "description": "Y2 coordinates for ranged `bar`, `rule`, `area`"
                 }
             },
@@ -3391,6 +3480,20 @@
             "required": [
                 "mark"
             ],
+            "type": "object"
+        },
+        "ValueDef": {
+            "description": "Definition object for a constant value of an encoding channel.",
+            "properties": {
+                "value": {
+                    "description": "A constant value in visual domain.",
+                    "type": [
+                        "string",
+                        "number",
+                        "boolean"
+                    ]
+                }
+            },
             "type": "object"
         },
         "VerticalAlign": {


### PR DESCRIPTION
Fix #1861 

`ChannelDef = FieldDef | ValueDef`

Rename `*ChannelDef` / `ChannelDef*` => `*FieldDef`
- `ChannelDefWithScale` => `ScaleFieldDef`
- `PositionChannelDef` => `PositionFieldDef`
- `ChannelDefWithLegend` => `LegendFieldDef`
- `OrderChannelDef` => `OrderFieldDef`
