### PR TITLE
[WIP] Support short form of `{range: {scheme: <string>}}` with `{range: string}`

### DIFF
--- a/examples/specs/stacked_area.vl.json
+++ b/examples/specs/stacked_area.vl.json
@@ -11,7 +11,7 @@
     "y": {
       "aggregate": "sum", "field": "count","type": "quantitative"
     },
-    "color": {"field":"series", "type":"nominal", "scale":{"scheme": "category20b"}}
+    "color": {"field":"series", "type":"nominal", "scale": {"range":  {"scheme": "category20b"}}}
   },
   "config": {"cell": {"width": 300, "height": 200}}
 }

--- a/examples/specs/stacked_area_normalize.vl.json
+++ b/examples/specs/stacked_area_normalize.vl.json
@@ -11,7 +11,7 @@
       "aggregate": "sum", "field": "count","type": "quantitative",
       "axis": null
     },
-    "color": {"field":"series", "type":"nominal", "scale":{"scheme": "category20b"}}
+    "color": {"field":"series", "type":"nominal", "scale": {"range":  {"scheme": "category20b"}}}
   },
   "config": {"cell": {"width": 300, "height": 200}, "mark": {"stacked": "normalize"}}
 }

--- a/examples/specs/stacked_area_stream.vl.json
+++ b/examples/specs/stacked_area_stream.vl.json
@@ -11,7 +11,7 @@
       "aggregate": "sum", "field": "count","type": "quantitative",
       "axis": null
     },
-    "color": {"field":"series", "type":"nominal", "scale":{"scheme": "category20b"}}
+    "color": {"field":"series", "type":"nominal", "scale": {"range":  {"scheme": "category20b"}}}
   },
   "config": {"cell": {"width": 300, "height": 200}, "mark": {"stacked": "center"}}
 }

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -3,12 +3,12 @@ import * as log from '../../log';
 import {COLUMN, ROW, X, Y, SHAPE, SIZE, COLOR, OPACITY, Channel} from '../../channel';
 import {Config} from '../../config';
 import {Mark} from '../../mark';
-import {Scale, ScaleConfig, ScaleType, scaleTypeSupportProperty} from '../../scale';
+import {Scale, ScaleConfig, ScaleType, Range, isRangeScheme, scaleTypeSupportProperty, scaleTypeSupportScheme} from '../../scale';
 import * as util from '../../util';
 
 import {channelScalePropertyIncompatability} from './scale';
 
-export type RangeMixins = {range: string | Array<number|string|{data: string, field:string}>} | {rangeStep: number} | {scheme: string};
+export type RangeMixins = {range: Range | string} | {rangeStep: number};
 
 /**
  * Return mixins that includes one of the range properties (range, rangeStep, scheme).
@@ -21,7 +21,7 @@ export default function rangeMixins(
 
   // Check if any of the range properties is specified.
   // If so, check if it is compatible and make sure that we only output one of the properties
-  for (let property of ['range', 'rangeStep', 'scheme']) {
+  for (let property of ['range', 'rangeStep']) {
     const specifiedValue = specifiedScale[property];
     if (specifiedValue !== undefined) {
       let supportedByScaleType = scaleTypeSupportProperty(scaleType, property);
@@ -34,8 +34,7 @@ export default function rangeMixins(
         switch (property) {
           case 'range':
             return {range: specifiedValue};
-          case 'scheme':
-            return {scheme: specifiedValue};
+
           case 'rangeStep':
             if (topLevelSize === undefined) {
               if (specifiedValue !== null) {

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -22,7 +22,7 @@ export default function rangeMixins(
   // Check if any of the range properties is specified.
   // If so, check if it is compatible and make sure that we only output one of the properties
   for (let property of ['range', 'rangeStep']) {
-    const specifiedValue = specifiedScale[property];
+    let specifiedValue = specifiedScale[property];
     if (specifiedValue !== undefined) {
       let supportedByScaleType = scaleTypeSupportProperty(scaleType, property);
       const channelIncompatability = channelScalePropertyIncompatability(channel, property);
@@ -33,6 +33,10 @@ export default function rangeMixins(
       } else {
         switch (property) {
           case 'range':
+            if (util.isString(specifiedValue)) {
+              specifiedValue = {scheme: specifiedValue};
+            }
+
             if (isRangeScheme(specifiedValue)) {
               if (!scaleTypeSupportScheme(scaleType)) {
                 log.warn(log.message.scalePropertyNotWorkWithScaleType(scaleType, 'range.scheme', channel));

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -83,17 +83,9 @@ export default function rangeMixins(
       const rangeMax = sizeRangeMax(mark, xyRangeSteps, config);
       return {range: [rangeMin, rangeMax]};
     case SHAPE:
-      return {range: config.point.shapes};
     case COLOR:
-      if (scaleType === 'ordinal') {
-        // Only nominal data uses ordinal scale by default
-        return {scheme: config.mark.nominalColorScheme};
-      }
-      // TODO(#1737): support sequentialColorRange (with linear scale) if sequentialColorScheme is not specified.
-      // TODO: support custom rangeMin, rangeMax
-      // else -- ordinal, time, or quantitative
-      // TODO: support linearColorRange
-      return {scheme: config.mark.sequentialColorScheme};
+      return {range: {scheme: defaultScheme(channel, scaleType)}};
+
 
     case OPACITY:
       // TODO: support custom rangeMin, rangeMax
@@ -101,6 +93,20 @@ export default function rangeMixins(
   }
   /* istanbul ignore next: should never reach here */
   throw new Error(`Scale range undefined for channel ${channel}`);
+}
+
+function defaultScheme(channel: 'shape' | 'color', scaleType: ScaleType) {
+  if (channel === 'shape') {
+    return 'symbol';
+  } else { // color
+    if (scaleType === 'ordinal') {
+      // Only nominal data uses ordinal scale by default
+      return 'category';
+    } else if (scaleType === 'index') {
+      return 'ordinal';
+    }
+    return 'ramp';
+  }
 }
 
 function sizeRangeMin(mark: Mark, zero: boolean, config: Config) {

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -33,8 +33,17 @@ export default function rangeMixins(
       } else {
         switch (property) {
           case 'range':
-            return {range: specifiedValue};
+            if (isRangeScheme(specifiedValue)) {
+              if (!scaleTypeSupportScheme(scaleType)) {
+                log.warn(log.message.scalePropertyNotWorkWithScaleType(scaleType, 'range.scheme', channel));
+              } else {
+                return {range: specifiedValue};
+              }
+            } else {
+              return {range: specifiedValue};
+            }
 
+            break;
           case 'rangeStep':
             if (topLevelSize === undefined) {
               if (specifiedValue !== null) {

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -37,7 +37,13 @@ export default function rangeMixins(
               if (!scaleTypeSupportScheme(scaleType)) {
                 log.warn(log.message.scalePropertyNotWorkWithScaleType(scaleType, 'range.scheme', channel));
               } else {
-                return {range: specifiedValue};
+                return {
+                  // Augment specified range scheme with scheme
+                  // (just in case users only want to override extent / count)
+                  range: util.extend({
+                    scheme: defaultScheme(channel, scaleType)
+                  }, specifiedValue)
+                };
               }
             } else {
               return {range: specifiedValue};
@@ -104,18 +110,21 @@ export default function rangeMixins(
   throw new Error(`Scale range undefined for channel ${channel}`);
 }
 
-function defaultScheme(channel: 'shape' | 'color', scaleType: ScaleType) {
-  if (channel === 'shape') {
-    return 'symbol';
-  } else { // color
-    if (scaleType === 'ordinal') {
-      // Only nominal data uses ordinal scale by default
-      return 'category';
-    } else if (scaleType === 'index') {
-      return 'ordinal';
-    }
-    return 'ramp';
+function defaultScheme(channel: Channel, scaleType: ScaleType) {
+  switch (channel) {
+    case SHAPE:
+      return 'symbol';
+    case COLOR:
+      if (scaleType === 'ordinal') {
+        // Only nominal data uses ordinal scale by default
+        return 'category';
+      } else if (scaleType === 'index') {
+        return 'ordinal';
+      }
+      return 'ramp';
   }
+  log.warn('No default scheme for channel ' + channel + '.');
+  return undefined;
 }
 
 function sizeRangeMin(mark: Mark, zero: boolean, config: Config) {

--- a/src/compile/scale/scale.ts
+++ b/src/compile/scale/scale.ts
@@ -51,11 +51,6 @@ export function channelScalePropertyIncompatability(channel: Channel, propName: 
         return log.message.CANNOT_USE_PADDING_WITH_FACET;
       }
       return undefined; // GOOD!
-    case 'scheme':
-      if (channel !== 'color') {
-        return log.message.CANNOT_USE_SCHEME_WITH_NON_COLOR;
-      }
-      return undefined;
     case 'type':
     case 'domain':
     case 'round':

--- a/src/compile/scale/type.ts
+++ b/src/compile/scale/type.ts
@@ -100,9 +100,14 @@ function defaultType(specifiedScale: Scale, fieldDef: FieldDef, channel: Channel
  * - range = linear
  */
 function continuousColorScaleType(specifiedScale: Scale, rangeScaleType: 'linear' | 'time'): ScaleType {
-  if (isRangeScheme(specifiedScale.range)) {
+  let range = specifiedScale.range;
+  if (util.isString(range)) {
+    range = {scheme: range};
+  }
+
+  if (isRangeScheme(range)) {
     return ScaleType.SEQUENTIAL;
-  } else if (specifiedScale.range) {
+  } else if (range) {
     return rangeScaleType;
   }
   // TODO: make default type also depend on config

--- a/src/compile/scale/type.ts
+++ b/src/compile/scale/type.ts
@@ -4,7 +4,7 @@ import {Config} from '../../config';
 import {hasScale, supportScaleType, Channel} from '../../channel';
 import {FieldDef, ScaleFieldDef} from '../../fielddef';
 import {Mark} from '../../mark';
-import {Scale, ScaleType} from '../../scale';
+import {Scale, ScaleType, isRangeScheme} from '../../scale';
 
 import * as util from '../../util';
 
@@ -100,7 +100,7 @@ function defaultType(specifiedScale: Scale, fieldDef: FieldDef, channel: Channel
  * - range = linear
  */
 function continuousColorScaleType(specifiedScale: Scale, rangeScaleType: 'linear' | 'time'): ScaleType {
-  if (specifiedScale.scheme) {
+  if (isRangeScheme(specifiedScale.range)) {
     return ScaleType.SEQUENTIAL;
   } else if (specifiedScale.range) {
     return rangeScaleType;

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -65,12 +65,6 @@ export interface MarkConfig {
    */
   color?: string;
 
-  /** Default color scheme for nominal (categorical) data */
-  nominalColorScheme?: string;
-
-  /** Default color scheme for ordinal, quantitative and temporal field */
-  sequentialColorScheme?: string;
-
   /**
    * Default Fill Color.  This has higher precedence than config.color
    */
@@ -188,8 +182,6 @@ export interface MarkConfig {
 
 export const defaultMarkConfig: MarkConfig = {
   color: '#4682b4',
-  nominalColorScheme: 'category10',
-  sequentialColorScheme: 'Greens',
 
   minOpacity: 0.3,
   maxOpacity: 0.8,

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -304,3 +304,7 @@ export function scaleTypeSupportProperty(scaleType: ScaleType, propName: string)
   /* istanbul ignore next: should never reach here*/
   throw new Error(`Invalid scale property ${propName}.`);
 }
+
+export function scaleTypeSupportScheme(scaleType: ScaleType): scaleType is 'sequential' | 'ordinal' | 'index' {
+  return scaleType === 'sequential' || scaleType === 'ordinal' || scaleType === 'index';
+}

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -158,6 +158,25 @@ export const defaultScaleConfig = {
   useRawDomain: false,
 };
 
+export interface RangeScheme {
+  /**
+   * Color scheme that determines output color of an ordinal/sequential color scale.
+   */
+  scheme: string;
+
+  // TODO: add docs
+  extent?: number[];
+
+  // TODO: add docs
+  count?: number;
+}
+
+export type Range = number[] | string[] | RangeScheme;
+
+export function isRangeScheme(range: Range): range is RangeScheme {
+  return range && 'scheme' in range;
+}
+
 export interface Scale {
   type?: ScaleType;
   /**
@@ -168,8 +187,7 @@ export interface Scale {
   /**
    * The range of the scale, representing the set of visual values. For numeric values, the range can take the form of a two-element array with minimum and maximum values. For ordinal or quantized data, the range may by an array of desired output values, which are mapped to elements in the specified domain.
    */
-  range?: number[] | string[]; // TODO: declare vgRangeDomain
-
+  range?: Range; // TODO: declare vgRangeDomain
 
   /**
    * If true, rounds numeric output values to integers. This can be helpful for snapping to the pixel grid.
@@ -190,11 +208,6 @@ export interface Scale {
    * @nullable
    */
   rangeStep?: number | null;
-
-  /**
-   * Color scheme that determines output color of an index/ordinal/sequential color scale.
-   */
-  scheme?: string;
 
   /**
    * (For `row` and `column` only) A pixel value for padding between cells in the trellis plots.
@@ -253,7 +266,7 @@ export interface Scale {
 }
 
 export const SCALE_PROPERTIES = [
-  'type', 'domain', 'range', 'round', 'rangeStep', 'scheme', 'padding', 'clamp', 'nice',
+  'type', 'domain', 'range', 'round', 'rangeStep', 'padding', 'clamp', 'nice',
   'exponent', 'zero',
   // TODO: add interpolate here
   // FIXME: determine if 'useRawDomain' should really be included here
@@ -264,9 +277,8 @@ export function scaleTypeSupportProperty(scaleType: ScaleType, propName: string)
   switch (propName) {
     case 'type':
     case 'domain':
-      return true;
     case 'range':
-      return scaleType !== 'sequential'; // sequential only support scheme
+      return true;
     case 'round':
       return isContinuousToContinuous(scaleType) || scaleType === 'band' || scaleType === 'point';
     case 'rangeStep':
@@ -275,9 +287,6 @@ export function scaleTypeSupportProperty(scaleType: ScaleType, propName: string)
       return contains(['point', 'band'], scaleType);
     case 'paddingInner':
       return scaleType === 'band';
-    case 'scheme':
-      // ordinal can use nominal color scheme, sequential can use sequential color scheme
-      return contains(['ordinal', 'sequential', 'index'], scaleType);
     case 'clamp':
       return isContinuousToContinuous(scaleType) || scaleType === 'sequential';
     case 'nice':

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -162,7 +162,7 @@ export interface RangeScheme {
   /**
    * Color scheme that determines output color of an ordinal/sequential color scale.
    */
-  scheme: string;
+  scheme?: string;
 
   // TODO: add docs
   extent?: number[];
@@ -174,7 +174,7 @@ export interface RangeScheme {
 export type Range = number[] | string[] | RangeScheme;
 
 export function isRangeScheme(range: Range): range is RangeScheme {
-  return range && 'scheme' in range;
+  return range && (!!range['scheme'] || !!range['extent'] || !!range['count']);
 }
 
 export interface Scale {

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -171,7 +171,7 @@ export interface RangeScheme {
   count?: number;
 }
 
-export type Range = number[] | string[] | RangeScheme;
+export type Range = number[] | string[] | RangeScheme | string;
 
 export function isRangeScheme(range: Range): range is RangeScheme {
   return range && (!!range['scheme'] || !!range['extent'] || !!range['count']);
@@ -184,6 +184,7 @@ export interface Scale {
    */
   domain?: number[] | string[] | DateTime[];
 
+  // FIXME missing description for scheme.
   /**
    * The range of the scale, representing the set of visual values. For numeric values, the range can take the form of a two-element array with minimum and maximum values. For ordinal or quantized data, the range may by an array of desired output values, which are mapped to elements in the specified domain.
    */

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -1,5 +1,5 @@
 import {StackOffset} from './stack';
-import {ScaleType, NiceTime} from './scale';
+import {ScaleType, RangeScheme, NiceTime} from './scale';
 import {isArray} from './util';
 
 export interface VgData {
@@ -51,7 +51,7 @@ export type VgScale = {
   domain?: any[] | UnionedDomain | VgDataRef,
   domainMin?: any,
   domainMax?: any
-  range?: any[] | VgDataRef | string,
+  range?: any[] | VgDataRef | string | RangeScheme,
   rangeMin?: any,
   rangeMax?: any,
   scheme?: string,

--- a/test/compile/scale/parse.test.ts
+++ b/test/compile/scale/parse.test.ts
@@ -40,7 +40,7 @@ describe('src/compile', function() {
           field: 'origin',
           sort: true
         });
-        assert.deepEqual(scales.main.scheme, 'category');
+        assert.deepEqual(scales.main.range, {scheme: 'category'});
         assert.deepEqual(scales.main.rangeStep, undefined);
       });
     });

--- a/test/compile/scale/parse.test.ts
+++ b/test/compile/scale/parse.test.ts
@@ -40,7 +40,7 @@ describe('src/compile', function() {
           field: 'origin',
           sort: true
         });
-        assert.deepEqual(scales.main.scheme, 'category10');
+        assert.deepEqual(scales.main.scheme, 'category');
         assert.deepEqual(scales.main.rangeStep, undefined);
       });
     });

--- a/test/compile/scale/range.test.ts
+++ b/test/compile/scale/range.test.ts
@@ -142,6 +142,13 @@ describe('compile/scale', () => {
         );
       });
 
+      it('should use the specified range scheme string for a nominal color field.', () => {
+        assert.deepEqual(
+          rangeMixins('color', 'ordinal', {range:'warm'}, defaultConfig, undefined, 'point', undefined, []),
+          {range: {scheme: 'warm'}}
+        );
+      });
+
       it('should use the specified range for a nominal color field.', () => {
         assert.deepEqual(
           rangeMixins('color', 'ordinal', {range: ['red', 'green', 'blue']}, defaultConfig, undefined, 'point', undefined, []),

--- a/test/compile/scale/range.test.ts
+++ b/test/compile/scale/range.test.ts
@@ -137,8 +137,8 @@ describe('compile/scale', () => {
     describe('color', function() {
       it('should use the specified scheme for a nominal color field.', () => {
         assert.deepEqual(
-          rangeMixins('color', 'ordinal', {scheme: 'warm'}, defaultConfig, undefined, 'point', undefined, []),
-          {scheme: 'warm'}
+          rangeMixins('color', 'ordinal', {range:{scheme: 'warm'}}, defaultConfig, undefined, 'point', undefined, []),
+          {range: {scheme: 'warm'}}
         );
       });
 

--- a/test/compile/scale/range.test.ts
+++ b/test/compile/scale/range.test.ts
@@ -149,8 +149,12 @@ describe('compile/scale', () => {
         );
       });
 
-      // TODO: nominalColorRange, linearColorRange
-
+      it('should use {scheme: "category"} for a nominal color field if only extend is provided.', () => {
+        assert.deepEqual(
+          rangeMixins('color', 'ordinal', {range: {extent: [0.2, 1]}}, defaultConfig, undefined, 'point', undefined, []),
+          {range: {scheme: 'category', extent: [0.2, 1]}}
+        );
+      });
 
       it('should use {scheme: "category"} for a nominal color field.', () => {
         assert.deepEqual(

--- a/test/compile/scale/range.test.ts
+++ b/test/compile/scale/range.test.ts
@@ -154,21 +154,21 @@ describe('compile/scale', () => {
       it('should use default nominalColorScheme for a nominal color field.', () => {
         assert.deepEqual(
           rangeMixins('color', 'ordinal', {}, defaultConfig, undefined, 'point', undefined, []),
-          {scheme: mark.defaultMarkConfig.nominalColorScheme}
+          {range: {scheme: 'category'}}
         );
       });
 
       it('should use default sequentialColorScheme for an ordinal color field.', () => {
         assert.deepEqual(
           rangeMixins('color', 'index', {}, defaultConfig,  undefined, 'point', undefined, []),
-          {scheme: mark.defaultMarkConfig.sequentialColorScheme}
+          {range: {scheme: 'ordinal'}}
         );
       });
 
       it('should use default sequentialColorScheme for a temporal/quantitative color field.', () => {
         assert.deepEqual(
           rangeMixins('color', 'sequential', {}, defaultConfig, undefined, 'point', undefined, []),
-          {scheme: mark.defaultMarkConfig.sequentialColorScheme}
+          {range: {scheme: 'ramp'}}
         );
       });
     });
@@ -305,7 +305,7 @@ describe('compile/scale', () => {
       it('should use default shapes as shape\'s scale range.', () => {
         assert.deepEqual(
           rangeMixins('shape', 'ordinal', {}, defaultConfig, undefined, 'point', undefined, []),
-          {range: mark.defaultPointConfig.shapes}
+          {range: {scheme: 'symbol'}}
         );
       });
     });

--- a/test/compile/scale/range.test.ts
+++ b/test/compile/scale/range.test.ts
@@ -137,7 +137,7 @@ describe('compile/scale', () => {
     describe('color', function() {
       it('should use the specified scheme for a nominal color field.', () => {
         assert.deepEqual(
-          rangeMixins('color', 'ordinal', {range:{scheme: 'warm'}}, defaultConfig, undefined, 'point', undefined, []),
+          rangeMixins('color', 'ordinal', {range: {scheme: 'warm'}}, defaultConfig, undefined, 'point', undefined, []),
           {range: {scheme: 'warm'}}
         );
       });
@@ -151,21 +151,22 @@ describe('compile/scale', () => {
 
       // TODO: nominalColorRange, linearColorRange
 
-      it('should use default nominalColorScheme for a nominal color field.', () => {
+
+      it('should use {scheme: "category"} for a nominal color field.', () => {
         assert.deepEqual(
           rangeMixins('color', 'ordinal', {}, defaultConfig, undefined, 'point', undefined, []),
           {range: {scheme: 'category'}}
         );
       });
 
-      it('should use default sequentialColorScheme for an ordinal color field.', () => {
+      it('should use {scheme: "ordinal"} for an ordinal color field.', () => {
         assert.deepEqual(
           rangeMixins('color', 'index', {}, defaultConfig,  undefined, 'point', undefined, []),
           {range: {scheme: 'ordinal'}}
         );
       });
 
-      it('should use default sequentialColorScheme for a temporal/quantitative color field.', () => {
+      it('should use {scheme: "ramp"} for a temporal/quantitative color field.', () => {
         assert.deepEqual(
           rangeMixins('color', 'sequential', {}, defaultConfig, undefined, 'point', undefined, []),
           {range: {scheme: 'ramp'}}
@@ -302,7 +303,7 @@ describe('compile/scale', () => {
     });
 
     describe('shape', function() {
-      it('should use default shapes as shape\'s scale range.', () => {
+      it('should use default symbol scheme as shape\'s scale range.', () => {
         assert.deepEqual(
           rangeMixins('shape', 'ordinal', {}, defaultConfig, undefined, 'point', undefined, []),
           {range: {scheme: 'symbol'}}

--- a/test/compile/scale/type.test.ts
+++ b/test/compile/scale/type.test.ts
@@ -305,6 +305,16 @@ describe('compile/scale', () => {
         );
       });
 
+      it('should return sequential scale for quantitative color field if a short form of range scheme is provided.', () => {
+        assert.equal(
+          scaleType(
+            {field: 'a', type: QUANTITATIVE, scale: {range: 'viridis'}},
+            'color', 'point', undefined, defaultConfig
+          ),
+          ScaleType.SEQUENTIAL
+        );
+      });
+
       it('should return linear scale for quantitative color field if range is provided.', () => {
         assert.equal(
           scaleType(

--- a/test/compile/scale/type.test.ts
+++ b/test/compile/scale/type.test.ts
@@ -209,7 +209,7 @@ describe('compile/scale', () => {
       it('should return sequential scale for temporal color field if scheme is provided.', () => {
         assert.equal(
           scaleType(
-            {field: 'a', type: TEMPORAL, scale: {scheme: 'viridis'}},
+            {field: 'a', type: TEMPORAL, scale: {range: {scheme: 'viridis'}}},
             'color', 'point', undefined, defaultConfig
           ),
           ScaleType.SEQUENTIAL
@@ -298,7 +298,7 @@ describe('compile/scale', () => {
       it('should return sequential scale for quantitative color field if scheme is provided.', () => {
         assert.equal(
           scaleType(
-            {field: 'a', type: QUANTITATIVE, scale: {scheme: 'viridis'}},
+            {field: 'a', type: QUANTITATIVE, scale: {range: {scheme: 'viridis'}}},
             'color', 'point', undefined, defaultConfig
           ),
           ScaleType.SEQUENTIAL

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -82,10 +82,6 @@
                     "minimum": 0,
                     "type": "number"
                 },
-                "nominalColorScheme": {
-                    "description": "Default color scheme for nominal (categorical) data",
-                    "type": "string"
-                },
                 "opacity": {
                     "maximum": 1,
                     "minimum": 0,
@@ -94,10 +90,6 @@
                 "orient": {
                     "$ref": "#/definitions/Orient",
                     "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
-                },
-                "sequentialColorScheme": {
-                    "description": "Default color scheme for ordinal, quantitative and temporal field",
-                    "type": "string"
                 },
                 "stacked": {
                     "$ref": "#/definitions/StackOffset"
@@ -595,10 +587,6 @@
                     "minimum": 0,
                     "type": "number"
                 },
-                "nominalColorScheme": {
-                    "description": "Default color scheme for nominal (categorical) data",
-                    "type": "string"
-                },
                 "opacity": {
                     "maximum": 1,
                     "minimum": 0,
@@ -607,10 +595,6 @@
                 "orient": {
                     "$ref": "#/definitions/Orient",
                     "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
-                },
-                "sequentialColorScheme": {
-                    "description": "Default color scheme for ordinal, quantitative and temporal field",
-                    "type": "string"
                 },
                 "stacked": {
                     "$ref": "#/definitions/StackOffset"
@@ -1849,10 +1833,6 @@
                     "minimum": 0,
                     "type": "number"
                 },
-                "nominalColorScheme": {
-                    "description": "Default color scheme for nominal (categorical) data",
-                    "type": "string"
-                },
                 "opacity": {
                     "maximum": 1,
                     "minimum": 0,
@@ -1861,10 +1841,6 @@
                 "orient": {
                     "$ref": "#/definitions/Orient",
                     "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
-                },
-                "sequentialColorScheme": {
-                    "description": "Default color scheme for ordinal, quantitative and temporal field",
-                    "type": "string"
                 },
                 "stacked": {
                     "$ref": "#/definitions/StackOffset"
@@ -1963,10 +1939,6 @@
                     "minimum": 0,
                     "type": "number"
                 },
-                "nominalColorScheme": {
-                    "description": "Default color scheme for nominal (categorical) data",
-                    "type": "string"
-                },
                 "opacity": {
                     "maximum": 1,
                     "minimum": 0,
@@ -1975,10 +1947,6 @@
                 "orient": {
                     "$ref": "#/definitions/Orient",
                     "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
-                },
-                "sequentialColorScheme": {
-                    "description": "Default color scheme for ordinal, quantitative and temporal field",
-                    "type": "string"
                 },
                 "stacked": {
                     "$ref": "#/definitions/StackOffset"
@@ -2173,10 +2141,6 @@
                     "minimum": 0,
                     "type": "number"
                 },
-                "nominalColorScheme": {
-                    "description": "Default color scheme for nominal (categorical) data",
-                    "type": "string"
-                },
                 "opacity": {
                     "maximum": 1,
                     "minimum": 0,
@@ -2185,10 +2149,6 @@
                 "orient": {
                     "$ref": "#/definitions/Orient",
                     "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
-                },
-                "sequentialColorScheme": {
-                    "description": "Default color scheme for ordinal, quantitative and temporal field",
-                    "type": "string"
                 },
                 "shape": {
                     "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.",
@@ -2404,10 +2364,6 @@
                     "minimum": 0,
                     "type": "number"
                 },
-                "nominalColorScheme": {
-                    "description": "Default color scheme for nominal (categorical) data",
-                    "type": "string"
-                },
                 "opacity": {
                     "maximum": 1,
                     "minimum": 0,
@@ -2416,10 +2372,6 @@
                 "orient": {
                     "$ref": "#/definitions/Orient",
                     "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
-                },
-                "sequentialColorScheme": {
-                    "description": "Default color scheme for ordinal, quantitative and temporal field",
-                    "type": "string"
                 },
                 "stacked": {
                     "$ref": "#/definitions/StackOffset"
@@ -2502,10 +2454,6 @@
                     "minimum": 0,
                     "type": "number"
                 },
-                "nominalColorScheme": {
-                    "description": "Default color scheme for nominal (categorical) data",
-                    "type": "string"
-                },
                 "opacity": {
                     "maximum": 1,
                     "minimum": 0,
@@ -2514,10 +2462,6 @@
                 "orient": {
                     "$ref": "#/definitions/Orient",
                     "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
-                },
-                "sequentialColorScheme": {
-                    "description": "Default color scheme for ordinal, quantitative and temporal field",
-                    "type": "string"
                 },
                 "stacked": {
                     "$ref": "#/definitions/StackOffset"
@@ -2838,10 +2782,6 @@
                     "minimum": 0,
                     "type": "number"
                 },
-                "nominalColorScheme": {
-                    "description": "Default color scheme for nominal (categorical) data",
-                    "type": "string"
-                },
                 "opacity": {
                     "maximum": 1,
                     "minimum": 0,
@@ -2850,10 +2790,6 @@
                 "orient": {
                     "$ref": "#/definitions/Orient",
                     "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
-                },
-                "sequentialColorScheme": {
-                    "description": "Default color scheme for ordinal, quantitative and temporal field",
-                    "type": "string"
                 },
                 "size": {
                     "description": "The pixel area each the point/circle/square.\nFor example: in the case of circles, the radius is determined in part by the square root of the size value.",
@@ -3010,10 +2946,6 @@
                     "minimum": 0,
                     "type": "number"
                 },
-                "nominalColorScheme": {
-                    "description": "Default color scheme for nominal (categorical) data",
-                    "type": "string"
-                },
                 "opacity": {
                     "maximum": 1,
                     "minimum": 0,
@@ -3027,10 +2959,6 @@
                     "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the x and y properties.",
                     "minimum": 0,
                     "type": "number"
-                },
-                "sequentialColorScheme": {
-                    "description": "Default color scheme for ordinal, quantitative and temporal field",
-                    "type": "string"
                 },
                 "shortTimeLabels": {
                     "description": "Whether month names and weekday names should be abbreviated.",
@@ -3140,10 +3068,6 @@
                     "minimum": 0,
                     "type": "number"
                 },
-                "nominalColorScheme": {
-                    "description": "Default color scheme for nominal (categorical) data",
-                    "type": "string"
-                },
                 "opacity": {
                     "maximum": 1,
                     "minimum": 0,
@@ -3152,10 +3076,6 @@
                 "orient": {
                     "$ref": "#/definitions/Orient",
                     "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
-                },
-                "sequentialColorScheme": {
-                    "description": "Default color scheme for ordinal, quantitative and temporal field",
-                    "type": "string"
                 },
                 "stacked": {
                     "$ref": "#/definitions/StackOffset"

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -2314,9 +2314,6 @@
                     "type": "string"
                 }
             },
-            "required": [
-                "scheme"
-            ],
             "type": "object"
         },
         "RectConfig": {

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -2338,6 +2338,27 @@
             ],
             "type": "object"
         },
+        "RangeScheme": {
+            "properties": {
+                "count": {
+                    "type": "number"
+                },
+                "extent": {
+                    "items": {
+                        "type": "number"
+                    },
+                    "type": "array"
+                },
+                "scheme": {
+                    "description": "Color scheme that determines output color of an ordinal/sequential color scale.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "scheme"
+            ],
+            "type": "object"
+        },
         "RectConfig": {
             "properties": {
                 "color": {
@@ -2608,6 +2629,9 @@
                             "type": "array"
                         },
                         {
+                            "$ref": "#/definitions/RangeScheme"
+                        },
+                        {
                             "items": {
                                 "type": "number"
                             },
@@ -2631,10 +2655,6 @@
                 "round": {
                     "description": "If true, rounds numeric output values to integers. This can be helpful for snapping to the pixel grid.\n\n__Default Rule:__ `true` for `\"x\"`, `\"y\"`, `\"row\"`, `\"column\"` channels if scale config's `round` is `true`; `false` otherwise.",
                     "type": "boolean"
-                },
-                "scheme": {
-                    "description": "Color scheme that determines output color of an index/ordinal/sequential color scale.",
-                    "type": "string"
                 },
                 "spacing": {
                     "description": "(For `row` and `column` only) A pixel value for padding between cells in the trellis plots.",


### PR DESCRIPTION
Please merge #1865 first.

Not sure if we should do this yet -- just an idea.  

`{range: {scheme: <string>}}` seems a bit annoyingly nested.