### PR TITLE
Escapes col names containing dots per Vega (fixes #1175)

### DIFF
--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -156,6 +156,8 @@ export function field(fieldDef: FieldDef, opt: FieldRefOption = {}) {
 
   if (opt.datum) {
     field = `datum["${field}"]`;
+  } else if (field !== undefined && field.indexOf('.') !== -1) { // dot in fieldname
+    field = `[${field}]`;
   }
 
   return field;


### PR DESCRIPTION
Should be a quick fix.

Tested and verified with 
```
{
  "description": "A simple bar chart with a field name containing a dot.",
  "data": {
    "values": [
      {"a.a": "A","b": 28}, {"a.a": "B","b": 55}
    ]
  },
  "mark": "bar",
  "encoding": {
    "x": {"field": "a.a", "type": "ordinal"},
    "y": {"field": "b", "type": "quantitative"}
  }
}
```

Aside: we don't seem to have any explicit test coverage of `field()` in `fieldDef.ts`... is this intentional? 