### PR TITLE
[WIP] removed AxisOrient namespace

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -73,4 +73,6 @@ git push --tags
 
 # TODO: re-publish to github pages when we are ready to release 2.0.
 #  3. GITHUB PAGES PUBLISH
-# . ./scripts/deploy-gh.sh
+# . scripts/deploy-gh.sh
+
+scripts/deploy-schema.sh

--- a/src/aggregate.ts
+++ b/src/aggregate.ts
@@ -1,8 +1,4 @@
 
-export namespace AggregateOp {
-
-}
-
 export type AggregateOp = 'argmax' | 'argmin' | 'average' | 'count'
   | 'distinct' | 'max' | 'mean' | 'median' | 'min' | 'missing' | 'modeskew'
   | 'q1' | 'q3' | 'stdev' | 'stdevp' | 'sum' | 'valid' | 'values' | 'variance'

--- a/src/aggregate.ts
+++ b/src/aggregate.ts
@@ -1,75 +1,54 @@
 
 export namespace AggregateOp {
-    export const VALUES: 'values' = 'values';
-    export const COUNT: 'count' = 'count';
-    export const VALID: 'valid' = 'valid';
-    export const MISSING: 'missing' = 'missing';
-    export const DISTINCT: 'distinct' = 'distinct';
-    export const SUM: 'sum' = 'sum';
-    export const MEAN: 'mean' = 'mean';
-    export const AVERAGE: 'average' = 'average';
-    export const VARIANCE: 'variance' = 'variance';
-    export const VARIANCEP: 'variancep' = 'variancep';
-    export const STDEV: 'stdev' = 'stdev';
-    export const STDEVP: 'stdevp' = 'stdevp';
-    export const MEDIAN: 'median' = 'median';
-    export const Q1: 'q1' = 'q1';
-    export const Q3: 'q3' = 'q3';
-    export const MODESKEW: 'modeskew' = 'modeskew';
-    export const MIN: 'min' = 'min';
-    export const MAX: 'max' = 'max';
-    export const ARGMIN: 'argmin' = 'argmin';
-    export const ARGMAX: 'argmax' = 'argmax';;
+
 }
 
-export type AggregateOp = typeof AggregateOp.ARGMAX | typeof AggregateOp.ARGMIN | typeof AggregateOp.AVERAGE
-  | typeof AggregateOp.COUNT | typeof AggregateOp.DISTINCT | typeof AggregateOp.MAX | typeof AggregateOp.MEAN
-  | typeof AggregateOp.MEDIAN | typeof AggregateOp.MIN | typeof AggregateOp.MISSING | typeof AggregateOp.MODESKEW
-  | typeof AggregateOp.Q1 | typeof AggregateOp.Q3 | typeof AggregateOp.STDEV | typeof AggregateOp.STDEVP
-  | typeof AggregateOp.SUM | typeof AggregateOp.VALID | typeof AggregateOp.VALUES | typeof AggregateOp.VARIANCE
-  | typeof AggregateOp.VARIANCEP;
+export type AggregateOp = 'argmax' | 'argmin' | 'average' | 'count'
+  | 'distinct' | 'max' | 'mean' | 'median' | 'min' | 'missing' | 'modeskew'
+  | 'q1' | 'q3' | 'stdev' | 'stdevp' | 'sum' | 'valid' | 'values' | 'variance'
+  | 'variancep';
 
 export const AGGREGATE_OPS = [
-    AggregateOp.VALUES,
-    AggregateOp.COUNT,
-    AggregateOp.VALID,
-    AggregateOp.MISSING,
-    AggregateOp.DISTINCT,
-    AggregateOp.SUM,
-    AggregateOp.MEAN,
-    AggregateOp.AVERAGE,
-    AggregateOp.VARIANCE,
-    AggregateOp.VARIANCEP,
-    AggregateOp.STDEV,
-    AggregateOp.STDEVP,
-    AggregateOp.MEDIAN,
-    AggregateOp.Q1,
-    AggregateOp.Q3,
-    AggregateOp.MODESKEW,
-    AggregateOp.MIN,
-    AggregateOp.MAX,
-    AggregateOp.ARGMIN,
-    AggregateOp.ARGMAX,
+    'values',
+    'count',
+    'valid',
+    'missing',
+    'distinct',
+    'sum',
+    'mean',
+    'average',
+    'variance',
+    'variancep',
+    'stdev',
+    'stdevp',
+    'median',
+    'q1',
+    'q3',
+    'modeskew',
+    'min',
+    'max',
+    'argmin',
+    'argmax',
 ];
 
 /** Additive-based aggregation operations.  These can be applied to stack. */
 export const SUM_OPS = [
-    AggregateOp.COUNT,
-    AggregateOp.SUM,
-    AggregateOp.DISTINCT,
-    AggregateOp.VALID,
-    AggregateOp.MISSING
+    'count',
+    'sum',
+    'distinct',
+    'valid',
+    'missing'
 ];
 
 /**
  * Aggregation operators that always produce values within the range [domainMin, domainMax].
  */
 export const SHARED_DOMAIN_OPS = [
-    AggregateOp.MEAN,
-    AggregateOp.AVERAGE,
-    AggregateOp.MEDIAN,
-    AggregateOp.Q1,
-    AggregateOp.Q3,
-    AggregateOp.MIN,
-    AggregateOp.MAX,
+    'mean',
+    'average',
+    'median',
+    'q1',
+    'q3',
+    'min',
+    'max',
 ];

--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -1,6 +1,6 @@
 import * as log from '../log';
 
-import {AggregateOp} from '../aggregate';
+// import {AggregateOp} from '../aggregate';
 import {TEXT, Channel} from '../channel';
 import {Config, CellConfig} from '../config';
 import {FieldDef, OrderFieldDef, field} from '../fielddef';
@@ -60,7 +60,7 @@ export function numberFormat(fieldDef: FieldDef, format: string, config: Config,
 
     if (format) {
       return format;
-    } else if (fieldDef.aggregate === AggregateOp.COUNT && channel === TEXT) {
+    } else if (fieldDef.aggregate === 'count' && channel === TEXT) {
       // FIXME: need a more holistic way to deal with this.
       return 'd';
     }

--- a/src/compile/data/summary.ts
+++ b/src/compile/data/summary.ts
@@ -1,4 +1,4 @@
-import {AggregateOp} from '../../aggregate';
+// import {AggregateOp} from '../../aggregate';
 import {SUMMARY} from '../../data';
 import {field, FieldDef} from '../../fielddef';
 import {keys, vals, reduce, hash, Dict, StringSet} from '../../util';
@@ -37,7 +37,7 @@ export namespace summary {
 
     model.forEach(function(fieldDef: FieldDef) {
       if (fieldDef.aggregate) {
-        if (fieldDef.aggregate === AggregateOp.COUNT) {
+        if (fieldDef.aggregate === 'count') {
           meas['*'] = meas['*'] || {};
           /* tslint:disable:no-string-literal */
           meas['*']['count'] = true;

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -181,11 +181,11 @@ export function isMeasure(fieldDef: FieldDef) {
 }
 
 export function count(): FieldDef {
-  return { field: '*', aggregate: AggregateOp.COUNT, type: QUANTITATIVE};
+  return { field: '*', aggregate: 'count', type: QUANTITATIVE};
 }
 
 export function isCount(fieldDef: FieldDef) {
-  return fieldDef.aggregate === AggregateOp.COUNT;
+  return fieldDef.aggregate === 'count';
 }
 
 export function title(fieldDef: FieldDef, config: Config) {

--- a/test/fielddef.test.ts
+++ b/test/fielddef.test.ts
@@ -49,11 +49,14 @@ describe('fieldDef', () => {
     });
 
     it('should return correct title for aggregate', () => {
+      // if "aggregate: 'mean' as 'mean'" is changed to "aggregate: 'mean'", it won't pass the test because
+      // it will show that type of 'mean' is string instead of 'mean'
       const fieldDef = {field: 'f', type: QUANTITATIVE, aggregate: 'mean' as 'mean'};
       assert.equal(title(fieldDef, {}), 'MEAN(f)');
     });
 
     it('should return correct title for count', () => {
+      // The same test error shows up here if 'count' as 'count' is changed to only 'count'
       const fieldDef = {field: '*', type: QUANTITATIVE, aggregate: 'count' as 'count'};
       assert.equal(title(fieldDef, {countTitle: 'baz!'}), 'baz!');
     });

--- a/test/fielddef.test.ts
+++ b/test/fielddef.test.ts
@@ -1,6 +1,5 @@
 import {assert} from 'chai';
 
-import {AggregateOp} from '../src/aggregate';
 import {Channel} from '../src/channel';
 import {defaultType, normalize, title} from '../src/fielddef';
 import * as log from '../src/log';
@@ -50,12 +49,12 @@ describe('fieldDef', () => {
     });
 
     it('should return correct title for aggregate', () => {
-      const fieldDef = {field: 'f', type: QUANTITATIVE, aggregate: AggregateOp.MEAN};
+      const fieldDef = {field: 'f', type: QUANTITATIVE, aggregate: 'mean' as 'mean'};
       assert.equal(title(fieldDef, {}), 'MEAN(f)');
     });
 
     it('should return correct title for count', () => {
-      const fieldDef = {field: '*', type: QUANTITATIVE, aggregate: AggregateOp.COUNT};
+      const fieldDef = {field: '*', type: QUANTITATIVE, aggregate: 'count' as 'count'};
       assert.equal(title(fieldDef, {countTitle: 'baz!'}), 'baz!');
     });
 
@@ -75,4 +74,3 @@ describe('fieldDef', () => {
     });
   });
 });
-

--- a/test/stack.test.ts
+++ b/test/stack.test.ts
@@ -4,7 +4,6 @@ import {assert} from 'chai';
 
 import * as log from '../src/log';
 
-import {AggregateOp} from '../src/aggregate';
 import {X, Y, DETAIL} from '../src/channel';
 import {BAR, AREA, RECT, PRIMITIVE_MARKS} from '../src/mark';
 import {ScaleType} from '../src/scale';
@@ -247,7 +246,7 @@ describe('stack', () => {
 
   it('should always be disabled if the aggregated axis has non-summative aggregate', () => {
     [undefined, StackOffset.CENTER, StackOffset.ZERO, StackOffset.NORMALIZE].forEach((stacked) => {
-      [AggregateOp.AVERAGE, AggregateOp.VARIANCE, AggregateOp.Q3].forEach((aggregate) => {
+      ['average' as 'average', 'variance' as 'variance', 'q3' as 'q3'].forEach((aggregate) => {
         const marks = stacked === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
         marks.forEach((mark) => {
           log.runLocalLogger((localLogger) => {

--- a/test/stack.test.ts
+++ b/test/stack.test.ts
@@ -246,6 +246,8 @@ describe('stack', () => {
 
   it('should always be disabled if the aggregated axis has non-summative aggregate', () => {
     [undefined, StackOffset.CENTER, StackOffset.ZERO, StackOffset.NORMALIZE].forEach((stacked) => {
+      // ['average', 'variance', 'q3'] will be interpreted as array of string instead of
+      // array of AxisOrient type, so I put type casting here.
       ['average' as 'average', 'variance' as 'variance', 'q3' as 'q3'].forEach((aggregate) => {
         const marks = stacked === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
         marks.forEach((mark) => {


### PR DESCRIPTION
Fix #1675 
Test error showed up in `fielddef.test.ts` and `stack.test.ts` if I didn't put the type casting in the string literals that I replace with the removed namespace. It will show that the new replacing string literals are of type `string` instead of `AxisOrient`.  
  
