### PR TITLE
Refactor scale/type to take more minimalist input

### DIFF
--- a/src/compile/scale/init.ts
+++ b/src/compile/scale/init.ts
@@ -25,7 +25,10 @@ export default function init(
   let specifiedScale = (fieldDef || {}).scale || {};
 
   let scale: Scale = {
-    type: scaleType(fieldDef, channel, mark, topLevelSize, config)
+    type: scaleType(
+      specifiedScale.type, fieldDef.type, channel, fieldDef.timeUnit, mark,
+      topLevelSize !== undefined, specifiedScale.rangeStep, config.scale
+    )
   };
 
   // Use specified value if compatible or determine default values for each property

--- a/src/compile/scale/type.ts
+++ b/src/compile/scale/type.ts
@@ -1,56 +1,63 @@
 import * as log from '../../log';
 
-import {Config} from '../../config';
 import {hasScale, supportScaleType, Channel} from '../../channel';
-import {FieldDef, ScaleFieldDef} from '../../fielddef';
 import {Mark} from '../../mark';
-import {Scale, ScaleType} from '../../scale';
+import {ScaleType, ScaleConfig} from '../../scale';
+import {TimeUnit} from '../../timeunit';
+import {Type} from '../../type';
 
 import * as util from '../../util';
+
 
 /**
  * Determine if there is a specified scale type and if it is appropriate,
  * or determine default type if type is unspecified or inappropriate.
  */
-export default function type(fieldDef: ScaleFieldDef, channel: Channel,
-  mark: Mark, topLevelSize: number | undefined, config: Config): ScaleType {
+// NOTE: CompassQL uses this method.
+export default function type(
+  specifiedType: ScaleType, type: Type, channel: Channel, timeUnit: TimeUnit, mark: Mark,
+  hasTopLevelSize: boolean, specifiedRangeStep: number, scaleConfig: ScaleConfig): ScaleType {
 
   if (!hasScale(channel)) {
     // There is no scale for these channels
     return null;
   }
-  let specifiedScale = fieldDef.scale || {};
-  const specifiedType = specifiedScale.type;
   if (specifiedType !== undefined) {
     // Check if explicitly specified scale type is supported by the channel
     if (supportScaleType(channel, specifiedType)) {
       return specifiedType;
     } else {
-      const newScaleType = defaultType(specifiedScale, fieldDef, channel, mark, topLevelSize, config);
+      const newScaleType = defaultType(
+        type, channel, timeUnit, mark,
+        hasTopLevelSize, specifiedRangeStep,  scaleConfig
+      );
       log.warn(log.message.scaleTypeNotWorkWithChannel(channel, specifiedType, newScaleType));
       return newScaleType;
     }
   }
 
-  return defaultType(specifiedScale, fieldDef, channel, mark, topLevelSize, config);
+  return defaultType(
+    type, channel, timeUnit, mark,
+    hasTopLevelSize, specifiedRangeStep, scaleConfig
+  );
 }
 
 /**
  * Determine appropriate default scale type.
  */
-function defaultType(specifiedScale: Scale, fieldDef: FieldDef, channel: Channel,
-    mark: Mark, topLevelSize: number | undefined, config: Config): ScaleType {
+function defaultType(type: Type, channel: Channel, timeUnit: TimeUnit, mark: Mark,
+  hasTopLevelSize: boolean, specifiedRangeStep: number, scaleConfig: ScaleConfig): ScaleType {
 
   if (util.contains(['row', 'column'], channel)) {
     return ScaleType.BAND;
   }
 
-  switch (fieldDef.type) {
+  switch (type) {
     case 'nominal':
       if (channel === 'color' || channelRangeType(channel) === 'discrete') {
         return ScaleType.ORDINAL;
       }
-      return discreteToContinuousType(channel, mark, specifiedScale, topLevelSize, config);
+      return discreteToContinuousType(channel, mark, hasTopLevelSize, specifiedRangeStep, scaleConfig);
 
     case 'ordinal':
       if (channel === 'color') {
@@ -59,7 +66,7 @@ function defaultType(specifiedScale: Scale, fieldDef: FieldDef, channel: Channel
         log.warn(log.message.discreteChannelCannotEncode(channel, 'ordinal'));
         return ScaleType.ORDINAL;
       }
-      return discreteToContinuousType(channel, mark, specifiedScale, topLevelSize, config);
+      return discreteToContinuousType(channel, mark, hasTopLevelSize, specifiedRangeStep, scaleConfig);
 
     case 'temporal':
       if (channel === 'color') {
@@ -71,13 +78,13 @@ function defaultType(specifiedScale: Scale, fieldDef: FieldDef, channel: Channel
         // TODO: consider using quantize (equivalent to binning) once we have it
         return ScaleType.ORDINAL;
       }
-      switch (fieldDef.timeUnit) {
+      switch (timeUnit) {
         // These time unit use discrete scale by default
         case 'hours':
         case 'day':
         case 'month':
         case 'quarter':
-          return discreteToContinuousType(channel, mark, specifiedScale, topLevelSize, config);
+          return discreteToContinuousType(channel, mark, hasTopLevelSize, specifiedRangeStep, scaleConfig);
       }
       return ScaleType.TIME;
 
@@ -95,14 +102,17 @@ function defaultType(specifiedScale: Scale, fieldDef: FieldDef, channel: Channel
   }
 
   /* istanbul ignore next: should never reach this */
-  throw new Error(log.message.invalidFieldType(fieldDef.type));
+  throw new Error(log.message.invalidFieldType(type));
 }
 
 /**
  * Determines default scale type for nominal/ordinal field.
  * @returns BAND or POINT scale based on channel, mark, and rangeStep
  */
-function discreteToContinuousType(channel: Channel, mark: Mark, specifiedScale: Scale, topLevelSize: number | undefined, config: Config): ScaleType {
+function discreteToContinuousType(
+    channel: Channel, mark: Mark, hasTopLevelSize: boolean,
+    specifiedRangeStep: number, scaleConfig: ScaleConfig): ScaleType {
+
   if (util.contains(['x', 'y'], channel)) {
     if (mark === 'rect') {
       // The rect mark should fit into a band.
@@ -111,7 +121,7 @@ function discreteToContinuousType(channel: Channel, mark: Mark, specifiedScale: 
     if (mark === 'bar') {
       // For bar, use band only if there is no rangeStep since we need to use band for fit mode.
       // However, for non-fit mode, point scale provides better center position.
-      if (haveRangeStep(specifiedScale, topLevelSize, config)) {
+      if (haveRangeStep(hasTopLevelSize, specifiedRangeStep, scaleConfig)) {
         return ScaleType.POINT;
       }
       return ScaleType.BAND;
@@ -121,15 +131,15 @@ function discreteToContinuousType(channel: Channel, mark: Mark, specifiedScale: 
   return ScaleType.POINT;
 }
 
-function haveRangeStep(specifiedScale: Scale, topLevelSize: number | undefined, config: Config) {
-  if (topLevelSize !== undefined) {
+function haveRangeStep(hasTopLevelSize: boolean, specifiedRangeStep: number, scaleConfig: ScaleConfig) {
+  if (hasTopLevelSize) {
     // if topLevelSize is provided, rangeStep will be dropped.
     return false;
   }
-  if (specifiedScale.rangeStep !== undefined) {
-    return specifiedScale.rangeStep !== null;
+  if (specifiedRangeStep !== undefined) {
+    return specifiedRangeStep !== null;
   }
-  return !!config.scale.rangeStep;
+  return !!scaleConfig.rangeStep;
 }
 
 export function channelRangeType(channel: Channel):

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -298,7 +298,7 @@ export function scaleTypeSupportProperty(scaleType: ScaleType, propName: string)
     case 'nice':
       return isContinuousToContinuous(scaleType) || scaleType === 'sequential' || scaleType as any === 'quantize';
     case 'exponent':
-      return scaleType === 'pow';
+      return scaleType === 'pow' || scaleType === 'log';
     case 'zero':
       // TODO: what about quantize, threshold?
       return !hasDiscreteDomain(scaleType) && !contains(['log', 'time', 'utc'], scaleType);

--- a/src/type.ts
+++ b/src/type.ts
@@ -1,4 +1,5 @@
 /** Constants and utilities for data type */
+/** Data type based on level of measurement */
 
 export namespace Type {
   export const QUANTITATIVE: 'quantitative' = 'quantitative';

--- a/test/compile/scale/type.test.ts
+++ b/test/compile/scale/type.test.ts
@@ -6,7 +6,7 @@ import {defaultConfig} from '../../../src/config';
 import {X, Y, ROW, COLUMN, CHANNELS} from '../../../src/channel';
 import {PRIMITIVE_MARKS} from '../../../src/mark';
 import {ScaleType} from '../../../src/scale';
-import {ORDINAL, NOMINAL, TEMPORAL, QUANTITATIVE} from '../../../src/type';
+import {ORDINAL, NOMINAL} from '../../../src/type';
 import scaleType, {channelRangeType} from '../../../src/compile/scale/type';
 import {TimeUnit} from '../../../src/timeunit';
 import * as util from '../../../src/util';
@@ -15,11 +15,7 @@ describe('compile/scale', () => {
   describe('type()', () => {
     it('should return null for channel without scale', function() {
       assert.deepEqual(
-        scaleType({
-          field: 'a',
-          type: 'temporal',
-          timeUnit: TimeUnit.YEARMONTH
-        }, 'detail', 'point', undefined, defaultConfig),
+        scaleType(undefined, 'temporal', 'detail', 'yearmonth', 'point', undefined, undefined, defaultConfig),
         null
       );
     });
@@ -28,11 +24,7 @@ describe('compile/scale', () => {
       it('should return band for row/column', function() {
         [ROW, COLUMN].forEach((channel) => {
           assert.deepEqual(
-            scaleType({
-              field: 'a',
-              type: 'temporal',
-              timeUnit: TimeUnit.YEARMONTH
-            }, channel, 'point', undefined, defaultConfig),
+            scaleType(undefined, 'temporal', channel, 'yearmonth', 'point', undefined, undefined, defaultConfig),
             ScaleType.BAND
           );
         });
@@ -43,12 +35,7 @@ describe('compile/scale', () => {
           [ScaleType.LINEAR, ScaleType.ORDINAL, ScaleType.POINT].forEach((badScaleType) => {
             log.runLocalLogger((localLogger) => {
               assert.deepEqual(
-                scaleType({
-                  field: 'a',
-                  type: 'temporal',
-                  timeUnit: TimeUnit.YEARMONTH,
-                  scale: {type: badScaleType}
-                }, channel, 'point', undefined, defaultConfig),
+                scaleType(badScaleType, 'temporal', channel, 'yearmonth', 'point', undefined, undefined, defaultConfig),
                 ScaleType.BAND
               );
               assert.equal(localLogger.warns[0], log.message.scaleTypeNotWorkWithChannel(channel, badScaleType, ScaleType.BAND));
@@ -62,14 +49,14 @@ describe('compile/scale', () => {
       describe('color', () => {
         it('should return ordinal scale for nominal data by default.', () => {
           assert.equal(
-            scaleType({field: 'a', type: NOMINAL}, 'color', 'point', undefined,     defaultConfig),
+            scaleType(undefined, 'nominal', 'color', undefined, 'point', undefined, undefined, defaultConfig),
             ScaleType.ORDINAL
           );
         });
 
         it('should return ordinal scale for ordinal data.', () => {
           assert.equal(
-            scaleType({field: 'a', type: ORDINAL}, 'color', 'point', undefined, defaultConfig),
+            scaleType(undefined, 'ordinal', 'color', undefined, 'point', undefined, undefined, defaultConfig),
             ScaleType.ORDINAL
           );
         });
@@ -78,10 +65,7 @@ describe('compile/scale', () => {
       describe('discrete channel (shape)', () => {
         it('should return ordinal for nominal field', function() {
           assert.deepEqual(
-            scaleType({
-              field: 'a',
-              type: 'nominal'
-            }, 'shape', 'point', undefined, defaultConfig),
+            scaleType(undefined, 'nominal', 'shape', undefined, 'point', undefined, undefined, defaultConfig),
             ScaleType.ORDINAL
           );
         });
@@ -90,11 +74,7 @@ describe('compile/scale', () => {
           [ScaleType.LINEAR, ScaleType.BAND, ScaleType.POINT].forEach((badScaleType) => {
             log.runLocalLogger((localLogger) => {
               assert.deepEqual(
-                scaleType({
-                  field: 'a',
-                  type: 'nominal',
-                  scale: {type: badScaleType}
-                }, 'shape', 'point', undefined, defaultConfig),
+                scaleType(badScaleType, 'nominal', 'shape', undefined, 'point', undefined, undefined, defaultConfig),
                 ScaleType.ORDINAL
               );
               assert.equal(localLogger.warns[0], log.message.scaleTypeNotWorkWithChannel('shape', badScaleType, ScaleType.ORDINAL));
@@ -104,10 +84,7 @@ describe('compile/scale', () => {
 
         it('should return ordinal for an ordinal field and throw a warning.', log.wrap((localLogger) => {
           assert.deepEqual(
-            scaleType({
-              field: 'a',
-              type: 'ordinal',
-            }, 'shape', 'point', undefined, defaultConfig),
+            scaleType(undefined, 'ordinal', 'shape', undefined, 'point', undefined, undefined, defaultConfig),
             ScaleType.ORDINAL
           );
           assert.equal(localLogger.warns[0], log.message.discreteChannelCannotEncode('shape', 'ordinal'));
@@ -124,7 +101,7 @@ describe('compile/scale', () => {
             [ORDINAL, NOMINAL].forEach((t) => {
               [X, Y].forEach((channel) => {
                 assert.equal(
-                  scaleType({field: 'a', type: t}, channel, mark, undefined, defaultConfig),
+                  scaleType(undefined, t, channel, undefined, mark, undefined, undefined, defaultConfig),
                   ScaleType.POINT
                 );
               });
@@ -136,7 +113,7 @@ describe('compile/scale', () => {
           [ORDINAL, NOMINAL].forEach((t) => {
             [X, Y].forEach((channel) => {
               assert.equal(
-                scaleType({field: 'a', type: t}, channel, 'rect', undefined, defaultConfig),
+                scaleType(undefined, t, channel, undefined, 'rect', undefined, undefined, defaultConfig),
                 ScaleType.BAND
               );
             });
@@ -146,7 +123,7 @@ describe('compile/scale', () => {
         it('should return band scale for X,Y when mark is bar and rangeStep is null (fit)', () => {
           [ORDINAL, NOMINAL].forEach((t) => {
             [X, Y].forEach((channel) => {
-              assert.equal(scaleType({field: 'a', type: t, scale: {rangeStep: null}}, channel, 'bar', undefined, defaultConfig), ScaleType.BAND);
+              assert.equal(scaleType(undefined, t, channel, undefined, 'bar', null, undefined, defaultConfig), ScaleType.BAND);
             });
           });
         });
@@ -154,7 +131,7 @@ describe('compile/scale', () => {
         it('should return point scale for X,Y when mark is bar and rangeStep is defined', () => {
           [ORDINAL, NOMINAL].forEach((t) => {
             [X, Y].forEach((channel) => {
-              assert.equal(scaleType({field: 'a', type: t, scale: {rangeStep: 21}}, channel, 'bar', undefined, defaultConfig), ScaleType.POINT);
+              assert.equal(scaleType(undefined, t, channel, undefined, 'bar', undefined, 21, defaultConfig), ScaleType.POINT);
             });
           });
         });
@@ -162,7 +139,7 @@ describe('compile/scale', () => {
         it('should return point scale for X,Y when mark is point', () => {
           [ORDINAL, NOMINAL].forEach((t) => {
             [X, Y].forEach((channel) => {
-              assert.equal(scaleType({field: 'a', type: t}, channel, 'point', undefined, defaultConfig), ScaleType.POINT);
+              assert.equal(scaleType(undefined, t, channel, undefined, 'point', undefined, undefined, defaultConfig), ScaleType.POINT);
             });
           });
         });
@@ -171,7 +148,7 @@ describe('compile/scale', () => {
           [ORDINAL, NOMINAL].forEach((t) => {
             [X, Y].forEach((channel) => {
               log.runLocalLogger((localLogger) => {
-                assert.equal(scaleType({field: 'a', type: t, scale: {type: 'ordinal'}}, channel, 'point', undefined, defaultConfig), ScaleType.POINT);
+                assert.equal(scaleType('ordinal', t, channel, undefined, 'point', undefined, undefined, defaultConfig), ScaleType.POINT);
                 assert.equal(localLogger.warns[0], log.message.scaleTypeNotWorkWithChannel(channel, 'ordinal', 'point'));
               });
             });
@@ -184,9 +161,9 @@ describe('compile/scale', () => {
             [ORDINAL, NOMINAL].forEach((t) => {
               OTHER_CONTINUOUS_CHANNELS.forEach((channel) => {
                 assert.equal(
-                  scaleType({field: 'a', type: t}, channel, mark, undefined, defaultConfig),
+                  scaleType(undefined, t, channel, undefined, mark, undefined, undefined, defaultConfig),
                   ScaleType.POINT,
-                  `${channel}, ${mark}, ${t} ` + scaleType({field: 'a', type: t}, channel, mark, undefined, defaultConfig)
+                  `${channel}, ${mark}, ${t} ` + scaleType(undefined, t, channel, undefined, mark, undefined, undefined, defaultConfig)
                 );
               });
             });
@@ -198,41 +175,14 @@ describe('compile/scale', () => {
     describe('temporal', () => {
       it('should return sequential scale for temporal color field by default.', () => {
         assert.equal(
-          scaleType(
-            {field: 'a', type: TEMPORAL},
-            'color', 'point', undefined, defaultConfig
-          ),
-          ScaleType.SEQUENTIAL
-        );
-      });
-
-      it('should return sequential scale for temporal color field if scheme is provided.', () => {
-        assert.equal(
-          scaleType(
-            {field: 'a', type: TEMPORAL, scale: {scheme: 'viridis'}},
-            'color', 'point', undefined, defaultConfig
-          ),
-          ScaleType.SEQUENTIAL
-        );
-      });
-
-      it('should return sequential scale for temporal color field  if range is provided.', () => {
-        assert.equal(
-          scaleType(
-            {field: 'a', type: TEMPORAL, scale: {range: ['cyan', 'blue']}},
-            'color', 'point', undefined, defaultConfig
-          ),
+          scaleType(undefined, 'temporal','color', undefined, 'point', undefined, undefined, defaultConfig),
           ScaleType.SEQUENTIAL
         );
       });
 
       it('should return ordinal for temporal field and throw a warning.', log.wrap((localLogger) => {
         assert.deepEqual(
-          scaleType({
-            field: 'a',
-            type: 'temporal',
-            timeUnit: TimeUnit.YEARMONTH
-          }, 'shape', 'point', undefined, defaultConfig),
+          scaleType(undefined, 'temporal', 'shape', 'yearmonth', 'point', undefined, undefined, defaultConfig),
           ScaleType.ORDINAL
         );
         assert.equal(localLogger.warns[0], log.message.discreteChannelCannotEncode('shape', 'temporal'));
@@ -261,11 +211,7 @@ describe('compile/scale', () => {
         ];
         for (const timeUnit of TIMEUNITS) {
           assert.deepEqual(
-            scaleType({
-              field: 'a',
-              type: 'temporal',
-              timeUnit: timeUnit
-            }, Y, 'point', undefined, defaultConfig),
+            scaleType(undefined, 'temporal', Y, timeUnit, 'point', undefined, undefined, defaultConfig),
             ScaleType.TIME
           );
         }
@@ -274,11 +220,7 @@ describe('compile/scale', () => {
       it('should return a discrete scale for hours, day, month, quarter for x-y', function() {
         [TimeUnit.MONTH, TimeUnit.HOURS, TimeUnit.DAY, TimeUnit.QUARTER].forEach((timeUnit) => {
           assert.deepEqual(
-            scaleType({
-              field: 'a',
-              type: 'temporal',
-              timeUnit: timeUnit
-            }, Y, 'point', undefined, defaultConfig),
+            scaleType(undefined, 'temporal', Y, timeUnit, 'point', undefined, undefined, defaultConfig),
             ScaleType.POINT
           );
         });
@@ -287,40 +229,14 @@ describe('compile/scale', () => {
     describe('quantitative', () => {
       it('should return sequential scale for quantitative color field by default.', () => {
         assert.equal(
-          scaleType(
-            {field: 'a', type: QUANTITATIVE},
-            'color', 'point', undefined, defaultConfig
-          ),
-          ScaleType.SEQUENTIAL
-        );
-      });
-
-      it('should return sequential scale for quantitative color field if scheme is provided.', () => {
-        assert.equal(
-          scaleType(
-            {field: 'a', type: QUANTITATIVE, scale: {scheme: 'viridis'}},
-            'color', 'point', undefined, defaultConfig
-          ),
-          ScaleType.SEQUENTIAL
-        );
-      });
-
-      it('should return sequential scale for quantitative color field if range is provided.', () => {
-        assert.equal(
-          scaleType(
-            {field: 'a', type: QUANTITATIVE, scale: {range: ['cyan', 'blue']}},
-            'color', 'point', undefined, defaultConfig
-          ),
+          scaleType(undefined, 'quantitative', 'color', undefined, 'point', undefined, undefined, defaultConfig),
           ScaleType.SEQUENTIAL
         );
       });
 
       it('should return ordinal for encoding quantitative field with a discrete channel and throw a warning.', log.wrap((localLogger) => {
         assert.deepEqual(
-          scaleType({
-            field: 'a',
-            type: 'quantitative',
-          }, 'shape', 'point', undefined, defaultConfig),
+          scaleType(undefined, 'quantitative', 'shape', undefined, 'point', undefined, undefined, defaultConfig),
           ScaleType.ORDINAL
         );
         assert.equal(localLogger.warns[0], log.message.discreteChannelCannotEncode('shape', 'quantitative'));
@@ -328,10 +244,7 @@ describe('compile/scale', () => {
 
       it('should return linear scale for quantitative by default.', () => {
         assert.equal(
-          scaleType(
-            {field: 'a', type: QUANTITATIVE},
-            'x', 'point', undefined, defaultConfig
-          ),
+          scaleType(undefined, 'quantitative', 'x', undefined, 'point', undefined, undefined, defaultConfig),
           ScaleType.LINEAR
         );
       });


### PR DESCRIPTION
Instead of taking a whole FieldDef and specified Scale, only take parts that matter.  

(for easier usage in CompassQL)

  