### PR TITLE
Add mark role to the output  + refactor mark compiler's vgMark

### DIFF
--- a/src/compile/mark/area.ts
+++ b/src/compile/mark/area.ts
@@ -9,9 +9,7 @@ import {MarkCompiler} from './base';
 import * as ref from './valueref';
 
 export const area: MarkCompiler = {
-  markType: () => {
-    return 'area';
-  },
+  vgMark: 'area',
   role: undefined,
   encodeEntry: (model: UnitModel) => {
     let e: VgEncodeEntry = {};

--- a/src/compile/mark/area.ts
+++ b/src/compile/mark/area.ts
@@ -12,6 +12,7 @@ export const area: MarkCompiler = {
   markType: () => {
     return 'area';
   },
+  role: undefined,
   encodeEntry: (model: UnitModel) => {
     let e: VgEncodeEntry = {};
     const config = model.config();

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -15,9 +15,7 @@ import {MarkCompiler} from './base';
 import * as ref from './valueref';
 
 export const bar: MarkCompiler = {
-  markType: () => {
-    return 'rect';
-  },
+  vgMark: 'rect',
   role: 'bar',
   encodeEntry: (model: UnitModel) => {
     const stack = model.stack();

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -18,6 +18,7 @@ export const bar: MarkCompiler = {
   markType: () => {
     return 'rect';
   },
+  role: 'bar',
   encodeEntry: (model: UnitModel) => {
     const stack = model.stack();
     let e: VgEncodeEntry = extend(

--- a/src/compile/mark/base.ts
+++ b/src/compile/mark/base.ts
@@ -5,6 +5,15 @@ import {VgEncodeEntry} from '../../vega.schema';
  * Abstract interface for compiling a Vega-Lite primitive mark type.
  */
 export interface MarkCompiler {
+  /**
+   * Underlying vega Mark type for the Vega-Lite mark.
+   */
   markType: () => 'area' | 'line' | 'symbol' | 'rect' | 'rule' | 'text';
+
+  /**
+   * Vega's Mark role, which enables use to use config.<vega-lite>.* in parser.
+   * Basically for marks that are not Vega marks, we output roles for all of them.
+   */
+  role: 'bar' | 'point' | 'circle' | 'square' | 'tick' | undefined;
   encodeEntry: (model: UnitModel) => VgEncodeEntry;
 }

--- a/src/compile/mark/base.ts
+++ b/src/compile/mark/base.ts
@@ -8,7 +8,7 @@ export interface MarkCompiler {
   /**
    * Underlying vega Mark type for the Vega-Lite mark.
    */
-  markType: () => 'area' | 'line' | 'symbol' | 'rect' | 'rule' | 'text';
+  vgMark: 'area' | 'line' | 'symbol' | 'rect' | 'rule' | 'text';
 
   /**
    * Vega's Mark role, which enables use to use config.<vega-lite>.* in parser.

--- a/src/compile/mark/line.ts
+++ b/src/compile/mark/line.ts
@@ -11,9 +11,7 @@ import {MarkCompiler} from './base';
 import * as ref from './valueref';
 
 export const line: MarkCompiler = {
-  markType: () => {
-    return 'line';
-  },
+  vgMark: 'line',
   role: undefined,
   encodeEntry: (model: UnitModel) => {
     let e: VgEncodeEntry = {};

--- a/src/compile/mark/line.ts
+++ b/src/compile/mark/line.ts
@@ -14,6 +14,7 @@ export const line: MarkCompiler = {
   markType: () => {
     return 'line';
   },
+  role: undefined,
   encodeEntry: (model: UnitModel) => {
     let e: VgEncodeEntry = {};
     const config = model.config();

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -2,6 +2,7 @@ import {X, Y, COLOR, NONSPATIAL_CHANNELS, Channel} from '../../channel';
 import {AREA, LINE, TEXT as TEXTMARK} from '../../mark';
 import {contains, without} from '../../util';
 
+import {MarkCompiler} from './base';
 import {area} from './area';
 import {bar} from './bar';
 import {line} from './line';
@@ -14,7 +15,7 @@ import {tick} from './tick';
 import {FacetModel} from '../facet';
 import {UnitModel} from '../unit';
 
-const markCompiler = {
+const markCompiler: {[type: string]: MarkCompiler} = {
   area: area,
   bar: bar,
   line: line,
@@ -57,7 +58,7 @@ function parsePathMark(model: UnitModel) {
   let pathMarks: any = [
     {
       name: model.name('marks'),
-      type: markCompiler[mark].markType(),
+      type: markCompiler[mark].vgMark,
       // If has subfacet for line/area group, need to use faceted data from below.
       // FIXME: support sorting path order (in connected scatterplot)
       from: {data: (details.length > 0 ? FACETED_PATH_PREFIX : '') + dataFrom(model)},
@@ -116,7 +117,7 @@ function parseNonPathMark(model: UnitModel) {
 
   marks.push({
     name: model.name('marks'),
-    type: markCompiler[mark].markType(),
+    type: markCompiler[mark].vgMark,
     ...(role? {role} : {}),
     from: {data: dataFrom(model)},
     encode: { update: markCompiler[mark].encodeEntry(model)}

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -94,6 +94,8 @@ function parsePathMark(model: UnitModel) {
 function parseNonPathMark(model: UnitModel) {
   const mark = model.mark();
 
+  const role = markCompiler[mark].role;
+
   let marks: any[] = []; // TODO: vgMarks
   if (mark === TEXTMARK &&
     model.channelHasField(COLOR) &&
@@ -115,6 +117,7 @@ function parseNonPathMark(model: UnitModel) {
   marks.push({
     name: model.name('marks'),
     type: markCompiler[mark].markType(),
+    ...(role? {role} : {}),
     from: {data: dataFrom(model)},
     encode: { update: markCompiler[mark].encodeEntry(model)}
   });

--- a/src/compile/mark/point.ts
+++ b/src/compile/mark/point.ts
@@ -43,6 +43,7 @@ export const point: MarkCompiler = {
   markType: () => {
     return 'symbol';
   },
+  role: 'point',
   encodeEntry: (model: UnitModel) => {
     return encodeEntry(model);
   }
@@ -52,6 +53,7 @@ export const circle: MarkCompiler = {
   markType: () => {
     return 'symbol';
   },
+  role: 'circle',
   encodeEntry: (model: UnitModel) => {
     return encodeEntry(model, 'circle');
   }
@@ -61,6 +63,7 @@ export const square: MarkCompiler = {
   markType: () => {
     return 'symbol';
   },
+  role: 'square',
   encodeEntry: (model: UnitModel) => {
     return encodeEntry(model, 'square');
   }

--- a/src/compile/mark/point.ts
+++ b/src/compile/mark/point.ts
@@ -40,9 +40,7 @@ function shape(shapeDef: LegendFieldDef, scaleName: string, scale: Scale, pointC
 }
 
 export const point: MarkCompiler = {
-  markType: () => {
-    return 'symbol';
-  },
+  vgMark: 'symbol',
   role: 'point',
   encodeEntry: (model: UnitModel) => {
     return encodeEntry(model);
@@ -50,9 +48,7 @@ export const point: MarkCompiler = {
 };
 
 export const circle: MarkCompiler = {
-  markType: () => {
-    return 'symbol';
-  },
+  vgMark: 'symbol',
   role: 'circle',
   encodeEntry: (model: UnitModel) => {
     return encodeEntry(model, 'circle');
@@ -60,9 +56,7 @@ export const circle: MarkCompiler = {
 };
 
 export const square: MarkCompiler = {
-  markType: () => {
-    return 'symbol';
-  },
+  vgMark: 'symbol',
   role: 'square',
   encodeEntry: (model: UnitModel) => {
     return encodeEntry(model, 'square');

--- a/src/compile/mark/rect.ts
+++ b/src/compile/mark/rect.ts
@@ -16,6 +16,7 @@ export const rect: MarkCompiler = {
   markType: () => {
     return 'rect';
   },
+  role: undefined,
   encodeEntry: (model: UnitModel) => {
     let e: VgEncodeEntry = extend(
       x(model),

--- a/src/compile/mark/rect.ts
+++ b/src/compile/mark/rect.ts
@@ -13,9 +13,7 @@ import {MarkCompiler} from './base';
 import * as ref from './valueref';
 
 export const rect: MarkCompiler = {
-  markType: () => {
-    return 'rect';
-  },
+  vgMark: 'rect',
   role: undefined,
   encodeEntry: (model: UnitModel) => {
     let e: VgEncodeEntry = extend(

--- a/src/compile/mark/rule.ts
+++ b/src/compile/mark/rule.ts
@@ -8,9 +8,7 @@ import {MarkCompiler} from './base';
 import * as ref from './valueref';
 
 export const rule: MarkCompiler = {
-  markType: () => {
-    return 'rule';
-  },
+  vgMark: 'rule',
   role: undefined,
   encodeEntry: (model: UnitModel) => {
     let e: VgEncodeEntry = {};

--- a/src/compile/mark/rule.ts
+++ b/src/compile/mark/rule.ts
@@ -11,6 +11,7 @@ export const rule: MarkCompiler = {
   markType: () => {
     return 'rule';
   },
+  role: undefined,
   encodeEntry: (model: UnitModel) => {
     let e: VgEncodeEntry = {};
     const orient = model.config().mark.orient;

--- a/src/compile/mark/text.ts
+++ b/src/compile/mark/text.ts
@@ -17,9 +17,7 @@ export interface TextCompiler extends MarkCompiler {
 }
 
 export const text: TextCompiler = {
-  markType: () => {
-    return 'text';
-  },
+  vgMark: 'text',
   role: undefined,
 
   background: (model: UnitModel) => {

--- a/src/compile/mark/text.ts
+++ b/src/compile/mark/text.ts
@@ -20,6 +20,7 @@ export const text: TextCompiler = {
   markType: () => {
     return 'text';
   },
+  role: undefined,
 
   background: (model: UnitModel) => {
     return {

--- a/src/compile/mark/tick.ts
+++ b/src/compile/mark/tick.ts
@@ -14,6 +14,7 @@ export const tick: MarkCompiler = {
   markType: () => {
     return 'rect';
   },
+  role: 'tick',
 
   encodeEntry: (model: UnitModel) => {
     let e: VgEncodeEntry = {};

--- a/src/compile/mark/tick.ts
+++ b/src/compile/mark/tick.ts
@@ -11,9 +11,7 @@ import {MarkCompiler} from './base';
 import * as ref from './valueref';
 
 export const tick: MarkCompiler = {
-  markType: () => {
-    return 'rect';
-  },
+  vgMark: 'rect',
   role: 'tick',
 
   encodeEntry: (model: UnitModel) => {

--- a/test/compile/mark/area.test.ts
+++ b/test/compile/mark/area.test.ts
@@ -8,10 +8,6 @@ import {area} from '../../../src/compile/mark/area';
 import {ExtendedUnitSpec} from '../../../src/spec';
 
 describe('Mark: Area', function() {
-  it('should return the correct mark type', function() {
-    assert.equal(area.markType(), 'area');
-  });
-
   function verticalArea(moreEncoding = {}): ExtendedUnitSpec {
     return {
       "mark": "area",

--- a/test/compile/mark/bar.test.ts
+++ b/test/compile/mark/bar.test.ts
@@ -7,10 +7,6 @@ import {defaultScaleConfig} from '../../../src/scale';
 import {bar} from '../../../src/compile/mark/bar';
 
 describe('Mark: Bar', function() {
-  it('should return the correct mark type', function() {
-    assert.equal(bar.markType(), 'rect');
-  });
-
   describe('simple vertical', function() {
     const model = parseUnitModel({
       "data": {"url": 'data/cars.json'},

--- a/test/compile/mark/line.test.ts
+++ b/test/compile/mark/line.test.ts
@@ -10,9 +10,6 @@ import {LINE} from '../../../src/mark';
 import {line} from '../../../src/compile/mark/line';
 
 describe('Mark: Line', function() {
-  it('should return the correct mark type', function() {
-    assert.equal(line.markType(), 'line');
-  });
 
   describe('with x, y', function() {
     const model = parseUnitModel({

--- a/test/compile/mark/point.test.ts
+++ b/test/compile/mark/point.test.ts
@@ -9,9 +9,6 @@ import {point, square, circle} from '../../../src/compile/mark/point';
 import {ExtendedUnitSpec} from '../../../src/spec';
 
 describe('Mark: Point', function() {
-  it('should return the correct mark type', function() {
-    assert.equal(point.markType(), 'symbol');
-  });
 
   function pointXY(moreEncoding = {}): ExtendedUnitSpec {
     return {
@@ -214,10 +211,6 @@ describe('Mark: Point', function() {
 });
 
 describe('Mark: Square', function() {
-  it('should return the correct mark type', function() {
-    assert.equal(square.markType(), 'symbol');
-  });
-
   it('should have correct shape', function() {
     const model = parseUnitModel({
       "mark": "square",
@@ -263,10 +256,6 @@ describe('Mark: Square', function() {
 });
 
 describe('Mark: Circle', function() {
-  it('should return the correct mark type', function() {
-    assert.equal(circle.markType(), 'symbol');
-  });
-
   const model = parseUnitModel({
     "mark": "circle",
     "encoding": {

--- a/test/compile/mark/rect.test.ts
+++ b/test/compile/mark/rect.test.ts
@@ -5,10 +5,6 @@ import {parseUnitModel} from '../../util';
 import {rect} from '../../../src/compile/mark/rect';
 
 describe('Mark: Rect', function() {
-  it('should return the correct mark type', function() {
-    assert.equal(rect.markType(), 'rect');
-  });
-
   describe('simple vertical', function() {
     const model = parseUnitModel({
       "data": {"url": 'data/cars.json'},

--- a/test/compile/mark/rule.test.ts
+++ b/test/compile/mark/rule.test.ts
@@ -6,9 +6,6 @@ import {X, Y, COLOR} from '../../../src/channel';
 import {rule} from '../../../src/compile/mark/rule';
 
 describe('Mark: Rule', function() {
-  it('should return the correct mark type', function() {
-    assert.equal(rule.markType(), 'rule');
-  });
 
   describe('with x-only', () => {
     const model = parseUnitModel({

--- a/test/compile/mark/text.test.ts
+++ b/test/compile/mark/text.test.ts
@@ -7,10 +7,6 @@ import {X, Y} from '../../../src/channel';
 import {ExtendedUnitSpec} from '../../../src/spec';
 
 describe('Mark: Text', function() {
-  it('should return correct marktype', function() {
-    assert.equal(text.markType(), 'text');
-  });
-
   describe('with nothing', function() {
     const spec: ExtendedUnitSpec = {
       "mark": "text",

--- a/test/compile/mark/tick.test.ts
+++ b/test/compile/mark/tick.test.ts
@@ -13,10 +13,6 @@ import {X, Y, SIZE} from '../../../src/channel';
 import {tick} from '../../../src/compile/mark/tick';
 
 describe('Mark: Tick', function() {
-  it('should return the correct mark type', function() {
-    assert.equal(tick.markType(), 'rect');
-  });
-
   describe('with stacked x', function() {
     // This is a simplified example for stacked tick.
     // In reality this will be used as stacked's overlayed marker


### PR DESCRIPTION
so that we can leverage Vega mark config for marks that are not Vega marks