### PR TITLE
Separate CompositeMark from (primitive) Mark

### DIFF
--- a/src/compositemark.ts
+++ b/src/compositemark.ts
@@ -1,0 +1,64 @@
+import {Encoding} from './encoding';
+import {GenericUnitSpec, LayerSpec} from './spec';
+
+export const ERRORBAR: 'error-bar' = 'error-bar';
+export type ERRORBAR = typeof ERRORBAR;
+
+export type UnitNormalizer = (spec: GenericUnitSpec<any, any>)=> LayerSpec;
+
+/**
+ * Registry index for all composite mark's normalizer
+ */
+const normalizerRegistry: {[mark: string]: UnitNormalizer} = {};
+
+export function add(mark: string, normalizer: UnitNormalizer) {
+  normalizerRegistry[mark] = normalizer;
+}
+
+export function remove(mark: string) {
+  delete normalizerRegistry[mark];
+}
+
+/**
+ * Transform a unit spec with composite mark into a normal layer spec.
+ */
+export function normalize(
+    // This GenericUnitSpec has any as Encoding because unit specs with composite mark can have additional encoding channels.
+    spec: GenericUnitSpec<string, any>
+  ): LayerSpec {
+
+  const mark = spec.mark;
+  const normalizer = normalizerRegistry[mark];
+  if (normalizer) {
+    return normalizer(spec);
+  }
+
+  throw new Error(`Unregistered composite mark ${mark}`);
+}
+
+
+add(ERRORBAR, (spec: GenericUnitSpec<ERRORBAR, Encoding>): LayerSpec => {
+  const {mark: _m, encoding: encoding, ...outerSpec} = spec;
+  const {size: _s, ...encodingWithoutSize} = encoding;
+  const {x2: _x2, y2: _y2, ...encodingWithoutX2Y2} = encoding;
+
+  return {
+    ...outerSpec,
+    layer: [
+      {
+        mark: 'rule',
+        encoding: encodingWithoutSize
+      },{ // Lower tick
+        mark: 'tick',
+        encoding: encodingWithoutX2Y2
+      }, { // Upper tick
+        mark: 'tick',
+        encoding: {
+          ...encodingWithoutX2Y2,
+          ...(encoding.x2 ? {x: encoding.x2} : {}),
+          ...(encoding.y2 ? {y: encoding.y2} : {})
+        }
+      }
+    ]
+  };
+});

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -1,4 +1,4 @@
-import {contains, extend} from './util';
+import {extend, toSet} from './util';
 
 export namespace Mark {
   export const AREA: 'area' = 'area';
@@ -11,13 +11,13 @@ export namespace Mark {
   export const TICK: 'tick' = 'tick';
   export const CIRCLE: 'circle' = 'circle';
   export const SQUARE: 'square' = 'square';
-  export const ERRORBAR: 'error-bar' = 'error-bar';
 }
+
+/**
+ * All types of primitive marks.
+ */
 export type Mark = typeof Mark.AREA | typeof Mark.BAR | typeof Mark.LINE | typeof Mark.POINT | typeof Mark.TEXT | typeof Mark.TICK | typeof Mark.RECT | typeof Mark.RULE | typeof Mark.CIRCLE | typeof Mark.SQUARE;
 
-export type CompositeMark = typeof Mark.ERRORBAR;
-
-export type AnyMark = Mark | CompositeMark;
 
 export const AREA = Mark.AREA;
 export const BAR = Mark.BAR;
@@ -31,12 +31,12 @@ export const RULE = Mark.RULE;
 export const CIRCLE = Mark.CIRCLE;
 export const SQUARE = Mark.SQUARE;
 
-export const ERRORBAR = Mark.ERRORBAR;
-export const PRIMITIVE_MARKS = [AREA, BAR, LINE, POINT, TEXT, TICK, RULE, CIRCLE, SQUARE];
-export const COMPOSITE_MARKS = [ERRORBAR];
+export const PRIMITIVE_MARKS = [AREA, BAR, LINE, POINT, TEXT, TICK, RECT, RULE, CIRCLE, SQUARE];
 
-export function isCompositeMark(mark: AnyMark): mark is CompositeMark {
-  return contains(COMPOSITE_MARKS, mark);
+const PRIMITIVE_MARK_INDEX = toSet(PRIMITIVE_MARKS);
+
+export function isPrimitiveMark(mark: string): mark is Mark {
+  return mark in PRIMITIVE_MARK_INDEX;
 }
 
 export type FontStyle = 'normal' | 'italic';

--- a/src/vl.ts
+++ b/src/vl.ts
@@ -2,6 +2,7 @@ export import axis = require('./axis');
 export import aggregate = require('./aggregate');
 export import bin = require('./bin');
 export import channel = require('./channel');
+export import compositeMark = require('./compositemark');
 export {compile}  from './compile/compile';
 export import config = require('./config');
 export import data = require('./data');

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -2,13 +2,13 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "anyOf": [
         {
-            "$ref": "#/definitions/GenericUnitSpec<AnyMark, EncodingWithFacet>"
+            "$ref": "#/definitions/GenericUnitSpec<string, EncodingWithFacet>"
         },
         {
-            "$ref": "#/definitions/GenericFacetSpec<GenericUnitSpec<AnyMark, EncodingWithFacet>>"
+            "$ref": "#/definitions/GenericFacetSpec<GenericUnitSpec<string, EncodingWithFacet>>"
         },
         {
-            "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<AnyMark, EncodingWithFacet>>"
+            "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<string, EncodingWithFacet>>"
         }
     ],
     "definitions": {
@@ -1339,7 +1339,7 @@
             ],
             "type": "object"
         },
-        "GenericFacetSpec<GenericUnitSpec<AnyMark, EncodingWithFacet>>": {
+        "GenericFacetSpec<GenericUnitSpec<string, EncodingWithFacet>>": {
             "additionalProperties": false,
             "properties": {
                 "$schema": {
@@ -1403,10 +1403,10 @@
                 "spec": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/GenericUnitSpec<AnyMark, EncodingWithFacet>"
+                            "$ref": "#/definitions/GenericUnitSpec<string, EncodingWithFacet>"
                         },
                         {
-                            "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<AnyMark, EncodingWithFacet>>"
+                            "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<string, EncodingWithFacet>>"
                         }
                     ]
                 },
@@ -1421,7 +1421,7 @@
             ],
             "type": "object"
         },
-        "GenericLayerSpec<GenericUnitSpec<AnyMark, EncodingWithFacet>>": {
+        "GenericLayerSpec<GenericUnitSpec<string, EncodingWithFacet>>": {
             "additionalProperties": false,
             "properties": {
                 "$schema": {
@@ -1456,10 +1456,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/GenericUnitSpec<AnyMark, EncodingWithFacet>"
+                                "$ref": "#/definitions/GenericUnitSpec<string, EncodingWithFacet>"
                             },
                             {
-                                "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<AnyMark, EncodingWithFacet>>"
+                                "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<string, EncodingWithFacet>>"
                             }
                         ]
                     },
@@ -1509,23 +1509,7 @@
             ],
             "type": "object"
         },
-        "GenericUnitSpec.M": {
-            "enum": [
-                "area",
-                "bar",
-                "circle",
-                "error-bar",
-                "line",
-                "point",
-                "rect",
-                "rule",
-                "square",
-                "text",
-                "tick"
-            ],
-            "type": "string"
-        },
-        "GenericUnitSpec<AnyMark, EncodingWithFacet>": {
+        "GenericUnitSpec<string, EncodingWithFacet>": {
             "additionalProperties": false,
             "properties": {
                 "$schema": {
@@ -1560,8 +1544,8 @@
                     "type": "number"
                 },
                 "mark": {
-                    "$ref": "#/definitions/GenericUnitSpec.M",
-                    "description": "The mark type.\nOne of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, and `\"text\"`."
+                    "description": "The mark type.\nOne of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, and `\"text\"`.",
+                    "type": "string"
                 },
                 "name": {
                     "description": "Name of the visualization for later reference.",


### PR DESCRIPTION
- Provide API for registering new type of CompositeMark
- Remove AnyMark as "any mark" can be any string as long as the string is a primitive mark or a  registered composite mark
- Add isPrimitiveMark() instead of isCompositeMark()

