### PR TITLE
Refactor private properties

### DIFF
--- a/src/compile/axis/encode.ts
+++ b/src/compile/axis/encode.ts
@@ -38,7 +38,7 @@ export function grid(model: Model, channel: Channel, gridPropsSpec: any, _?: VgA
 export function labels(model: Model, channel: Channel, labelsSpec: any, def: VgAxis) {
   const fieldDef = model.fieldDef(channel);
   const axis = model.axis(channel);
-  const config = model.config();
+  const config = model.config;
 
   // Text
   if (contains([NOMINAL, ORDINAL], fieldDef.type) && axis.labelMaxLength) {

--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -111,7 +111,6 @@ function parseAxis(channel: Channel, model: Model, isGridAxis: boolean): VgAxis 
 
 function getSpecifiedOrDefaultValue(property: keyof VgAxis, specifiedAxis: Axis, channel: Channel, model: Model, isGridAxis: boolean) {
   const fieldDef = model.fieldDef(channel);
-  const config = model.config();
 
   switch (property) {
     case 'domain':
@@ -119,7 +118,7 @@ function getSpecifiedOrDefaultValue(property: keyof VgAxis, specifiedAxis: Axis,
     case 'ticks':
       return isGridAxis ? false : specifiedAxis[property];
     case 'format':
-      return rules.format(specifiedAxis, channel, fieldDef, config);
+      return rules.format(specifiedAxis, channel, fieldDef, model.config);
     case 'grid':
       return rules.grid(model, channel, isGridAxis); // FIXME: refactor this
     case 'gridScale':
@@ -129,7 +128,7 @@ function getSpecifiedOrDefaultValue(property: keyof VgAxis, specifiedAxis: Axis,
     case 'tickCount':
       return rules.tickCount(specifiedAxis, channel, fieldDef); // TODO: scaleType
     case 'title':
-      return rules.title(specifiedAxis, fieldDef, config, isGridAxis);
+      return rules.title(specifiedAxis, fieldDef, model.config, isGridAxis);
     case 'values':
       return rules.values(specifiedAxis);
     case 'zindex':

--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -45,7 +45,7 @@ export function applyConfig(e: VgEncodeEntry,
 }
 
 export function applyMarkConfig(e: VgEncodeEntry, model: UnitModel, propsList: string[]) {
-  return applyConfig(e, model.config().mark, propsList);
+  return applyConfig(e, model.config.mark, propsList);
 }
 
 /**

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -75,10 +75,10 @@ function assemble(model: Model) {
 }
 
 export function topLevelBasicProperties(model: Model) {
-  const config = model.config();
+  const config = model.config;
   return extend(
     // TODO: Add other top-level basic properties (#1778)
-    {padding: model.padding() || config.padding},
+    {padding: model.padding || config.padding},
     {autosize: 'pad'},
     config.viewport ? {viewport: config.viewport} : {},
     config.background ? {background: config.background} : {}
@@ -88,19 +88,19 @@ export function topLevelBasicProperties(model: Model) {
 export function assembleRootGroup(model: Model) {
   let rootGroup:any = extend(
     {
-      name: model.name('main'),
+      name: model.getName('main'),
       type: 'group',
     },
-    model.description() ? {description: model.description()} : {},
+    model.description ? {description: model.description} : {},
     {
-      from: {data: model.name(LAYOUT +'')},
+      from: {data: model.getName(LAYOUT +'')},
       encode: {
         update: extend(
           {
-            width: {field: model.name('width')},
-            height: {field: model.name('height')}
+            width: {field: model.getName('width')},
+            height: {field: model.getName('height')}
           },
-          model.assembleParentGroupProperties(model.config().cell)
+          model.assembleParentGroupProperties(model.config.cell)
         )
       }
     });

--- a/src/compile/data/bin.ts
+++ b/src/compile/data/bin.ts
@@ -32,7 +32,7 @@ function parse(model: Model): Dict<VgTransform[]> {
 
       const transform: VgTransform[] = [];
       if (!binTrans.extent) {
-        const extentSignal = model.name(fieldDef.field + '_extent');
+        const extentSignal = model.getName(fieldDef.field + '_extent');
         transform.push({
           type: 'extent',
           field: fieldDef.field,
@@ -53,7 +53,7 @@ function parse(model: Model): Dict<VgTransform[]> {
       if (hasDiscreteDomainOrHasLegend) {
         // read format from axis or legend, if there is no format then use config.numberFormat
         const format = (model.axis(channel) || model.legend(channel) || {}).format ||
-          model.config().numberFormat;
+          model.config.numberFormat;
 
         const startField = field(fieldDef, {datum: true, binSuffix: 'start'});
         const endField = field(fieldDef, {datum: true, binSuffix: 'end'});
@@ -78,7 +78,7 @@ export const bin: DataComponentCompiler<Dict<VgTransform[]>> = {
   parseFacet: function(model: FacetModel) {
     let binComponent = parse(model);
 
-    const childDataComponent = model.child().component.data;
+    const childDataComponent = model.child.component.data;
 
     // If child doesn't have its own data source, then merge
     if (!childDataComponent.source) {
@@ -92,7 +92,7 @@ export const bin: DataComponentCompiler<Dict<VgTransform[]>> = {
   parseLayer: function (model: LayerModel) {
     let binComponent = parse(model);
 
-    model.children().forEach((child) => {
+    model.children.forEach((child) => {
       const childDataComponent = child.component.data;
 
       // If child doesn't have its own data source, then merge

--- a/src/compile/data/filter.ts
+++ b/src/compile/data/filter.ts
@@ -36,7 +36,7 @@ export const filter: DataComponentCompiler<string> = {
   parseFacet: function(model: FacetModel) {
     let filterComponent = parse(model);
 
-    const childDataComponent = model.child().component.data;
+    const childDataComponent = model.child.component.data;
 
     // If child doesn't have its own data source but has filter, then merge
     if (!childDataComponent.source && childDataComponent.filter) {
@@ -52,7 +52,7 @@ export const filter: DataComponentCompiler<string> = {
   parseLayer: function(model: LayerModel) {
     // Note that this `filter.parseLayer` method is called before `source.parseLayer`
     let filterComponent = parse(model);
-    model.children().forEach((child) => {
+    model.children.forEach((child) => {
       const childDataComponent = child.component.data;
       if (model.compatibleSource(child) && childDataComponent.filter && childDataComponent.filter === filterComponent) {
         // same filter in child so we can just delete it

--- a/src/compile/data/formatparse.ts
+++ b/src/compile/data/formatparse.ts
@@ -61,7 +61,7 @@ function parse(model: Model): Dict<string> {
   });
 
   // Custom parse should override inferred parse
-  const data = model.data();
+  const data = model.data;
   if (data && isUrlData(data) && data.format && data.format.parse) {
     const parse = data.format.parse;
     keys(parse).forEach((field) => {
@@ -79,7 +79,7 @@ export const formatParse: DataComponentCompiler<Dict<string>> = {
     let parseComponent = parse(model);
 
     // If child doesn't have its own data source, but has its own parse, then merge
-    const childDataComponent = model.child().component.data;
+    const childDataComponent = model.child.component.data;
     if (!childDataComponent.source && childDataComponent.formatParse) {
       extend(parseComponent, childDataComponent.formatParse);
       delete childDataComponent.formatParse;
@@ -90,7 +90,7 @@ export const formatParse: DataComponentCompiler<Dict<string>> = {
   parseLayer: function(model: LayerModel) {
     // note that we run this before source.parseLayer
     let parseComponent = parse(model);
-    model.children().forEach((child) => {
+    model.children.forEach((child) => {
       const childDataComponent = child.component.data;
       if (model.compatibleSource(child) && !differ(childDataComponent.formatParse, parseComponent)) {
         // merge parse up if the child does not have an incompatible parse

--- a/src/compile/data/formula.ts
+++ b/src/compile/data/formula.ts
@@ -20,7 +20,7 @@ export const formula: DataComponentCompiler<Dict<Formula>> = {
   parseFacet: function(model: FacetModel): Dict<Formula> {
     let formulaComponent = parse(model);
 
-    const childDataComponent = model.child().component.data;
+    const childDataComponent = model.child.component.data;
 
     // If child doesn't have its own data source, then merge
     if (!childDataComponent.source) {
@@ -32,7 +32,7 @@ export const formula: DataComponentCompiler<Dict<Formula>> = {
 
   parseLayer: function(model: LayerModel): Dict<Formula> {
     let formulaComponent = parse(model);
-    model.children().forEach((child) => {
+    model.children.forEach((child) => {
       const childDataComponent = child.component.data;
       if (!childDataComponent.source && childDataComponent.calculate) {
         extend(formulaComponent || {}, childDataComponent.calculate);

--- a/src/compile/data/nonpositivefilter.ts
+++ b/src/compile/data/nonpositivefilter.ts
@@ -22,7 +22,7 @@ export const nonPositiveFilter: DataComponentCompiler<Dict<boolean>> = {
   },
 
   parseFacet: function(model: FacetModel) {
-    const childDataComponent = model.child().component.data;
+    const childDataComponent = model.child.component.data;
 
     // If child doesn't have its own data source, then consider merging
     if (!childDataComponent.source) {
@@ -38,7 +38,7 @@ export const nonPositiveFilter: DataComponentCompiler<Dict<boolean>> = {
     // note that we run this before source.parseLayer
     let nonPositiveFilterComponent = {};
 
-    model.children().forEach((child) => {
+    model.children.forEach((child) => {
       const childDataComponent = child.component.data;
       if (model.compatibleSource(child) && !differ(childDataComponent.nonPositiveFilter, nonPositiveFilterComponent)) {
         extend(nonPositiveFilterComponent, childDataComponent.nonPositiveFilter);

--- a/src/compile/data/nullfilter.ts
+++ b/src/compile/data/nullfilter.ts
@@ -40,7 +40,7 @@ export const nullFilter: DataComponentCompiler<Dict<FieldDef>> = {
   parseFacet: function(model: FacetModel) {
     let nullFilterComponent = parse(model);
 
-    const childDataComponent = model.child().component.data;
+    const childDataComponent = model.child.component.data;
 
     // If child doesn't have its own data source, then merge
     if (!childDataComponent.source) {
@@ -56,7 +56,7 @@ export const nullFilter: DataComponentCompiler<Dict<FieldDef>> = {
     // FIXME: null filters are not properly propagated right now
     let nullFilterComponent = parse(model);
 
-    model.children().forEach((child) => {
+    model.children.forEach((child) => {
       const childDataComponent = child.component.data;
       if (model.compatibleSource(child) && !differ<FieldDef>(childDataComponent.nullFilter, nullFilterComponent)) {
         extend(nullFilterComponent, childDataComponent.nullFilter);

--- a/src/compile/data/pathorder.ts
+++ b/src/compile/data/pathorder.ts
@@ -18,16 +18,16 @@ export const pathOrder: DataComponentCompiler<VgSort> = {
     if (contains(['line', 'area'], model.mark())) {
       if (model.mark() === 'line' && model.channelHasField('order')) {
         // For only line, sort by the order field if it is specified.
-        return sortParams(model.encoding().order);
+        return sortParams(model.encoding.order);
       } else {
         // For both line and area, we sort values based on dimension by default
-        const dimensionChannel: 'x' | 'y' = model.config().mark.orient === 'horizontal' ? 'y' : 'x';
+        const dimensionChannel: 'x' | 'y' = model.config.mark.orient === 'horizontal' ? 'y' : 'x';
         const sort = model.sort(dimensionChannel);
         const sortField = isSortField(sort) ?
           field({
             // FIXME: this op might not already exist?
             // FIXME: what if dimensionChannel (x or y) contains custom domain?
-            aggregate: isAggregate(model.encoding()) ? sort.op : undefined,
+            aggregate: isAggregate(model.encoding) ? sort.op : undefined,
             field: sort.field
           }) :
           model.field(dimensionChannel, {binSuffix: 'start'});
@@ -43,7 +43,7 @@ export const pathOrder: DataComponentCompiler<VgSort> = {
   },
 
   parseFacet: function(model: FacetModel) {
-    const childDataComponent = model.child().component.data;
+    const childDataComponent = model.child.component.data;
 
     // If child doesn't have its own data source, then consider merging
     if (!childDataComponent.source) {
@@ -60,7 +60,7 @@ export const pathOrder: DataComponentCompiler<VgSort> = {
     let pathOrderComponent: VgSort = null;
     let stringifiedPathOrder: string = null;
 
-    for (let child of model.children()) {
+    for (let child of model.children) {
       const childDataComponent = child.component.data;
       if (model.compatibleSource(child) && childDataComponent.pathOrder !== null) {
         if (pathOrderComponent === null) {
@@ -75,7 +75,7 @@ export const pathOrder: DataComponentCompiler<VgSort> = {
 
     if (pathOrderComponent !== null) {
       // If we merge pathOrderComponent, remove them from children.
-      for (let child of model.children()) {
+      for (let child of model.children) {
         delete child.component.data.pathOrder;
       }
     }

--- a/src/compile/data/source.ts
+++ b/src/compile/data/source.ts
@@ -15,7 +15,7 @@ import {timeUnit} from './timeunit';
 
 export namespace source {
   function parse(model: Model): VgData {
-    let data = model.data();
+    let data = model.data;
 
     if (data) {
       // If data is explicitly provided
@@ -51,7 +51,7 @@ export namespace source {
       }
 
       return sourceData;
-    } else if (!model.parent()) {
+    } else if (!model.parent) {
       // If data is not explicitly provided but the model is a root,
       // need to produce a source as well
       return {name: model.dataName(SOURCE)};
@@ -63,9 +63,9 @@ export namespace source {
 
   export function parseFacet(model: FacetModel) {
     let sourceData = parse(model);
-    if (!model.child().component.data.source) {
+    if (!model.child.component.data.source) {
       // If the child does not have its own source, have to rename its source.
-      model.child().renameData(model.child().dataName(SOURCE), model.dataName(SOURCE));
+      model.child.renameData(model.child.dataName(SOURCE), model.dataName(SOURCE));
     }
 
     return sourceData;
@@ -73,7 +73,7 @@ export namespace source {
 
   export function parseLayer(model: LayerModel) {
     let sourceData = parse(model);
-    model.children().forEach((child) => {
+    model.children.forEach((child) => {
       const childData = child.component.data;
 
       if (model.compatibleSource(child)) {

--- a/src/compile/data/stack.ts
+++ b/src/compile/data/stack.ts
@@ -54,9 +54,7 @@ export interface StackComponent {
 
 
 function getStackByFields(model: UnitModel) {
-  const stackProperties = model.stack();
-
-  return stackProperties.stackBy.reduce((fields, by) => {
+  return model.stack.stackBy.reduce((fields, by) => {
     const channel = by.channel;
     const fieldDef = by.fieldDef;
 
@@ -77,7 +75,7 @@ function getStackByFields(model: UnitModel) {
 export const stack: DataComponentCompiler<StackComponent> = {
 
   parseUnit: function(model: UnitModel): StackComponent {
-    const stackProperties = model.stack();
+    const stackProperties = model.stack;
     if (!stackProperties) {
       return undefined;
     }
@@ -96,7 +94,7 @@ export const stack: DataComponentCompiler<StackComponent> = {
     }
 
     const stackby = getStackByFields(model);
-    const orderDef = model.encoding().order;
+    const orderDef = model.encoding.order;
 
     let sort: VgSort;
     if (orderDef) {
@@ -130,7 +128,7 @@ export const stack: DataComponentCompiler<StackComponent> = {
   },
 
   parseFacet: function(model: FacetModel): StackComponent {
-    const child = model.child();
+    const child = model.child;
     const childDataComponent = child.component.data;
     // FIXME: Correctly support facet of layer of stack.
     if (childDataComponent.stack) {

--- a/src/compile/data/summary.ts
+++ b/src/compile/data/summary.ts
@@ -59,7 +59,7 @@ export namespace summary {
   }
 
   export function parseFacet(model: FacetModel): SummaryComponent[] {
-    const childDataComponent = model.child().component.data;
+    const childDataComponent = model.child.component.data;
 
     // FIXME: this could be incorrect for faceted layer charts.
 
@@ -69,8 +69,8 @@ export namespace summary {
         // add facet fields as dimensions
         summaryComponent.dimensions = model.reduce(addDimension, summaryComponent.dimensions);
 
-        const summaryNameWithoutPrefix = summaryComponent.name.substr(model.child().name('').length);
-        model.child().renameData(summaryComponent.name, summaryNameWithoutPrefix);
+        const summaryNameWithoutPrefix = summaryComponent.name.substr(model.child.getName('').length);
+        model.child.renameData(summaryComponent.name, summaryNameWithoutPrefix);
         summaryComponent.name = summaryNameWithoutPrefix;
         return summaryComponent;
       });
@@ -106,7 +106,7 @@ export namespace summary {
 
     // Combine summaries for children that don't have a distinct source
     // (either having its own data source, or its own tranformation of the same data source).
-    model.children().forEach((child) => {
+    model.children.forEach((child) => {
       const childDataComponent = child.component.data;
       if (!childDataComponent.source && childDataComponent.summary) {
         // Merge the summaries if we can

--- a/src/compile/data/timeunit.ts
+++ b/src/compile/data/timeunit.ts
@@ -32,7 +32,7 @@ export const timeUnit: DataComponentCompiler<Dict<VgFormulaTransform>> = {
   parseFacet: function (model: FacetModel) {
     let timeUnitComponent = parse(model);
 
-    const childDataComponent = model.child().component.data;
+    const childDataComponent = model.child.component.data;
 
     // If child doesn't have its own data source, then merge
     if (!childDataComponent.source) {
@@ -44,7 +44,7 @@ export const timeUnit: DataComponentCompiler<Dict<VgFormulaTransform>> = {
 
   parseLayer: function(model: LayerModel) {
     let timeUnitComponent = parse(model);
-    model.children().forEach((child) => {
+    model.children.forEach((child) => {
       const childDataComponent = child.component.data;
       if (!childDataComponent.source) {
         extend(timeUnitComponent, childDataComponent.timeUnit);

--- a/src/compile/layout.ts
+++ b/src/compile/layout.ts
@@ -114,7 +114,7 @@ export function parseFacetLayout(model: FacetModel): LayoutComponent {
 }
 
 function parseFacetSizeLayout(model: FacetModel, channel: Channel): SizeComponent {
-  const childLayoutComponent = model.child().component.layout;
+  const childLayoutComponent = model.child.component.layout;
   const sizeType = channel === ROW ? 'height' : 'width';
   const childSizeComponent: SizeComponent = childLayoutComponent[sizeType];
 
@@ -124,7 +124,7 @@ function parseFacetSizeLayout(model: FacetModel, channel: Channel): SizeComponen
     const distinct = extend(getDistinct(model, channel), childSizeComponent.distinct);
     const formula = childSizeComponent.formula.concat([{
       as: model.channelSizeName(channel),
-      expr: facetSizeFormula(model, channel, model.child().channelSizeName(channel))
+      expr: facetSizeFormula(model, channel, model.child.channelSizeName(channel))
     }]);
 
     delete childLayoutComponent[sizeType];
@@ -141,7 +141,7 @@ function facetSizeFormula(model: FacetModel, channel: Channel, innerSize: string
   if (model.channelHasField(channel)) {
     return '(datum["' + innerSize + '"] + ' + model.spacing(channel) + ')' + ' * ' + cardinalityExpr(model, channel);
   } else {
-    return 'datum["' + innerSize + '"] + ' + model.config().scale.facetSpacing; // need to add outer padding for facet
+    return 'datum["' + innerSize + '"] + ' + model.config.scale.facetSpacing; // need to add outer padding for facet
   }
 }
 
@@ -157,7 +157,7 @@ function parseLayerSizeLayout(model: LayerModel, channel: Channel): SizeComponen
     // For shared scale, we can simply merge the layout into one data source
     // TODO: don't just take the layout from the first child
 
-    const childLayoutComponent = model.children()[0].component.layout;
+    const childLayoutComponent = model.children[0].component.layout;
     const sizeType = channel === Y ? 'height' : 'width';
     const childSizeComponent: SizeComponent = childLayoutComponent[sizeType];
 
@@ -167,7 +167,7 @@ function parseLayerSizeLayout(model: LayerModel, channel: Channel): SizeComponen
       expr: childSizeComponent.formula[0].expr
     }];
 
-    model.children().forEach((child) => {
+    model.children.forEach((child) => {
       delete child.component.layout[sizeType];
     });
 

--- a/src/compile/legend/encode.ts
+++ b/src/compile/legend/encode.ts
@@ -33,7 +33,7 @@ export function symbols(fieldDef: FieldDef, symbolsSpec: any, model: UnitModel, 
       break;
   }
 
-  const cfg = model.config();
+  const cfg = model.config;
   const filled = cfg.mark.filled;
 
   let config = channel === COLOR ?
@@ -56,7 +56,7 @@ export function symbols(fieldDef: FieldDef, symbolsSpec: any, model: UnitModel, 
   }
 
   let value: VgValueRef;
-  const colorDef = model.encoding().color;
+  const colorDef = model.encoding.color;
   if (isValueDef(colorDef)) {
     value = {value: colorDef.value};
   }
@@ -131,7 +131,7 @@ export function symbols(fieldDef: FieldDef, symbolsSpec: any, model: UnitModel, 
 
 export function labels(fieldDef: FieldDef, labelsSpec: any, model: UnitModel, channel: Channel) {
   const legend = model.legend(channel);
-  const config = model.config();
+  const config = model.config;
 
   let labels:any = {};
 

--- a/src/compile/legend/parse.ts
+++ b/src/compile/legend/parse.ts
@@ -27,7 +27,7 @@ function getLegendDefWithScale(model: UnitModel, channel: Channel): VgLegend {
   switch (channel) {
     case COLOR:
       const scale = model.scaleName(COLOR) + suffix;
-      return model.config().mark.filled ? {fill: scale} : {stroke: scale};
+      return model.config.mark.filled ? {fill: scale} : {stroke: scale};
     case SIZE:
       return {size: model.scaleName(SIZE) + suffix};
     case SHAPE:
@@ -68,13 +68,12 @@ export function parseLegend(model: UnitModel, channel: Channel): VgLegend {
 
 function getSpecifiedOrDefaultValue(property: keyof VgLegend, specifiedLegend: Legend, channel: Channel, model: Model) {
   const fieldDef = model.fieldDef(channel);
-  const config = model.config();
 
   switch (property) {
     case 'format':
-      return numberFormat(fieldDef, specifiedLegend.format, config, channel);
+      return numberFormat(fieldDef, specifiedLegend.format, model.config, channel);
     case 'title':
-      return rules.title(specifiedLegend, fieldDef, config);
+      return rules.title(specifiedLegend, fieldDef, model.config);
     case 'values':
       return rules.values(specifiedLegend);
     case 'type':

--- a/src/compile/mark/area.ts
+++ b/src/compile/mark/area.ts
@@ -13,24 +13,22 @@ export const area: MarkCompiler = {
   role: undefined,
   encodeEntry: (model: UnitModel) => {
     let e: VgEncodeEntry = {};
-    const config = model.config();
+    const {config, encoding, stack} = model;
 
     // We should always have orient as we augment it in config.ts
     const orient = config.mark.orient;
     e.orient = {value: orient} ;
 
-    const stack = model.stack();
-
     // TODO: refactor how refer to scale as discussed in https://github.com/vega/vega-lite/pull/1613
 
-    e.x = ref.stackable(X, model.encoding().x, model.scaleName(X), model.scale(X), stack, 'base');
-    e.y = ref.stackable(Y, model.encoding().y, model.scaleName(Y), model.scale(Y), stack, 'base');
+    e.x = ref.stackable(X, encoding.x, model.scaleName(X), model.scale(X), stack, 'base');
+    e.y = ref.stackable(Y, encoding.y, model.scaleName(Y), model.scale(Y), stack, 'base');
 
     // Have only x2 or y2 based on orientation
     if (orient === 'horizontal') {
-      e.x2 = ref.stackable2(X2, model.encoding().x, model.encoding().x2, model.scaleName(X), model.scale(X), stack, 'base');
+      e.x2 = ref.stackable2(X2, encoding.x, encoding.x2, model.scaleName(X), model.scale(X), stack, 'base');
     } else {
-      e.y2 = ref.stackable2(Y2, model.encoding().y, model.encoding().y2, model.scaleName(Y), model.scale(Y), stack, 'base');
+      e.y2 = ref.stackable2(Y2, encoding.y, encoding.y2, model.scaleName(Y), model.scale(Y), stack, 'base');
     }
 
     applyColorAndOpacity(e, model);

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -18,7 +18,7 @@ export const bar: MarkCompiler = {
   vgMark: 'rect',
   role: 'bar',
   encodeEntry: (model: UnitModel) => {
-    const stack = model.stack();
+    const stack = model.stack;
     let e: VgEncodeEntry = extend(
       x(model, stack),
       y(model, stack)
@@ -30,17 +30,17 @@ export const bar: MarkCompiler = {
 
 function x(model: UnitModel, stack: StackProperties) {
   let e: VgEncodeEntry = {};
-  const config = model.config();
-  const orient = model.config().mark.orient;
-  const sizeDef = model.encoding().size;
+  const {config, encoding} = model;
+  const orient = model.config.mark.orient;
+  const sizeDef = model.encoding.size;
 
-  const xDef = model.encoding().x;
+  const xDef = model.encoding.x;
   const xScaleName = model.scaleName(X);
   const xScale = model.scale(X);
   // x, x2, and width -- we must specify two of these in all conditions
   if (orient === 'horizontal') {
     e.x = ref.stackable(X, xDef, xScaleName, model.scale(X), stack, 'base');
-    e.x2 = ref.stackable2(X2, xDef, model.encoding().x2, xScaleName, model.scale(X), stack, 'base');
+    e.x2 = ref.stackable2(X2, xDef, encoding.x2, xScaleName, model.scale(X), stack, 'base');
     return e;
   } else { // vertical
     if (isFieldDef(xDef)) {
@@ -61,7 +61,7 @@ function x(model: UnitModel, stack: StackProperties) {
     e.xc = ref.midPoint(X, xDef, xScaleName, model.scale(X),
       extend(ref.midX(config), {offset: 1}) // TODO: config.singleBarOffset
     );
-    e.width = ref.midPoint(SIZE, model.encoding().size, model.scaleName(SIZE), model.scale(SIZE),
+    e.width = ref.midPoint(SIZE, encoding.size, model.scaleName(SIZE), model.scale(SIZE),
       defaultSizeRef(xScaleName, model.scale(X), config)
     );
     return e;
@@ -70,17 +70,17 @@ function x(model: UnitModel, stack: StackProperties) {
 
 function y(model: UnitModel, stack: StackProperties) {
   let e: VgEncodeEntry = {};
-  const config = model.config();
-  const orient = model.config().mark.orient;
-  const sizeDef = model.encoding().size;
+  const {config, encoding} = model;
+  const orient = model.config.mark.orient;
+  const sizeDef = encoding.size;
 
-  const yDef = model.encoding().y;
+  const yDef = encoding.y;
   const yScaleName = model.scaleName(Y);
   const yScale = model.scale(Y);
   // y, y2 & height -- we must specify two of these in all conditions
   if (orient === 'vertical') {
-    e.y = ref.stackable(Y, model.encoding().y, yScaleName, model.scale(Y), stack, 'base');
-    e.y2 = ref.stackable2(Y2, model.encoding().y, model.encoding().y2, yScaleName, model.scale(Y), stack, 'base');
+    e.y = ref.stackable(Y, yDef, yScaleName, model.scale(Y), stack, 'base');
+    e.y2 = ref.stackable2(Y2, yDef, encoding.y2, yScaleName, model.scale(Y), stack, 'base');
     return e;
   } else {
     if (isFieldDef(yDef)) {
@@ -98,7 +98,7 @@ function y(model: UnitModel, stack: StackProperties) {
     e.yc = ref.midPoint(Y, yDef, yScaleName, model.scale(Y),
       ref.midY(config)
     );
-    e.height = ref.midPoint(SIZE, model.encoding().size, model.scaleName(SIZE), model.scale(SIZE),
+    e.height = ref.midPoint(SIZE, encoding.size, model.scaleName(SIZE), model.scale(SIZE),
       defaultSizeRef(yScaleName, model.scale(Y), config)
     );
     return e;

--- a/src/compile/mark/common.ts
+++ b/src/compile/mark/common.ts
@@ -9,7 +9,7 @@ import * as ref from './valueref';
 
 
 export function applyColorAndOpacity(e: VgEncodeEntry, model: UnitModel) {
-  const config = model.config();
+  const config = model.config;
   const filled = config.mark.filled;
 
   // TODO: remove this once we correctly integrate theme
@@ -21,8 +21,8 @@ export function applyColorAndOpacity(e: VgEncodeEntry, model: UnitModel) {
     applyMarkConfig(e, model, STROKE_CONFIG);
   }
 
-  let colorRef = ref.midPoint('color', model.encoding().color, model.scaleName('color'), model.scale('color'), undefined);
-  let opacityRef = ref.midPoint('opacity', model.encoding().opacity, model.scaleName('opacity'), model.scale('opacity'), config.mark.opacity && {value: config.mark.opacity});
+  let colorRef = ref.midPoint('color', model.encoding.color, model.scaleName('color'), model.scale('color'), undefined);
+  let opacityRef = ref.midPoint('opacity', model.encoding.opacity, model.scaleName('opacity'), model.scale('opacity'), config.mark.opacity && {value: config.mark.opacity});
 
   if (colorRef !== undefined) {
     if (filled) {
@@ -33,7 +33,7 @@ export function applyColorAndOpacity(e: VgEncodeEntry, model: UnitModel) {
   } else { // TODO: remove this once we correctly integrate theme
     // apply color config if there is no fill / stroke config
     e[filled ? 'fill' : 'stroke'] = e[filled ? 'fill' : 'stroke'] ||
-      {value: model.config().mark.color};
+      {value: model.config.mark.color};
   }
 
   // If there is no fill, always fill symbols

--- a/src/compile/mark/line.ts
+++ b/src/compile/mark/line.ts
@@ -15,15 +15,13 @@ export const line: MarkCompiler = {
   role: undefined,
   encodeEntry: (model: UnitModel) => {
     let e: VgEncodeEntry = {};
-    const config = model.config();
-    const stack = model.stack();
 
     // TODO: refactor how refer to scale as discussed in https://github.com/vega/vega-lite/pull/1613
 
-    e.x = ref.stackable(X, model.encoding().x, model.scaleName(X), model.scale(X), stack, 'base');
-    e.y = ref.stackable(Y, model.encoding().y, model.scaleName(Y), model.scale(Y), stack, 'base');
+    e.x = ref.stackable(X, model.encoding.x, model.scaleName(X), model.scale(X), model.stack, 'base');
+    e.y = ref.stackable(Y, model.encoding.y, model.scaleName(Y), model.scale(Y), model.stack, 'base');
 
-    const _size = size(model.encoding().size, config);
+    const _size = size(model.encoding.size, model.config);
     if (_size) {e.strokeWidth = _size;}
 
     applyColorAndOpacity(e, model);

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -38,11 +38,11 @@ export function parseMark(model: UnitModel): any[] {
 
 // FIXME: maybe this should not be here.  Need re-think and refactor, esp. after having all composition in.
 function dataFrom(model: UnitModel): string {
-  const parent = model.parent();
+  const parent = model.parent;
   if (parent && parent.isFacet()) {
     return (parent as FacetModel).facetedTable();
   }
-  if (model.stack()) {
+  if (model.stack) {
     return model.dataName('stacked');
   }
   return model.dataTable();
@@ -57,7 +57,7 @@ function parsePathMark(model: UnitModel) {
 
   let pathMarks: any = [
     {
-      name: model.name('marks'),
+      name: model.getName('marks'),
       type: markCompiler[mark].vgMark,
       // If has subfacet for line/area group, need to use faceted data from below.
       // FIXME: support sorting path order (in connected scatterplot)
@@ -70,7 +70,7 @@ function parsePathMark(model: UnitModel) {
     // TODO: for non-stacked plot, map order to zindex. (Maybe rename order for layer to zindex?)
 
     return [{
-      name: model.name('pathgroup'),
+      name: model.getName('pathgroup'),
       type: 'group',
       from: {
         facet: {
@@ -102,7 +102,7 @@ function parseNonPathMark(model: UnitModel) {
   // TODO: for non-stacked plot, map order to zindex. (Maybe rename order for layer to zindex?)
 
   marks.push({
-    name: model.name('marks'),
+    name: model.getName('marks'),
     type: markCompiler[mark].vgMark,
     ...(role? {role} : {}),
     from: {data: dataFrom(model)},

--- a/src/compile/mark/point.ts
+++ b/src/compile/mark/point.ts
@@ -12,20 +12,19 @@ import * as ref from './valueref';
 
 function encodeEntry(model: UnitModel, fixedShape?: string) {
   let e: VgEncodeEntry = {};
-  const config = model.config();
+  const {config, encoding, stack} = model;
   const markSpecificConfig: SymbolConfig = fixedShape ? config[fixedShape] : config.point;
-  const stack = model.stack();
 
   // TODO: refactor how refer to scale as discussed in https://github.com/vega/vega-lite/pull/1613
 
-  e.x = ref.stackable(X, model.encoding().x, model.scaleName(X), model.scale(X), stack, ref.midX(config));
-  e.y = ref.stackable(Y, model.encoding().y, model.scaleName(Y), model.scale(Y), stack, ref.midY(config));
+  e.x = ref.stackable(X, encoding.x, model.scaleName(X), model.scale(X), stack, ref.midX(config));
+  e.y = ref.stackable(Y, encoding.y, model.scaleName(Y), model.scale(Y), stack, ref.midY(config));
 
-  e.size = ref.midPoint(SIZE, model.encoding().size, model.scaleName(SIZE), model.scale(SIZE),
+  e.size = ref.midPoint(SIZE, encoding.size, model.scaleName(SIZE), model.scale(SIZE),
     {value: markSpecificConfig.size}
   );
 
-  e.shape = shape(model.encoding().shape, model.scaleName(SHAPE), model.scale(SHAPE), config.point, fixedShape);
+  e.shape = shape(encoding.shape, model.scaleName(SHAPE), model.scale(SHAPE), config.point, fixedShape);
 
   applyColorAndOpacity(e, model);
   return e;

--- a/src/compile/mark/rect.ts
+++ b/src/compile/mark/rect.ts
@@ -28,8 +28,8 @@ export const rect: MarkCompiler = {
 function x(model: UnitModel) {
   let e: VgEncodeEntry = {};
 
-  const xDef = model.encoding().x;
-  const x2Def = model.encoding().x2;
+  const xDef = model.encoding.x;
+  const x2Def = model.encoding.x2;
   const xScaleName = model.scaleName(X);
   const xScale = model.scale(X);
 
@@ -56,8 +56,8 @@ function x(model: UnitModel) {
 function y(model: UnitModel) {
   let e: VgEncodeEntry = {};
 
-  const yDef = model.encoding().y;
-  const y2Def = model.encoding().y2;
+  const yDef = model.encoding.y;
+  const y2Def = model.encoding.y2;
   const yScaleName = model.scaleName(Y);
   const yScale = model.scale(Y);
 

--- a/src/compile/mark/rule.ts
+++ b/src/compile/mark/rule.ts
@@ -12,25 +12,24 @@ export const rule: MarkCompiler = {
   role: undefined,
   encodeEntry: (model: UnitModel) => {
     let e: VgEncodeEntry = {};
-    const orient = model.config().mark.orient;
-    const config = model.config();
+    const orient = model.config.mark.orient;
+    const {config, encoding, stack} = model;
 
     // TODO: refactor how refer to scale as discussed in https://github.com/vega/vega-lite/pull/1613
-    const stack = model.stack();
 
-    e.x = ref.stackable(X,model.encoding().x, model.scaleName(X), model.scale(X), stack, 'base');
-    e.y = ref.stackable(Y, model.encoding().y, model.scaleName(Y), model.scale(Y), stack, 'base');
+    e.x = ref.stackable(X, encoding.x, model.scaleName(X), model.scale(X), stack, 'base');
+    e.y = ref.stackable(Y, encoding.y, model.scaleName(Y), model.scale(Y), stack, 'base');
 
     if(orient === 'vertical') {
-      e.y2 = ref.stackable2(Y2, model.encoding().y, model.encoding().y2, model.scaleName(Y), model.scale(Y), stack, 'baseOrMax');
+      e.y2 = ref.stackable2(Y2, encoding.y, encoding.y2, model.scaleName(Y), model.scale(Y), stack, 'baseOrMax');
     } else {
-      e.x2 = ref.stackable2(X2, model.encoding().x, model.encoding().x2, model.scaleName(X), model.scale(X), stack, 'baseOrMax');
+      e.x2 = ref.stackable2(X2, encoding.x, encoding.x2, model.scaleName(X), model.scale(X), stack, 'baseOrMax');
     }
 
     // FIXME: this function would overwrite strokeWidth but shouldn't
     applyColorAndOpacity(e, model);
 
-    e.strokeWidth = ref.midPoint(SIZE, model.encoding().size, model.scaleName(SIZE), model.scale(SIZE), {
+    e.strokeWidth = ref.midPoint(SIZE, encoding.size, model.scaleName(SIZE), model.scale(SIZE), {
       value: config.rule.strokeWidth
     });
 

--- a/src/compile/mark/text.ts
+++ b/src/compile/mark/text.ts
@@ -18,19 +18,18 @@ export const text: MarkCompiler = {
   encodeEntry: (model: UnitModel) => {
     let e: VgEncodeEntry = {};
 
-    applyConfig(e, model.config().text,
+    applyConfig(e, model.config.text,
       ['angle', 'align', 'baseline', 'dx', 'dy', 'font', 'fontWeight',
         'fontStyle', 'radius', 'theta', 'text']);
 
-    const config = model.config();
-    const stack = model.stack();
-    const textDef = model.encoding().text;
+    const {config, encoding, stack} = model;
+    const textDef = encoding.text;
 
     // TODO: refactor how refer to scale as discussed in https://github.com/vega/vega-lite/pull/1613
-    e.x = ref.stackable(X, model.encoding().x, model.scaleName(X), model.scale(X), stack, xDefault(config, textDef));
-    e.y = ref.stackable(Y, model.encoding().y, model.scaleName(Y), model.scale(Y), stack, ref.midY(config));
+    e.x = ref.stackable(X, encoding.x, model.scaleName(X), model.scale(X), stack, xDefault(config, textDef));
+    e.y = ref.stackable(Y, encoding.y, model.scaleName(Y), model.scale(Y), stack, ref.midY(config));
 
-    e.fontSize = ref.midPoint(SIZE, model.encoding().size, model.scaleName(SIZE), model.scale(SIZE),
+    e.fontSize = ref.midPoint(SIZE, encoding.size, model.scaleName(SIZE), model.scale(SIZE),
        {value: config.text.fontSize}
     );
 

--- a/src/compile/mark/tick.ts
+++ b/src/compile/mark/tick.ts
@@ -16,20 +16,19 @@ export const tick: MarkCompiler = {
 
   encodeEntry: (model: UnitModel) => {
     let e: VgEncodeEntry = {};
-    const config = model.config();
-    const stack = model.stack();
+    const {config, encoding, stack} = model;
 
     // TODO: refactor how refer to scale as discussed in https://github.com/vega/vega-lite/pull/1613
 
-    e.xc = ref.stackable(X, model.encoding().x, model.scaleName(X), model.scale(X), stack, ref.midX(config));
-    e.yc = ref.stackable(Y, model.encoding().y, model.scaleName(Y), model.scale(Y), stack, ref.midY(config));
+    e.xc = ref.stackable(X, encoding.x, model.scaleName(X), model.scale(X), stack, ref.midX(config));
+    e.yc = ref.stackable(Y, encoding.y, model.scaleName(Y), model.scale(Y), stack, ref.midY(config));
 
     if (config.mark.orient === 'horizontal') {
-      e.width = size(model.encoding().size, model.scaleName(SIZE), model.scale(SIZE), config, (model.scale(X) || {}).rangeStep);
+      e.width = size(encoding.size, model.scaleName(SIZE), model.scale(SIZE), config, (model.scale(X) || {}).rangeStep);
       e.height = {value: config.tick.thickness};
     } else {
       e.width = {value: config.tick.thickness};
-      e.height = size(model.encoding().size, model.scaleName(SIZE), model.scale(SIZE), config, (model.scale(Y) || {}).rangeStep);
+      e.height = size(encoding.size, model.scaleName(SIZE), model.scale(SIZE), config, (model.scale(Y) || {}).rangeStep);
     }
 
     applyColorAndOpacity(e, model);

--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -37,7 +37,7 @@ export default function domain(scale: Scale, model: Model, channel:Channel): any
   }
 
   // For stack, use STACKED data.
-  const stack = model.stack();
+  const stack = model.stack;
   if (stack && channel === stack.fieldChannel) {
     if(stack.offset === 'normalize') {
       return [0, 1];

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -139,8 +139,8 @@ export function forEach(mapping: any,
   });
 }
 
-export function reduce<T>(mapping: any,
-    f: (acc: any, fd: FieldDef, c: Channel) => any,
+export function reduce<T, U>(mapping: U,
+    f: (acc: any, fd: FieldDef, c: Channel) => U,
     init: T, thisArg?: any) {
   if (!mapping) {
     return init;

--- a/test/compile/config.test.ts
+++ b/test/compile/config.test.ts
@@ -18,7 +18,7 @@ describe('Config', function() {
             "x": {"type": "quantitative", "field": "bar"}
           },
         });
-        assert.equal(model.config().mark.orient, 'vertical');
+        assert.equal(model.config.mark.orient, 'vertical');
         assert.equal(localLogger.warns[0], log.message.unclearOrientContinuous(BAR));
       });
     });
@@ -29,7 +29,7 @@ describe('Config', function() {
           "mark": "bar",
           encoding: {}
         });
-        assert.equal(model.config().mark.orient, undefined);
+        assert.equal(model.config.mark.orient, undefined);
         assert.equal(localLogger.warns[0], log.message.unclearOrientDiscreteOrEmpty(BAR));
       });
     });
@@ -43,7 +43,7 @@ describe('Config', function() {
             "y": {"type": "ordinal", "field": "bar"}
           },
         });
-        assert.equal(model.config().mark.orient, undefined);
+        assert.equal(model.config.mark.orient, undefined);
         assert.equal(localLogger.warns[0], log.message.unclearOrientDiscreteOrEmpty(BAR));
       });
     });
@@ -57,7 +57,7 @@ describe('Config', function() {
           "x": {"type": "ordinal", "field": "bar"}
         },
       });
-      assert.equal(model.config().mark.orient, 'vertical');
+      assert.equal(model.config.mark.orient, 'vertical');
     });
 
     it('should return correct orient for horizontal bar', function() {
@@ -68,7 +68,7 @@ describe('Config', function() {
           "y": {"type": "ordinal", "field": "bar"}
         },
       });
-      assert.equal(model.config().mark.orient, 'horizontal');
+      assert.equal(model.config.mark.orient, 'horizontal');
     });
 
     it('should return correct orient for vertical bar with raw temporal dimension', function() {
@@ -79,7 +79,7 @@ describe('Config', function() {
           "x": {"type": "temporal", "field": "bar"}
         },
       });
-      assert.equal(model.config().mark.orient, 'vertical');
+      assert.equal(model.config.mark.orient, 'vertical');
     });
 
     it('should return correct orient for horizontal bar with raw temporal dimension', function() {
@@ -90,7 +90,7 @@ describe('Config', function() {
           "y": {"type": "temporal", "field": "bar"}
         },
       });
-      assert.equal(model.config().mark.orient, 'horizontal');
+      assert.equal(model.config.mark.orient, 'horizontal');
     });
 
     it('should return correct orient for vertical tick', function() {
@@ -101,7 +101,7 @@ describe('Config', function() {
           "y": {"type": "ordinal", "field": "bar"}
         },
       });
-      assert.equal(model.config().mark.orient, 'vertical');
+      assert.equal(model.config.mark.orient, 'vertical');
     });
 
     it('should return correct orient for vertical tick with bin', function() {
@@ -112,7 +112,7 @@ describe('Config', function() {
           "y": {"type": "quantitative", "field": "bar", "bin": true}
         },
       });
-      assert.equal(model.config().mark.orient, 'vertical');
+      assert.equal(model.config.mark.orient, 'vertical');
     });
 
     it('should return correct orient for vertical tick of continuous timeUnit dotplot', function() {
@@ -123,7 +123,7 @@ describe('Config', function() {
           "y": {"type": "ordinal", "field": "bar"}
         },
       });
-      assert.equal(model.config().mark.orient, 'vertical');
+      assert.equal(model.config.mark.orient, 'vertical');
     });
 
     it('should return correct orient for horizontal tick', function() {
@@ -134,7 +134,7 @@ describe('Config', function() {
           "x": {"type": "ordinal", "field": "bar"}
         },
       });
-      assert.equal(model.config().mark.orient, 'horizontal');
+      assert.equal(model.config.mark.orient, 'horizontal');
     });
 
     it('should return correct orient for vertical rule', function() {
@@ -144,7 +144,7 @@ describe('Config', function() {
           "x": {"value": 0},
         },
       });
-      assert.equal(model.config().mark.orient, 'vertical');
+      assert.equal(model.config.mark.orient, 'vertical');
     });
 
     it('should return correct orient for horizontal rule', function() {
@@ -154,7 +154,7 @@ describe('Config', function() {
           "y": {"value": 0},
         },
       });
-      assert.equal(orient(model.mark(), model.encoding(), {}), 'horizontal');
+      assert.equal(orient(model.mark(), model.encoding, {}), 'horizontal');
     });
 
     it('should return correct orient for horizontal rules without x2 ', function() {
@@ -166,7 +166,7 @@ describe('Config', function() {
         },
       });
 
-      assert.equal(orient(model.mark(), model.encoding(), {}), 'horizontal');
+      assert.equal(orient(model.mark(), model.encoding, {}), 'horizontal');
     });
 
     it('should return correct orient for vertical rules without y2 ', function() {
@@ -178,7 +178,7 @@ describe('Config', function() {
         },
       });
 
-      assert.equal(orient(model.mark(), model.encoding(), {}), 'vertical');
+      assert.equal(orient(model.mark(), model.encoding, {}), 'vertical');
     });
 
     it('should return correct orient for vertical rule with range', function() {
@@ -190,7 +190,7 @@ describe('Config', function() {
           "y2": {"type": "quantitative", "field": "baz"}
         },
       });
-      assert.equal(orient(model.mark(), model.encoding(), {}), 'vertical');
+      assert.equal(orient(model.mark(), model.encoding, {}), 'vertical');
     });
 
     it('should return correct orient for horizontal rule with range', function() {
@@ -202,7 +202,7 @@ describe('Config', function() {
           "x2": {"type": "quantitative", "field": "baz"}
         },
       });
-      assert.equal(orient(model.mark(), model.encoding(), {}), 'horizontal');
+      assert.equal(orient(model.mark(), model.encoding, {}), 'horizontal');
     });
 
     it('should return correct orient for horizontal rule with range and no ordinal', function() {
@@ -213,7 +213,7 @@ describe('Config', function() {
           "x2": {"type": "quantitative", "field": "baz"}
         },
       });
-      assert.equal(model.config().mark.orient, 'horizontal');
+      assert.equal(model.config.mark.orient, 'horizontal');
     });
 
     it('should return correct orient for vertical rule with range and no ordinal', function() {
@@ -224,7 +224,7 @@ describe('Config', function() {
           "y2": {"type": "quantitative", "field": "baz"}
         },
       });
-      assert.equal(model.config().mark.orient, 'vertical');
+      assert.equal(model.config.mark.orient, 'vertical');
     });
   });
 });

--- a/test/compile/data/pathorder.test.ts
+++ b/test/compile/data/pathorder.test.ts
@@ -105,7 +105,7 @@ describe('compile/data/pathorder', function() {
           }
         }
       });
-      const child = model.child();
+      const child = model.child;
       child.component.data = {
         pathOrder: pathOrder.parseUnit(child as any)
       } as any;
@@ -144,7 +144,7 @@ describe('compile/data/pathorder', function() {
           }
         }
       }) as LayerModel;
-      const children = model.children();
+      const children = model.children;
       children[0].component.data = {
         pathOrder: pathOrder.parseUnit(children[0])
       } as any;

--- a/test/compile/data/stack.test.ts
+++ b/test/compile/data/stack.test.ts
@@ -145,7 +145,7 @@ describe('compile/data/stack', () => {
           }
         }
       });
-      const child = model.child();
+      const child = model.child;
       child.component.data = mockDataComponent();
       child.component.data.stack = {
         name: 'stacked',
@@ -191,7 +191,7 @@ describe('compile/data/stack', () => {
           }
         }
       });
-      const child = model.child();
+      const child = model.child;
       child.component.data = mockDataComponent();
       child.component.data.stack = {
         name: 'stacked',
@@ -236,7 +236,7 @@ describe('compile/data/stack', () => {
           }
         }
       });
-      const child = model.child();
+      const child = model.child;
       child.component.data = mockDataComponent();
       child.component.data.stack = undefined;
 

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -37,7 +37,7 @@ describe('FacetModel', function() {
             encoding: {}
           }
         });
-        assert.equal(model.facet()['shape'], undefined);
+        assert.equal(model.facet['shape'], undefined);
         assert.equal(localLogger.warns[0], log.message.incompatibleChannel(SHAPE, 'facet'));
       });
     });
@@ -53,7 +53,7 @@ describe('FacetModel', function() {
             encoding: {}
           }
         });
-        assert.equal(model.facet().row, undefined);
+        assert.equal(model.facet.row, undefined);
         assert.equal(localLogger.warns[0], log.message.emptyFieldDef({type: ORDINAL}, ROW));
       });
     });
@@ -69,7 +69,7 @@ describe('FacetModel', function() {
             encoding: {}
           }
         });
-        assert.deepEqual(model.facet().row, {field: 'a', type: 'quantitative'});
+        assert.deepEqual(model.facet.row, {field: 'a', type: 'quantitative'});
         assert.equal(localLogger.warns[0], log.message.facetChannelShouldBeDiscrete(ROW));
       });
     });

--- a/test/compile/layer.test.ts
+++ b/test/compile/layer.test.ts
@@ -27,10 +27,10 @@ describe('Layer', function() {
           }
         }]
       });
-      assert.equal(model.children().length, 2);
+      assert.equal(model.children.length, 2);
       model.parseScale();
 
-      assert.deepEqual(model.component.scale['x'].main.domain, {
+      assert.deepEqual(model.component.scales['x'].main.domain, {
         fields: [{
           data: 'layer_0_source',
           field: 'a'
@@ -56,10 +56,10 @@ describe('Layer', function() {
           }
         }]
       });
-      assert.equal(model.children().length, 2);
+      assert.equal(model.children.length, 2);
       model.parseScale();
 
-      assert.deepEqual(model.component.scale['x'].main.domain, {
+      assert.deepEqual(model.component.scales['x'].main.domain, {
         fields: [{
           data: 'layer_0_source',
           field: 'bin_a_start'
@@ -90,7 +90,7 @@ describe('Layer', function() {
       });
       model.parseScale();
 
-      assert.deepEqual(model.component.scale['x'].main.domain, {
+      assert.deepEqual(model.component.scales['x'].main.domain, {
         fields: [
           [1, 2, 3],
           {

--- a/test/compile/mark/mark.test.ts
+++ b/test/compile/mark/mark.test.ts
@@ -82,7 +82,7 @@ describe('Mark', function() {
             }
           }
         });
-        const markGroup = parseMark(model.child() as UnitModel);
+        const markGroup = parseMark(model.child as UnitModel);
         assert.equal(markGroup[0].from.data, 'faceted-data');
       });
     });

--- a/test/compile/mark/rule.test.ts
+++ b/test/compile/mark/rule.test.ts
@@ -123,7 +123,7 @@ describe('Mark: Rule', function() {
     const props = rule.encodeEntry(model);
 
     it('should create vertical rule that emulates bar chart', function() {
-      assert.equal(model.config().mark.orient, 'vertical');
+      assert.equal(model.config.mark.orient, 'vertical');
 
       assert.deepEqual(props.x, {scale: X, field: 'a'});
       assert.deepEqual(props.y, {scale: Y, field: 'b'});
@@ -143,7 +143,7 @@ describe('Mark: Rule', function() {
     const props = rule.encodeEntry(model);
 
     it('should create horizontal rule that emulates bar chart', function() {
-      assert.equal(model.config().mark.orient, 'horizontal');
+      assert.equal(model.config.mark.orient, 'horizontal');
 
       assert.deepEqual(props.x, {scale: X, field: 'b'});
       assert.deepEqual(props.x2, {scale: X, value: 0});

--- a/test/compile/mark/text.test.ts
+++ b/test/compile/mark/text.test.ts
@@ -133,7 +133,7 @@ describe('Mark: Text', function() {
         "data": {"url": "data/cars.json"}
       };
     const model = parseModel(spec);
-    const props = text.encodeEntry(model.children()[0] as any);
+    const props = text.encodeEntry(model.children[0] as any);
 
     it('should fit cell on x', function() {
       assert.deepEqual(props.x, {field: {group: 'width'}, offset: -5});

--- a/test/compile/unit.test.ts
+++ b/test/compile/unit.test.ts
@@ -25,7 +25,7 @@ describe('UnitModel', function() {
             shape: {field: 'a', type: 'quantitative'}
           }
         });
-        assert.equal(model.encoding().shape, undefined);
+        assert.equal(model.encoding.shape, undefined);
         assert.equal(localLogger.warns[0], log.message.incompatibleChannel(SHAPE, BAR));
       });
     });
@@ -38,7 +38,7 @@ describe('UnitModel', function() {
             x: {type: 'quantitative'}
           }
         });
-        assert.equal(model.encoding().x, undefined);
+        assert.equal(model.encoding.x, undefined);
         assert.equal(localLogger.warns[0], log.message.emptyFieldDef({type: QUANTITATIVE}, X));
       });
     });
@@ -55,7 +55,7 @@ describe('UnitModel', function() {
             ]
           }
         });
-        assert.deepEqual(model.encoding().detail, [
+        assert.deepEqual(model.encoding.detail, [
           {field: 'a', type: 'ordinal'},
           {value: 'b'}
         ]);


### PR DESCRIPTION
Remove _ for privat properties. Use plural for dictionaries of scales, axes, and legends. Make more properties read only. Remove accessor functions for parent, description, padding, children, child, stack, and data.

Fixes #1941