### PR TITLE
Audit Axis Config

### DIFF
--- a/examples/specs/area.vl.json
+++ b/examples/specs/area.vl.json
@@ -6,11 +6,14 @@
     "x": {
       "timeUnit": "yearmonth", "field": "date", "type": "temporal",
       "scale": {"nice": "month"},
-      "axis": {"axisWidth": 0, "format": "%Y", "labelAngle": 0}
+      "axis": {"format": "%Y", "labelAngle": 0}
     },
     "y": {
       "aggregate": "sum", "field": "count","type": "quantitative"
     }
   },
-  "config": {"cell": {"width": 300, "height": 200}}
+  "config": {
+    "cell": {"width": 300, "height": 200},
+    "axis": {"domainWidth": 0}
+  }
 }

--- a/examples/specs/bar_grouped.vl.json
+++ b/examples/specs/bar_grouped.vl.json
@@ -10,7 +10,7 @@
     "column": {
       "field": "age", "type": "ordinal",
       "scale": {"spacing": 4},
-      "axis": {"orient": "bottom", "axisWidth": 1, "offset": -8}
+      "axis": {"orient": "bottom", "offset": -8}
     },
     "y": {
       "aggregate": "sum", "field": "people", "type": "quantitative",
@@ -26,5 +26,8 @@
       "scale": {"range": ["#EA98D2", "#659CCA"]}
     }
   },
-  "config": {"facet": {"cell": {"strokeWidth": 0}}}
+  "config": {
+    "facet": {"cell": {"strokeWidth": 0}},
+    "axis": {"domainWidth": 1}
+  }
 }

--- a/examples/specs/bar_grouped_horizontal.vl.json
+++ b/examples/specs/bar_grouped_horizontal.vl.json
@@ -10,7 +10,7 @@
     "row": {
       "field": "age", "type": "ordinal",
       "scale": {"spacing": 4},
-      "axis": {"orient": "left", "axisWidth": 1, "offset": -8}
+      "axis": {"orient": "left", "offset": -8}
     },
     "x": {
       "aggregate": "sum", "field": "people", "type": "quantitative",
@@ -26,5 +26,8 @@
       "scale": {"range": ["#EA98D2", "#659CCA"]}
     }
   },
-  "config": {"facet": {"cell": {"strokeWidth": 0}}}
+  "config": {
+    "facet": {"cell": {"strokeWidth": 0}},
+    "axis":{ "domainWidth": 1}
+  }
 }

--- a/examples/specs/line_month.vl.json
+++ b/examples/specs/line_month.vl.json
@@ -4,10 +4,12 @@
   "mark": "line",
   "encoding": {
     "x": {
-      "timeUnit": "month", "field": "date", "type": "temporal",
-      "axis": {"shortTimeLabels": true}
+      "timeUnit": "month", "field": "date", "type": "temporal"
     },
     "y": {"aggregate": "mean", "field": "temp", "type": "quantitative"}
   },
-  "config": {"mark": {"interpolate": "monotone"}}
+  "config": {
+    "mark": {"interpolate": "monotone"},
+    "axis": {"shortTimeLabels": true}
+  }
 }

--- a/examples/specs/stacked_area.vl.json
+++ b/examples/specs/stacked_area.vl.json
@@ -7,12 +7,15 @@
     "x": {
       "timeUnit": "yearmonth", "field": "date", "type": "temporal",
       "scale": {"nice": "month"},
-      "axis": {"axisWidth": 0, "format": "%Y", "labelAngle": 0}
+      "axis": {"format": "%Y", "labelAngle": 0}
     },
     "y": {
       "aggregate": "sum", "field": "count","type": "quantitative"
     },
     "color": {"field":"series", "type":"nominal", "scale":{"scheme": "category20b"}}
   },
-  "config": {"cell": {"width": 300, "height": 200}}
+  "config": {
+    "cell": {"width": 300, "height": 200},
+    "axis": {"domainWidth": 0}
+  }
 }

--- a/examples/specs/stacked_area_normalize.vl.json
+++ b/examples/specs/stacked_area_normalize.vl.json
@@ -6,7 +6,7 @@
     "x": {
       "timeUnit": "yearmonth", "field": "date", "type": "temporal",
       "scale": {"nice": "month"},
-      "axis": {"axisWidth": 0, "format": "%Y", "labelAngle": 0}
+      "axis": {"format": "%Y", "labelAngle": 0}
     },
     "y": {
       "aggregate": "sum", "field": "count","type": "quantitative",
@@ -14,5 +14,9 @@
     },
     "color": {"field":"series", "type":"nominal", "scale":{"scheme": "category20b"}}
   },
-  "config": {"cell": {"width": 300, "height": 200}, "stack": "normalize"}
+  "config": {
+    "cell": {"width": 300, "height": 200},
+    "axis": {"domainWidth": 0},
+    "stack": "normalize"
+  }
 }

--- a/examples/specs/stacked_area_stream.vl.json
+++ b/examples/specs/stacked_area_stream.vl.json
@@ -18,5 +18,5 @@
     "cell": {"width": 300, "height": 200},
     "axis": {"domainWidth": 0},
     "stack": "center"
-    }
+  }
 }

--- a/examples/specs/stacked_area_stream.vl.json
+++ b/examples/specs/stacked_area_stream.vl.json
@@ -6,7 +6,7 @@
     "x": {
       "timeUnit": "yearmonth", "field": "date", "type": "temporal",
       "scale": {"nice": "month"},
-      "axis": {"axisWidth": 0, "format": "%Y", "labelAngle": 0, "tickSize": 0}
+      "axis": {"format": "%Y", "labelAngle": 0, "tickSize": 0}
     },
     "y": {
       "aggregate": "sum", "field": "count","type": "quantitative",
@@ -14,5 +14,9 @@
     },
     "color": {"field":"series", "type":"nominal", "scale":{"scheme": "category20b"}}
   },
-  "config": {"cell": {"width": 300, "height": 200}, "stack": "center"}
+  "config": {
+    "cell": {"width": 300, "height": 200},
+    "axis": {"domainWidth": 0},
+    "stack": "center"
+    }
 }

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -4,17 +4,17 @@ import {VgAxisEncode} from './vega.schema';
 export type AxisOrient = 'top' | 'right' | 'left' | 'bottom';
 
 export interface AxisConfig extends AxisBase {
-  // ---------- General ----------
+  // ---------- Axis ----------
   /**
-   * Width of the axis line
+   * Width of the domain line
    */
   domainWidth?: number;
 
-  // ---------- Axis ----------
   /**
-   * Color of axis line.
+   * Color of axis domain line.
    */
   domainColor?: string;
+
   // ---------- Grid ----------
   /**
    * Color of gridlines.
@@ -41,7 +41,6 @@ export interface AxisConfig extends AxisBase {
   gridWidth?: number;
 
   // ---------- Ticks ----------
-
   /**
    * The color of the axis's tick.
    */
@@ -62,6 +61,7 @@ export interface AxisConfig extends AxisBase {
    * @minimum 0
    */
   labelFontSize?: number;
+
   /**
    * The width, in pixels, of ticks.
    * @minimum 0
@@ -89,11 +89,6 @@ export interface AxisConfig extends AxisBase {
    * Weight of the title.
    */
   titleFontWeight?: string | number;
-
-  /**
-   * A title offset value for the axis.
-   */
-  titleOffset?: number;
 }
 
 // TODO: add comment for properties that we rely on Vega's default to produce
@@ -105,10 +100,6 @@ export const defaultAxisConfig: AxisConfig = {
 
 export const defaultFacetAxisConfig: AxisConfig = {
   domainWidth: 0,
-  // TODO: remove these
-  domain: false,
-  grid: false,
-  ticks: false
 };
 
 export interface Axis extends AxisBase {
@@ -116,31 +107,39 @@ export interface Axis extends AxisBase {
    * The padding, in pixels, between axis and text labels.
    */
   labelPadding?: number;
+
   /**
    * The formatting pattern for axis labels.
    */
   format?: string; // default value determined by config.format anyway
+
   /**
    * The orientation of the axis. One of top, bottom, left or right. The orientation can be used to further specialize the axis type (e.g., a y axis oriented for the right edge of the chart).
    */
   orient?: AxisOrient;
+
   /**
    * The offset, in pixels, by which to displace the axis from the edge of the enclosing group or data rectangle.
    */
   offset?: number;
+
   // FIXME: Add Description
   position?: number;
+
   /**
    * A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are "nice" (multiples of 2, 5, 10) and lie within the underlying scale's range.
    * @minimum 0
    * @TJS-type integer
    */
   tickCount?: number;
+
   /**
    * A title for the axis. Shows field name and its function by default.
    */
   title?: string;
+
   values?: number[] | DateTime[];
+
   /**
    * A non-positive integer indicating z-index of the axis.
    * If zindex is 0, axes should be drawn behind all chart elements.
@@ -149,69 +148,81 @@ export interface Axis extends AxisBase {
    * @minimum 0
    */
   zindex?: number;
+
   /**
    * Optional mark definitions for custom axis encoding.
    */
   encode?: VgAxisEncode;
 }
 
-export interface AxisBase {
-  /**
-   * Whether to include the axis domain line.
-   */
-  domain?: boolean;
-  /**
-   * A flag indicate if gridlines should be created in addition to ticks. If `grid` is unspecified, the default value is `true` for ROW and COL. For X and Y, the default value is `true` for quantitative and time fields and `false` otherwise.
-   */
-  grid?: boolean;
-  /**
-   * Enable or disable labels.
-   */
-  labels?: boolean;
-  /**
-   * The rotation angle of the axis labels.
-   * @minimum 0
-   * @maximum 360
-   */
-  labelAngle?: number;
+export interface AxisBase extends VgAxisBase, VlAxisBase {}
+
+export interface VlAxisBase {
   /**
    * Truncate labels that are too long.
    * @minimum 1
    * @TJS-type integer
    */
   labelMaxLength?: number;
+}
+
+export interface VgAxisBase {
+  /**
+   * Whether to include the axis domain line.
+   */
+  domain?: boolean;
+
+  /**
+   * A flag indicate if gridlines should be created in addition to ticks. If `grid` is unspecified, the default value is `true` for ROW and COL. For X and Y, the default value is `true` for quantitative and time fields and `false` otherwise.
+   */
+  grid?: boolean;
+
+  /**
+   * Enable or disable labels.
+   */
+  labels?: boolean;
+
+  /**
+   * The rotation angle of the axis labels.
+   * @minimum 0
+   * @maximum 360
+   */
+  labelAngle?: number;  // FIXME: not sure if this should be a theme
+
   /**
    * Whether the axis should include ticks.
    */
   ticks?: boolean;
+
   /**
    * The size, in pixels, of major, minor and end ticks.
    * @minimum 0
    */
   tickSize?: number;
+
   /**
    * Max length for axis title if the title is automatically generated from the field's description. By default, this is automatically based on cell size and characterWidth property.
    * @minimum 0
    * @TJS-type integer
    */
   titleMaxLength?: number;
+
   /**
    * The padding, in pixels, between title and axis.
    */
   titlePadding?: number;
+
   /**
    * Minimum extent, which determines the offset between axis ticks and labels.
    */
   minExtent?: number;
+
   /**
    * Maximum extent, which determines the offset between axis ticks and labels.
    */
   maxExtent?: number;
-  /**
-   * Whether month and day names should be abbreviated.
-   */
-  shortTimeLabels?: boolean;
 }
+
 
 export const AXIS_PROPERTIES:(keyof Axis)[] = [
   // a) properties with special rules (so it has axis[property] methods) -- call rule functions
@@ -219,3 +230,5 @@ export const AXIS_PROPERTIES:(keyof Axis)[] = [
   // b) properties without rules, only produce default values in the schema, or explicit value if specified
     'labelPadding', 'maxExtent', 'minExtent', 'offset', 'position', 'tickSize', 'titlePadding'
 ];
+
+export const AXIS_BASE_PROPERTIES:(keyof VlAxisBase)[] = ['labelMaxLength'];

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -3,42 +3,19 @@ import {VgAxisEncode} from './vega.schema';
 
 export type AxisOrient = 'top' | 'right' | 'left' | 'bottom';
 
-export interface AxisConfig {
+export interface AxisConfig extends AxisBase {
   // ---------- General ----------
   /**
    * Width of the axis line
    */
-  axisWidth?: number;
-  /**
-   * A non-positive integer indicating z-index of the axis.
-   * If zindex is 0, axes should be drawn behind all chart elements.
-   * To put them in front, use zindex = 1.
-   * @TJS-type integer
-   * @minimum 0
-   */
-  zindex?: number;
-  /**
-   * The offset, in pixels, by which to displace the axis from the edge of the enclosing group or data rectangle.
-   */
-  offset?: number;
+  domainWidth?: number;
 
   // ---------- Axis ----------
   /**
    * Color of axis line.
    */
-  axisColor?: string;
-
-  /**
-   * Whether to include the axis domain line.
-   */
-  domain?: boolean;
-
+  domainColor?: string;
   // ---------- Grid ----------
-  /**
-   * A flag indicate if gridlines should be created in addition to ticks. If `grid` is unspecified, the default value is `true` for ROW and COL. For X and Y, the default value is `true` for quantitative and time fields and `false` otherwise.
-   */
-  grid?: boolean;
-
   /**
    * Color of gridlines.
    */
@@ -63,62 +40,7 @@ export interface AxisConfig {
    */
   gridWidth?: number;
 
-  // ---------- Labels ----------
-  /**
-   * Enable or disable labels.
-   */
-  labels?: boolean;
-
-  /**
-   * The rotation angle of the axis labels.
-   * @minimum 0
-   * @minimum 360
-   */
-  labelAngle?: number;
-  /**
-   * Text alignment for the Label.
-   */
-  labelAlign?: string;
-  /**
-   * Text baseline for the label.
-   */
-  labelBaseline?: string;
-  /**
-   * Truncate labels that are too long.
-   * @minimum 1
-   * @TJS-type integer
-   */
-  labelMaxLength?: number;
-  /**
-   * The padding, in pixels, between axis and text labels.
-   */
-  labelPadding?: number;
-  /**
-   * Whether month and day names should be abbreviated.
-   */
-  shortTimeLabels?: boolean;
-  // FIXME: Add Description
-  position?: number;
-
   // ---------- Ticks ----------
-  /**
-   * If provided, sets the number of minor ticks between major ticks (the value 9 results in decimal subdivision). Only applicable for axes visualizing quantitative scales.
-   * @minimum 0
-   * @TJS-type integer
-   */
-  subdivide?: number;
-
-  /**
-   * Whether the axis should include ticks.
-   */
-  ticks?: boolean;
-
-  /**
-   * A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are "nice" (multiples of 2, 5, 10) and lie within the underlying scale's range.
-   * @minimum 0
-   * @TJS-type integer
-   */
-  tickCount?: number;
 
   /**
    * The color of the axis's tick.
@@ -128,44 +50,18 @@ export interface AxisConfig {
   /**
    * The color of the tick label, can be in hex color code or regular color name.
    */
-  tickLabelColor?: string;
+  labelColor?: string;
 
   /**
    * The font of the tick label.
    */
-  tickLabelFont?: string;
+  labelFont?: string;
 
   /**
    * The font size of label, in pixels.
    * @minimum 0
    */
-  tickLabelFontSize?: number;
-
-  /**
-   * The padding, in pixels, between ticks and text labels.
-   */
-  tickPadding?: number;
-  /**
-   * The size, in pixels, of major, minor and end ticks.
-   * @minimum 0
-   */
-  tickSize?: number;
-  /**
-   * The size, in pixels, of major ticks.
-   * @minimum 0
-   */
-  tickSizeMajor?: number;
-  /**
-   * The size, in pixels, of minor ticks.
-   * @minimum 0
-   */
-  tickSizeMinor?: number;
-  /**
-   * The size, in pixels, of end ticks.
-   * @minimum 0
-   */
-  tickSizeEnd?: number;
-
+  labelFontSize?: number;
   /**
    * The width, in pixels, of ticks.
    * @minimum 0
@@ -198,29 +94,6 @@ export interface AxisConfig {
    * A title offset value for the axis.
    */
   titleOffset?: number;
-  /**
-   * Max length for axis title if the title is automatically generated from the field's description. By default, this is automatically based on cell size and characterWidth property.
-   * @minimum 0
-   * @TJS-type integer
-   */
-  titleMaxLength?: number;
-  /**
-   * The padding, in pixels, between title and axis.
-   */
-  titlePadding?: number;
-  // ---------- Other ----------
-  /**
-   * Optional mark definitions for custom axis encoding.
-   */
-  encode?: VgAxisEncode;
-  /**
-   * Minimum extent, which determines the offset between axis ticks and labels.
-   */
-  minExtent?: number;
-  /**
-   * Maximum extent, which determines the offset between axis ticks and labels.
-   */
-  maxExtent?: number;
 }
 
 // TODO: add comment for properties that we rely on Vega's default to produce
@@ -231,20 +104,18 @@ export const defaultAxisConfig: AxisConfig = {
 };
 
 export const defaultFacetAxisConfig: AxisConfig = {
-  axisWidth: 0,
+  domainWidth: 0,
   // TODO: remove these
   domain: false,
   grid: false,
   ticks: false
 };
 
-export interface Axis extends AxisConfig {
+export interface Axis extends AxisBase {
   /**
-   * The rotation angle of the axis labels.
-   * @minimum 0
-   * @maximum 360
+   * The padding, in pixels, between axis and text labels.
    */
-  labelAngle?: number;
+  labelPadding?: number;
   /**
    * The formatting pattern for axis labels.
    */
@@ -254,16 +125,97 @@ export interface Axis extends AxisConfig {
    */
   orient?: AxisOrient;
   /**
+   * The offset, in pixels, by which to displace the axis from the edge of the enclosing group or data rectangle.
+   */
+  offset?: number;
+  // FIXME: Add Description
+  position?: number;
+  /**
+   * A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are "nice" (multiples of 2, 5, 10) and lie within the underlying scale's range.
+   * @minimum 0
+   * @TJS-type integer
+   */
+  tickCount?: number;
+  /**
    * A title for the axis. Shows field name and its function by default.
    */
   title?: string;
   values?: number[] | DateTime[];
+  /**
+   * A non-positive integer indicating z-index of the axis.
+   * If zindex is 0, axes should be drawn behind all chart elements.
+   * To put them in front, use zindex = 1.
+   * @TJS-type integer
+   * @minimum 0
+   */
+  zindex?: number;
+  /**
+   * Optional mark definitions for custom axis encoding.
+   */
+  encode?: VgAxisEncode;
+}
+
+export interface AxisBase {
+  /**
+   * Whether to include the axis domain line.
+   */
+  domain?: boolean;
+  /**
+   * A flag indicate if gridlines should be created in addition to ticks. If `grid` is unspecified, the default value is `true` for ROW and COL. For X and Y, the default value is `true` for quantitative and time fields and `false` otherwise.
+   */
+  grid?: boolean;
+  /**
+   * Enable or disable labels.
+   */
+  labels?: boolean;
+  /**
+   * The rotation angle of the axis labels.
+   * @minimum 0
+   * @maximum 360
+   */
+  labelAngle?: number;
+  /**
+   * Truncate labels that are too long.
+   * @minimum 1
+   * @TJS-type integer
+   */
+  labelMaxLength?: number;
+  /**
+   * Whether the axis should include ticks.
+   */
+  ticks?: boolean;
+  /**
+   * The size, in pixels, of major, minor and end ticks.
+   * @minimum 0
+   */
+  tickSize?: number;
+  /**
+   * Max length for axis title if the title is automatically generated from the field's description. By default, this is automatically based on cell size and characterWidth property.
+   * @minimum 0
+   * @TJS-type integer
+   */
+  titleMaxLength?: number;
+  /**
+   * The padding, in pixels, between title and axis.
+   */
+  titlePadding?: number;
+  /**
+   * Minimum extent, which determines the offset between axis ticks and labels.
+   */
+  minExtent?: number;
+  /**
+   * Maximum extent, which determines the offset between axis ticks and labels.
+   */
+  maxExtent?: number;
+  /**
+   * Whether month and day names should be abbreviated.
+   */
+  shortTimeLabels?: boolean;
 }
 
 export const AXIS_PROPERTIES:(keyof Axis)[] = [
   // a) properties with special rules (so it has axis[property] methods) -- call rule functions
   'domain', 'format', 'labels', 'grid', 'orient', 'ticks', 'tickSize', 'tickCount',  'title', 'values', 'zindex',
   // b) properties without rules, only produce default values in the schema, or explicit value if specified
-    'labelPadding', 'maxExtent', 'minExtent', 'offset', 'position', 'subdivide', 'tickPadding', 'tickSize', 'tickSizeEnd',
-    'tickSizeMajor', 'tickSizeMinor', 'titleOffset', 'titlePadding'
+    'labelPadding', 'maxExtent', 'minExtent', 'offset', 'position', 'tickSize', 'titlePadding'
 ];

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -1,95 +1,9 @@
 import {DateTime} from './datetime';
-import {VgAxisEncode} from './vega.schema';
+import {VgAxisEncode, VgAxisBase, VgAxisConfig} from './vega.schema';
 
 export type AxisOrient = 'top' | 'right' | 'left' | 'bottom';
 
-export interface AxisConfig extends AxisBase {
-  // ---------- Axis ----------
-  /**
-   * Width of the domain line
-   */
-  domainWidth?: number;
-
-  /**
-   * Color of axis domain line.
-   */
-  domainColor?: string;
-
-  // ---------- Grid ----------
-  /**
-   * Color of gridlines.
-   */
-  gridColor?: string;
-
-  /**
-   * The offset (in pixels) into which to begin drawing with the grid dash array.
-   * @minimum 0
-   */
-  gridDash?: number[];
-
-  /**
-   * The stroke opacity of grid (value between [0,1])
-   * @minimum 0
-   * @maximum 1
-   */
-  gridOpacity?: number;
-
-  /**
-   * The grid width, in pixels.
-   * @minimum 0
-   */
-  gridWidth?: number;
-
-  // ---------- Ticks ----------
-  /**
-   * The color of the axis's tick.
-   */
-  tickColor?: string;
-
-  /**
-   * The color of the tick label, can be in hex color code or regular color name.
-   */
-  labelColor?: string;
-
-  /**
-   * The font of the tick label.
-   */
-  labelFont?: string;
-
-  /**
-   * The font size of label, in pixels.
-   * @minimum 0
-   */
-  labelFontSize?: number;
-
-  /**
-   * The width, in pixels, of ticks.
-   * @minimum 0
-   */
-  tickWidth?: number;
-
-  // ---------- Title ----------
-  /**
-   * Color of the title, can be in hex color code or regular color name.
-   */
-  titleColor?: string;
-
-  /**
-   * Font of the title.
-   */
-  titleFont?: string;
-
-  /**
-   * Size of the title.
-   * @minimum 0
-   */
-  titleFontSize?: number;
-
-  /**
-   * Weight of the title.
-   */
-  titleFontWeight?: string | number;
-}
+export interface AxisConfig extends VgAxisConfig, VlOnlyAxisConfig {}
 
 // TODO: add comment for properties that we rely on Vega's default to produce
 // more concise Vega output.
@@ -102,7 +16,7 @@ export const defaultFacetAxisConfig: AxisConfig = {
   domainWidth: 0,
 };
 
-export interface Axis extends AxisBase {
+export interface Axis extends VgAxisBase, VlOnlyAxisConfig {
   /**
    * The padding, in pixels, between axis and text labels.
    */
@@ -155,9 +69,9 @@ export interface Axis extends AxisBase {
   encode?: VgAxisEncode;
 }
 
-export interface AxisBase extends VgAxisBase, VlAxisBase {}
+export interface AxisBase extends VgAxisBase, VlOnlyAxisConfig {}
 
-export interface VlAxisBase {
+export interface VlOnlyAxisConfig {
   /**
    * Truncate labels that are too long.
    * @minimum 1
@@ -166,64 +80,6 @@ export interface VlAxisBase {
   labelMaxLength?: number;
 }
 
-export interface VgAxisBase {
-  /**
-   * Whether to include the axis domain line.
-   */
-  domain?: boolean;
-
-  /**
-   * A flag indicate if gridlines should be created in addition to ticks. If `grid` is unspecified, the default value is `true` for ROW and COL. For X and Y, the default value is `true` for quantitative and time fields and `false` otherwise.
-   */
-  grid?: boolean;
-
-  /**
-   * Enable or disable labels.
-   */
-  labels?: boolean;
-
-  /**
-   * The rotation angle of the axis labels.
-   * @minimum 0
-   * @maximum 360
-   */
-  labelAngle?: number;  // FIXME: not sure if this should be a theme
-
-  /**
-   * Whether the axis should include ticks.
-   */
-  ticks?: boolean;
-
-  /**
-   * The size, in pixels, of major, minor and end ticks.
-   * @minimum 0
-   */
-  tickSize?: number;
-
-  /**
-   * Max length for axis title if the title is automatically generated from the field's description. By default, this is automatically based on cell size and characterWidth property.
-   * @minimum 0
-   * @TJS-type integer
-   */
-  titleMaxLength?: number;
-
-  /**
-   * The padding, in pixels, between title and axis.
-   */
-  titlePadding?: number;
-
-  /**
-   * Minimum extent, which determines the offset between axis ticks and labels.
-   */
-  minExtent?: number;
-
-  /**
-   * Maximum extent, which determines the offset between axis ticks and labels.
-   */
-  maxExtent?: number;
-}
-
-
 export const AXIS_PROPERTIES:(keyof Axis)[] = [
   // a) properties with special rules (so it has axis[property] methods) -- call rule functions
   'domain', 'format', 'labels', 'grid', 'orient', 'ticks', 'tickSize', 'tickCount',  'title', 'values', 'zindex',
@@ -231,4 +87,4 @@ export const AXIS_PROPERTIES:(keyof Axis)[] = [
     'labelPadding', 'maxExtent', 'minExtent', 'offset', 'position', 'tickSize', 'titlePadding'
 ];
 
-export const AXIS_BASE_PROPERTIES:(keyof VlAxisBase)[] = ['labelMaxLength'];
+export const VL_AXIS_BASE_PROPERTIES:(keyof VlOnlyAxisConfig)[] = ['labelMaxLength'];

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -66,8 +66,6 @@ export interface Axis extends VgAxisBase, VlOnlyAxisConfig {
   encode?: VgAxisEncode;
 }
 
-export interface AxisBase extends VgAxisBase, VlOnlyAxisConfig {}
-
 export interface VlOnlyAxisConfig {
   /**
    * Truncate labels that are too long.
@@ -84,4 +82,4 @@ export const AXIS_PROPERTIES:(keyof Axis)[] = [
     'labelPadding', 'maxExtent', 'minExtent', 'offset', 'position', 'tickSize', 'titlePadding'
 ];
 
-export const VL_AXIS_BASE_PROPERTIES:(keyof VlOnlyAxisConfig)[] = ['labelMaxLength'];
+export const VL_ONLY_AXIS_PROPERTIES:(keyof VlOnlyAxisConfig)[] = ['labelMaxLength'];

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -5,9 +5,6 @@ export type AxisOrient = 'top' | 'right' | 'left' | 'bottom';
 
 export interface AxisConfig extends VgAxisConfig, VlOnlyAxisConfig {}
 
-// TODO: add comment for properties that we rely on Vega's default to produce
-// more concise Vega output.
-
 export const defaultAxisConfig: AxisConfig = {
   labelMaxLength: 25,
 };

--- a/src/compile/axis/encode.ts
+++ b/src/compile/axis/encode.ts
@@ -23,7 +23,7 @@ export function labels(model: Model, channel: Channel, labelsSpec: any, def: VgA
   } else if (fieldDef.type === TEMPORAL) {
     labelsSpec = extend({
       text: {
-        signal: timeFormatExpression('datum.value', fieldDef.timeUnit, axis.format, axis.shortTimeLabels, config)
+        signal: timeFormatExpression('datum.value', fieldDef.timeUnit, axis.format, config.axis.shortTimeLabels, config)
       }
     }, labelsSpec);
   }

--- a/src/compile/axis/encode.ts
+++ b/src/compile/axis/encode.ts
@@ -23,7 +23,7 @@ export function labels(model: Model, channel: Channel, labelsSpec: any, def: VgA
   } else if (fieldDef.type === TEMPORAL) {
     labelsSpec = extend({
       text: {
-        signal: timeFormatExpression('datum.value', fieldDef.timeUnit, axis.format, config.axis.shortTimeLabels, config)
+        signal: timeFormatExpression('datum.value', fieldDef.timeUnit, axis.format, config.axis.shortTimeLabels, config.timeFormat)
       }
     }, labelsSpec);
   }

--- a/src/compile/axis/encode.ts
+++ b/src/compile/axis/encode.ts
@@ -7,34 +7,6 @@ import {timeFormatExpression} from '../common';
 import {Model} from '../model';
 
 // TODO: @yuhanlu -- please change method signature to require only what are really needed
-export function domain(model: Model, channel: Channel, domainPropsSpec: any, _?: VgAxis) {
-  const axis = model.axis(channel);
-
-  return extend(
-    axis.axisColor !== undefined ?
-      {stroke: {value: axis.axisColor}} :
-      {},
-    axis.axisWidth !== undefined ?
-      {strokeWidth: {value: axis.axisWidth}} :
-      {},
-    domainPropsSpec || {}
-  );
-}
-
-// TODO: @yuhanlu -- please change method signature to require only what are really needed
-export function grid(model: Model, channel: Channel, gridPropsSpec: any, _?: VgAxis) {
-  const axis = model.axis(channel);
-
-  return extend(
-    axis.gridColor !== undefined ? {stroke: {value: axis.gridColor}} : {},
-    axis.gridOpacity !== undefined ? {strokeOpacity: {value: axis.gridOpacity}} : {},
-    axis.gridWidth !== undefined ? {strokeWidth : {value: axis.gridWidth}} : {},
-    axis.gridDash !== undefined ? {strokeDashOffset : {value: axis.gridDash}} : {},
-    gridPropsSpec || {}
-  );
-}
-
-// TODO: @yuhanlu -- please change method signature to require only what are really needed
 export function labels(model: Model, channel: Channel, labelsSpec: any, def: VgAxis) {
   const fieldDef = model.fieldDef(channel);
   const axis = model.axis(channel);
@@ -66,74 +38,29 @@ export function labels(model: Model, channel: Channel, labelsSpec: any, def: VgA
     }
   }
 
-  if (axis.labelAlign !== undefined) {
-    labelsSpec.align = {value: axis.labelAlign};
-  } else {
-    // Auto set align if rotated
+  // Auto set align if rotated
+  // TODO: consider other value besides 270, 90
+  if (labelsSpec.angle) {
+    if (labelsSpec.angle.value === 270) {
+      labelsSpec.align = {
+        value: def.orient === 'top' ? 'left':
+                (channel === X || channel === COLUMN) ? 'right' :
+                'center'
+      };
+    } else if (labelsSpec.angle.value === 90) {
+      labelsSpec.align = {value: 'center'};
+    }
+  }
+
+  if (labelsSpec.angle) {
+    // Auto set baseline if rotated
     // TODO: consider other value besides 270, 90
-    if (labelsSpec.angle) {
-      if (labelsSpec.angle.value === 270) {
-        labelsSpec.align = {
-          value: def.orient === 'top' ? 'left':
-                  (channel === X || channel === COLUMN) ? 'right' :
-                  'center'
-        };
-      } else if (labelsSpec.angle.value === 90) {
-        labelsSpec.align = {value: 'center'};
-      }
+    if (labelsSpec.angle.value === 270) {
+      labelsSpec.baseline = {value: (channel === X || channel === COLUMN) ? 'middle' : 'bottom'};
+    } else if (labelsSpec.angle.value === 90) {
+      labelsSpec.baseline = {value: 'bottom'};
     }
-  }
-
-  if (axis.labelBaseline !== undefined) {
-    labelsSpec.baseline = {value: axis.labelBaseline};
-  } else {
-    if (labelsSpec.angle) {
-      // Auto set baseline if rotated
-      // TODO: consider other value besides 270, 90
-      if (labelsSpec.angle.value === 270) {
-        labelsSpec.baseline = {value: (channel === X || channel === COLUMN) ? 'middle' : 'bottom'};
-      } else if (labelsSpec.angle.value === 90) {
-        labelsSpec.baseline = {value: 'bottom'};
-      }
-    }
-  }
-
-  if (axis.tickLabelColor !== undefined) {
-      labelsSpec.fill = {value: axis.tickLabelColor};
-  }
-
-  if (axis.tickLabelFont !== undefined) {
-      labelsSpec.font = {value: axis.tickLabelFont};
-  }
-
-  if (axis.tickLabelFontSize !== undefined) {
-      labelsSpec.fontSize = {value: axis.tickLabelFontSize};
   }
 
   return keys(labelsSpec).length === 0 ? undefined : labelsSpec;
-}
-
-// TODO: @yuhanlu -- please change method signature to require only what are really needed
-export function ticks(model: Model, channel: Channel, ticksPropsSpec: any, _?: VgAxis) {
-  const axis = model.axis(channel);
-
-  return extend(
-    axis.tickColor !== undefined ? {stroke : {value: axis.tickColor}} : {},
-    axis.tickWidth !== undefined ? {strokeWidth: {value: axis.tickWidth}} : {},
-    ticksPropsSpec || {}
-  );
-}
-
-// TODO: @yuhanlu -- please change method signature to require only what are really needed
-export function title(model: Model, channel: Channel, titlePropsSpec: any, _?: VgAxis) {
-  const axis = model.axis(channel);
-
-  return extend(
-    axis.titleColor !== undefined ? {fill : {value: axis.titleColor}} : {},
-    axis.titleFont !== undefined ? {font: {value: axis.titleFont}} : {},
-    axis.titleFontSize !== undefined ? {fontSize: {value: axis.titleFontSize}} : {},
-    axis.titleFontWeight !== undefined ? {fontWeight: {value: axis.titleFontWeight}} : {},
-
-    titlePropsSpec || {}
-  );
 }

--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -100,7 +100,7 @@ function parseAxis(channel: Channel, model: Model, isGridAxis: boolean): VgAxis 
     // as different require different parameters.
     let value;
     if (part === 'labels') {
-        value = encode[part](model, channel, encodeSpec.labels || {}, vgAxis);
+        value = encode.labels(model, channel, encodeSpec.labels || {}, vgAxis);
     } else {
         value = encodeSpec[part] || {};
     }
@@ -118,10 +118,12 @@ function getSpecifiedOrDefaultValue(property: keyof VgAxis, specifiedAxis: Axis,
   const fieldDef = model.fieldDef(channel);
 
   switch (property) {
-    case 'domain':
     case 'labels':
-    case 'ticks':
       return isGridAxis ? false : specifiedAxis[property];
+    case 'domain':
+      return rules.domain(property, specifiedAxis, isGridAxis, channel);
+    case 'ticks':
+      return rules.ticks(property, specifiedAxis, isGridAxis, channel);
     case 'format':
       return rules.format(specifiedAxis, channel, fieldDef, model.config);
     case 'grid':

--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -98,7 +98,12 @@ function parseAxis(channel: Channel, model: Model, isGridAxis: boolean): VgAxis 
     }
     // TODO(@yuhanlu): instead of calling encode[part], break this line based on part type
     // as different require different parameters.
-    const value = encode[part](model, channel, encodeSpec.labels || {}, vgAxis);
+    let value;
+    if (part === 'labels') {
+        value = encode[part](model, channel, encodeSpec.labels || {}, vgAxis);
+    } else {
+        value = encodeSpec[part] || {};
+    }
 
     if (value !== undefined && keys(value).length > 0) {
       vgAxis.encode = vgAxis.encode || {};

--- a/src/compile/axis/rules.ts
+++ b/src/compile/axis/rules.ts
@@ -1,6 +1,7 @@
 import * as log from '../../log';
 
 import {Axis} from '../../axis';
+import {VgAxis} from '../../vega.schema';
 import {COLUMN, ROW, X, Y, Channel} from '../../channel';
 import {Config} from '../../config';
 import {DateTime, isDateTime, timestamp} from '../../datetime';
@@ -31,7 +32,7 @@ export function gridShow(model: Model, channel: Channel) {
 export function grid(model: Model, channel: Channel, isGridAxis: boolean) {
   if (channel === ROW || channel === COLUMN) {
     // never apply grid for ROW and COLUMN since we manually create rule-group for them
-    return undefined;
+    return false;
   }
 
   if (!isGridAxis) {
@@ -123,3 +124,13 @@ export function zindex(specifiedAxis: Axis, isGridAxis: boolean) {
   }
   return 1; // otherwise return undefined and use Vega's default.
 };
+
+export function domainAndTicks(property: keyof VgAxis, specifiedAxis: Axis, isGridAxis: boolean, channel: Channel) {
+  if (isGridAxis || channel === ROW || channel === COLUMN) {
+    return false;
+  }
+  return specifiedAxis[property];
+}
+
+export const domain = domainAndTicks;
+export const ticks = domainAndTicks;

--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -72,10 +72,10 @@ export function numberFormat(fieldDef: FieldDef, format: string, config: Config,
 /**
  * Returns the time expression used for axis/legend labels or text mark for a temporal field
  */
-export function timeFormatExpression(field: string, timeUnit: TimeUnit, format: string, shortTimeLabels: boolean, config: Config): string {
+export function timeFormatExpression(field: string, timeUnit: TimeUnit, format: string, shortTimeLabels: boolean, timeFormatConfig: string): string {
   if (!timeUnit || format) {
     // If there is not time unit, or if user explicitly specify format for axis/legend/text.
-    const _format = format || config.timeFormat; // only use config.timeFormat if there is no timeUnit.
+    const _format = format || timeFormatConfig; // only use config.timeFormat if there is no timeUnit.
     return `timeFormat(${field}, '${_format}')`;
   } else {
     return formatExpression(timeUnit, field, shortTimeLabels);

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -1,6 +1,6 @@
 import * as log from '../log';
 
-import {Axis, VlOnlyAxisConfig, VL_AXIS_BASE_PROPERTIES} from '../axis';
+import {Axis, VlOnlyAxisConfig, VL_ONLY_AXIS_PROPERTIES} from '../axis';
 import {COLUMN, ROW, X, Y, Channel} from '../channel';
 import {defaultConfig, Config} from '../config';
 import {Facet} from '../facet';
@@ -127,15 +127,15 @@ export class FacetModel extends Model {
       if (facet[channel]) {
         const axisSpec = facet[channel].axis;
         if (axisSpec !== false) {
-          let vlAxisBase: VlOnlyAxisConfig = {};
-          VL_AXIS_BASE_PROPERTIES.forEach(function(property) {
+          let vlAxisProperties: VlOnlyAxisConfig = {};
+          VL_ONLY_AXIS_PROPERTIES.forEach(function(property) {
             if (config.facet.axis[property] !== undefined) {
-              vlAxisBase[property] = config.facet.axis[property];
+              vlAxisProperties[property] = config.facet.axis[property];
             }
           });
 
           const modelAxis = _axis[channel] = {
-            ...vlAxisBase,
+            ...vlAxisProperties,
             ...axisSpec
           };
 

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -1,6 +1,6 @@
 import * as log from '../log';
 
-import {Axis} from '../axis';
+import {Axis, defaultFacetAxisConfig} from '../axis';
 import {COLUMN, ROW, X, Y, Channel} from '../channel';
 import {defaultConfig, Config} from '../config';
 import {Facet} from '../facet';
@@ -66,7 +66,7 @@ export class FacetModel extends Model {
 
     const facet  = this.facet = this.initFacet(spec.facet);
     this.scales  = this.initScalesAndSpacing(facet, config);
-    this.axes   = this.initAxis(facet, config, child);
+    this.axes   = this.initAxis(facet, child);
     this.legends = {};
   }
 
@@ -121,14 +121,14 @@ export class FacetModel extends Model {
     }, {});
   }
 
-  private initAxis(facet: Facet, config: Config, child: Model): Dict<Axis> {
+  private initAxis(facet: Facet, child: Model): Dict<Axis> {
     const model = this;
     return [ROW, COLUMN].reduce(function(_axis, channel) {
       if (facet[channel]) {
         const axisSpec = facet[channel].axis;
         if (axisSpec !== false) {
           const modelAxis = _axis[channel] = extend({},
-            config.facet.axis,
+            defaultFacetAxisConfig,
             axisSpec === true ? {} : axisSpec || {}
           );
 

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -1,6 +1,6 @@
 import * as log from '../log';
 
-import {Axis, defaultFacetAxisConfig} from '../axis';
+import {Axis, VlOnlyAxisConfig, VL_AXIS_BASE_PROPERTIES} from '../axis';
 import {COLUMN, ROW, X, Y, Channel} from '../channel';
 import {defaultConfig, Config} from '../config';
 import {Facet} from '../facet';
@@ -66,7 +66,7 @@ export class FacetModel extends Model {
 
     const facet  = this.facet = this.initFacet(spec.facet);
     this.scales  = this.initScalesAndSpacing(facet, config);
-    this.axes   = this.initAxis(facet, child);
+    this.axes   = this.initAxis(facet, config, child);
     this.legends = {};
   }
 
@@ -121,14 +121,21 @@ export class FacetModel extends Model {
     }, {});
   }
 
-  private initAxis(facet: Facet, child: Model): Dict<Axis> {
+  private initAxis(facet: Facet, config: Config, child: Model): Dict<Axis> {
     const model = this;
     return [ROW, COLUMN].reduce(function(_axis, channel) {
       if (facet[channel]) {
         const axisSpec = facet[channel].axis;
         if (axisSpec !== false) {
+          let vlAxisBase: VlOnlyAxisConfig = {};
+          VL_AXIS_BASE_PROPERTIES.forEach(function(property) {
+            if (config.facet.axis[property] !== undefined) {
+              vlAxisBase[property] = config.facet.axis[property];
+            }
+          });
+
           const modelAxis = _axis[channel] = {
-            ...defaultFacetAxisConfig,
+            ...vlAxisBase,
             ...axisSpec
           };
 

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -127,10 +127,10 @@ export class FacetModel extends Model {
       if (facet[channel]) {
         const axisSpec = facet[channel].axis;
         if (axisSpec !== false) {
-          const modelAxis = _axis[channel] = extend({},
-            defaultFacetAxisConfig,
-            axisSpec === true ? {} : axisSpec || {}
-          );
+          const modelAxis = _axis[channel] = {
+            ...defaultFacetAxisConfig,
+            ...axisSpec
+          };
 
           if (channel === ROW) {
             const yAxis: any = child.axis(Y);

--- a/src/compile/legend/encode.ts
+++ b/src/compile/legend/encode.ts
@@ -146,7 +146,7 @@ export function labels(fieldDef: FieldDef, labelsSpec: any, model: UnitModel, ch
   } else if (fieldDef.type === TEMPORAL) {
     labelsSpec = extend({
       text: {
-        signal: timeFormatExpression('datum.value', fieldDef.timeUnit, legend.format, legend.shortTimeLabels, config)
+        signal: timeFormatExpression('datum.value', fieldDef.timeUnit, legend.format, legend.shortTimeLabels, config.timeFormat)
       }
     }, labelsSpec || {});
   }

--- a/src/compile/mark/text.ts
+++ b/src/compile/mark/text.ts
@@ -61,7 +61,7 @@ function textRef(textDef: TextFieldDef | ValueDef<any>, config: Config): VgValue
         };
       } else if (TEMPORAL === textDef.type) {
         return {
-          signal: timeFormatExpression(field(textDef, {datum: true}), textDef.timeUnit, textDef.format, config.text.shortTimeLabels, config)
+          signal: timeFormatExpression(field(textDef, {datum: true}), textDef.timeUnit, textDef.format, config.text.shortTimeLabels, config.timeFormat)
         };
       } else {
         return {field: textDef.field};

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -1,6 +1,6 @@
 import * as log from '../log';
 
-import {Axis, VlOnlyAxisConfig, VL_AXIS_BASE_PROPERTIES} from '../axis';
+import {Axis, VlOnlyAxisConfig, VL_ONLY_AXIS_PROPERTIES} from '../axis';
 import {X, Y, X2, Y2, Channel, UNIT_CHANNELS,  UNIT_SCALE_CHANNELS, NONSPATIAL_SCALE_CHANNELS, supportMark} from '../channel';
 import {defaultConfig, Config, CellConfig} from '../config';
 import {SOURCE, SUMMARY} from '../data';
@@ -234,14 +234,14 @@ export class UnitModel extends Model {
 
         // We no longer support false in the schema, but we keep false here for backward compatability.
         if (axisSpec !== null && axisSpec !== false) {
-          let vlAxisBase: VlOnlyAxisConfig = {};
-          VL_AXIS_BASE_PROPERTIES.forEach(function(property) {
+          let vlAxisProperties: VlOnlyAxisConfig = {};
+          VL_ONLY_AXIS_PROPERTIES.forEach(function(property) {
             if (config.axis[property] !== undefined) {
-              vlAxisBase[property] = config.axis[property];
+              vlAxisProperties[property] = config.axis[property];
             }
           });
           _axis[channel] = {
-            ...vlAxisBase,
+            ...vlAxisProperties,
             ...axisSpec
           };
         }

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -234,14 +234,14 @@ export class UnitModel extends Model {
 
         // We no longer support false in the schema, but we keep false here for backward compatability.
         if (axisSpec !== null && axisSpec !== false) {
-          let vlAxisProperties: VlOnlyAxisConfig = {};
+          let vlOnlyAxisProperties: VlOnlyAxisConfig = {};
           VL_ONLY_AXIS_PROPERTIES.forEach(function(property) {
             if (config.axis[property] !== undefined) {
-              vlAxisProperties[property] = config.axis[property];
+              vlOnlyAxisProperties[property] = config.axis[property];
             }
           });
           _axis[channel] = {
-            ...vlAxisProperties,
+            ...vlOnlyAxisProperties,
             ...axisSpec
           };
         }

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -1,6 +1,6 @@
 import * as log from '../log';
 
-import {Axis, VlAxisBase, AXIS_BASE_PROPERTIES} from '../axis';
+import {Axis, VlOnlyAxisConfig, VL_AXIS_BASE_PROPERTIES} from '../axis';
 import {X, Y, X2, Y2, Channel, UNIT_CHANNELS,  UNIT_SCALE_CHANNELS, NONSPATIAL_SCALE_CHANNELS, supportMark} from '../channel';
 import {defaultConfig, Config, CellConfig} from '../config';
 import {SOURCE, SUMMARY} from '../data';
@@ -234,14 +234,13 @@ export class UnitModel extends Model {
 
         // We no longer support false in the schema, but we keep false here for backward compatability.
         if (axisSpec !== null && axisSpec !== false) {
-          let vlAxisBase: VlAxisBase = {};
-          AXIS_BASE_PROPERTIES.forEach(function(property) {
-            if (encoding !== undefined && encoding[property] !== undefined) {
-              vlAxisBase[property] = encoding[property];
+          let vlAxisBase: VlOnlyAxisConfig = {};
+          VL_AXIS_BASE_PROPERTIES.forEach(function(property) {
+            if (config.axis[property] !== undefined) {
+              vlAxisBase[property] = config.axis[property];
             }
           });
           _axis[channel] = {
-            labelMaxLength: config.axis.labelMaxLength,
             ...vlAxisBase,
             ...axisSpec
           };

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -1,6 +1,6 @@
 import * as log from '../log';
 
-import {Axis} from '../axis';
+import {Axis, defaultAxisConfig} from '../axis';
 import {X, Y, X2, Y2, Channel, UNIT_CHANNELS,  UNIT_SCALE_CHANNELS, NONSPATIAL_SCALE_CHANNELS, supportMark} from '../channel';
 import {defaultConfig, Config, CellConfig} from '../config';
 import {SOURCE, SUMMARY} from '../data';
@@ -81,7 +81,7 @@ export class UnitModel extends Model {
       config.text = initTextConfig(encoding, config);
     }
 
-    this.axes = this.initAxes(encoding, config);
+    this.axes = this.initAxes(encoding);
     this.legends = this.initLegend(encoding, config);
 
     // width / height
@@ -221,7 +221,7 @@ export class UnitModel extends Model {
     return {width, height};
   }
 
-  private initAxes(encoding: Encoding, config: Config): Dict<Axis> {
+  private initAxes(encoding: Encoding): Dict<Axis> {
     return [X, Y].reduce(function(_axis, channel) {
       // Position Axis
 
@@ -235,8 +235,8 @@ export class UnitModel extends Model {
         // We no longer support false in the schema, but we keep false here for backward compatability.
         if (axisSpec !== null && axisSpec !== false) {
           _axis[channel] = extend({},
-            config.axis,
-            axisSpec === true ? {} : axisSpec ||  {}
+          defaultAxisConfig,
+          axisSpec === true ? {} : axisSpec ||  {}
           );
         }
       }

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -1,6 +1,6 @@
 import * as log from '../log';
 
-import {Axis, defaultAxisConfig} from '../axis';
+import {Axis, VlAxisBase, AXIS_BASE_PROPERTIES} from '../axis';
 import {X, Y, X2, Y2, Channel, UNIT_CHANNELS,  UNIT_SCALE_CHANNELS, NONSPATIAL_SCALE_CHANNELS, supportMark} from '../channel';
 import {defaultConfig, Config, CellConfig} from '../config';
 import {SOURCE, SUMMARY} from '../data';
@@ -81,7 +81,7 @@ export class UnitModel extends Model {
       config.text = initTextConfig(encoding, config);
     }
 
-    this.axes = this.initAxes(encoding);
+    this.axes = this.initAxes(encoding, config);
     this.legends = this.initLegend(encoding, config);
 
     // width / height
@@ -221,7 +221,7 @@ export class UnitModel extends Model {
     return {width, height};
   }
 
-  private initAxes(encoding: Encoding): Dict<Axis> {
+  private initAxes(encoding: Encoding, config: Config): Dict<Axis> {
     return [X, Y].reduce(function(_axis, channel) {
       // Position Axis
 
@@ -234,10 +234,17 @@ export class UnitModel extends Model {
 
         // We no longer support false in the schema, but we keep false here for backward compatability.
         if (axisSpec !== null && axisSpec !== false) {
-          _axis[channel] = extend({},
-          defaultAxisConfig,
-          axisSpec === true ? {} : axisSpec ||  {}
-          );
+          let vlAxisBase: VlAxisBase = {};
+          AXIS_BASE_PROPERTIES.forEach(function(property) {
+            if (encoding !== undefined && encoding[property] !== undefined) {
+              vlAxisBase[property] = encoding[property];
+            }
+          });
+          _axis[channel] = {
+            labelMaxLength: config.axis.labelMaxLength,
+            ...vlAxisBase,
+            ...axisSpec
+          };
         }
       }
       return _axis;

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -180,3 +180,154 @@ export interface VgImputeTransform {
   method?: 'value' | 'median' | 'max' | 'min' | 'mean';
   value?: any;
 }
+
+export interface VgAxisBase {
+  /**
+   * Whether to include the axis domain line.
+   */
+  domain?: boolean;
+
+  /**
+   * A flag indicate if gridlines should be created in addition to ticks. If `grid` is unspecified, the default value is `true` for ROW and COL. For X and Y, the default value is `true` for quantitative and time fields and `false` otherwise.
+   */
+  grid?: boolean;
+
+  /**
+   * Enable or disable labels.
+   */
+  labels?: boolean;
+
+  /**
+   * The rotation angle of the axis labels.
+   * @minimum 0
+   * @maximum 360
+   */
+  labelAngle?: number;  // FIXME: not sure if this should be a theme
+
+  /**
+   * Whether the axis should include ticks.
+   */
+  ticks?: boolean;
+
+  /**
+   * The size, in pixels, of major, minor and end ticks.
+   * @minimum 0
+   */
+  tickSize?: number;
+
+  /**
+   * Max length for axis title if the title is automatically generated from the field's description. By default, this is automatically based on cell size and characterWidth property.
+   * @minimum 0
+   * @TJS-type integer
+   */
+  titleMaxLength?: number;
+
+  /**
+   * The padding, in pixels, between title and axis.
+   */
+  titlePadding?: number;
+
+  /**
+   * Minimum extent, which determines the offset between axis ticks and labels.
+   */
+  minExtent?: number;
+
+  /**
+   * Maximum extent, which determines the offset between axis ticks and labels.
+   */
+  maxExtent?: number;
+}
+
+export interface VgAxisConfig extends VgAxisBase {
+ // ---------- Axis ----------
+  /**
+   * Width of the domain line
+   */
+  domainWidth?: number;
+
+  /**
+   * Color of axis domain line.
+   */
+  domainColor?: string;
+
+  // ---------- Grid ----------
+  /**
+   * Color of gridlines.
+   */
+  gridColor?: string;
+
+  /**
+   * The offset (in pixels) into which to begin drawing with the grid dash array.
+   * @minimum 0
+   */
+  gridDash?: number[];
+
+  /**
+   * The stroke opacity of grid (value between [0,1])
+   * @minimum 0
+   * @maximum 1
+   */
+  gridOpacity?: number;
+
+  /**
+   * The grid width, in pixels.
+   * @minimum 0
+   */
+  gridWidth?: number;
+
+  // ---------- Ticks ----------
+  /**
+   * The color of the axis's tick.
+   */
+  tickColor?: string;
+
+  /**
+   * The color of the tick label, can be in hex color code or regular color name.
+   */
+  labelColor?: string;
+
+  /**
+   * The font of the tick label.
+   */
+  labelFont?: string;
+
+  /**
+   * The font size of label, in pixels.
+   * @minimum 0
+   */
+  labelFontSize?: number;
+
+  /**
+   * The width, in pixels, of ticks.
+   * @minimum 0
+   */
+  tickWidth?: number;
+
+  // ---------- Title ----------
+  /**
+   * Color of the title, can be in hex color code or regular color name.
+   */
+  titleColor?: string;
+
+  /**
+   * Font of the title.
+   */
+  titleFont?: string;
+
+  /**
+   * Size of the title.
+   * @minimum 0
+   */
+  titleFontSize?: number;
+
+  /**
+   * Weight of the title.
+   */
+  titleFontWeight?: string | number;
+  /**
+   * Whether month names and weekday names should be abbreviated.
+   */
+  shortTimeLabels?: boolean;
+}
+
+

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -181,6 +181,10 @@ export interface VgImputeTransform {
   value?: any;
 }
 
+/**
+ * Base object for Vega's Axis and Axis Config.
+ * All of these properties are both properties of Vega's Axis and Axis Config.
+ */
 export interface VgAxisBase {
   /**
    * Whether to include the axis domain line.

--- a/test/compile/axis/encode.test.ts
+++ b/test/compile/axis/encode.test.ts
@@ -7,76 +7,6 @@ import * as encode from '../../../src/compile/axis/encode';
 
 
 describe('compile/axis', () => {
-  describe('encode.domain()', function() {
-    it('axisColor should change axis\'s color', function() {
-        const model = parseModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: "quantitative", axis: {axisColor: '#fff'}}
-        }
-      });
-        const axes = encode.domain(model, 'x', {});
-        assert.equal(axes.stroke.value, '#fff');
-    });
-
-    it('axisWidth should change axis\'s width', function() {
-        const model = parseModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: "quantitative", axis: {axisWidth: 2}}
-        }
-      });
-        const axes = encode.domain(model, 'x', {});
-        assert.equal(axes.strokeWidth.value, 2);
-    });
-  });
-
-  describe('encode.grid()', function(){
-      it('gridColor should change grid\'s color', function() {
-        const model = parseModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: "quantitative", axis: {gridColor: '#fff'}}
-        }
-      });
-        const axes = encode.grid(model, 'x', {});
-        assert.equal(axes.stroke.value, '#fff');
-    });
-
-    it('gridOpacity should change grid\'s opacity', function(){
-        const model = parseModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: "quantitative", axis: {grid: true, gridOpacity: 0.6}}
-        }
-      });
-        const axes = encode.grid(model, 'x', {});
-        assert.equal(axes.strokeOpacity.value, 0.6);
-    });
-
-     it('gridWidth should change grid\'s width', function(){
-        const model = parseModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: "quantitative", axis: {grid: true, gridWidth: 2}}
-        }
-      });
-        const axes = encode.grid(model, 'x', {});
-        assert.equal(axes.strokeWidth.value, 2);
-    });
-
-    it('gridDash should change grid\'s dash offset', function(){
-        const model = parseModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: "quantitative", axis: {grid: true, gridDash: [2]}}
-        }
-      });
-        const axes = encode.grid(model, 'x', {});
-        assert.deepEqual(axes.strokeDashOffset.value, [2]);
-    });
-  });
-
   describe('encode.labels()', function () {
     it('should show truncated labels by default', function () {
       const labels = encode.labels(parseUnitModel({
@@ -88,17 +18,6 @@ describe('compile/axis', () => {
       assert.deepEqual(labels.text.signal, 'truncate(datum.value, 25)');
     });
 
-    it('should rotate labels if labelAngle is defined', function() {
-      const model = parseUnitModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: "quantitative", axis: {labelAngle: -45}}
-        }
-      });
-      const labels = encode.labels(model, 'x', {}, {});
-      assert.equal(labels.angle.value, -45);
-    });
-
     it('should rotate label', function() {
       const model = parseUnitModel({
         mark: "point",
@@ -108,7 +27,6 @@ describe('compile/axis', () => {
       });
       const labels = encode.labels(model, 'x', {}, {});
       assert.equal(labels.angle.value, 270);
-      assert.equal(labels.baseline.value, 'middle');
     });
 
     it('should also rotate labels if the channel is column', function() {
@@ -120,7 +38,6 @@ describe('compile/axis', () => {
       });
       const labels = encode.labels(model, 'column', {}, {});
       assert.equal(labels.angle.value, 270);
-      assert.equal(labels.baseline.value, 'middle');
     });
 
     it('should have correct text.signal for quarter timeUnits', function () {
@@ -145,109 +62,6 @@ describe('compile/axis', () => {
       const labels = encode.labels(model, 'x', {}, {});
       let expected = "'Q' + quarter(datum.value) + ' ' + timeFormat(datum.value, '%b %Y')";
       assert.equal(labels.text.signal, expected);
-    });
-
-    it('tickLabelColor should change with axis\'s label\' color', function() {
-      const model = parseModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: 'quantitative', axis:{tickLabelColor: "blue"}}
-        }
-      });
-      const labels = encode.labels(model, 'x', {}, {});
-      assert.equal(labels.fill.value, "blue");
-    });
-
-    it('tickLabelFont should change with axis\'s label\'s font', function() {
-      const model = parseModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: 'quantitative', axis:{tickLabelFont: "Helvetica Neue"}}
-        }
-      });
-      const labels = encode.labels(model, 'x', {}, {});
-      assert.equal(labels.font.value, "Helvetica Neue");
-    });
-
-    it('tickLabelFontSize should change with axis\'s label\'s font size', function() {
-      const model = parseModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: 'quantitative', axis:{tickLabelFontSize: 20}}
-        }
-      });
-      const labels = encode.labels(model, 'x', {}, {});
-      assert.equal(labels.fontSize.value, 20);
-    });
-  });
-
-  describe('encode.ticks()', function() {
-    it('tickColor should change axis\'s ticks\'s color', function() {
-        const model = parseModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: "quantitative", axis: {tickColor: '#123'}}
-        }
-      });
-        const axes = encode.ticks(model, 'x', {});
-        assert.equal(axes.stroke.value, '#123');
-    });
-
-    it('tickWidth should change axis\'s ticks\'s color', function() {
-        const model = parseModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: "quantitative", axis: {tickWidth: 13}}
-        }
-      });
-        const axes = encode.ticks(model, 'x', {});
-        assert.equal(axes.strokeWidth.value, 13);
-    });
-  });
-
-  describe('encode.title()', function() {
-    it('titleColor should change axis\'s title\'s color', function() {
-        const model = parseModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: "quantitative", axis: {titleColor: '#abc'}}
-        }
-      });
-        const axes = encode.title(model, 'x', {});
-        assert.equal(axes.fill.value, '#abc');
-    });
-
-    it('titleFont should change axis\'s title\'s font', function() {
-        const model = parseModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: "quantitative", axis: {titleFont: 'anything'}}
-        }
-      });
-        const axes = encode.title(model, 'x', {});
-        assert.equal(axes.font.value, 'anything');
-    });
-
-    it('titleFontSize should change axis\'s title\'s font size', function() {
-        const model = parseModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: "quantitative", axis: {titleFontSize: 56}}
-        }
-      });
-        const axes = encode.title(model, 'x', {});
-        assert.equal(axes.fontSize.value, 56);
-    });
-
-    it('titleFontWeight should change axis\'s title\'s font weight', function() {
-        const model = parseModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: "quantitative", axis: {titleFontWeight: 'bold'}}
-        }
-      });
-        const axes = encode.title(model, 'x', {});
-        assert.equal(axes.fontWeight.value, 'bold');
     });
   });
 });

--- a/test/compile/axis/parse.test.ts
+++ b/test/compile/axis/parse.test.ts
@@ -71,7 +71,7 @@ describe('Axis', function() {
           x: {
             field: "a",
             type: "quantitative",
-            axis: {grid: true, gridColor: "blue", gridWidth: 20}
+            axis: {grid: true}
           }
         }
       });
@@ -79,7 +79,6 @@ describe('Axis', function() {
       assert.isObject(def);
       assert.equal(def.orient, 'bottom');
       assert.equal(def.scale, 'x');
-      assert.deepEqual(def.encode.grid.update, {stroke: {value: "blue"}, strokeWidth: {value: 20}});
     });
   });
 
@@ -95,17 +94,6 @@ describe('Axis', function() {
       assert.isObject(def);
       assert.equal(def.orient, 'bottom');
       assert.equal(def.scale, 'x');
-    });
-
-    it('should produce correct encode block if needed', () => {
-      const model = parseUnitModel({
-        mark: "point",
-        encoding: {
-          x: {field: "a", type: "quantitative", "axis": {"axisColor": "#0099ff"}}
-        }
-      });
-      const def = axisParse.parseMainAxis(X, model);
-      assert.equal(def.encode.domain.update.stroke.value, '#0099ff');
     });
   });
 

--- a/test/compile/axis/rules.test.ts
+++ b/test/compile/axis/rules.test.ts
@@ -34,7 +34,7 @@ describe('compile/axis', ()=> {
             x: {field: 'a', type: 'quantitative'}
           }
         }), COLUMN, true);
-      assert.deepEqual(grid, undefined);
+      assert.deepEqual(grid, false);
     });
 
     it('should return undefined for ROW', function () {
@@ -44,7 +44,7 @@ describe('compile/axis', ()=> {
             x: {field: 'a', type: 'quantitative'}
           }
         }), ROW, true);
-      assert.deepEqual(grid, undefined);
+      assert.deepEqual(grid, false);
     });
     it('should return undefined for non-gridAxis', function () {
       const grid = rules.grid(parseModel({

--- a/test/compile/common.test.ts
+++ b/test/compile/common.test.ts
@@ -12,30 +12,30 @@ describe('Common', function() {
   describe('timeFormat()', function() {
     it('should get the right time expression for month with shortTimeLabels=true', function() {
       const fieldDef: FieldDef = {timeUnit: TimeUnit.MONTH, field: 'a', type: TEMPORAL};
-      const expression = timeFormatExpression(field(fieldDef, {datum: true}), TimeUnit.MONTH, undefined, true, defaultConfig);
+      const expression = timeFormatExpression(field(fieldDef, {datum: true}), TimeUnit.MONTH, undefined, true, defaultConfig.timeFormat);
       assert.equal(expression, `timeFormat(datum["month_a"], '%b')`);
     });
 
     it('should get the right time expression for month with shortTimeLabels=false', function() {
       const fieldDef: FieldDef = {timeUnit: TimeUnit.MONTH, field: 'a', type: TEMPORAL};
-      const expression = timeFormatExpression(field(fieldDef, {datum: true}), TimeUnit.MONTH, undefined, false, defaultConfig);
+      const expression = timeFormatExpression(field(fieldDef, {datum: true}), TimeUnit.MONTH, undefined, false, defaultConfig.timeFormat);
       assert.equal(expression, `timeFormat(datum["month_a"], '%B')`);
     });
 
     it('should get the right time expression for yearmonth with custom format', function() {
       const fieldDef: FieldDef = {timeUnit: TimeUnit.YEARMONTH, field: 'a', type: TEMPORAL};
-      const expression = timeFormatExpression(field(fieldDef, {datum: true}), TimeUnit.MONTH, '%Y', true, defaultConfig);
+      const expression = timeFormatExpression(field(fieldDef, {datum: true}), TimeUnit.MONTH, '%Y', true, defaultConfig.timeFormat);
       assert.equal(expression, `timeFormat(datum["yearmonth_a"], '%Y')`);
     });
 
     it('should get the right time expression for quarter', function() {
       const fieldDef: FieldDef = {timeUnit: TimeUnit.QUARTER, field: 'a', type: TEMPORAL};
-      const expression = timeFormatExpression(field(fieldDef, {datum: true}), TimeUnit.QUARTER, undefined, true, defaultConfig);
+      const expression = timeFormatExpression(field(fieldDef, {datum: true}), TimeUnit.QUARTER, undefined, true, defaultConfig.timeFormat);
       assert.equal(expression, `'Q' + quarter(datum["quarter_a"])`);
     });
 
     it('should get the right time expression for yearquarter', function() {
-      const expression = timeFormatExpression('datum["data"]', TimeUnit.YEARQUARTER, undefined, true, defaultConfig);
+      const expression = timeFormatExpression('datum["data"]', TimeUnit.YEARQUARTER, undefined, true, defaultConfig.timeFormat);
       assert.equal(expression, `'Q' + quarter(datum["data"]) + ' ' + timeFormat(datum["data"], '%y')`);
     });
   });

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -379,7 +379,7 @@ describe('compile/facet', () => {
   });
 
   describe('initAxis', () => {
-    it('should should have defaultFacetAxisConfig that domainWidth = 0', () => {
+    it('should map properties of vl config in config.facet.axis', () => {
       const model = parseFacetModel({
         facet: {
           row: {field: 'a', type: 'ordinal'}
@@ -389,12 +389,29 @@ describe('compile/facet', () => {
           encoding: {
             "x": {"aggregate": "sum", "field": "yield", "type": "quantitative"},
             "y": {"field": "variety", "type": "nominal"},
-          }
-        }
+          },
+        },
+        config: {"facet": {"axis": {"labelMaxLength": 123}}}
       });
-      assert.deepEqual(model.axis(ROW), {"domainWidth": 0, "orient": "right", "labelAngle": 90});
+      assert.deepEqual(model.axis(ROW), {"labelMaxLength": 123, "orient": "right", "labelAngle": 90});
+    });
+
+    it('should not map non vl config properties in config.facet.axis', () => {
+      const model = parseFacetModel({
+        facet: {
+          row: {field: 'a', type: 'ordinal'}
+        },
+        spec: {
+          mark: 'point',
+          encoding: {
+            "x": {"aggregate": "sum", "field": "yield", "type": "quantitative"},
+            "y": {"field": "variety", "type": "nominal"},
+          },
+        },
+        config: {"facet": {"axis": {"domainWidth": 123}}}
+      });
+      assert.deepEqual(model.axis(ROW), {"orient": "right", "labelAngle": 90});
     });
   });
-
 });
 

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -377,5 +377,24 @@ describe('compile/facet', () => {
       });
     });
   });
+
+  describe('initAxis', () => {
+    it('should should have defaultFacetAxisConfig that domainWidth = 0', () => {
+      const model = parseFacetModel({
+        facet: {
+          row: {field: 'a', type: 'ordinal'}
+        },
+        spec: {
+          mark: 'point',
+          encoding: {
+            "x": {"aggregate": "sum", "field": "yield", "type": "quantitative"},
+            "y": {"field": "variety", "type": "nominal"},
+          }
+        }
+      });
+      assert.deepEqual(model.axis(ROW), {"domainWidth": 0, "orient": "right", "labelAngle": 90});
+    });
+  });
+
 });
 

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -379,7 +379,7 @@ describe('compile/facet', () => {
   });
 
   describe('initAxis', () => {
-    it('should map properties of vl config in config.facet.axis', () => {
+    it('should include properties of VlOnlyAxisConfig in config.facet.axis', () => {
       const model = parseFacetModel({
         facet: {
           row: {field: 'a', type: 'ordinal'}
@@ -396,7 +396,7 @@ describe('compile/facet', () => {
       assert.deepEqual(model.axis(ROW), {"labelMaxLength": 123, "orient": "right", "labelAngle": 90});
     });
 
-    it('should not map non vl config properties in config.facet.axis', () => {
+    it('should not include properties of non-VlOnlyAxisConfig in config.facet.axis', () => {
       const model = parseFacetModel({
         facet: {
           row: {field: 'a', type: 'ordinal'}

--- a/test/compile/unit.test.ts
+++ b/test/compile/unit.test.ts
@@ -158,6 +158,19 @@ describe('UnitModel', function() {
       assert.equal(model.axis(Y).labelMaxLength, 123);
     });
 
+    it('it should not match non vl-config properties', () => {
+      const model = parseUnitModel({
+        mark: 'point',
+        encoding: {
+          x: {field: 'a', type: 'ordinal'},
+          y: {field: 'b', type: 'ordinal'}
+        },
+        config: {axis: {domainWidth: 123}}
+      });
+
+      assert.equal(model.axis(X)['domainWidth'], undefined);
+    });
+
     it('it should have axis.offset = encode.x.axis.offset', () => {
       const model = parseUnitModel({
         mark: 'point',

--- a/test/compile/unit.test.ts
+++ b/test/compile/unit.test.ts
@@ -158,7 +158,7 @@ describe('UnitModel', function() {
       assert.equal(model.axis(Y).labelMaxLength, 123);
     });
 
-    it('it should not match non vl-config properties', () => {
+    it('should not include properties of non-VlOnlyAxisConfig in config.facet.axis', () => {
       const model = parseUnitModel({
         mark: 'point',
         encoding: {

--- a/test/compile/unit.test.ts
+++ b/test/compile/unit.test.ts
@@ -2,7 +2,7 @@ import {assert} from 'chai';
 
 import * as log from '../../src/log';
 import {UnitModel} from '../../src/compile/unit';
-import {X, SHAPE, DETAIL} from '../../src/channel';
+import {X, Y, SHAPE, DETAIL} from '../../src/channel';
 import {BAR} from '../../src/mark';
 import {UnitSpec} from '../../src/spec';
 import {QUANTITATIVE} from '../../src/type';
@@ -140,6 +140,35 @@ describe('UnitModel', function() {
 
       assert.equal(model.width, undefined);
       assert.equal(model.height, undefined);
+    });
+  });
+
+  describe('initAxes', () => {
+    it('it should have axis.labelMaxLength = config.axis.labelMaxLength', () => {
+      const model = parseUnitModel({
+        mark: 'point',
+        encoding: {
+          x: {field: 'a', type: 'ordinal'},
+          y: {field: 'b', type: 'ordinal'}
+        },
+        config: {axis: {labelMaxLength: 123}}
+      });
+
+      assert.equal(model.axis(X).labelMaxLength, 123);
+      assert.equal(model.axis(Y).labelMaxLength, 123);
+    });
+
+    it('it should have axis.offset = encode.x.axis.offset', () => {
+      const model = parseUnitModel({
+        mark: 'point',
+        encoding: {
+          x: {field: 'a', type: 'ordinal', axis: {offset: 345}},
+          y: {field: 'b', type: 'ordinal'}
+        },
+        config: {axis: {labelMaxLength: 123}}
+      });
+
+      assert.equal(model.axis(X).offset, 345);
     });
   });
 });

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -319,6 +319,10 @@
                     "description": "Minimum extent, which determines the offset between axis ticks and labels.",
                     "type": "number"
                 },
+                "shortTimeLabels": {
+                    "description": "Whether month names and weekday names should be abbreviated.",
+                    "type": "boolean"
+                },
                 "tickColor": {
                     "description": "The color of the axis's tick.",
                     "type": "string"

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -136,14 +136,6 @@
         "Axis": {
             "additionalProperties": false,
             "properties": {
-                "axisColor": {
-                    "description": "Color of axis line.",
-                    "type": "string"
-                },
-                "axisWidth": {
-                    "description": "Width of the axis line",
-                    "type": "number"
-                },
                 "domain": {
                     "description": "Whether to include the axis domain line.",
                     "type": "boolean"
@@ -160,42 +152,11 @@
                     "description": "A flag indicate if gridlines should be created in addition to ticks. If `grid` is unspecified, the default value is `true` for ROW and COL. For X and Y, the default value is `true` for quantitative and time fields and `false` otherwise.",
                     "type": "boolean"
                 },
-                "gridColor": {
-                    "description": "Color of gridlines.",
-                    "type": "string"
-                },
-                "gridDash": {
-                    "description": "The offset (in pixels) into which to begin drawing with the grid dash array.",
-                    "items": {
-                        "type": "number"
-                    },
-                    "minimum": 0,
-                    "type": "array"
-                },
-                "gridOpacity": {
-                    "description": "The stroke opacity of grid (value between [0,1])",
-                    "maximum": 1,
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "gridWidth": {
-                    "description": "The grid width, in pixels.",
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "labelAlign": {
-                    "description": "Text alignment for the Label.",
-                    "type": "string"
-                },
                 "labelAngle": {
                     "description": "The rotation angle of the axis labels.",
                     "maximum": 360,
                     "minimum": 0,
                     "type": "number"
-                },
-                "labelBaseline": {
-                    "description": "Text baseline for the label.",
-                    "type": "string"
                 },
                 "labelMaxLength": {
                     "description": "Truncate labels that are too long.",
@@ -233,59 +194,13 @@
                     "description": "Whether month and day names should be abbreviated.",
                     "type": "boolean"
                 },
-                "subdivide": {
-                    "description": "If provided, sets the number of minor ticks between major ticks (the value 9 results in decimal subdivision). Only applicable for axes visualizing quantitative scales.",
-                    "minimum": 0,
-                    "type": "integer"
-                },
-                "tickColor": {
-                    "description": "The color of the axis's tick.",
-                    "type": "string"
-                },
                 "tickCount": {
                     "description": "A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are \"nice\" (multiples of 2, 5, 10) and lie within the underlying scale's range.",
                     "minimum": 0,
                     "type": "integer"
                 },
-                "tickLabelColor": {
-                    "description": "The color of the tick label, can be in hex color code or regular color name.",
-                    "type": "string"
-                },
-                "tickLabelFont": {
-                    "description": "The font of the tick label.",
-                    "type": "string"
-                },
-                "tickLabelFontSize": {
-                    "description": "The font size of label, in pixels.",
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "tickPadding": {
-                    "description": "The padding, in pixels, between ticks and text labels.",
-                    "type": "number"
-                },
                 "tickSize": {
                     "description": "The size, in pixels, of major, minor and end ticks.",
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "tickSizeEnd": {
-                    "description": "The size, in pixels, of end ticks.",
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "tickSizeMajor": {
-                    "description": "The size, in pixels, of major ticks.",
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "tickSizeMinor": {
-                    "description": "The size, in pixels, of minor ticks.",
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "tickWidth": {
-                    "description": "The width, in pixels, of ticks.",
                     "minimum": 0,
                     "type": "number"
                 },
@@ -297,34 +212,10 @@
                     "description": "A title for the axis. Shows field name and its function by default.",
                     "type": "string"
                 },
-                "titleColor": {
-                    "description": "Color of the title, can be in hex color code or regular color name.",
-                    "type": "string"
-                },
-                "titleFont": {
-                    "description": "Font of the title.",
-                    "type": "string"
-                },
-                "titleFontSize": {
-                    "description": "Size of the title.",
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "titleFontWeight": {
-                    "description": "Weight of the title.",
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
                 "titleMaxLength": {
                     "description": "Max length for axis title if the title is automatically generated from the field's description. By default, this is automatically based on cell size and characterWidth property.",
                     "minimum": 0,
                     "type": "integer"
-                },
-                "titleOffset": {
-                    "description": "A title offset value for the axis.",
-                    "type": "number"
                 },
                 "titlePadding": {
                     "description": "The padding, in pixels, between title and axis.",
@@ -357,21 +248,17 @@
         "AxisConfig": {
             "additionalProperties": false,
             "properties": {
-                "axisColor": {
-                    "description": "Color of axis line.",
-                    "type": "string"
-                },
-                "axisWidth": {
-                    "description": "Width of the axis line",
-                    "type": "number"
-                },
                 "domain": {
                     "description": "Whether to include the axis domain line.",
                     "type": "boolean"
                 },
-                "encode": {
-                    "$ref": "#/definitions/VgAxisEncode",
-                    "description": "Optional mark definitions for custom axis encoding."
+                "domainColor": {
+                    "description": "Color of axis line.",
+                    "type": "string"
+                },
+                "domainWidth": {
+                    "description": "Width of the axis line",
+                    "type": "number"
                 },
                 "grid": {
                     "description": "A flag indicate if gridlines should be created in addition to ticks. If `grid` is unspecified, the default value is `true` for ROW and COL. For X and Y, the default value is `true` for quantitative and time fields and `false` otherwise.",
@@ -400,27 +287,29 @@
                     "minimum": 0,
                     "type": "number"
                 },
-                "labelAlign": {
-                    "description": "Text alignment for the Label.",
-                    "type": "string"
-                },
                 "labelAngle": {
                     "description": "The rotation angle of the axis labels.",
-                    "minimum": 360,
+                    "maximum": 360,
+                    "minimum": 0,
                     "type": "number"
                 },
-                "labelBaseline": {
-                    "description": "Text baseline for the label.",
+                "labelColor": {
+                    "description": "The color of the tick label, can be in hex color code or regular color name.",
                     "type": "string"
+                },
+                "labelFont": {
+                    "description": "The font of the tick label.",
+                    "type": "string"
+                },
+                "labelFontSize": {
+                    "description": "The font size of label, in pixels.",
+                    "minimum": 0,
+                    "type": "number"
                 },
                 "labelMaxLength": {
                     "description": "Truncate labels that are too long.",
                     "minimum": 1,
                     "type": "integer"
-                },
-                "labelPadding": {
-                    "description": "The padding, in pixels, between axis and text labels.",
-                    "type": "number"
                 },
                 "labels": {
                     "description": "Enable or disable labels.",
@@ -434,65 +323,16 @@
                     "description": "Minimum extent, which determines the offset between axis ticks and labels.",
                     "type": "number"
                 },
-                "offset": {
-                    "description": "The offset, in pixels, by which to displace the axis from the edge of the enclosing group or data rectangle.",
-                    "type": "number"
-                },
-                "position": {
-                    "type": "number"
-                },
                 "shortTimeLabels": {
                     "description": "Whether month and day names should be abbreviated.",
                     "type": "boolean"
-                },
-                "subdivide": {
-                    "description": "If provided, sets the number of minor ticks between major ticks (the value 9 results in decimal subdivision). Only applicable for axes visualizing quantitative scales.",
-                    "minimum": 0,
-                    "type": "integer"
                 },
                 "tickColor": {
                     "description": "The color of the axis's tick.",
                     "type": "string"
                 },
-                "tickCount": {
-                    "description": "A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are \"nice\" (multiples of 2, 5, 10) and lie within the underlying scale's range.",
-                    "minimum": 0,
-                    "type": "integer"
-                },
-                "tickLabelColor": {
-                    "description": "The color of the tick label, can be in hex color code or regular color name.",
-                    "type": "string"
-                },
-                "tickLabelFont": {
-                    "description": "The font of the tick label.",
-                    "type": "string"
-                },
-                "tickLabelFontSize": {
-                    "description": "The font size of label, in pixels.",
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "tickPadding": {
-                    "description": "The padding, in pixels, between ticks and text labels.",
-                    "type": "number"
-                },
                 "tickSize": {
                     "description": "The size, in pixels, of major, minor and end ticks.",
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "tickSizeEnd": {
-                    "description": "The size, in pixels, of end ticks.",
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "tickSizeMajor": {
-                    "description": "The size, in pixels, of major ticks.",
-                    "minimum": 0,
-                    "type": "number"
-                },
-                "tickSizeMinor": {
-                    "description": "The size, in pixels, of minor ticks.",
                     "minimum": 0,
                     "type": "number"
                 },
@@ -537,11 +377,6 @@
                 "titlePadding": {
                     "description": "The padding, in pixels, between title and axis.",
                     "type": "number"
-                },
-                "zindex": {
-                    "description": "A non-positive integer indicating z-index of the axis.\nIf zindex is 0, axes should be drawn behind all chart elements.\nTo put them in front, use zindex = 1.",
-                    "minimum": 0,
-                    "type": "integer"
                 }
             },
             "type": "object"

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -190,10 +190,6 @@
                 "position": {
                     "type": "number"
                 },
-                "shortTimeLabels": {
-                    "description": "Whether month and day names should be abbreviated.",
-                    "type": "boolean"
-                },
                 "tickCount": {
                     "description": "A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are \"nice\" (multiples of 2, 5, 10) and lie within the underlying scale's range.",
                     "minimum": 0,
@@ -253,11 +249,11 @@
                     "type": "boolean"
                 },
                 "domainColor": {
-                    "description": "Color of axis line.",
+                    "description": "Color of axis domain line.",
                     "type": "string"
                 },
                 "domainWidth": {
-                    "description": "Width of the axis line",
+                    "description": "Width of the domain line",
                     "type": "number"
                 },
                 "grid": {
@@ -323,10 +319,6 @@
                     "description": "Minimum extent, which determines the offset between axis ticks and labels.",
                     "type": "number"
                 },
-                "shortTimeLabels": {
-                    "description": "Whether month and day names should be abbreviated.",
-                    "type": "boolean"
-                },
                 "tickColor": {
                     "description": "The color of the axis's tick.",
                     "type": "string"
@@ -369,10 +361,6 @@
                     "description": "Max length for axis title if the title is automatically generated from the field's description. By default, this is automatically based on cell size and characterWidth property.",
                     "minimum": 0,
                     "type": "integer"
-                },
-                "titleOffset": {
-                    "description": "A title offset value for the axis.",
-                    "type": "number"
                 },
                 "titlePadding": {
                     "description": "The padding, in pixels, between title and axis.",


### PR DESCRIPTION
Update Axis Properties and Config.  (Part of #1845)

  - Rename `axisWidth` to `domainWidth`, `axisColor` to `domainColor`, `tickLabelColor` to `labelColor`, `tickLabelFont` to `labelFont`, `tickLabelFontSize` to `labelFontSize`, `tickPadding` to `labelPadding`, `titleOffset` to `titlePadding`
  - Separate Axis from AxisConfig. Make these properties only available as `Axis` properties:  `domain `, `grid `, `labels `, `labelMaxLength `, `labelPadding `, `maxExtent`, `minExtent`, `offset `, `position `, `shortTimeLabels `, `ticks `, `tickCount `, `tickSize`, `titleMaxLength`, `titlePadding`, `zindex`
  - Remove `labelAlign`, `labelBaseline`, `subdivide`, `tickSizeMajor`, `tickSizeMinor`, `tickSizeEnd` from Axis Config
  
  - Remove related code for Vega Axis config as Vega parser will handle these configs.
  
