### PR TITLE
Legend Properties/Config refactor

### DIFF
--- a/src/compile/legend/encode.ts
+++ b/src/compile/legend/encode.ts
@@ -86,10 +86,7 @@ export function symbols(fieldDef: FieldDef, symbolsSpec: any, model: UnitModel, 
   const shapeDef = model.encoding.shape;
   if (channel !== SHAPE) {
     if (isValueDef(shapeDef)) {
-      value = {value: shapeDef.value};
-    }
-    if (value !== undefined) {
-      symbols.shape = value;
+      symbols.shape = {value: shapeDef.value};
     }
   }
 

--- a/src/compile/legend/encode.ts
+++ b/src/compile/legend/encode.ts
@@ -14,7 +14,6 @@ import {UnitModel} from '../unit';
 export function symbols(fieldDef: FieldDef, symbolsSpec: any, model: UnitModel, channel: Channel) {
   let symbols:any = {};
   const mark = model.mark();
-  const legend = model.legend(channel);
 
   switch (mark) {
     case BAR:
@@ -75,9 +74,7 @@ export function symbols(fieldDef: FieldDef, symbolsSpec: any, model: UnitModel, 
       {value: cfg.mark.color};
   }
 
-  if (legend.symbolColor !== undefined) {
-    symbols.fill = {value: legend.symbolColor};
-  } else if (symbols.fill === undefined) {
+  if (symbols.fill === undefined) {
     // fall back to mark config colors for legend fill
     if (cfg.mark.fill !== undefined) {
       symbols.fill = {value: cfg.mark.fill};
@@ -87,16 +84,8 @@ export function symbols(fieldDef: FieldDef, symbolsSpec: any, model: UnitModel, 
   }
 
   if (channel !== SHAPE) {
-    if (legend.symbolShape !== undefined) {
-      symbols.shape = {value: legend.symbolShape};
-    } else if (cfg.point.shape !== undefined) {
+    if (cfg.point.shape !== undefined) {
       symbols.shape = {value: cfg.point.shape};
-    }
-  }
-
-  if (channel !== SIZE) {
-    if (legend.symbolSize !== undefined) {
-      symbols.size = {value: legend.symbolSize};
     }
   }
 
@@ -118,10 +107,6 @@ export function symbols(fieldDef: FieldDef, symbolsSpec: any, model: UnitModel, 
       default:
         throw Error(`Legend for channel ${channel} not implemented`);
     }
-  }
-
-  if (legend.symbolStrokeWidth !== undefined) {
-    symbols.strokeWidth = {value: legend.symbolStrokeWidth};
   }
 
   symbols = extend(symbols, symbolsSpec || {});
@@ -146,29 +131,11 @@ export function labels(fieldDef: FieldDef, labelsSpec: any, model: UnitModel, ch
   } else if (fieldDef.type === TEMPORAL) {
     labelsSpec = extend({
       text: {
-        signal: timeFormatExpression('datum.value', fieldDef.timeUnit, legend.format, legend.shortTimeLabels, config.timeFormat)
+
+        // FIXME: shortTimeLabels set as true by default
+        signal: timeFormatExpression('datum.value', fieldDef.timeUnit, legend.format, config.legend.shortTimeLabels, config.timeFormat)
       }
     }, labelsSpec || {});
-  }
-
-  if (legend.labelAlign !== undefined) {
-    labels.align = {value: legend.labelAlign};
-  }
-
-  if (legend.labelColor !== undefined) {
-    labels.fill = {value: legend.labelColor};
-  }
-
-  if (legend.labelFont !== undefined) {
-    labels.font = {value: legend.labelFont};
-  }
-
-  if (legend.labelFontSize !== undefined) {
-    labels.fontSize = {value: legend.labelFontSize};
-  }
-
-  if (legend.labelBaseline !== undefined) {
-    labels.baseline = {value: legend.labelBaseline};
   }
 
   labels = extend(labels, labelsSpec || {});
@@ -176,28 +143,3 @@ export function labels(fieldDef: FieldDef, labelsSpec: any, model: UnitModel, ch
   return keys(labels).length > 0 ? labels : undefined;
 }
 
-export function title(fieldDef: FieldDef, titleSpec: any, model: UnitModel, channel: Channel) {
-  const legend = model.legend(channel);
-
-  let titles:any = {};
-
-  if (legend.titleColor !== undefined) {
-    titles.fill = {value: legend.titleColor};
-  }
-
-  if (legend.titleFont !== undefined) {
-    titles.font = {value: legend.titleFont};
-  }
-
-  if (legend.titleFontSize !== undefined) {
-    titles.fontSize = {value: legend.titleFontSize};
-  }
-
-  if (legend.titleFontWeight !== undefined) {
-    titles.fontWeight = {value: legend.titleFontWeight};
-  }
-
-  titles = extend(titles, titleSpec || {});
-
-  return keys(titles).length > 0 ? titles : undefined;
-}

--- a/src/compile/legend/encode.ts
+++ b/src/compile/legend/encode.ts
@@ -83,9 +83,13 @@ export function symbols(fieldDef: FieldDef, symbolsSpec: any, model: UnitModel, 
     }
   }
 
+  const shapeDef = model.encoding.shape;
   if (channel !== SHAPE) {
-    if (cfg.point.shape !== undefined) {
-      symbols.shape = {value: cfg.point.shape};
+    if (isValueDef(shapeDef)) {
+      value = {value: shapeDef.value};
+    }
+    if (value !== undefined) {
+      symbols.shape = value;
     }
   }
 
@@ -131,8 +135,6 @@ export function labels(fieldDef: FieldDef, labelsSpec: any, model: UnitModel, ch
   } else if (fieldDef.type === TEMPORAL) {
     labelsSpec = extend({
       text: {
-
-        // FIXME: shortTimeLabels set as true by default
         signal: timeFormatExpression('datum.value', fieldDef.timeUnit, legend.format, config.legend.shortTimeLabels, config.timeFormat)
       }
     }, labelsSpec || {});

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -7,7 +7,7 @@ import {SOURCE, SUMMARY} from '../data';
 import {Encoding, dropInvalidFieldDefs} from '../encoding';
 import * as vlEncoding from '../encoding'; // TODO: remove
 import {FieldDef, FieldRefOption, field, isFieldDef} from '../fielddef';
-import {Legend, VlLegendBase ,LEGEND_BASE_PROPERTIES} from '../legend';
+import {Legend, VlOnlyLegendBase ,VL_ONLY_LEGEND_PROPERTIES} from '../legend';
 import {Mark, MarkDef, TEXT as TEXT_MARK, FILL_STROKE_CONFIG, isMarkDef} from '../mark';
 import {Scale, ScaleConfig, hasDiscreteDomain} from '../scale';
 import {UnitSpec} from '../spec';
@@ -82,7 +82,7 @@ export class UnitModel extends Model {
     this.encoding = initEncoding(mark, encoding, this.stack, config);
 
     this.axes = this.initAxes(encoding, config);
-    this.legends = this.initLegend(encoding);
+    this.legends = this.initLegend(encoding, config);
 
     // Selections will be initialized upon parse.
     this.selection = spec.selection;
@@ -209,20 +209,20 @@ export class UnitModel extends Model {
     }, {});
   }
 
-  private initLegend(encoding: Encoding): Dict<Legend> {
+  private initLegend(encoding: Encoding, config: Config): Dict<Legend> {
     return NONSPATIAL_SCALE_CHANNELS.reduce(function(_legend, channel) {
       const channelDef = encoding[channel];
       if (isFieldDef(channelDef)) {
         const legendSpec = channelDef.legend;
         // We no longer support false in the schema, but we keep false here for backward compatability.
-        let vlLegendBase: VlLegendBase = {};
-          LEGEND_BASE_PROPERTIES.forEach(function(property) {
-            if (encoding !== undefined && encoding[property] !== undefined) {
-              vlLegendBase[property] = encoding[property];
-            }
-          });
+        let vlLegendBase: VlOnlyLegendBase = {};
+        VL_ONLY_LEGEND_PROPERTIES.forEach(function(property) {
+          if (config.legend[property] !== undefined) {
+            vlLegendBase[property] = config.legend[property];
+          }
+        });
         if (legendSpec !== null && legendSpec !== false) {
-          _legend[channel] = {vlLegendBase, ...legendSpec};
+          _legend[channel] = {...vlLegendBase, ...legendSpec};
         }
       }
       return _legend;

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -7,7 +7,7 @@ import {SOURCE, SUMMARY} from '../data';
 import {Encoding, dropInvalidFieldDefs} from '../encoding';
 import * as vlEncoding from '../encoding'; // TODO: remove
 import {FieldDef, FieldRefOption, field, isFieldDef} from '../fielddef';
-import {Legend, VlOnlyLegendBase ,VL_ONLY_LEGEND_PROPERTIES} from '../legend';
+import {Legend} from '../legend';
 import {Mark, MarkDef, TEXT as TEXT_MARK, FILL_STROKE_CONFIG, isMarkDef} from '../mark';
 import {Scale, ScaleConfig, hasDiscreteDomain} from '../scale';
 import {UnitSpec} from '../spec';
@@ -214,15 +214,8 @@ export class UnitModel extends Model {
       const channelDef = encoding[channel];
       if (isFieldDef(channelDef)) {
         const legendSpec = channelDef.legend;
-        // We no longer support false in the schema, but we keep false here for backward compatability.
-        let vlLegendBase: VlOnlyLegendBase = {};
-        VL_ONLY_LEGEND_PROPERTIES.forEach(function(property) {
-          if (config.legend[property] !== undefined) {
-            vlLegendBase[property] = config.legend[property];
-          }
-        });
         if (legendSpec !== null && legendSpec !== false) {
-          _legend[channel] = {...vlLegendBase, ...legendSpec};
+          _legend[channel] = {...legendSpec};
         }
       }
       return _legend;

--- a/src/legend.ts
+++ b/src/legend.ts
@@ -1,44 +1,7 @@
 import {DateTime} from './datetime';
-import {VgLegendEncode} from './vega.schema';
+import {VgLegendEncode, VgLegendBase} from './vega.schema';
 
-export interface LegendConfig {
-  // ---------- General ----------
-  /**
-   * Optional mark definitions for custom legend encoding.
-   */
-  encode?: VgLegendEncode;
-  /**
-   * Padding (in pixels) between legend entries in a symbol legend.
-   */
-  entryPadding?: number;
-  /**
-   * The orientation of the legend. One of "left" or "right". This determines how the legend is positioned within the scene. The default is "right".
-   */
-  orient?: string;
-  /**
-   * The offset, in pixels, by which to displace the legend from the edge of the enclosing group or data rectangle.
-   */
-  offset?: number;
-  /**
-   * The padding, in pixels, between the legend and axis.
-   */
-  padding?: number;
-  /**
-   * The margin around the legend, in pixels
-   */
-  margin?: number;
-  /**
-   * The number of ticks for legend.
-   */
-  tickCount?: number;
-  /**
-   * A non-positive integer indicating z-index of the legend.
-   * If zindex is 0, legend should be drawn behind all chart elements.
-   * To put them in front, use zindex = 1.
-   * @TJS-type integer
-   * @minimum 0
-   */
-  zindex?: number;
+export interface LegendConfig extends LegendBase {
   // ---------- Gradient ----------
   /**
    * The color of the gradient stroke, can be in hex color code or regular color name.
@@ -99,7 +62,7 @@ export interface LegendConfig {
    * The shape of the legend symbol, can be the 'circle', 'square', 'cross', 'diamond',
    * 'triangle-up', 'triangle-down', or else a custom SVG path string.
    */
-  symbolShape?: string;
+  symbolType?: string;
   /**
    * The size of the legend symbol, in pixels.
    * @mimimum 0
@@ -139,11 +102,22 @@ export interface LegendConfig {
 /**
  * Properties of a legend or boolean flag for determining whether to show it.
  */
-export interface Legend extends LegendConfig {
+export interface Legend extends LegendBase {
+  /**
+   * Optional mark definitions for custom legend encoding.
+   */
+  encode?: VgLegendEncode;
+
   /**
    * An optional formatting pattern for legend labels. Vega uses D3\'s format pattern.
    */
   format?: string;
+
+  /**
+   * The number of ticks for legend.
+   */
+  tickCount?: number;
+
   /**
    * A title for the legend. (Shows field name and its function by default.)
    */
@@ -159,10 +133,24 @@ export interface Legend extends LegendConfig {
    * The type of the legend. Use `symbol` to create a discrete legend and `gradient` for a continuous color gradient.
    */
   type?: 'symbol' | 'gradient';
+
+  /**
+   * A non-positive integer indicating z-index of the legend.
+   * If zindex is 0, legend should be drawn behind all chart elements.
+   * To put them in front, use zindex = 1.
+   * @TJS-type integer
+   * @minimum 0
+   */
+  zindex?: number;
 }
+
+// FIXME: unsure about properties/config to put in VlLegendBase
+export interface VlLegendBase {}
+
+export interface LegendBase extends VgLegendBase, VlLegendBase {}
 
 export const defaultLegendConfig: LegendConfig = {
   orient: undefined, // implicitly "right"
 };
 
-export const LEGEND_PROPERTIES:(keyof Legend)[] = ['entryPadding', 'format', 'offset', 'orient', 'tickCount', 'title', 'titlePadding', 'type', 'values' ,'zindex'];
+export const LEGEND_PROPERTIES:(keyof Legend)[] = ['entryPadding', 'format', 'offset', 'orient', 'tickCount', 'title', 'type', 'values' ,'zindex'];

--- a/src/legend.ts
+++ b/src/legend.ts
@@ -7,72 +7,82 @@ export interface LegendConfig extends LegendBase {
    * The color of the gradient stroke, can be in hex color code or regular color name.
    */
   gradientStrokeColor?: string;
+
   /**
    * The width of the gradient stroke, in pixels.
    * @mimimum 0
    */
   gradientStrokeWidth?: number;
+
   /**
    * The height of the gradient, in pixels.
    * @mimimum 0
    */
   gradientHeight?: number;
+
   /**
    * The width of the gradient, in pixels.
    * @mimimum 0
    */
   gradientWidth?: number;
+
   // ---------- Label ----------
   /**
    * The alignment of the legend label, can be left, middle or right.
    */
   labelAlign?: string;
+
   /**
    * The position of the baseline of legend label, can be top, middle or bottom.
    */
   labelBaseline?: string;
+
   /**
    * The color of the legend label, can be in hex color code or regular color name.
    */
   labelColor?: string;
+
   /**
    * The font of the legend label.
    */
   labelFont?: string;
+
   /**
    * The font size of legend label.
    * @mimimum 0
    */
   labelFontSize?: number;
+
   /**
    * The offset of the legend label.
    * @mimimum 0
    */
   labelOffset?: number;
-  /**
-   * Whether month names and weekday names should be abbreviated.
-   */
-  shortTimeLabels?: boolean;
+
   // ---------- Symbols ----------
   /**
    * The color of the legend symbol,
    */
   symbolColor?: string;
+
   /**
    * The shape of the legend symbol, can be the 'circle', 'square', 'cross', 'diamond',
    * 'triangle-up', 'triangle-down', or else a custom SVG path string.
    */
   symbolType?: string;
+
   /**
    * The size of the legend symbol, in pixels.
    * @mimimum 0
    */
   symbolSize?: number;
+
   /**
    * The width of the symbol's stroke.
    * @minimum 0
    */
   symbolStrokeWidth?: number;
+
   // ---------- Title ----------
   /**
    * Optional mark property definitions for custom legend styling.
@@ -81,18 +91,22 @@ export interface LegendConfig extends LegendBase {
    * The color of the legend title, can be in hex color code or regular color name.
    */
   titleColor?: string;
+
   /**
    * The font of the legend title.
    */
   titleFont?: string;
+
   /**
    * The font size of the legend title.
    */
   titleFontSize?: number;
+
   /**
    * The font weight of the legend title.
    */
   titleFontWeight?: string | number;
+
   /**
    * The padding, in pixels, between title and legend.
    */
@@ -144,8 +158,12 @@ export interface Legend extends LegendBase {
   zindex?: number;
 }
 
-// FIXME: unsure about properties/config to put in VlLegendBase
-export interface VlLegendBase {}
+export interface VlLegendBase {
+  /**
+   * Whether month names and weekday names should be abbreviated.
+   */
+  shortTimeLabels?: boolean;
+}
 
 export interface LegendBase extends VgLegendBase, VlLegendBase {}
 
@@ -154,3 +172,5 @@ export const defaultLegendConfig: LegendConfig = {
 };
 
 export const LEGEND_PROPERTIES:(keyof Legend)[] = ['entryPadding', 'format', 'offset', 'orient', 'tickCount', 'title', 'type', 'values' ,'zindex'];
+
+export const LEGEND_BASE_PROPERTIES:(keyof VlLegendBase)[] = ['shortTimeLabels'];

--- a/src/legend.ts
+++ b/src/legend.ts
@@ -1,5 +1,5 @@
 import {DateTime} from './datetime';
-import { VgLegendEncode, VgLegendBase, VgLegendConfig } from './vega.schema';
+import {VgLegendEncode, VgLegendBase, VgLegendConfig} from './vega.schema';
 
 export interface LegendConfig extends VgLegendConfig, VlOnlyLegendBase {}
 

--- a/src/legend.ts
+++ b/src/legend.ts
@@ -1,7 +1,12 @@
 import {DateTime} from './datetime';
 import {VgLegendEncode, VgLegendBase, VgLegendConfig} from './vega.schema';
 
-export interface LegendConfig extends VgLegendConfig, VlOnlyLegendBase {}
+export interface LegendConfig extends VgLegendConfig, VlOnlyLegendBase {
+  /**
+   * Whether month names and weekday names should be abbreviated.
+   */
+  shortTimeLabels?: boolean;
+}
 
 /**
  * Properties of a legend or boolean flag for determining whether to show it.
@@ -49,10 +54,7 @@ export interface Legend extends VgLegendBase, VlOnlyLegendBase {
 }
 
 export interface VlOnlyLegendBase {
-  /**
-   * Whether month names and weekday names should be abbreviated.
-   */
-  shortTimeLabels?: boolean;
+
 }
 
 export const defaultLegendConfig: LegendConfig = {
@@ -60,5 +62,3 @@ export const defaultLegendConfig: LegendConfig = {
 };
 
 export const LEGEND_PROPERTIES:(keyof Legend)[] = ['entryPadding', 'format', 'offset', 'orient', 'tickCount', 'title', 'type', 'values' ,'zindex'];
-
-export const VL_ONLY_LEGEND_PROPERTIES:(keyof VlOnlyLegendBase)[] = ['shortTimeLabels'];

--- a/src/legend.ts
+++ b/src/legend.ts
@@ -1,122 +1,12 @@
 import {DateTime} from './datetime';
-import {VgLegendEncode, VgLegendBase} from './vega.schema';
+import { VgLegendEncode, VgLegendBase, VgLegendConfig } from './vega.schema';
 
-export interface LegendConfig extends LegendBase {
-  // ---------- Gradient ----------
-  /**
-   * The color of the gradient stroke, can be in hex color code or regular color name.
-   */
-  gradientStrokeColor?: string;
-
-  /**
-   * The width of the gradient stroke, in pixels.
-   * @mimimum 0
-   */
-  gradientStrokeWidth?: number;
-
-  /**
-   * The height of the gradient, in pixels.
-   * @mimimum 0
-   */
-  gradientHeight?: number;
-
-  /**
-   * The width of the gradient, in pixels.
-   * @mimimum 0
-   */
-  gradientWidth?: number;
-
-  // ---------- Label ----------
-  /**
-   * The alignment of the legend label, can be left, middle or right.
-   */
-  labelAlign?: string;
-
-  /**
-   * The position of the baseline of legend label, can be top, middle or bottom.
-   */
-  labelBaseline?: string;
-
-  /**
-   * The color of the legend label, can be in hex color code or regular color name.
-   */
-  labelColor?: string;
-
-  /**
-   * The font of the legend label.
-   */
-  labelFont?: string;
-
-  /**
-   * The font size of legend label.
-   * @mimimum 0
-   */
-  labelFontSize?: number;
-
-  /**
-   * The offset of the legend label.
-   * @mimimum 0
-   */
-  labelOffset?: number;
-
-  // ---------- Symbols ----------
-  /**
-   * The color of the legend symbol,
-   */
-  symbolColor?: string;
-
-  /**
-   * The shape of the legend symbol, can be the 'circle', 'square', 'cross', 'diamond',
-   * 'triangle-up', 'triangle-down', or else a custom SVG path string.
-   */
-  symbolType?: string;
-
-  /**
-   * The size of the legend symbol, in pixels.
-   * @mimimum 0
-   */
-  symbolSize?: number;
-
-  /**
-   * The width of the symbol's stroke.
-   * @minimum 0
-   */
-  symbolStrokeWidth?: number;
-
-  // ---------- Title ----------
-  /**
-   * Optional mark property definitions for custom legend styling.
-   */
-  /**
-   * The color of the legend title, can be in hex color code or regular color name.
-   */
-  titleColor?: string;
-
-  /**
-   * The font of the legend title.
-   */
-  titleFont?: string;
-
-  /**
-   * The font size of the legend title.
-   */
-  titleFontSize?: number;
-
-  /**
-   * The font weight of the legend title.
-   */
-  titleFontWeight?: string | number;
-
-  /**
-   * The padding, in pixels, between title and legend.
-   */
-  titlePadding?: number;
-}
+export interface LegendConfig extends VgLegendConfig, VlOnlyLegendBase {}
 
 /**
  * Properties of a legend or boolean flag for determining whether to show it.
  */
-export interface Legend extends LegendBase {
+export interface Legend extends VgLegendBase, VlOnlyLegendBase {
   /**
    * Optional mark definitions for custom legend encoding.
    */
@@ -158,14 +48,12 @@ export interface Legend extends LegendBase {
   zindex?: number;
 }
 
-export interface VlLegendBase {
+export interface VlOnlyLegendBase {
   /**
    * Whether month names and weekday names should be abbreviated.
    */
   shortTimeLabels?: boolean;
 }
-
-export interface LegendBase extends VgLegendBase, VlLegendBase {}
 
 export const defaultLegendConfig: LegendConfig = {
   orient: undefined, // implicitly "right"
@@ -173,4 +61,4 @@ export const defaultLegendConfig: LegendConfig = {
 
 export const LEGEND_PROPERTIES:(keyof Legend)[] = ['entryPadding', 'format', 'offset', 'orient', 'tickCount', 'title', 'type', 'values' ,'zindex'];
 
-export const LEGEND_BASE_PROPERTIES:(keyof VlLegendBase)[] = ['shortTimeLabels'];
+export const VL_ONLY_LEGEND_PROPERTIES:(keyof VlOnlyLegendBase)[] = ['shortTimeLabels'];

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -374,11 +374,135 @@ export interface VgAxisConfig extends VgAxisBase {
 }
 
 export interface VgLegendBase {
+  /**
+   * Padding (in pixels) between legend entries in a symbol legend.
+   */
   entryPadding?: number;
 
+  /**
+   * The orientation of the legend. One of "left" or "right". This determines how the legend is positioned within the scene. The default is "right".
+   */
   orient?: string;
 
+  /**
+   * The offset, in pixels, by which to displace the legend from the edge of the enclosing group or data rectangle.
+   */
   offset?: number;
 
+  /**
+   * The padding, in pixels, between the legend and axis.
+   */
   padding?: number;
+}
+
+export interface VgLegendConfig extends VgLegendBase {
+  // ---------- Gradient ----------
+  /**
+   * The color of the gradient stroke, can be in hex color code or regular color name.
+   */
+  gradientStrokeColor?: string;
+
+  /**
+   * The width of the gradient stroke, in pixels.
+   * @mimimum 0
+   */
+  gradientStrokeWidth?: number;
+
+  /**
+   * The height of the gradient, in pixels.
+   * @mimimum 0
+   */
+  gradientHeight?: number;
+
+  /**
+   * The width of the gradient, in pixels.
+   * @mimimum 0
+   */
+  gradientWidth?: number;
+
+  // ---------- Label ----------
+  /**
+   * The alignment of the legend label, can be left, middle or right.
+   */
+  labelAlign?: string;
+
+  /**
+   * The position of the baseline of legend label, can be top, middle or bottom.
+   */
+  labelBaseline?: string;
+
+  /**
+   * The color of the legend label, can be in hex color code or regular color name.
+   */
+  labelColor?: string;
+
+  /**
+   * The font of the legend label.
+   */
+  labelFont?: string;
+
+  /**
+   * The font size of legend label.
+   * @mimimum 0
+   */
+  labelFontSize?: number;
+
+  /**
+   * The offset of the legend label.
+   * @mimimum 0
+   */
+  labelOffset?: number;
+
+  // ---------- Symbols ----------
+  /**
+   * The color of the legend symbol,
+   */
+  symbolColor?: string;
+
+  /**
+   * The shape of the legend symbol, can be the 'circle', 'square', 'cross', 'diamond',
+   * 'triangle-up', 'triangle-down', or else a custom SVG path string.
+   */
+  symbolType?: string;
+
+  /**
+   * The size of the legend symbol, in pixels.
+   * @mimimum 0
+   */
+  symbolSize?: number;
+
+  /**
+   * The width of the symbol's stroke.
+   * @minimum 0
+   */
+  symbolStrokeWidth?: number;
+
+  // ---------- Title ----------
+  /**
+   * Optional mark property definitions for custom legend styling.
+   */
+  /**
+   * The color of the legend title, can be in hex color code or regular color name.
+   */
+  titleColor?: string;
+
+  /**
+   * The font of the legend title.
+   */
+  titleFont?: string;
+
+  /**
+   * The font size of the legend title.
+   */
+  titleFontSize?: number;
+
+  /**
+   * The font weight of the legend title.
+   */
+  titleFontWeight?: string | number;
+
+  /**
+   * The padding, in pixels, between title and legend.
+   */
+  titlePadding?: number;
 }

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -459,9 +459,9 @@ export interface VgLegendConfig extends VgLegendBase {
    */
   symbolColor?: string;
 
+  // FIXME: need better description
   /**
-   * The shape of the legend symbol, can be the 'circle', 'square', 'cross', 'diamond',
-   * 'triangle-up', 'triangle-down', or else a custom SVG path string.
+   * Default shape type (such as "circle") for legend symbols.
    */
   symbolType?: string;
 

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -404,19 +404,19 @@ export interface VgLegendConfig extends VgLegendBase {
 
   /**
    * The width of the gradient stroke, in pixels.
-   * @mimimum 0
+   * @minimum 0
    */
   gradientStrokeWidth?: number;
 
   /**
    * The height of the gradient, in pixels.
-   * @mimimum 0
+   * @minimum 0
    */
   gradientHeight?: number;
 
   /**
    * The width of the gradient, in pixels.
-   * @mimimum 0
+   * @minimum 0
    */
   gradientWidth?: number;
 
@@ -443,13 +443,13 @@ export interface VgLegendConfig extends VgLegendBase {
 
   /**
    * The font size of legend label.
-   * @mimimum 0
+   * @minimum 0
    */
   labelFontSize?: number;
 
   /**
    * The offset of the legend label.
-   * @mimimum 0
+   * @minimum 0
    */
   labelOffset?: number;
 
@@ -467,7 +467,7 @@ export interface VgLegendConfig extends VgLegendBase {
 
   /**
    * The size of the legend symbol, in pixels.
-   * @mimimum 0
+   * @minimum 0
    */
   symbolSize?: number;
 

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -372,3 +372,13 @@ export interface VgAxisConfig extends VgAxisBase {
    */
   shortTimeLabels?: boolean;
 }
+
+export interface VgLegendBase {
+  entryPadding?: number;
+
+  orient?: string;
+
+  offset?: number;
+
+  padding?: number;
+}

--- a/test/compile/legend/encode.test.ts
+++ b/test/compile/legend/encode.test.ts
@@ -32,48 +32,6 @@ describe('compile/legend', function() {
         assert.isUndefined(symbol.strokeDashOffset);
     });
 
-    it('should return specific color value', function() {
-      const symbol = encode.symbols({field: 'a'}, {}, parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: "a", type: "nominal"},
-            color: {field: "a", type: "nominal",  legend: {"symbolColor": "red"}}
-          }
-        }), COLOR);
-        assert.deepEqual(symbol.fill.value, "red");
-    });
-
-    it('should return specific shape value', function() {
-      const symbol = encode.symbols({field: 'a'}, {}, parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: "a", type: "nominal"},
-            color: {field: "a", type: "nominal", legend: {"symbolShape": "diamond"}}
-          }
-        }), COLOR);
-        assert.deepEqual(symbol.shape.value, "diamond");
-    });
-
-    it('should return specific size of the symbol', function() {
-      const symbol = encode.symbols({field: 'a'}, {}, parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: "a", type: "nominal"},
-            color: {field: "a", type: "nominal", legend: {"symbolSize": 20}}}
-        }), COLOR);
-        assert.deepEqual(symbol.size.value, 20);
-    });
-
-    it('should return not override size of the symbol for size channel', function() {
-      const symbol = encode.symbols({field: 'a'}, {}, parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: "a", type: "nominal"},
-            size: {field: "b", type: "quantitative", legend: {"symbolSize": 20}}}
-        }), SIZE);
-        assert.isUndefined(symbol.size);
-    });
-
     it('should return not override size of the symbol for shape channel', function() {
       const symbol = encode.symbols({field: 'a'}, {}, parseUnitModel({
           mark: "point",
@@ -82,16 +40,6 @@ describe('compile/legend', function() {
             shape: {field: "b", type: "nominal", legend: {"shape": "circle"}}}
         }), SHAPE);
         assert.isUndefined(symbol.size);
-    });
-
-    it('should return specific width of the symbol', function() {
-      const symbol = encode.symbols({field: 'a'}, {}, parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: "a", type: "nominal"},
-            color: {field: "a", type: "nominal", legend: {"symbolStrokeWidth": 20}}}
-        }), COLOR);
-        assert.deepEqual(symbol.strokeWidth.value, 20);
     });
 
     it('should create legend for SVG path', function() {
@@ -143,56 +91,6 @@ describe('compile/legend', function() {
   });
 
   describe('encode.labels', function() {
-    it('should return alignment value of the label', function() {
-      const label = encode.labels({field: 'a'}, {}, parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: "a", type: "nominal"},
-            color: {field: "a", type: "nominal", legend: {"labelAlign": "left"}}}
-        }), COLOR);
-        assert.deepEqual(label.align.value, "left");
-    });
-
-    it('should return color value of the label', function() {
-      const label = encode.labels({field: 'a'}, {}, parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: "a", type: "nominal"},
-            color: {field: "a", type: "nominal", legend: {"labelColor": "blue"}}}
-        }), COLOR);
-        assert.deepEqual(label.fill.value, "blue");
-    });
-
-    it('should return font of the label', function() {
-      const label = encode.labels({field: 'a'}, {}, parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: "a", type: "nominal"},
-            color: {field: "a", type: "nominal", legend: {"labelFont": "what"}}}
-        }), COLOR);
-        assert.deepEqual(label.font.value, "what");
-    });
-
-    it('should return font size of the label', function() {
-      const label = encode.labels({field: 'a'}, {}, parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: "a", type: "nominal"},
-            color: {field: "a", type: "nominal", legend: {"labelFontSize": 20}}}
-        }), COLOR);
-        assert.deepEqual(label.fontSize.value, 20);
-    });
-
-    it('should return baseline of the label', function() {
-      const label = encode.labels({field: 'a'}, {}, parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: "a", type: "nominal"},
-            color: {field: "a", type: "nominal", legend: {"labelBaseline": "middle"}}}
-        }), COLOR);
-        assert.deepEqual(label.baseline.value, "middle");
-    });
-
     it('should return correct expression for the timeUnit: TimeUnit.MONTH', function() {
       const model = parseUnitModel({
         mark: "point",
@@ -233,48 +131,6 @@ describe('compile/legend', function() {
         scale: "color_bin_legend_label"
       };
       assert.deepEqual(label.text, expected);
-    });
-  });
-
-  describe('encode.title', function() {
-    it('should return color of the title', function() {
-      const title = encode.title({field: 'a'}, {}, parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: "a", type: "nominal"},
-            color: {field: "a", type: "nominal", legend: {"titleColor": "black"}}}
-        }), COLOR);
-        assert.deepEqual(title.fill.value, "black");
-    });
-
-    it('should return font of the title', function() {
-      const title = encode.title({field: 'a'}, {}, parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: "a", type: "nominal"},
-            color: {field: "a", type: "nominal", legend: {"titleFont": "abcd"}}}
-        }), COLOR);
-        assert.deepEqual(title.font.value, "abcd");
-    });
-
-    it('should return font size of the title', function() {
-      const title = encode.title({field: 'a'}, {}, parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: "a", type: "nominal"},
-            color: {field: "a", type: "nominal", legend: {"titleFontSize": 22}}}
-        }), COLOR);
-        assert.deepEqual(title.fontSize.value, 22);
-    });
-
-    it('should return font weight of the title', function() {
-      const title = encode.title({field: 'a'}, {}, parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: "a", type: "nominal"},
-            color: {field: "a", type: "nominal", legend: {"titleFontWeight": 5}}}
-        }), COLOR);
-        assert.deepEqual(title.fontWeight.value, 5);
     });
   });
 });

--- a/test/compile/legend/encode.test.ts
+++ b/test/compile/legend/encode.test.ts
@@ -42,23 +42,6 @@ describe('compile/legend', function() {
         assert.isUndefined(symbol.size);
     });
 
-    it('should create legend for SVG path', function() {
-      const symbol = encode.symbols({field: 'a'}, {}, parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: "a", type: "nominal"},
-            color: {field: "a", type: "nominal"}
-          },
-          config: {
-            point: {
-              shape: "M0,0.2L0.2351,0.3236 0.1902,0.0618 0.3804,-0.1236 0.1175,-0.1618 0,-0.4 -0.1175,-0.1618 -0.3804,-0.1236 -0.1902,0.0618 -0.2351,0.3236 0,0.2Z"
-            }
-          }
-        }), COLOR);
-
-        assert.deepEqual(symbol.shape.value, "M0,0.2L0.2351,0.3236 0.1902,0.0618 0.3804,-0.1236 0.1175,-0.1618 0,-0.4 -0.1175,-0.1618 -0.3804,-0.1236 -0.1902,0.0618 -0.2351,0.3236 0,0.2Z");
-    });
-
     it('should override color for binned and continous scales', function() {
       const symbol = encode.symbols({field: 'a', bin: true}, {}, parseUnitModel({
           mark: "point",

--- a/test/compile/legend/encode.test.ts
+++ b/test/compile/legend/encode.test.ts
@@ -42,6 +42,16 @@ describe('compile/legend', function() {
         assert.isUndefined(symbol.size);
     });
 
+    it('should return specific symbols.shape.value if user has specified', function() {
+      const symbol = encode.symbols({field: 'a'}, {}, parseUnitModel({
+          mark: "point",
+          encoding: {
+            x: {field: "a", type: "nominal"},
+            shape: {value: "square"}}
+        }), COLOR);
+        assert.deepEqual(symbol.shape.value, 'square');
+    });
+
     it('should override color for binned and continous scales', function() {
       const symbol = encode.symbols({field: 'a', bin: true}, {}, parseUnitModel({
           mark: "point",

--- a/test/compile/legend/parse.test.ts
+++ b/test/compile/legend/parse.test.ts
@@ -19,16 +19,5 @@ describe('compile/legend', function() {
       assert.isObject(def);
       assert.equal(def.title, "a");
     });
-
-    it('should produce correct encode block if needed', () => {
-      const model = parseUnitModel({
-        mark: "point",
-        encoding: {
-          color: {field: "a", type: "quantitative", "legend": {"labelColor": "#0099ff"}}
-        }
-      });
-      const def = legendParse.parseLegend(model, COLOR);
-      assert.equal(def.encode.labels.update.fill.value, '#0099ff');
-    });
   });
 });

--- a/test/compile/unit.test.ts
+++ b/test/compile/unit.test.ts
@@ -2,7 +2,7 @@ import {assert} from 'chai';
 
 import * as log from '../../src/log';
 import {UnitModel} from '../../src/compile/unit';
-import {X, Y, SHAPE, DETAIL} from '../../src/channel';
+import {X, Y, COLOR, SHAPE, DETAIL} from '../../src/channel';
 import {BAR} from '../../src/mark';
 import {UnitSpec} from '../../src/spec';
 import {QUANTITATIVE} from '../../src/type';
@@ -182,6 +182,35 @@ describe('UnitModel', function() {
       });
 
       assert.equal(model.axis(X).offset, 345);
+    });
+  });
+
+  describe('initLegend', () => {
+    it('it should have axis.labelMaxLength = config.axis.labelMaxLength', () => {
+      const model = parseUnitModel({
+        mark: 'point',
+        encoding: {
+          x: {field: 'a', type: 'ordinal'},
+          y: {field: 'b', type: 'ordinal'},
+          color: {field: 'a', type: 'ordinal'}
+        },
+        config: {legend: {shortTimeLabels: true}}
+      });
+      assert.equal(model.legend(COLOR).shortTimeLabels, true);
+    });
+
+    it('should not include properties of non-VlOnlyLegendConfig in config.legend', () => {
+      const model = parseUnitModel({
+        mark: 'point',
+        encoding: {
+          x: {field: 'a', type: 'ordinal'},
+          y: {field: 'b', type: 'ordinal'},
+          color: {field: 'a', type: 'ordinal'}
+        },
+        config: {legend: {entryPadding: 123}}
+      });
+
+      assert.equal(model.legend(COLOR)['entryPadding'], undefined);
     });
   });
 });

--- a/test/compile/unit.test.ts
+++ b/test/compile/unit.test.ts
@@ -2,7 +2,7 @@ import {assert} from 'chai';
 
 import * as log from '../../src/log';
 import {UnitModel} from '../../src/compile/unit';
-import {X, Y, COLOR, SHAPE, DETAIL} from '../../src/channel';
+import {X, Y, SHAPE, DETAIL} from '../../src/channel';
 import {BAR} from '../../src/mark';
 import {UnitSpec} from '../../src/spec';
 import {QUANTITATIVE} from '../../src/type';
@@ -182,35 +182,6 @@ describe('UnitModel', function() {
       });
 
       assert.equal(model.axis(X).offset, 345);
-    });
-  });
-
-  describe('initLegend', () => {
-    it('it should have axis.labelMaxLength = config.axis.labelMaxLength', () => {
-      const model = parseUnitModel({
-        mark: 'point',
-        encoding: {
-          x: {field: 'a', type: 'ordinal'},
-          y: {field: 'b', type: 'ordinal'},
-          color: {field: 'a', type: 'ordinal'}
-        },
-        config: {legend: {shortTimeLabels: true}}
-      });
-      assert.equal(model.legend(COLOR).shortTimeLabels, true);
-    });
-
-    it('should not include properties of non-VlOnlyLegendConfig in config.legend', () => {
-      const model = parseUnitModel({
-        mark: 'point',
-        encoding: {
-          x: {field: 'a', type: 'ordinal'},
-          y: {field: 'b', type: 'ordinal'},
-          color: {field: 'a', type: 'ordinal'}
-        },
-        config: {legend: {entryPadding: 123}}
-      });
-
-      assert.equal(model.legend(COLOR)['entryPadding'], undefined);
     });
   });
 });

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -1656,6 +1656,10 @@
                 "shape": {
                     "type": "string"
                 },
+                "shortTimeLabels": {
+                    "description": "Whether month names and weekday names should be abbreviated.",
+                    "type": "boolean"
+                },
                 "tickCount": {
                     "description": "The number of ticks for legend.",
                     "type": "number"

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -1660,10 +1660,6 @@
                 "shape": {
                     "type": "string"
                 },
-                "shortTimeLabels": {
-                    "description": "Whether month names and weekday names should be abbreviated.",
-                    "type": "boolean"
-                },
                 "tickCount": {
                     "description": "The number of ticks for legend.",
                     "type": "number"
@@ -1720,6 +1716,7 @@
                 },
                 "gradientHeight": {
                     "description": "The height of the gradient, in pixels.",
+                    "minimum": 0,
                     "type": "number"
                 },
                 "gradientStrokeColor": {
@@ -1728,10 +1725,12 @@
                 },
                 "gradientStrokeWidth": {
                     "description": "The width of the gradient stroke, in pixels.",
+                    "minimum": 0,
                     "type": "number"
                 },
                 "gradientWidth": {
                     "description": "The width of the gradient, in pixels.",
+                    "minimum": 0,
                     "type": "number"
                 },
                 "labelAlign": {
@@ -1752,10 +1751,12 @@
                 },
                 "labelFontSize": {
                     "description": "The font size of legend label.",
+                    "minimum": 0,
                     "type": "number"
                 },
                 "labelOffset": {
                     "description": "The offset of the legend label.",
+                    "minimum": 0,
                     "type": "number"
                 },
                 "offset": {
@@ -1780,6 +1781,7 @@
                 },
                 "symbolSize": {
                     "description": "The size of the legend symbol, in pixels.",
+                    "minimum": 0,
                     "type": "number"
                 },
                 "symbolStrokeWidth": {

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -1638,6 +1638,7 @@
                     "description": "Optional mark definitions for custom legend encoding."
                 },
                 "entryPadding": {
+                    "description": "Padding (in pixels) between legend entries in a symbol legend.",
                     "type": "number"
                 },
                 "format": {
@@ -1645,12 +1646,15 @@
                     "type": "string"
                 },
                 "offset": {
+                    "description": "The offset, in pixels, by which to displace the legend from the edge of the enclosing group or data rectangle.",
                     "type": "number"
                 },
                 "orient": {
+                    "description": "The orientation of the legend. One of \"left\" or \"right\". This determines how the legend is positioned within the scene. The default is \"right\".",
                     "type": "string"
                 },
                 "padding": {
+                    "description": "The padding, in pixels, between the legend and axis.",
                     "type": "number"
                 },
                 "shape": {
@@ -1711,6 +1715,7 @@
             "additionalProperties": false,
             "properties": {
                 "entryPadding": {
+                    "description": "Padding (in pixels) between legend entries in a symbol legend.",
                     "type": "number"
                 },
                 "gradientHeight": {
@@ -1754,12 +1759,15 @@
                     "type": "number"
                 },
                 "offset": {
+                    "description": "The offset, in pixels, by which to displace the legend from the edge of the enclosing group or data rectangle.",
                     "type": "number"
                 },
                 "orient": {
+                    "description": "The orientation of the legend. One of \"left\" or \"right\". This determines how the legend is positioned within the scene. The default is \"right\".",
                     "type": "string"
                 },
                 "padding": {
+                    "description": "The padding, in pixels, between the legend and axis.",
                     "type": "number"
                 },
                 "shortTimeLabels": {
@@ -1780,7 +1788,7 @@
                     "type": "number"
                 },
                 "symbolType": {
-                    "description": "The shape of the legend symbol, can be the 'circle', 'square', 'cross', 'diamond',\n'triangle-up', 'triangle-down', or else a custom SVG path string.",
+                    "description": "Default shape type (such as \"circle\") for legend symbols.",
                     "type": "string"
                 },
                 "titleColor": {

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -1638,92 +1638,23 @@
                     "description": "Optional mark definitions for custom legend encoding."
                 },
                 "entryPadding": {
-                    "description": "Padding (in pixels) between legend entries in a symbol legend.",
                     "type": "number"
                 },
                 "format": {
                     "description": "An optional formatting pattern for legend labels. Vega uses D3\\'s format pattern.",
                     "type": "string"
                 },
-                "gradientHeight": {
-                    "description": "The height of the gradient, in pixels.",
-                    "type": "number"
-                },
-                "gradientStrokeColor": {
-                    "description": "The color of the gradient stroke, can be in hex color code or regular color name.",
-                    "type": "string"
-                },
-                "gradientStrokeWidth": {
-                    "description": "The width of the gradient stroke, in pixels.",
-                    "type": "number"
-                },
-                "gradientWidth": {
-                    "description": "The width of the gradient, in pixels.",
-                    "type": "number"
-                },
-                "labelAlign": {
-                    "description": "The alignment of the legend label, can be left, middle or right.",
-                    "type": "string"
-                },
-                "labelBaseline": {
-                    "description": "The position of the baseline of legend label, can be top, middle or bottom.",
-                    "type": "string"
-                },
-                "labelColor": {
-                    "description": "The color of the legend label, can be in hex color code or regular color name.",
-                    "type": "string"
-                },
-                "labelFont": {
-                    "description": "The font of the legend label.",
-                    "type": "string"
-                },
-                "labelFontSize": {
-                    "description": "The font size of legend label.",
-                    "type": "number"
-                },
-                "labelOffset": {
-                    "description": "The offset of the legend label.",
-                    "type": "number"
-                },
-                "margin": {
-                    "description": "The margin around the legend, in pixels",
-                    "type": "number"
-                },
                 "offset": {
-                    "description": "The offset, in pixels, by which to displace the legend from the edge of the enclosing group or data rectangle.",
                     "type": "number"
                 },
                 "orient": {
-                    "description": "The orientation of the legend. One of \"left\" or \"right\". This determines how the legend is positioned within the scene. The default is \"right\".",
                     "type": "string"
                 },
                 "padding": {
-                    "description": "The padding, in pixels, between the legend and axis.",
                     "type": "number"
                 },
                 "shape": {
                     "type": "string"
-                },
-                "shortTimeLabels": {
-                    "description": "Whether month names and weekday names should be abbreviated.",
-                    "type": "boolean"
-                },
-                "symbolColor": {
-                    "description": "The color of the legend symbol,",
-                    "type": "string"
-                },
-                "symbolShape": {
-                    "description": "The shape of the legend symbol, can be the 'circle', 'square', 'cross', 'diamond',\n'triangle-up', 'triangle-down', or else a custom SVG path string.",
-                    "type": "string"
-                },
-                "symbolSize": {
-                    "description": "The size of the legend symbol, in pixels.",
-                    "type": "number"
-                },
-                "symbolStrokeWidth": {
-                    "description": "The width of the symbol's stroke.",
-                    "minimum": 0,
-                    "type": "number"
                 },
                 "tickCount": {
                     "description": "The number of ticks for legend.",
@@ -1732,29 +1663,6 @@
                 "title": {
                     "description": "A title for the legend. (Shows field name and its function by default.)",
                     "type": "string"
-                },
-                "titleColor": {
-                    "description": "Optional mark property definitions for custom legend styling.\nThe color of the legend title, can be in hex color code or regular color name.",
-                    "type": "string"
-                },
-                "titleFont": {
-                    "description": "The font of the legend title.",
-                    "type": "string"
-                },
-                "titleFontSize": {
-                    "description": "The font size of the legend title.",
-                    "type": "number"
-                },
-                "titleFontWeight": {
-                    "description": "The font weight of the legend title.",
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                },
-                "titlePadding": {
-                    "description": "The padding, in pixels, between title and legend.",
-                    "type": "number"
                 },
                 "type": {
                     "description": "The type of the legend. Use `symbol` to create a discrete legend and `gradient` for a continuous color gradient.",
@@ -1798,12 +1706,7 @@
         "LegendConfig": {
             "additionalProperties": false,
             "properties": {
-                "encode": {
-                    "$ref": "#/definitions/VgLegendEncode",
-                    "description": "Optional mark definitions for custom legend encoding."
-                },
                 "entryPadding": {
-                    "description": "Padding (in pixels) between legend entries in a symbol legend.",
                     "type": "number"
                 },
                 "gradientHeight": {
@@ -1846,20 +1749,13 @@
                     "description": "The offset of the legend label.",
                     "type": "number"
                 },
-                "margin": {
-                    "description": "The margin around the legend, in pixels",
-                    "type": "number"
-                },
                 "offset": {
-                    "description": "The offset, in pixels, by which to displace the legend from the edge of the enclosing group or data rectangle.",
                     "type": "number"
                 },
                 "orient": {
-                    "description": "The orientation of the legend. One of \"left\" or \"right\". This determines how the legend is positioned within the scene. The default is \"right\".",
                     "type": "string"
                 },
                 "padding": {
-                    "description": "The padding, in pixels, between the legend and axis.",
                     "type": "number"
                 },
                 "shortTimeLabels": {
@@ -1868,10 +1764,6 @@
                 },
                 "symbolColor": {
                     "description": "The color of the legend symbol,",
-                    "type": "string"
-                },
-                "symbolShape": {
-                    "description": "The shape of the legend symbol, can be the 'circle', 'square', 'cross', 'diamond',\n'triangle-up', 'triangle-down', or else a custom SVG path string.",
                     "type": "string"
                 },
                 "symbolSize": {
@@ -1883,9 +1775,9 @@
                     "minimum": 0,
                     "type": "number"
                 },
-                "tickCount": {
-                    "description": "The number of ticks for legend.",
-                    "type": "number"
+                "symbolType": {
+                    "description": "The shape of the legend symbol, can be the 'circle', 'square', 'cross', 'diamond',\n'triangle-up', 'triangle-down', or else a custom SVG path string.",
+                    "type": "string"
                 },
                 "titleColor": {
                     "description": "Optional mark property definitions for custom legend styling.\nThe color of the legend title, can be in hex color code or regular color name.",
@@ -1909,11 +1801,6 @@
                 "titlePadding": {
                     "description": "The padding, in pixels, between title and legend.",
                     "type": "number"
-                },
-                "zindex": {
-                    "description": "A non-positive integer indicating z-index of the legend.\nIf zindex is 0, legend should be drawn behind all chart elements.\nTo put them in front, use zindex = 1.",
-                    "minimum": 0,
-                    "type": "integer"
                 }
             },
             "type": "object"


### PR DESCRIPTION
Update Legend Properties and Config. (Part of #1845)
- Add `symbolType`
- Remove `margin`, `symbolShape` from Legend Config
- Separate Legend from LegendConfig. Make these properties only available as Legend properties: `entryPadding`, `orient`, `offset`, `padding`, `tickCount`, `zindex`
- Remove related code for Vega Legend configs
