### PR TITLE
Revert "Remove unnecessary Mark namespace"

### DIFF
--- a/src/mark.ts
+++ b/src/mark.ts
@@ -1,22 +1,35 @@
 import {extend, toSet} from './util';
 
-export const AREA: 'area' = 'area';
-export const BAR: 'bar' = 'bar';
-export const LINE: 'line' = 'line';
-export const POINT: 'point' = 'point';
-export const RECT: 'rect' = 'rect';
-export const RULE: 'rule' = 'rule';
-export const TEXT: 'text' = 'text';
-export const TICK: 'tick' = 'tick';
-export const CIRCLE: 'circle' = 'circle';
-export const SQUARE: 'square' = 'square';
-export const ERRORBAR: 'error-bar' = 'error-bar';
+export namespace Mark {
+  export const AREA: 'area' = 'area';
+  export const BAR: 'bar' = 'bar';
+  export const LINE: 'line' = 'line';
+  export const POINT: 'point' = 'point';
+  export const RECT: 'rect' = 'rect';
+  export const RULE: 'rule' = 'rule';
+  export const TEXT: 'text' = 'text';
+  export const TICK: 'tick' = 'tick';
+  export const CIRCLE: 'circle' = 'circle';
+  export const SQUARE: 'square' = 'square';
+}
 
 /**
  * All types of primitive marks.
  */
-export type Mark = 'area' | 'bar'  | 'line' | 'point' |
-  'rect' | 'rule' | 'text' | 'tick' | 'circle' | 'square';
+export type Mark = typeof Mark.AREA | typeof Mark.BAR | typeof Mark.LINE | typeof Mark.POINT | typeof Mark.TEXT | typeof Mark.TICK | typeof Mark.RECT | typeof Mark.RULE | typeof Mark.CIRCLE | typeof Mark.SQUARE;
+
+
+export const AREA = Mark.AREA;
+export const BAR = Mark.BAR;
+export const LINE = Mark.LINE;
+export const POINT = Mark.POINT;
+export const TEXT = Mark.TEXT;
+export const TICK = Mark.TICK;
+export const RECT = Mark.RECT;
+export const RULE = Mark.RULE;
+
+export const CIRCLE = Mark.CIRCLE;
+export const SQUARE = Mark.SQUARE;
 
 export const PRIMITIVE_MARKS = [AREA, BAR, LINE, POINT, TEXT, TICK, RECT, RULE, CIRCLE, SQUARE];
 


### PR DESCRIPTION
This reverts commit f895054a0dd611e3ffed347a96dddcaf74fa1c32.

cc: @willium turns out we actually use this everywhere in CompassQL... removing it will be a disaster --- sorry for merging conflicts

