### PR TITLE
Rename VlOnlyAxisConfig => VlOnlyAxisBase

### DIFF
--- a/src/axis.ts
+++ b/src/axis.ts
@@ -3,7 +3,7 @@ import {VgAxisEncode, VgAxisBase, VgAxisConfig} from './vega.schema';
 
 export type AxisOrient = 'top' | 'right' | 'left' | 'bottom';
 
-export interface AxisConfig extends VgAxisConfig, VlOnlyAxisConfig {}
+export interface AxisConfig extends VgAxisConfig, VlOnlyAxisBase {}
 
 export const defaultAxisConfig: AxisConfig = {
   labelMaxLength: 25,
@@ -13,7 +13,7 @@ export const defaultFacetAxisConfig: AxisConfig = {
   domainWidth: 0,
 };
 
-export interface Axis extends VgAxisBase, VlOnlyAxisConfig {
+export interface Axis extends VgAxisBase, VlOnlyAxisBase {
   /**
    * The padding, in pixels, between axis and text labels.
    */
@@ -66,7 +66,12 @@ export interface Axis extends VgAxisBase, VlOnlyAxisConfig {
   encode?: VgAxisEncode;
 }
 
-export interface VlOnlyAxisConfig {
+
+/**
+ * Base object for properties that are shared between Axis and Axis Config.
+ * These properties are not in Vega Axis and Axis Config.
+ */
+export interface VlOnlyAxisBase {
   /**
    * Truncate labels that are too long.
    * @minimum 1
@@ -82,4 +87,4 @@ export const AXIS_PROPERTIES:(keyof Axis)[] = [
     'labelPadding', 'maxExtent', 'minExtent', 'offset', 'position', 'tickSize', 'titlePadding'
 ];
 
-export const VL_ONLY_AXIS_PROPERTIES:(keyof VlOnlyAxisConfig)[] = ['labelMaxLength'];
+export const VL_ONLY_AXIS_PROPERTIES:(keyof VlOnlyAxisBase)[] = ['labelMaxLength'];

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -1,6 +1,6 @@
 import * as log from '../log';
 
-import {Axis, VlOnlyAxisConfig, VL_ONLY_AXIS_PROPERTIES} from '../axis';
+import {Axis, VlOnlyAxisBase, VL_ONLY_AXIS_PROPERTIES} from '../axis';
 import {COLUMN, ROW, X, Y, Channel} from '../channel';
 import {defaultConfig, Config} from '../config';
 import {Facet} from '../facet';
@@ -127,15 +127,15 @@ export class FacetModel extends Model {
       if (facet[channel]) {
         const axisSpec = facet[channel].axis;
         if (axisSpec !== false) {
-          let vlAxisProperties: VlOnlyAxisConfig = {};
+          let vlOnlyAxisProperties: VlOnlyAxisBase = {};
           VL_ONLY_AXIS_PROPERTIES.forEach(function(property) {
             if (config.facet.axis[property] !== undefined) {
-              vlAxisProperties[property] = config.facet.axis[property];
+              vlOnlyAxisProperties[property] = config.facet.axis[property];
             }
           });
 
           const modelAxis = _axis[channel] = {
-            ...vlAxisProperties,
+            ...vlOnlyAxisProperties,
             ...axisSpec
           };
 

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -1,6 +1,6 @@
 import * as log from '../log';
 
-import {Axis, VlOnlyAxisConfig, VL_ONLY_AXIS_PROPERTIES} from '../axis';
+import {Axis, VlOnlyAxisBase, VL_ONLY_AXIS_PROPERTIES} from '../axis';
 import {X, Y, X2, Y2, Channel, UNIT_CHANNELS,  UNIT_SCALE_CHANNELS, NONSPATIAL_SCALE_CHANNELS, supportMark} from '../channel';
 import {defaultConfig, Config, CellConfig} from '../config';
 import {SOURCE, SUMMARY} from '../data';
@@ -234,7 +234,7 @@ export class UnitModel extends Model {
 
         // We no longer support false in the schema, but we keep false here for backward compatability.
         if (axisSpec !== null && axisSpec !== false) {
-          let vlOnlyAxisProperties: VlOnlyAxisConfig = {};
+          let vlOnlyAxisProperties: VlOnlyAxisBase = {};
           VL_ONLY_AXIS_PROPERTIES.forEach(function(property) {
             if (config.axis[property] !== undefined) {
               vlOnlyAxisProperties[property] = config.axis[property];


### PR DESCRIPTION
(It should be *Base as labelMaxLength is an Axis property too.)

Also rename one local variable for consistency

cc: @Yuhanlu

(Please use the same format for `VlOnlyLegendBase`)

I think we should also ask Jeff if he wanna add `labelMaxLength` and `titleMaxLength` to Axis/Legend and their config in Vega.  (Maybe we can get rid of `VlOnlyAxis/LegendBase` and complicated code cause by it.)