### PR TITLE
Support conditional encoding

### DIFF
--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -79,7 +79,7 @@ export function parseUnitSelection(model: UnitModel, selDefs: Dict<SelectionDef>
       name: model.getName(name),
       events: isString(selDef.on) ? parseSelector(selDef.on, 'scope') : selDef.on,
       domain: 'data' as SelectionDomain, // TODO: Support def.domain
-      resolve: 'single' as SelectionResolutions
+      resolve: 'union' as SelectionResolutions
     }) as SelectionComponent;
 
     forEachTransform(selCmpt, function(txCompiler) {

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,5 +1,5 @@
 // utility for encoding mapping
-import {FieldDef, PositionFieldDef, LegendFieldDef, OrderFieldDef, ValueDef, TextFieldDef, isFieldDef, ChannelDef, isValueDef, normalize} from './fielddef';
+import {FieldDef, PositionFieldDef, LegendFieldDef, OrderFieldDef, ValueDef, TextFieldDef, isFieldDef, ChannelDef, isValueDef, normalize, ConditionalValueDef} from './fielddef';
 import {Channel, CHANNELS, supportMark} from './channel';
 import {Facet} from './facet';
 import {isArray, some, duplicate} from './util';
@@ -36,12 +36,12 @@ export interface Encoding {
    * (By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /
    * stroke color for `line` and `point`.)
    */
-  color?: LegendFieldDef | ValueDef<string>;
+  color?: LegendFieldDef<string> | ConditionalValueDef<string>;
 
   /**
    * Opacity of the marks – either can be a value or in a range.
    */
-  opacity?: LegendFieldDef | ValueDef<number>;
+  opacity?: LegendFieldDef<number> | ConditionalValueDef<number>;
 
   /**
    * Size of the mark.
@@ -51,14 +51,14 @@ export interface Encoding {
    * - For `text` – the text's font size.
    * - Size is currently unsupported for `line` and `area`.
    */
-  size?: LegendFieldDef | ValueDef<number>;
+  size?: LegendFieldDef<number> | ConditionalValueDef<number>;
 
   /**
    * The symbol's shape (only for `point` marks). The supported values are
    * `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,
    * or `"triangle-down"`, or else a custom SVG path string.
    */
-  shape?: LegendFieldDef | ValueDef<string>; // TODO: maybe distinguish ordinal-only
+  shape?: LegendFieldDef<string> | ConditionalValueDef<string>; // TODO: maybe distinguish ordinal-only
 
   /**
    * Additional levels of detail for grouping data in aggregate views and
@@ -69,7 +69,7 @@ export interface Encoding {
   /**
    * Text of the `text` mark.
    */
-  text?: TextFieldDef | ValueDef<string|number>;
+  text?: TextFieldDef | ConditionalValueDef<string|number>;
 
   /**
    * stack order for stacked marks or order of data points in line marks.

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -24,6 +24,10 @@ export interface ValueDef<T> {
   value?: T;
 }
 
+export interface ConditionalValueDef<T> extends ValueDef<T> {
+  condition?: Condition<T>;
+}
+
 /**
  *  Definition object for a data field, its type and transformation of an encoding channel.
  */
@@ -67,6 +71,11 @@ export interface FieldDef {
   title?: string;
 }
 
+export interface Condition<T> {
+  selection: string;
+  value: T;
+}
+
 export interface ScaleFieldDef extends FieldDef {
   scale?: Scale;
   sort?: SortField | SortOrder;
@@ -84,11 +93,13 @@ export interface PositionFieldDef extends ScaleFieldDef {
    */
   stack?: StackOffset;
 }
-export interface LegendFieldDef extends ScaleFieldDef {
+export interface LegendFieldDef<T> extends ScaleFieldDef {
    /**
     * @nullable
     */
   legend?: Legend;
+
+  condition?: Condition<T>;
 }
 
 // Detail
@@ -105,11 +116,13 @@ export interface TextFieldDef extends FieldDef {
    * The formatting pattern for text value. If not defined, this will be determined automatically.
    */
   format?: string;
+
+  condition?: Condition<string|number>;
 };
 
 export type ChannelDef = FieldDef | ValueDef<any>;
 
-export function isFieldDef(channelDef: ChannelDef): channelDef is FieldDef | PositionFieldDef | LegendFieldDef | OrderFieldDef | TextFieldDef {
+export function isFieldDef(channelDef: ChannelDef): channelDef is FieldDef | PositionFieldDef | LegendFieldDef<any> | OrderFieldDef | TextFieldDef {
   return channelDef && !!channelDef['field'];
 }
 

--- a/test/compile/selection/predicate.test.ts
+++ b/test/compile/selection/predicate.test.ts
@@ -1,0 +1,86 @@
+/* tslint:disable quotemark */
+
+import {assert} from 'chai';
+import {parseUnitModel} from '../../util';
+import * as selection from '../../../src/compile/selection/selection';
+import {nonPosition} from '../../../src/compile/mark/mixins';
+
+function getModel(selectionDef: any) {
+  const model = parseUnitModel({
+    "mark": "circle",
+    "encoding": {
+      "x": {"field": "Horsepower","type": "quantitative"},
+      "y": {"field": "Miles_per_Gallon","type": "quantitative"},
+      "color": {
+        "field": "Cylinders", "type": "O",
+        "condition": {
+          "selection": "!one",
+          "value": "grey"
+        }
+      },
+      "opacity": {
+        "field": "Origin", "type": "N",
+        "condition": {
+          "selection": "one",
+          "value": 0.5
+        }
+      }
+    }
+  });
+
+  model.component.selection = selection.parseUnitSelection(model, {
+    "one": selectionDef
+  });
+
+  return model;
+}
+
+
+describe('Selection Predicate', function() {
+  it('generates Vega production rules', function() {
+    const single = getModel({type: 'single'});
+    assert.deepEqual(nonPosition('color', single), {
+      color: [
+        {test: "!vlPoint(\"one_store\", parent._id, datum, \"union\", \"all\")", value: "grey"},
+        {scale: "color", field: "Cylinders"}
+      ]
+    });
+
+    assert.deepEqual(nonPosition('opacity', single), {
+      opacity: [
+        {test: "vlPoint(\"one_store\", parent._id, datum, \"union\", \"all\")", value: 0.5},
+        {scale: "opacity", field: "Origin"}
+      ]
+    });
+
+    const multi = getModel({type: 'multi'});
+    assert.deepEqual(nonPosition('color', multi), {
+      color: [
+        {test: "!vlPoint(\"one_store\", parent._id, datum, \"union\", \"all\")", value: "grey"},
+        {scale: "color", field: "Cylinders"}
+      ]
+    });
+
+    assert.deepEqual(nonPosition('opacity', multi), {
+      opacity: [
+        {test: "vlPoint(\"one_store\", parent._id, datum, \"union\", \"all\")", value: 0.5},
+        {scale: "opacity", field: "Origin"}
+      ]
+    });
+
+    const interval = getModel({type: 'interval'});
+    assert.deepEqual(nonPosition('color', interval), {
+      color: [
+        {test: "!vlInterval(\"one_store\", parent._id, datum, \"union\", \"all\")", value: "grey"},
+        {scale: "color", field: "Cylinders"}
+      ]
+    });
+
+    assert.deepEqual(nonPosition('opacity', interval), {
+      opacity: [
+        {test: "vlInterval(\"one_store\", parent._id, datum, \"union\", \"all\")", value: 0.5},
+        {scale: "opacity", field: "Origin"}
+      ]
+    });
+  });
+});

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -735,6 +735,99 @@
             },
             "type": "object"
         },
+        "Condition<number>": {
+            "additionalProperties": false,
+            "properties": {
+                "selection": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "selection",
+                "value"
+            ],
+            "type": "object"
+        },
+        "Condition<string | number>": {
+            "additionalProperties": false,
+            "properties": {
+                "selection": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": [
+                        "string",
+                        "number"
+                    ]
+                }
+            },
+            "required": [
+                "selection",
+                "value"
+            ],
+            "type": "object"
+        },
+        "Condition<string>": {
+            "additionalProperties": false,
+            "properties": {
+                "selection": {
+                    "type": "string"
+                },
+                "value": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "selection",
+                "value"
+            ],
+            "type": "object"
+        },
+        "ConditionalValueDef<number>": {
+            "additionalProperties": false,
+            "properties": {
+                "condition": {
+                    "$ref": "#/definitions/Condition<number>"
+                },
+                "value": {
+                    "description": "A constant value in visual domain.",
+                    "type": "number"
+                }
+            },
+            "type": "object"
+        },
+        "ConditionalValueDef<string | number>": {
+            "additionalProperties": false,
+            "properties": {
+                "condition": {
+                    "$ref": "#/definitions/Condition<string | number>"
+                },
+                "value": {
+                    "description": "A constant value in visual domain.",
+                    "type": [
+                        "string",
+                        "number"
+                    ]
+                }
+            },
+            "type": "object"
+        },
+        "ConditionalValueDef<string>": {
+            "additionalProperties": false,
+            "properties": {
+                "condition": {
+                    "$ref": "#/definitions/Condition<string>"
+                },
+                "value": {
+                    "description": "A constant value in visual domain.",
+                    "type": "string"
+                }
+            },
+            "type": "object"
+        },
         "Config": {
             "additionalProperties": false,
             "properties": {
@@ -1020,10 +1113,10 @@
                 "color": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/LegendFieldDef"
+                            "$ref": "#/definitions/LegendFieldDef<string>"
                         },
                         {
-                            "$ref": "#/definitions/ValueDef<string>"
+                            "$ref": "#/definitions/ConditionalValueDef<string>"
                         }
                     ],
                     "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
@@ -1049,10 +1142,10 @@
                 "opacity": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/LegendFieldDef"
+                            "$ref": "#/definitions/LegendFieldDef<number>"
                         },
                         {
-                            "$ref": "#/definitions/ValueDef<number>"
+                            "$ref": "#/definitions/ConditionalValueDef<number>"
                         }
                     ],
                     "description": "Opacity of the marks – either can be a value or in a range."
@@ -1078,10 +1171,10 @@
                 "shape": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/LegendFieldDef"
+                            "$ref": "#/definitions/LegendFieldDef<string>"
                         },
                         {
-                            "$ref": "#/definitions/ValueDef<string>"
+                            "$ref": "#/definitions/ConditionalValueDef<string>"
                         }
                     ],
                     "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
@@ -1089,10 +1182,10 @@
                 "size": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/LegendFieldDef"
+                            "$ref": "#/definitions/LegendFieldDef<number>"
                         },
                         {
-                            "$ref": "#/definitions/ValueDef<number>"
+                            "$ref": "#/definitions/ConditionalValueDef<number>"
                         }
                     ],
                     "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
@@ -1103,7 +1196,7 @@
                             "$ref": "#/definitions/TextFieldDef"
                         },
                         {
-                            "$ref": "#/definitions/ValueDef<string | number>"
+                            "$ref": "#/definitions/ConditionalValueDef<string | number>"
                         }
                     ],
                     "description": "Text of the `text` mark."
@@ -1918,7 +2011,7 @@
             },
             "type": "object"
         },
-        "LegendFieldDef": {
+        "LegendFieldDef<number>": {
             "additionalProperties": false,
             "properties": {
                 "aggregate": {
@@ -1935,6 +2028,76 @@
                         }
                     ],
                     "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
+                },
+                "condition": {
+                    "$ref": "#/definitions/Condition<number>"
+                },
+                "field": {
+                    "description": "Name of the field from which to pull a data value.",
+                    "type": "string"
+                },
+                "legend": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Legend"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
+                "scale": {
+                    "$ref": "#/definitions/Scale"
+                },
+                "sort": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/SortField"
+                        },
+                        {
+                            "enum": [
+                                "ascending",
+                                "descending"
+                            ],
+                            "type": "string"
+                        }
+                    ]
+                },
+                "timeUnit": {
+                    "$ref": "#/definitions/TimeUnit",
+                    "description": "Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`)."
+                },
+                "title": {
+                    "description": "Title for axis or legend.",
+                    "type": "string"
+                },
+                "type": {
+                    "$ref": "#/definitions/Type",
+                    "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case insensitive."
+                }
+            },
+            "type": "object"
+        },
+        "LegendFieldDef<string>": {
+            "additionalProperties": false,
+            "properties": {
+                "aggregate": {
+                    "$ref": "#/definitions/AggregateOp",
+                    "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`)."
+                },
+                "bin": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/Bin"
+                        },
+                        {
+                            "type": "boolean"
+                        }
+                    ],
+                    "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
+                },
+                "condition": {
+                    "$ref": "#/definitions/Condition<string>"
                 },
                 "field": {
                     "description": "Name of the field from which to pull a data value.",
@@ -3383,6 +3546,9 @@
                     ],
                     "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
                 },
+                "condition": {
+                    "$ref": "#/definitions/Condition<string | number>"
+                },
                 "field": {
                     "description": "Name of the field from which to pull a data value.",
                     "type": "string"
@@ -3697,31 +3863,6 @@
                 "value": {
                     "description": "A constant value in visual domain.",
                     "type": "number"
-                }
-            },
-            "type": "object"
-        },
-        "ValueDef<string | number>": {
-            "additionalProperties": false,
-            "description": "Definition object for a constant value of an encoding channel.",
-            "properties": {
-                "value": {
-                    "description": "A constant value in visual domain.",
-                    "type": [
-                        "string",
-                        "number"
-                    ]
-                }
-            },
-            "type": "object"
-        },
-        "ValueDef<string>": {
-            "additionalProperties": false,
-            "description": "Definition object for a constant value of an encoding channel.",
-            "properties": {
-                "value": {
-                    "description": "A constant value in visual domain.",
-                    "type": "string"
                 }
             },
             "type": "object"


### PR DESCRIPTION
(Merge #1970 first)

@arvind I just added scaffolding code for generating a Vega production rule from our conditional encoding syntax.  

I'll let you take over and add code for how to generate `"test"` property for selection. 

Since we no longer have to deal with how it interacts with transform, I think we're pretty close to have selection really working!

