### PR TITLE
Support `field` in condition

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1156,7 +1156,7 @@
       ],
       "type": "object"
     },
-    "ConditionLegendDefAlias<NumberValueDef>": {
+    "ConditionLegendDef<NumberValueDef>": {
       "anyOf": [
         {
           "$ref": "#/definitions/ConditionLegendFieldDef<NumberValueDef>"
@@ -1170,7 +1170,7 @@
       ],
       "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."
     },
-    "ConditionLegendDefAlias<StringValueDef>": {
+    "ConditionLegendDef<StringValueDef>": {
       "anyOf": [
         {
           "$ref": "#/definitions/ConditionLegendFieldDef<StringValueDef>"
@@ -1184,7 +1184,7 @@
       ],
       "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."
     },
-    "ConditionTextDefAlias": {
+    "ConditionTextDef": {
       "anyOf": [
         {
           "$ref": "#/definitions/ConditionTextFieldDef"
@@ -1390,15 +1390,6 @@
         "type"
       ],
       "type": "object"
-    },
-    "ConditionalLegendDef<number>": {
-      "$ref": "#/definitions/ConditionLegendDefAlias<NumberValueDef>"
-    },
-    "ConditionalLegendDef<string>": {
-      "$ref": "#/definitions/ConditionLegendDefAlias<StringValueDef>"
-    },
-    "ConditionalTextDef": {
-      "$ref": "#/definitions/ConditionTextDefAlias"
     },
     "ConditionLegendValueDef<NumberValueDef>": {
       "additionalProperties": false,
@@ -1792,7 +1783,7 @@
       "additionalProperties": false,
       "properties": {
         "color": {
-          "$ref": "#/definitions/ConditionalLegendDef<string>",
+          "$ref": "#/definitions/ConditionLegendDef<StringValueDef>",
           "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
         },
         "detail": {
@@ -1810,7 +1801,7 @@
           "description": "Additional levels of detail for grouping data in aggregate views and\nin line and area marks without mapping data to a specific visual channel."
         },
         "opacity": {
-          "$ref": "#/definitions/ConditionalLegendDef<number>",
+          "$ref": "#/definitions/ConditionLegendDef<NumberValueDef>",
           "description": "Opacity of the marks – either can be a value or a range."
         },
         "order": {
@@ -1828,23 +1819,30 @@
           "description": "stack order for stacked marks or order of data points in line marks."
         },
         "shape": {
-          "$ref": "#/definitions/ConditionalLegendDef<string>",
+          "$ref": "#/definitions/ConditionLegendDef<StringValueDef>",
           "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
         },
         "size": {
-          "$ref": "#/definitions/ConditionalLegendDef<number>",
+          "$ref": "#/definitions/ConditionLegendDef<NumberValueDef>",
           "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
         },
         "text": {
-          "$ref": "#/definitions/ConditionalTextDef",
+          "$ref": "#/definitions/ConditionTextDef",
           "description": "Text of the `text` mark."
         },
         "tooltip": {
-          "$ref": "#/definitions/ConditionalTextDef",
+          "$ref": "#/definitions/ConditionTextDef",
           "description": "The tooltip text to show upon mouse hover."
         },
         "x": {
-          "$ref": "#/definitions/PositionDef",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PositionFieldDef"
+            },
+            {
+              "$ref": "#/definitions/NumberValueDef"
+            }
+          ],
           "description": "X coordinates for `point`, `circle`, `square`,\n`line`, `rule`, `text`, and `tick`\n(or to width and height for `bar` and `area` marks)."
         },
         "x2": {
@@ -1859,7 +1857,14 @@
           "description": "X2 coordinates for ranged `bar`, `rule`, `area`."
         },
         "y": {
-          "$ref": "#/definitions/PositionDef",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PositionFieldDef"
+            },
+            {
+              "$ref": "#/definitions/NumberValueDef"
+            }
+          ],
           "description": "Y coordinates for `point`, `circle`, `square`,\n`line`, `rule`, `text`, and `tick`\n(or to width and height for `bar` and `area` marks)."
         },
         "y2": {
@@ -1880,7 +1885,7 @@
       "additionalProperties": false,
       "properties": {
         "color": {
-          "$ref": "#/definitions/ConditionalLegendDef<string>",
+          "$ref": "#/definitions/ConditionLegendDef<StringValueDef>",
           "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
         },
         "column": {
@@ -1902,7 +1907,7 @@
           "description": "Additional levels of detail for grouping data in aggregate views and\nin line and area marks without mapping data to a specific visual channel."
         },
         "opacity": {
-          "$ref": "#/definitions/ConditionalLegendDef<number>",
+          "$ref": "#/definitions/ConditionLegendDef<NumberValueDef>",
           "description": "Opacity of the marks – either can be a value or a range."
         },
         "order": {
@@ -1924,23 +1929,30 @@
           "description": "Vertical facets for trellis plots."
         },
         "shape": {
-          "$ref": "#/definitions/ConditionalLegendDef<string>",
+          "$ref": "#/definitions/ConditionLegendDef<StringValueDef>",
           "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
         },
         "size": {
-          "$ref": "#/definitions/ConditionalLegendDef<number>",
+          "$ref": "#/definitions/ConditionLegendDef<NumberValueDef>",
           "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
         },
         "text": {
-          "$ref": "#/definitions/ConditionalTextDef",
+          "$ref": "#/definitions/ConditionTextDef",
           "description": "Text of the `text` mark."
         },
         "tooltip": {
-          "$ref": "#/definitions/ConditionalTextDef",
+          "$ref": "#/definitions/ConditionTextDef",
           "description": "The tooltip text to show upon mouse hover."
         },
         "x": {
-          "$ref": "#/definitions/PositionDef",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PositionFieldDef"
+            },
+            {
+              "$ref": "#/definitions/NumberValueDef"
+            }
+          ],
           "description": "X coordinates for `point`, `circle`, `square`,\n`line`, `rule`, `text`, and `tick`\n(or to width and height for `bar` and `area` marks)."
         },
         "x2": {
@@ -1955,7 +1967,14 @@
           "description": "X2 coordinates for ranged `bar`, `rule`, `area`."
         },
         "y": {
-          "$ref": "#/definitions/PositionDef",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PositionFieldDef"
+            },
+            {
+              "$ref": "#/definitions/NumberValueDef"
+            }
+          ],
           "description": "Y coordinates for `point`, `circle`, `square`,\n`line`, `rule`, `text`, and `tick`\n(or to width and height for `bar` and `area` marks)."
         },
         "y2": {
@@ -3582,16 +3601,6 @@
         }
       ],
       "minimum": 0
-    },
-    "PositionDef": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/PositionFieldDef"
-        },
-        {
-          "$ref": "#/definitions/NumberValueDef"
-        }
-      ]
     },
     "PositionFieldDef": {
       "additionalProperties": false,

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -621,7 +621,7 @@
         },
         "encodings": {
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/SingleDefChannel"
           },
           "type": "array"
         },
@@ -4208,7 +4208,7 @@
         },
         "encodings": {
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/SingleDefChannel"
           },
           "type": "array"
         },
@@ -4320,6 +4320,25 @@
         "single",
         "multi",
         "interval"
+      ],
+      "type": [
+        "string"
+      ]
+    },
+    "SingleDefChannel": {
+      "enum": [
+        "x",
+        "y",
+        "x2",
+        "y2",
+        "row",
+        "column",
+        "size",
+        "shape",
+        "color",
+        "opacity",
+        "text",
+        "tooltip"
       ],
       "type": [
         "string"

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1346,6 +1346,15 @@
       ],
       "type": "object"
     },
+    "ConditionalLegendDef<Field,number>": {
+      "$ref": "#/definitions/Conditional<LegendFieldDef<Field,number>,ValueDef<number>>"
+    },
+    "ConditionalLegendDef<Field,string>": {
+      "$ref": "#/definitions/Conditional<LegendFieldDef<Field,string>,ValueDef<string>>"
+    },
+    "ConditionalTextDef": {
+      "$ref": "#/definitions/Conditional<TextFieldDef,ValueDef<(string|number|boolean)>>"
+    },
     "ConditionalValueDef<LegendFieldDef<Field,number>,ValueDef<number>>": {
       "additionalProperties": false,
       "description": "A ValueDef with Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
@@ -1738,7 +1747,7 @@
       "additionalProperties": false,
       "properties": {
         "color": {
-          "$ref": "#/definitions/Conditional<LegendFieldDef<Field,string>,ValueDef<string>>",
+          "$ref": "#/definitions/ConditionalLegendDef<Field,string>",
           "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
         },
         "detail": {
@@ -1756,7 +1765,7 @@
           "description": "Additional levels of detail for grouping data in aggregate views and\nin line and area marks without mapping data to a specific visual channel."
         },
         "opacity": {
-          "$ref": "#/definitions/Conditional<LegendFieldDef<Field,number>,ValueDef<number>>",
+          "$ref": "#/definitions/ConditionalLegendDef<Field,number>",
           "description": "Opacity of the marks – either can be a value or a range."
         },
         "order": {
@@ -1774,30 +1783,23 @@
           "description": "stack order for stacked marks or order of data points in line marks."
         },
         "shape": {
-          "$ref": "#/definitions/Conditional<LegendFieldDef<Field,string>,ValueDef<string>>",
+          "$ref": "#/definitions/ConditionalLegendDef<Field,string>",
           "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
         },
         "size": {
-          "$ref": "#/definitions/Conditional<LegendFieldDef<Field,number>,ValueDef<number>>",
+          "$ref": "#/definitions/ConditionalLegendDef<Field,number>",
           "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
         },
         "text": {
-          "$ref": "#/definitions/Conditional<TextFieldDef,ValueDef<(string|number|boolean)>>",
+          "$ref": "#/definitions/ConditionalTextDef",
           "description": "Text of the `text` mark."
         },
         "tooltip": {
-          "$ref": "#/definitions/Conditional<TextFieldDef,ValueDef<(string|number|boolean)>>",
+          "$ref": "#/definitions/ConditionalTextDef",
           "description": "The tooltip text to show upon mouse hover."
         },
         "x": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PositionFieldDef"
-            },
-            {
-              "$ref": "#/definitions/ValueDef<number>"
-            }
-          ],
+          "$ref": "#/definitions/PositionDef",
           "description": "X coordinates for `point`, `circle`, `square`,\n`line`, `rule`, `text`, and `tick`\n(or to width and height for `bar` and `area` marks)."
         },
         "x2": {
@@ -1812,14 +1814,7 @@
           "description": "X2 coordinates for ranged `bar`, `rule`, `area`."
         },
         "y": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PositionFieldDef"
-            },
-            {
-              "$ref": "#/definitions/ValueDef<number>"
-            }
-          ],
+          "$ref": "#/definitions/PositionDef",
           "description": "Y coordinates for `point`, `circle`, `square`,\n`line`, `rule`, `text`, and `tick`\n(or to width and height for `bar` and `area` marks)."
         },
         "y2": {
@@ -1840,7 +1835,7 @@
       "additionalProperties": false,
       "properties": {
         "color": {
-          "$ref": "#/definitions/Conditional<LegendFieldDef<Field,string>,ValueDef<string>>",
+          "$ref": "#/definitions/ConditionalLegendDef<Field,string>",
           "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
         },
         "column": {
@@ -1862,7 +1857,7 @@
           "description": "Additional levels of detail for grouping data in aggregate views and\nin line and area marks without mapping data to a specific visual channel."
         },
         "opacity": {
-          "$ref": "#/definitions/Conditional<LegendFieldDef<Field,number>,ValueDef<number>>",
+          "$ref": "#/definitions/ConditionalLegendDef<Field,number>",
           "description": "Opacity of the marks – either can be a value or a range."
         },
         "order": {
@@ -1884,30 +1879,23 @@
           "description": "Vertical facets for trellis plots."
         },
         "shape": {
-          "$ref": "#/definitions/Conditional<LegendFieldDef<Field,string>,ValueDef<string>>",
+          "$ref": "#/definitions/ConditionalLegendDef<Field,string>",
           "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
         },
         "size": {
-          "$ref": "#/definitions/Conditional<LegendFieldDef<Field,number>,ValueDef<number>>",
+          "$ref": "#/definitions/ConditionalLegendDef<Field,number>",
           "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
         },
         "text": {
-          "$ref": "#/definitions/Conditional<TextFieldDef,ValueDef<(string|number|boolean)>>",
+          "$ref": "#/definitions/ConditionalTextDef",
           "description": "Text of the `text` mark."
         },
         "tooltip": {
-          "$ref": "#/definitions/Conditional<TextFieldDef,ValueDef<(string|number|boolean)>>",
+          "$ref": "#/definitions/ConditionalTextDef",
           "description": "The tooltip text to show upon mouse hover."
         },
         "x": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PositionFieldDef"
-            },
-            {
-              "$ref": "#/definitions/ValueDef<number>"
-            }
-          ],
+          "$ref": "#/definitions/PositionDef",
           "description": "X coordinates for `point`, `circle`, `square`,\n`line`, `rule`, `text`, and `tick`\n(or to width and height for `bar` and `area` marks)."
         },
         "x2": {
@@ -1922,14 +1910,7 @@
           "description": "X2 coordinates for ranged `bar`, `rule`, `area`."
         },
         "y": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PositionFieldDef"
-            },
-            {
-              "$ref": "#/definitions/ValueDef<number>"
-            }
-          ],
+          "$ref": "#/definitions/PositionDef",
           "description": "Y coordinates for `point`, `circle`, `square`,\n`line`, `rule`, `text`, and `tick`\n(or to width and height for `bar` and `area` marks)."
         },
         "y2": {
@@ -3623,6 +3604,16 @@
         }
       ],
       "minimum": 0
+    },
+    "PositionDef": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PositionFieldDef"
+        },
+        {
+          "$ref": "#/definitions/ValueDef<number>"
+        }
+      ]
     },
     "PositionFieldDef": {
       "additionalProperties": false,

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1120,6 +1120,42 @@
       ],
       "type": "object"
     },
+    "ConditionOnlyDef<LegendFieldDef<Field,number>,ValueDef<number>>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/Condition<(LegendFieldDef<Field,number>|ValueDef<number>)>"
+        }
+      },
+      "required": [
+        "condition"
+      ],
+      "type": "object"
+    },
+    "ConditionOnlyDef<LegendFieldDef<Field,string>,ValueDef<string>>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/Condition<(LegendFieldDef<Field,string>|ValueDef<string>)>"
+        }
+      },
+      "required": [
+        "condition"
+      ],
+      "type": "object"
+    },
+    "ConditionOnlyDef<TextFieldDef,ValueDef<(string|number|boolean)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/Condition<(TextFieldDef|ValueDef<(string|number|boolean)>)>"
+        }
+      },
+      "required": [
+        "condition"
+      ],
+      "type": "object"
+    },
     "Conditional<LegendFieldDef<Field,number>,ValueDef<number>>": {
       "anyOf": [
         {
@@ -1127,6 +1163,9 @@
         },
         {
           "$ref": "#/definitions/ConditionalValueDef<LegendFieldDef<Field,number>,ValueDef<number>>"
+        },
+        {
+          "$ref": "#/definitions/ConditionOnlyDef<LegendFieldDef<Field,number>,ValueDef<number>>"
         }
       ],
       "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."
@@ -1138,6 +1177,9 @@
         },
         {
           "$ref": "#/definitions/ConditionalValueDef<LegendFieldDef<Field,string>,ValueDef<string>>"
+        },
+        {
+          "$ref": "#/definitions/ConditionOnlyDef<LegendFieldDef<Field,string>,ValueDef<string>>"
         }
       ],
       "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."
@@ -1149,6 +1191,9 @@
         },
         {
           "$ref": "#/definitions/ConditionalValueDef<TextFieldDef,ValueDef<(string|number|boolean)>>"
+        },
+        {
+          "$ref": "#/definitions/ConditionOnlyDef<TextFieldDef,ValueDef<(string|number|boolean)>>"
         }
       ],
       "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1209,7 +1209,7 @@
       ],
       "type": "object"
     },
-    "ConditionOnlyLegendDef<NumberValueDef>": {
+    "ConditionOnlyNumberLegendDef": {
       "additionalProperties": false,
       "properties": {
         "condition": {
@@ -1228,7 +1228,7 @@
       ],
       "type": "object"
     },
-    "ConditionOnlyLegendDef<StringValueDef>": {
+    "ConditionOnlyStringLegendDef": {
       "additionalProperties": false,
       "properties": {
         "condition": {
@@ -1266,30 +1266,30 @@
       ],
       "type": "object"
     },
-    "ConditionLegendDef<NumberValueDef>": {
+    "ConditionNumberLegendDef": {
       "anyOf": [
         {
-          "$ref": "#/definitions/ConditionLegendFieldDef<NumberValueDef>"
+          "$ref": "#/definitions/ConditionNumberLegendFieldDef"
         },
         {
-          "$ref": "#/definitions/ConditionLegendValueDef<NumberValueDef>"
+          "$ref": "#/definitions/ConditionNumberLegendValueDef"
         },
         {
-          "$ref": "#/definitions/ConditionOnlyLegendDef<NumberValueDef>"
+          "$ref": "#/definitions/ConditionOnlyNumberLegendDef"
         }
       ],
       "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."
     },
-    "ConditionLegendDef<StringValueDef>": {
+    "ConditionStringLegendDef": {
       "anyOf": [
         {
-          "$ref": "#/definitions/ConditionLegendFieldDef<StringValueDef>"
+          "$ref": "#/definitions/ConditionStringLegendFieldDef"
         },
         {
-          "$ref": "#/definitions/ConditionLegendValueDef<StringValueDef>"
+          "$ref": "#/definitions/ConditionStringLegendValueDef"
         },
         {
-          "$ref": "#/definitions/ConditionOnlyLegendDef<StringValueDef>"
+          "$ref": "#/definitions/ConditionOnlyStringLegendDef"
         }
       ],
       "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."
@@ -1308,7 +1308,7 @@
       ],
       "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."
     },
-    "ConditionLegendFieldDef<NumberValueDef>": {
+    "ConditionNumberLegendFieldDef": {
       "additionalProperties": false,
       "description": "A FieldDef with ConditionValueDef\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
       "properties": {
@@ -1379,7 +1379,7 @@
       ],
       "type": "object"
     },
-    "ConditionLegendFieldDef<StringValueDef>": {
+    "ConditionStringLegendFieldDef": {
       "additionalProperties": false,
       "description": "A FieldDef with ConditionValueDef\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
       "properties": {
@@ -1501,7 +1501,7 @@
       ],
       "type": "object"
     },
-    "ConditionLegendValueDef<NumberValueDef>": {
+    "ConditionNumberLegendValueDef": {
       "additionalProperties": false,
       "description": "A ValueDef with ConditionValueDef | FieldDef\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
       "properties": {
@@ -1525,7 +1525,7 @@
       ],
       "type": "object"
     },
-    "ConditionLegendValueDef<StringValueDef>": {
+    "ConditionStringLegendValueDef": {
       "additionalProperties": false,
       "description": "A ValueDef with ConditionValueDef | FieldDef\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
       "properties": {
@@ -1914,7 +1914,7 @@
       "additionalProperties": false,
       "properties": {
         "color": {
-          "$ref": "#/definitions/ConditionLegendDef<StringValueDef>",
+          "$ref": "#/definitions/ConditionStringLegendDef",
           "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
         },
         "detail": {
@@ -1932,7 +1932,7 @@
           "description": "Additional levels of detail for grouping data in aggregate views and\nin line and area marks without mapping data to a specific visual channel."
         },
         "opacity": {
-          "$ref": "#/definitions/ConditionLegendDef<NumberValueDef>",
+          "$ref": "#/definitions/ConditionNumberLegendDef",
           "description": "Opacity of the marks – either can be a value or a range."
         },
         "order": {
@@ -1950,11 +1950,11 @@
           "description": "stack order for stacked marks or order of data points in line marks."
         },
         "shape": {
-          "$ref": "#/definitions/ConditionLegendDef<StringValueDef>",
+          "$ref": "#/definitions/ConditionStringLegendDef",
           "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
         },
         "size": {
-          "$ref": "#/definitions/ConditionLegendDef<NumberValueDef>",
+          "$ref": "#/definitions/ConditionNumberLegendDef",
           "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
         },
         "text": {
@@ -2016,7 +2016,7 @@
       "additionalProperties": false,
       "properties": {
         "color": {
-          "$ref": "#/definitions/ConditionLegendDef<StringValueDef>",
+          "$ref": "#/definitions/ConditionStringLegendDef",
           "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
         },
         "column": {
@@ -2038,7 +2038,7 @@
           "description": "Additional levels of detail for grouping data in aggregate views and\nin line and area marks without mapping data to a specific visual channel."
         },
         "opacity": {
-          "$ref": "#/definitions/ConditionLegendDef<NumberValueDef>",
+          "$ref": "#/definitions/ConditionNumberLegendDef",
           "description": "Opacity of the marks – either can be a value or a range."
         },
         "order": {
@@ -2060,11 +2060,11 @@
           "description": "Vertical facets for trellis plots."
         },
         "shape": {
-          "$ref": "#/definitions/ConditionLegendDef<StringValueDef>",
+          "$ref": "#/definitions/ConditionStringLegendDef",
           "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
         },
         "size": {
-          "$ref": "#/definitions/ConditionLegendDef<NumberValueDef>",
+          "$ref": "#/definitions/ConditionNumberLegendDef",
           "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
         },
         "text": {
@@ -4938,7 +4938,7 @@
       ],
       "type": "object"
     },
-    "TopLevel<FacetedUnitSpec>": {
+    "TopLevelFacetedUnitSpec": {
       "additionalProperties": false,
       "properties": {
         "$schema": {
@@ -5008,7 +5008,7 @@
       ],
       "type": "object"
     },
-    "TopLevel<FacetedSpec>": {
+    "TopLevelFacetedSpec": {
       "additionalProperties": false,
       "properties": {
         "$schema": {
@@ -5074,7 +5074,7 @@
       ],
       "type": "object"
     },
-    "TopLevel<HConcatSpec>": {
+    "TopLevelHConcatSpec": {
       "additionalProperties": false,
       "properties": {
         "$schema": {
@@ -5139,7 +5139,7 @@
       ],
       "type": "object"
     },
-    "TopLevel<LayerSpec>": {
+    "TopLevelLayerSpec": {
       "additionalProperties": false,
       "properties": {
         "$schema": {
@@ -5210,7 +5210,7 @@
       ],
       "type": "object"
     },
-    "TopLevel<RepeatSpec>": {
+    "TopLevelRepeatSpec": {
       "additionalProperties": false,
       "properties": {
         "$schema": {
@@ -5276,7 +5276,7 @@
       ],
       "type": "object"
     },
-    "TopLevel<VConcatSpec>": {
+    "TopLevelVConcatSpec": {
       "additionalProperties": false,
       "properties": {
         "$schema": {
@@ -5344,22 +5344,22 @@
     "TopLevelExtendedSpec": {
       "anyOf": [
         {
-          "$ref": "#/definitions/TopLevel<FacetedUnitSpec>"
+          "$ref": "#/definitions/TopLevelFacetedUnitSpec"
         },
         {
-          "$ref": "#/definitions/TopLevel<LayerSpec>"
+          "$ref": "#/definitions/TopLevelLayerSpec"
         },
         {
-          "$ref": "#/definitions/TopLevel<FacetedSpec>"
+          "$ref": "#/definitions/TopLevelFacetedSpec"
         },
         {
-          "$ref": "#/definitions/TopLevel<RepeatSpec>"
+          "$ref": "#/definitions/TopLevelRepeatSpec"
         },
         {
-          "$ref": "#/definitions/TopLevel<VConcatSpec>"
+          "$ref": "#/definitions/TopLevelVConcatSpec"
         },
         {
-          "$ref": "#/definitions/TopLevel<HConcatSpec>"
+          "$ref": "#/definitions/TopLevelHConcatSpec"
         }
       ]
     },

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1032,7 +1032,7 @@
       "$ref": "#/definitions/CompositeUnitSpecAlias",
       "description": "Unit spec that can have a composite mark."
     },
-    "Condition<(LegendFieldDef<Field,number>|ValueDef<number>)>": {
+    "Condition<(LegendFieldDef|NumberValueDef)>": {
       "properties": {
         "selection": {
           "$ref": "#/definitions/LogicalOperand"
@@ -1043,7 +1043,7 @@
       ],
       "type": "object"
     },
-    "Condition<(LegendFieldDef<Field,string>|ValueDef<string>)>": {
+    "Condition<(LegendFieldDef|StringValueDef)>": {
       "properties": {
         "selection": {
           "$ref": "#/definitions/LogicalOperand"
@@ -1054,7 +1054,7 @@
       ],
       "type": "object"
     },
-    "Condition<(TextFieldDef|ValueDef<(string|number|boolean)>)>": {
+    "Condition<(TextFieldDef|TextValueDef)>": {
       "properties": {
         "selection": {
           "$ref": "#/definitions/LogicalOperand"
@@ -1065,7 +1065,7 @@
       ],
       "type": "object"
     },
-    "Condition<ValueDef<(string|number|boolean)>>": {
+    "Condition<TextValueDef>": {
       "additionalProperties": false,
       "properties": {
         "selection": {
@@ -1086,7 +1086,7 @@
       ],
       "type": "object"
     },
-    "Condition<ValueDef<number>>": {
+    "Condition<NumberValueDef>": {
       "additionalProperties": false,
       "properties": {
         "selection": {
@@ -1103,7 +1103,7 @@
       ],
       "type": "object"
     },
-    "Condition<ValueDef<string>>": {
+    "Condition<StringValueDef>": {
       "additionalProperties": false,
       "properties": {
         "selection": {
@@ -1120,11 +1120,11 @@
       ],
       "type": "object"
     },
-    "ConditionOnlyDef<LegendFieldDef<Field,number>,ValueDef<number>>": {
+    "ConditionOnlyLegendDef<NumberValueDef>": {
       "additionalProperties": false,
       "properties": {
         "condition": {
-          "$ref": "#/definitions/Condition<(LegendFieldDef<Field,number>|ValueDef<number>)>"
+          "$ref": "#/definitions/Condition<(LegendFieldDef|NumberValueDef)>"
         }
       },
       "required": [
@@ -1132,11 +1132,11 @@
       ],
       "type": "object"
     },
-    "ConditionOnlyDef<LegendFieldDef<Field,string>,ValueDef<string>>": {
+    "ConditionOnlyLegendDef<StringValueDef>": {
       "additionalProperties": false,
       "properties": {
         "condition": {
-          "$ref": "#/definitions/Condition<(LegendFieldDef<Field,string>|ValueDef<string>)>"
+          "$ref": "#/definitions/Condition<(LegendFieldDef|StringValueDef)>"
         }
       },
       "required": [
@@ -1144,11 +1144,11 @@
       ],
       "type": "object"
     },
-    "ConditionOnlyDef<TextFieldDef,ValueDef<(string|number|boolean)>>": {
+    "ConditionOnlyTextDef": {
       "additionalProperties": false,
       "properties": {
         "condition": {
-          "$ref": "#/definitions/Condition<(TextFieldDef|ValueDef<(string|number|boolean)>)>"
+          "$ref": "#/definitions/Condition<(TextFieldDef|TextValueDef)>"
         }
       },
       "required": [
@@ -1156,49 +1156,49 @@
       ],
       "type": "object"
     },
-    "Conditional<LegendFieldDef<Field,number>,ValueDef<number>>": {
+    "ConditionLegendDefAlias<NumberValueDef>": {
       "anyOf": [
         {
-          "$ref": "#/definitions/ConditionalFieldDef<LegendFieldDef<Field,number>,ValueDef<number>>"
+          "$ref": "#/definitions/ConditionLegendFieldDef<NumberValueDef>"
         },
         {
-          "$ref": "#/definitions/ConditionalValueDef<LegendFieldDef<Field,number>,ValueDef<number>>"
+          "$ref": "#/definitions/ConditionLegendValueDef<NumberValueDef>"
         },
         {
-          "$ref": "#/definitions/ConditionOnlyDef<LegendFieldDef<Field,number>,ValueDef<number>>"
+          "$ref": "#/definitions/ConditionOnlyLegendDef<NumberValueDef>"
         }
       ],
       "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."
     },
-    "Conditional<LegendFieldDef<Field,string>,ValueDef<string>>": {
+    "ConditionLegendDefAlias<StringValueDef>": {
       "anyOf": [
         {
-          "$ref": "#/definitions/ConditionalFieldDef<LegendFieldDef<Field,string>,ValueDef<string>>"
+          "$ref": "#/definitions/ConditionLegendFieldDef<StringValueDef>"
         },
         {
-          "$ref": "#/definitions/ConditionalValueDef<LegendFieldDef<Field,string>,ValueDef<string>>"
+          "$ref": "#/definitions/ConditionLegendValueDef<StringValueDef>"
         },
         {
-          "$ref": "#/definitions/ConditionOnlyDef<LegendFieldDef<Field,string>,ValueDef<string>>"
+          "$ref": "#/definitions/ConditionOnlyLegendDef<StringValueDef>"
         }
       ],
       "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."
     },
-    "Conditional<TextFieldDef,ValueDef<(string|number|boolean)>>": {
+    "ConditionTextDefAlias": {
       "anyOf": [
         {
-          "$ref": "#/definitions/ConditionalFieldDef<TextFieldDef,ValueDef<(string|number|boolean)>>"
+          "$ref": "#/definitions/ConditionTextFieldDef"
         },
         {
-          "$ref": "#/definitions/ConditionalValueDef<TextFieldDef,ValueDef<(string|number|boolean)>>"
+          "$ref": "#/definitions/ConditionTextValueDef"
         },
         {
-          "$ref": "#/definitions/ConditionOnlyDef<TextFieldDef,ValueDef<(string|number|boolean)>>"
+          "$ref": "#/definitions/ConditionOnlyTextDef"
         }
       ],
       "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."
     },
-    "ConditionalFieldDef<LegendFieldDef<Field,number>,ValueDef<number>>": {
+    "ConditionLegendFieldDef<NumberValueDef>": {
       "additionalProperties": false,
       "description": "A FieldDef with Condition<ValueDef>\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
       "properties": {
@@ -1225,7 +1225,7 @@
           "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
         },
         "condition": {
-          "$ref": "#/definitions/Condition<ValueDef<number>>"
+          "$ref": "#/definitions/Condition<NumberValueDef>"
         },
         "field": {
           "$ref": "#/definitions/Field",
@@ -1269,7 +1269,7 @@
       ],
       "type": "object"
     },
-    "ConditionalFieldDef<LegendFieldDef<Field,string>,ValueDef<string>>": {
+    "ConditionLegendFieldDef<StringValueDef>": {
       "additionalProperties": false,
       "description": "A FieldDef with Condition<ValueDef>\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
       "properties": {
@@ -1296,7 +1296,7 @@
           "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
         },
         "condition": {
-          "$ref": "#/definitions/Condition<ValueDef<string>>"
+          "$ref": "#/definitions/Condition<StringValueDef>"
         },
         "field": {
           "$ref": "#/definitions/Field",
@@ -1340,7 +1340,7 @@
       ],
       "type": "object"
     },
-    "ConditionalFieldDef<TextFieldDef,ValueDef<(string|number|boolean)>>": {
+    "ConditionTextFieldDef": {
       "additionalProperties": false,
       "description": "A FieldDef with Condition<ValueDef>\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
       "properties": {
@@ -1367,7 +1367,7 @@
           "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
         },
         "condition": {
-          "$ref": "#/definitions/Condition<ValueDef<(string|number|boolean)>>"
+          "$ref": "#/definitions/Condition<TextValueDef>"
         },
         "field": {
           "$ref": "#/definitions/Field",
@@ -1391,21 +1391,21 @@
       ],
       "type": "object"
     },
-    "ConditionalLegendDef<Field,number>": {
-      "$ref": "#/definitions/Conditional<LegendFieldDef<Field,number>,ValueDef<number>>"
+    "ConditionalLegendDef<number>": {
+      "$ref": "#/definitions/ConditionLegendDefAlias<NumberValueDef>"
     },
-    "ConditionalLegendDef<Field,string>": {
-      "$ref": "#/definitions/Conditional<LegendFieldDef<Field,string>,ValueDef<string>>"
+    "ConditionalLegendDef<string>": {
+      "$ref": "#/definitions/ConditionLegendDefAlias<StringValueDef>"
     },
     "ConditionalTextDef": {
-      "$ref": "#/definitions/Conditional<TextFieldDef,ValueDef<(string|number|boolean)>>"
+      "$ref": "#/definitions/ConditionTextDefAlias"
     },
-    "ConditionalValueDef<LegendFieldDef<Field,number>,ValueDef<number>>": {
+    "ConditionLegendValueDef<NumberValueDef>": {
       "additionalProperties": false,
       "description": "A ValueDef with Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
       "properties": {
         "condition": {
-          "$ref": "#/definitions/Condition<(LegendFieldDef<Field,number>|ValueDef<number>)>"
+          "$ref": "#/definitions/Condition<(LegendFieldDef|NumberValueDef)>"
         },
         "value": {
           "description": "A constant value in visual domain.",
@@ -1417,12 +1417,12 @@
       ],
       "type": "object"
     },
-    "ConditionalValueDef<LegendFieldDef<Field,string>,ValueDef<string>>": {
+    "ConditionLegendValueDef<StringValueDef>": {
       "additionalProperties": false,
       "description": "A ValueDef with Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
       "properties": {
         "condition": {
-          "$ref": "#/definitions/Condition<(LegendFieldDef<Field,string>|ValueDef<string>)>"
+          "$ref": "#/definitions/Condition<(LegendFieldDef|StringValueDef)>"
         },
         "value": {
           "description": "A constant value in visual domain.",
@@ -1434,12 +1434,12 @@
       ],
       "type": "object"
     },
-    "ConditionalValueDef<TextFieldDef,ValueDef<(string|number|boolean)>>": {
+    "ConditionTextValueDef": {
       "additionalProperties": false,
       "description": "A ValueDef with Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
       "properties": {
         "condition": {
-          "$ref": "#/definitions/Condition<(TextFieldDef|ValueDef<(string|number|boolean)>)>"
+          "$ref": "#/definitions/Condition<(TextFieldDef|TextValueDef)>"
         },
         "value": {
           "description": "A constant value in visual domain.",
@@ -1792,7 +1792,7 @@
       "additionalProperties": false,
       "properties": {
         "color": {
-          "$ref": "#/definitions/ConditionalLegendDef<Field,string>",
+          "$ref": "#/definitions/ConditionalLegendDef<string>",
           "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
         },
         "detail": {
@@ -1810,7 +1810,7 @@
           "description": "Additional levels of detail for grouping data in aggregate views and\nin line and area marks without mapping data to a specific visual channel."
         },
         "opacity": {
-          "$ref": "#/definitions/ConditionalLegendDef<Field,number>",
+          "$ref": "#/definitions/ConditionalLegendDef<number>",
           "description": "Opacity of the marks – either can be a value or a range."
         },
         "order": {
@@ -1828,11 +1828,11 @@
           "description": "stack order for stacked marks or order of data points in line marks."
         },
         "shape": {
-          "$ref": "#/definitions/ConditionalLegendDef<Field,string>",
+          "$ref": "#/definitions/ConditionalLegendDef<string>",
           "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
         },
         "size": {
-          "$ref": "#/definitions/ConditionalLegendDef<Field,number>",
+          "$ref": "#/definitions/ConditionalLegendDef<number>",
           "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
         },
         "text": {
@@ -1853,7 +1853,7 @@
               "$ref": "#/definitions/FieldDef"
             },
             {
-              "$ref": "#/definitions/ValueDef<number>"
+              "$ref": "#/definitions/NumberValueDef"
             }
           ],
           "description": "X2 coordinates for ranged `bar`, `rule`, `area`."
@@ -1868,7 +1868,7 @@
               "$ref": "#/definitions/FieldDef"
             },
             {
-              "$ref": "#/definitions/ValueDef<number>"
+              "$ref": "#/definitions/NumberValueDef"
             }
           ],
           "description": "Y2 coordinates for ranged `bar`, `rule`, `area`."
@@ -1880,7 +1880,7 @@
       "additionalProperties": false,
       "properties": {
         "color": {
-          "$ref": "#/definitions/ConditionalLegendDef<Field,string>",
+          "$ref": "#/definitions/ConditionalLegendDef<string>",
           "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
         },
         "column": {
@@ -1902,7 +1902,7 @@
           "description": "Additional levels of detail for grouping data in aggregate views and\nin line and area marks without mapping data to a specific visual channel."
         },
         "opacity": {
-          "$ref": "#/definitions/ConditionalLegendDef<Field,number>",
+          "$ref": "#/definitions/ConditionalLegendDef<number>",
           "description": "Opacity of the marks – either can be a value or a range."
         },
         "order": {
@@ -1924,11 +1924,11 @@
           "description": "Vertical facets for trellis plots."
         },
         "shape": {
-          "$ref": "#/definitions/ConditionalLegendDef<Field,string>",
+          "$ref": "#/definitions/ConditionalLegendDef<string>",
           "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
         },
         "size": {
-          "$ref": "#/definitions/ConditionalLegendDef<Field,number>",
+          "$ref": "#/definitions/ConditionalLegendDef<number>",
           "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
         },
         "text": {
@@ -1949,7 +1949,7 @@
               "$ref": "#/definitions/FieldDef"
             },
             {
-              "$ref": "#/definitions/ValueDef<number>"
+              "$ref": "#/definitions/NumberValueDef"
             }
           ],
           "description": "X2 coordinates for ranged `bar`, `rule`, `area`."
@@ -1964,7 +1964,7 @@
               "$ref": "#/definitions/FieldDef"
             },
             {
-              "$ref": "#/definitions/ValueDef<number>"
+              "$ref": "#/definitions/NumberValueDef"
             }
           ],
           "description": "Y2 coordinates for ranged `bar`, `rule`, `area`."
@@ -2921,74 +2921,7 @@
       },
       "type": "object"
     },
-    "LegendFieldDef<Field,number>": {
-      "additionalProperties": false,
-      "properties": {
-        "aggregate": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/AggregateOp"
-            },
-            {
-              "$ref": "#/definitions/CompositeAggregate"
-            }
-          ],
-          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
-        },
-        "bin": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/definitions/Bin"
-            }
-          ],
-          "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
-        },
-        "field": {
-          "$ref": "#/definitions/Field",
-          "description": "__Required.__ Name of the field from which to pull a data value.\n\n__Note:__ `field` is not required if `aggregate` is `count`."
-        },
-        "legend": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Legend"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "scale": {
-          "$ref": "#/definitions/Scale"
-        },
-        "sort": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SortField"
-            },
-            {
-              "$ref": "#/definitions/SortOrder"
-            }
-          ],
-          "description": "Sort order for a particular field.\nFor quantitative or temporal fields, this can be either `\"ascending\"` or `\"descending\"`\nFor quantitative or temporal fields, this can be `\"ascending\"`, `\"descending\"`, `\"none\"`, or a [sort field definition object](sort.html#sort-field) for sorting by an aggregate calculation of a specified sort field.\n\n__Default value:__ `\"ascending\"`"
-        },
-        "timeUnit": {
-          "$ref": "#/definitions/TimeUnit",
-          "description": "Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).\n\n__Default value:__ `undefined` (None)"
-        },
-        "type": {
-          "$ref": "#/definitions/Type",
-          "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case-insensitive."
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "type": "object"
-    },
-    "LegendFieldDef<Field,string>": {
+    "LegendFieldDef": {
       "additionalProperties": false,
       "properties": {
         "aggregate": {
@@ -3656,7 +3589,7 @@
           "$ref": "#/definitions/PositionFieldDef"
         },
         {
-          "$ref": "#/definitions/ValueDef<number>"
+          "$ref": "#/definitions/NumberValueDef"
         }
       ]
     },
@@ -5419,7 +5352,7 @@
       },
       "type": "object"
     },
-    "ValueDef<(string|number|boolean)>": {
+    "TextValueDef": {
       "additionalProperties": false,
       "description": "Definition object for a constant value of an encoding channel.",
       "properties": {
@@ -5437,7 +5370,7 @@
       ],
       "type": "object"
     },
-    "ValueDef<number>": {
+    "NumberValueDef": {
       "additionalProperties": false,
       "description": "Definition object for a constant value of an encoding channel.",
       "properties": {
@@ -5451,7 +5384,7 @@
       ],
       "type": "object"
     },
-    "ValueDef<string>": {
+    "StringValueDef": {
       "additionalProperties": false,
       "description": "Definition object for a constant value of an encoding channel.",
       "properties": {

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1266,13 +1266,13 @@
       ],
       "type": "object"
     },
-    "ConditionNumberLegendDef": {
+    "ConditionalNumberLegendDef": {
       "anyOf": [
         {
-          "$ref": "#/definitions/ConditionNumberLegendFieldDef"
+          "$ref": "#/definitions/ConditionalNumberLegendFieldDef"
         },
         {
-          "$ref": "#/definitions/ConditionNumberLegendValueDef"
+          "$ref": "#/definitions/ConditionalNumberLegendValueDef"
         },
         {
           "$ref": "#/definitions/ConditionOnlyNumberLegendDef"
@@ -1280,13 +1280,13 @@
       ],
       "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."
     },
-    "ConditionStringLegendDef": {
+    "ConditionalStringLegendDef": {
       "anyOf": [
         {
-          "$ref": "#/definitions/ConditionStringLegendFieldDef"
+          "$ref": "#/definitions/ConditionalStringLegendFieldDef"
         },
         {
-          "$ref": "#/definitions/ConditionStringLegendValueDef"
+          "$ref": "#/definitions/ConditionalStringLegendValueDef"
         },
         {
           "$ref": "#/definitions/ConditionOnlyStringLegendDef"
@@ -1294,13 +1294,13 @@
       ],
       "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."
     },
-    "ConditionTextDef": {
+    "ConditionalTextDef": {
       "anyOf": [
         {
-          "$ref": "#/definitions/ConditionTextFieldDef"
+          "$ref": "#/definitions/ConditionalTextFieldDef"
         },
         {
-          "$ref": "#/definitions/ConditionTextValueDef"
+          "$ref": "#/definitions/ConditionalTextValueDef"
         },
         {
           "$ref": "#/definitions/ConditionOnlyTextDef"
@@ -1308,7 +1308,7 @@
       ],
       "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."
     },
-    "ConditionNumberLegendFieldDef": {
+    "ConditionalNumberLegendFieldDef": {
       "additionalProperties": false,
       "description": "A FieldDef with ConditionValueDef\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
       "properties": {
@@ -1379,7 +1379,7 @@
       ],
       "type": "object"
     },
-    "ConditionStringLegendFieldDef": {
+    "ConditionalStringLegendFieldDef": {
       "additionalProperties": false,
       "description": "A FieldDef with ConditionValueDef\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
       "properties": {
@@ -1450,7 +1450,7 @@
       ],
       "type": "object"
     },
-    "ConditionTextFieldDef": {
+    "ConditionalTextFieldDef": {
       "additionalProperties": false,
       "description": "A FieldDef with ConditionValueDef\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
       "properties": {
@@ -1501,7 +1501,7 @@
       ],
       "type": "object"
     },
-    "ConditionNumberLegendValueDef": {
+    "ConditionalNumberLegendValueDef": {
       "additionalProperties": false,
       "description": "A ValueDef with ConditionValueDef | FieldDef\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
       "properties": {
@@ -1525,7 +1525,7 @@
       ],
       "type": "object"
     },
-    "ConditionStringLegendValueDef": {
+    "ConditionalStringLegendValueDef": {
       "additionalProperties": false,
       "description": "A ValueDef with ConditionValueDef | FieldDef\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
       "properties": {
@@ -1549,7 +1549,7 @@
       ],
       "type": "object"
     },
-    "ConditionTextValueDef": {
+    "ConditionalTextValueDef": {
       "additionalProperties": false,
       "description": "A ValueDef with ConditionValueDef | FieldDef\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
       "properties": {
@@ -1914,7 +1914,7 @@
       "additionalProperties": false,
       "properties": {
         "color": {
-          "$ref": "#/definitions/ConditionStringLegendDef",
+          "$ref": "#/definitions/ConditionalStringLegendDef",
           "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
         },
         "detail": {
@@ -1932,7 +1932,7 @@
           "description": "Additional levels of detail for grouping data in aggregate views and\nin line and area marks without mapping data to a specific visual channel."
         },
         "opacity": {
-          "$ref": "#/definitions/ConditionNumberLegendDef",
+          "$ref": "#/definitions/ConditionalNumberLegendDef",
           "description": "Opacity of the marks – either can be a value or a range."
         },
         "order": {
@@ -1950,19 +1950,19 @@
           "description": "stack order for stacked marks or order of data points in line marks."
         },
         "shape": {
-          "$ref": "#/definitions/ConditionStringLegendDef",
+          "$ref": "#/definitions/ConditionalStringLegendDef",
           "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
         },
         "size": {
-          "$ref": "#/definitions/ConditionNumberLegendDef",
+          "$ref": "#/definitions/ConditionalNumberLegendDef",
           "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
         },
         "text": {
-          "$ref": "#/definitions/ConditionTextDef",
+          "$ref": "#/definitions/ConditionalTextDef",
           "description": "Text of the `text` mark."
         },
         "tooltip": {
-          "$ref": "#/definitions/ConditionTextDef",
+          "$ref": "#/definitions/ConditionalTextDef",
           "description": "The tooltip text to show upon mouse hover."
         },
         "x": {
@@ -2016,7 +2016,7 @@
       "additionalProperties": false,
       "properties": {
         "color": {
-          "$ref": "#/definitions/ConditionStringLegendDef",
+          "$ref": "#/definitions/ConditionalStringLegendDef",
           "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
         },
         "column": {
@@ -2038,7 +2038,7 @@
           "description": "Additional levels of detail for grouping data in aggregate views and\nin line and area marks without mapping data to a specific visual channel."
         },
         "opacity": {
-          "$ref": "#/definitions/ConditionNumberLegendDef",
+          "$ref": "#/definitions/ConditionalNumberLegendDef",
           "description": "Opacity of the marks – either can be a value or a range."
         },
         "order": {
@@ -2060,19 +2060,19 @@
           "description": "Vertical facets for trellis plots."
         },
         "shape": {
-          "$ref": "#/definitions/ConditionStringLegendDef",
+          "$ref": "#/definitions/ConditionalStringLegendDef",
           "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
         },
         "size": {
-          "$ref": "#/definitions/ConditionNumberLegendDef",
+          "$ref": "#/definitions/ConditionalNumberLegendDef",
           "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
         },
         "text": {
-          "$ref": "#/definitions/ConditionTextDef",
+          "$ref": "#/definitions/ConditionalTextDef",
           "description": "Text of the `text` mark."
         },
         "tooltip": {
-          "$ref": "#/definitions/ConditionTextDef",
+          "$ref": "#/definitions/ConditionalTextDef",
           "description": "The tooltip text to show upon mouse hover."
         },
         "x": {

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1032,40 +1032,129 @@
       "$ref": "#/definitions/CompositeUnitSpecAlias",
       "description": "Unit spec that can have a composite mark."
     },
-    "Condition<(LegendFieldDef|NumberValueDef)>": {
+    "ConditionLegendFieldDef": {
+      "additionalProperties": false,
       "properties": {
+        "aggregate": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AggregateOp"
+            },
+            {
+              "$ref": "#/definitions/CompositeAggregate"
+            }
+          ],
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/Bin"
+            }
+          ],
+          "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
+        },
+        "field": {
+          "$ref": "#/definitions/Field",
+          "description": "__Required.__ Name of the field from which to pull a data value.\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "legend": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Legend"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "scale": {
+          "$ref": "#/definitions/Scale"
+        },
         "selection": {
           "$ref": "#/definitions/LogicalOperand"
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SortField"
+            },
+            {
+              "$ref": "#/definitions/SortOrder"
+            }
+          ],
+          "description": "Sort order for a particular field.\nFor quantitative or temporal fields, this can be either `\"ascending\"` or `\"descending\"`\nFor quantitative or temporal fields, this can be `\"ascending\"`, `\"descending\"`, `\"none\"`, or a [sort field definition object](sort.html#sort-field) for sorting by an aggregate calculation of a specified sort field.\n\n__Default value:__ `\"ascending\"`"
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case-insensitive."
         }
       },
       "required": [
-        "selection"
+        "selection",
+        "type"
       ],
       "type": "object"
     },
-    "Condition<(LegendFieldDef|StringValueDef)>": {
+    "ConditionTextFieldDef": {
+      "additionalProperties": false,
       "properties": {
+        "aggregate": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AggregateOp"
+            },
+            {
+              "$ref": "#/definitions/CompositeAggregate"
+            }
+          ],
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/Bin"
+            }
+          ],
+          "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
+        },
+        "field": {
+          "$ref": "#/definitions/Field",
+          "description": "__Required.__ Name of the field from which to pull a data value.\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "format": {
+          "description": "The formatting pattern for text value. If not defined, this will be determined automatically.",
+          "type": "string"
+        },
         "selection": {
           "$ref": "#/definitions/LogicalOperand"
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case-insensitive."
         }
       },
       "required": [
-        "selection"
+        "selection",
+        "type"
       ],
       "type": "object"
     },
-    "Condition<(TextFieldDef|TextValueDef)>": {
-      "properties": {
-        "selection": {
-          "$ref": "#/definitions/LogicalOperand"
-        }
-      },
-      "required": [
-        "selection"
-      ],
-      "type": "object"
-    },
-    "Condition<TextValueDef>": {
+    "ConditionTextValueDef": {
       "additionalProperties": false,
       "properties": {
         "selection": {
@@ -1086,7 +1175,7 @@
       ],
       "type": "object"
     },
-    "Condition<NumberValueDef>": {
+    "ConditionNumberValueDef": {
       "additionalProperties": false,
       "properties": {
         "selection": {
@@ -1103,7 +1192,7 @@
       ],
       "type": "object"
     },
-    "Condition<StringValueDef>": {
+    "ConditionStringValueDef": {
       "additionalProperties": false,
       "properties": {
         "selection": {
@@ -1124,7 +1213,14 @@
       "additionalProperties": false,
       "properties": {
         "condition": {
-          "$ref": "#/definitions/Condition<(LegendFieldDef|NumberValueDef)>"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionLegendFieldDef"
+            },
+            {
+              "$ref": "#/definitions/ConditionNumberValueDef"
+            }
+          ]
         }
       },
       "required": [
@@ -1136,7 +1232,14 @@
       "additionalProperties": false,
       "properties": {
         "condition": {
-          "$ref": "#/definitions/Condition<(LegendFieldDef|StringValueDef)>"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionLegendFieldDef"
+            },
+            {
+              "$ref": "#/definitions/ConditionStringValueDef"
+            }
+          ]
         }
       },
       "required": [
@@ -1148,7 +1251,14 @@
       "additionalProperties": false,
       "properties": {
         "condition": {
-          "$ref": "#/definitions/Condition<(TextFieldDef|TextValueDef)>"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionTextFieldDef"
+            },
+            {
+              "$ref": "#/definitions/ConditionTextValueDef"
+            }
+          ]
         }
       },
       "required": [
@@ -1200,7 +1310,7 @@
     },
     "ConditionLegendFieldDef<NumberValueDef>": {
       "additionalProperties": false,
-      "description": "A FieldDef with Condition<ValueDef>\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
+      "description": "A FieldDef with ConditionValueDef\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
       "properties": {
         "aggregate": {
           "anyOf": [
@@ -1225,7 +1335,7 @@
           "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
         },
         "condition": {
-          "$ref": "#/definitions/Condition<NumberValueDef>"
+          "$ref": "#/definitions/ConditionNumberValueDef"
         },
         "field": {
           "$ref": "#/definitions/Field",
@@ -1271,7 +1381,7 @@
     },
     "ConditionLegendFieldDef<StringValueDef>": {
       "additionalProperties": false,
-      "description": "A FieldDef with Condition<ValueDef>\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
+      "description": "A FieldDef with ConditionValueDef\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
       "properties": {
         "aggregate": {
           "anyOf": [
@@ -1296,7 +1406,7 @@
           "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
         },
         "condition": {
-          "$ref": "#/definitions/Condition<StringValueDef>"
+          "$ref": "#/definitions/ConditionStringValueDef"
         },
         "field": {
           "$ref": "#/definitions/Field",
@@ -1342,7 +1452,7 @@
     },
     "ConditionTextFieldDef": {
       "additionalProperties": false,
-      "description": "A FieldDef with Condition<ValueDef>\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
+      "description": "A FieldDef with ConditionValueDef\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
       "properties": {
         "aggregate": {
           "anyOf": [
@@ -1367,7 +1477,7 @@
           "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
         },
         "condition": {
-          "$ref": "#/definitions/Condition<TextValueDef>"
+          "$ref": "#/definitions/ConditionTextValueDef"
         },
         "field": {
           "$ref": "#/definitions/Field",
@@ -1393,10 +1503,17 @@
     },
     "ConditionLegendValueDef<NumberValueDef>": {
       "additionalProperties": false,
-      "description": "A ValueDef with Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
+      "description": "A ValueDef with ConditionValueDef | FieldDef\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
       "properties": {
         "condition": {
-          "$ref": "#/definitions/Condition<(LegendFieldDef|NumberValueDef)>"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionLegendFieldDef"
+            },
+            {
+              "$ref": "#/definitions/ConditionNumberValueDef"
+            }
+          ]
         },
         "value": {
           "description": "A constant value in visual domain.",
@@ -1410,10 +1527,17 @@
     },
     "ConditionLegendValueDef<StringValueDef>": {
       "additionalProperties": false,
-      "description": "A ValueDef with Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
+      "description": "A ValueDef with ConditionValueDef | FieldDef\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
       "properties": {
         "condition": {
-          "$ref": "#/definitions/Condition<(LegendFieldDef|StringValueDef)>"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionLegendFieldDef"
+            },
+            {
+              "$ref": "#/definitions/ConditionStringValueDef"
+            }
+          ]
         },
         "value": {
           "description": "A constant value in visual domain.",
@@ -1427,10 +1551,17 @@
     },
     "ConditionTextValueDef": {
       "additionalProperties": false,
-      "description": "A ValueDef with Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
+      "description": "A ValueDef with ConditionValueDef | FieldDef\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
       "properties": {
         "condition": {
-          "$ref": "#/definitions/Condition<(TextFieldDef|TextValueDef)>"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionTextFieldDef"
+            },
+            {
+              "$ref": "#/definitions/ConditionTextValueDef"
+            }
+          ]
         },
         "value": {
           "description": "A constant value in visual domain.",

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1032,82 +1032,44 @@
       "$ref": "#/definitions/CompositeUnitSpecAlias",
       "description": "Unit spec that can have a composite mark."
     },
-    "Condition<(string|number)>": {
+    "Condition<(LegendFieldDef<Field,number>|ValueDef<number>)>": {
+      "properties": {
+        "selection": {
+          "$ref": "#/definitions/LogicalOperand"
+        }
+      },
+      "required": [
+        "selection"
+      ],
+      "type": "object"
+    },
+    "Condition<(LegendFieldDef<Field,string>|ValueDef<string>)>": {
+      "properties": {
+        "selection": {
+          "$ref": "#/definitions/LogicalOperand"
+        }
+      },
+      "required": [
+        "selection"
+      ],
+      "type": "object"
+    },
+    "Condition<(TextFieldDef|ValueDef<(string|number|boolean)>)>": {
+      "properties": {
+        "selection": {
+          "$ref": "#/definitions/LogicalOperand"
+        }
+      },
+      "required": [
+        "selection"
+      ],
+      "type": "object"
+    },
+    "Condition<ValueDef<(string|number|boolean)>>": {
       "additionalProperties": false,
       "properties": {
         "selection": {
           "$ref": "#/definitions/LogicalOperand"
-        },
-        "value": {
-          "type": [
-            "string",
-            "number"
-          ]
-        }
-      },
-      "required": [
-        "selection",
-        "value"
-      ],
-      "type": "object"
-    },
-    "Condition<(string|number|boolean)>": {
-      "additionalProperties": false,
-      "properties": {
-        "selection": {
-          "$ref": "#/definitions/LogicalOperand"
-        },
-        "value": {
-          "type": [
-            "string",
-            "number",
-            "boolean"
-          ]
-        }
-      },
-      "required": [
-        "selection",
-        "value"
-      ],
-      "type": "object"
-    },
-    "Condition<number>": {
-      "additionalProperties": false,
-      "properties": {
-        "selection": {
-          "$ref": "#/definitions/LogicalOperand"
-        },
-        "value": {
-          "type": "number"
-        }
-      },
-      "required": [
-        "selection",
-        "value"
-      ],
-      "type": "object"
-    },
-    "Condition<string>": {
-      "additionalProperties": false,
-      "properties": {
-        "selection": {
-          "$ref": "#/definitions/LogicalOperand"
-        },
-        "value": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "selection",
-        "value"
-      ],
-      "type": "object"
-    },
-    "ConditionalValueDef<(string|number|boolean)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "$ref": "#/definitions/Condition<(string|number|boolean)>"
         },
         "value": {
           "description": "A constant value in visual domain.",
@@ -1119,15 +1081,277 @@
         }
       },
       "required": [
+        "selection",
         "value"
       ],
       "type": "object"
     },
-    "ConditionalValueDef<number>": {
+    "Condition<ValueDef<number>>": {
       "additionalProperties": false,
       "properties": {
+        "selection": {
+          "$ref": "#/definitions/LogicalOperand"
+        },
+        "value": {
+          "description": "A constant value in visual domain.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "selection",
+        "value"
+      ],
+      "type": "object"
+    },
+    "Condition<ValueDef<string>>": {
+      "additionalProperties": false,
+      "properties": {
+        "selection": {
+          "$ref": "#/definitions/LogicalOperand"
+        },
+        "value": {
+          "description": "A constant value in visual domain.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "selection",
+        "value"
+      ],
+      "type": "object"
+    },
+    "Conditional<LegendFieldDef<Field,number>,ValueDef<number>>": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ConditionalFieldDef<LegendFieldDef<Field,number>,ValueDef<number>>"
+        },
+        {
+          "$ref": "#/definitions/ConditionalValueDef<LegendFieldDef<Field,number>,ValueDef<number>>"
+        }
+      ],
+      "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."
+    },
+    "Conditional<LegendFieldDef<Field,string>,ValueDef<string>>": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ConditionalFieldDef<LegendFieldDef<Field,string>,ValueDef<string>>"
+        },
+        {
+          "$ref": "#/definitions/ConditionalValueDef<LegendFieldDef<Field,string>,ValueDef<string>>"
+        }
+      ],
+      "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."
+    },
+    "Conditional<TextFieldDef,ValueDef<(string|number|boolean)>>": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ConditionalFieldDef<TextFieldDef,ValueDef<(string|number|boolean)>>"
+        },
+        {
+          "$ref": "#/definitions/ConditionalValueDef<TextFieldDef,ValueDef<(string|number|boolean)>>"
+        }
+      ],
+      "description": "Generic type for conditional channelDef.\nF defines the underlying FieldDef type while V defines the underlying ValueDef type."
+    },
+    "ConditionalFieldDef<LegendFieldDef<Field,number>,ValueDef<number>>": {
+      "additionalProperties": false,
+      "description": "A FieldDef with Condition<ValueDef>\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
+      "properties": {
+        "aggregate": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AggregateOp"
+            },
+            {
+              "$ref": "#/definitions/CompositeAggregate"
+            }
+          ],
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/Bin"
+            }
+          ],
+          "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
+        },
         "condition": {
-          "$ref": "#/definitions/Condition<number>"
+          "$ref": "#/definitions/Condition<ValueDef<number>>"
+        },
+        "field": {
+          "$ref": "#/definitions/Field",
+          "description": "__Required.__ Name of the field from which to pull a data value.\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "legend": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Legend"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "scale": {
+          "$ref": "#/definitions/Scale"
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SortField"
+            },
+            {
+              "$ref": "#/definitions/SortOrder"
+            }
+          ],
+          "description": "Sort order for a particular field.\nFor quantitative or temporal fields, this can be either `\"ascending\"` or `\"descending\"`\nFor quantitative or temporal fields, this can be `\"ascending\"`, `\"descending\"`, `\"none\"`, or a [sort field definition object](sort.html#sort-field) for sorting by an aggregate calculation of a specified sort field.\n\n__Default value:__ `\"ascending\"`"
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case-insensitive."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "ConditionalFieldDef<LegendFieldDef<Field,string>,ValueDef<string>>": {
+      "additionalProperties": false,
+      "description": "A FieldDef with Condition<ValueDef>\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
+      "properties": {
+        "aggregate": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AggregateOp"
+            },
+            {
+              "$ref": "#/definitions/CompositeAggregate"
+            }
+          ],
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/Bin"
+            }
+          ],
+          "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
+        },
+        "condition": {
+          "$ref": "#/definitions/Condition<ValueDef<string>>"
+        },
+        "field": {
+          "$ref": "#/definitions/Field",
+          "description": "__Required.__ Name of the field from which to pull a data value.\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "legend": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Legend"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "scale": {
+          "$ref": "#/definitions/Scale"
+        },
+        "sort": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SortField"
+            },
+            {
+              "$ref": "#/definitions/SortOrder"
+            }
+          ],
+          "description": "Sort order for a particular field.\nFor quantitative or temporal fields, this can be either `\"ascending\"` or `\"descending\"`\nFor quantitative or temporal fields, this can be `\"ascending\"`, `\"descending\"`, `\"none\"`, or a [sort field definition object](sort.html#sort-field) for sorting by an aggregate calculation of a specified sort field.\n\n__Default value:__ `\"ascending\"`"
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case-insensitive."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "ConditionalFieldDef<TextFieldDef,ValueDef<(string|number|boolean)>>": {
+      "additionalProperties": false,
+      "description": "A FieldDef with Condition<ValueDef>\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
+      "properties": {
+        "aggregate": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AggregateOp"
+            },
+            {
+              "$ref": "#/definitions/CompositeAggregate"
+            }
+          ],
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/Bin"
+            }
+          ],
+          "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
+        },
+        "condition": {
+          "$ref": "#/definitions/Condition<ValueDef<(string|number|boolean)>>"
+        },
+        "field": {
+          "$ref": "#/definitions/Field",
+          "description": "__Required.__ Name of the field from which to pull a data value.\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "format": {
+          "description": "The formatting pattern for text value. If not defined, this will be determined automatically.",
+          "type": "string"
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "type": {
+          "$ref": "#/definitions/Type",
+          "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case-insensitive."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "ConditionalValueDef<LegendFieldDef<Field,number>,ValueDef<number>>": {
+      "additionalProperties": false,
+      "description": "A ValueDef with Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/Condition<(LegendFieldDef<Field,number>|ValueDef<number>)>"
         },
         "value": {
           "description": "A constant value in visual domain.",
@@ -1139,15 +1363,37 @@
       ],
       "type": "object"
     },
-    "ConditionalValueDef<string>": {
+    "ConditionalValueDef<LegendFieldDef<Field,string>,ValueDef<string>>": {
       "additionalProperties": false,
+      "description": "A ValueDef with Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
       "properties": {
         "condition": {
-          "$ref": "#/definitions/Condition<string>"
+          "$ref": "#/definitions/Condition<(LegendFieldDef<Field,string>|ValueDef<string>)>"
         },
         "value": {
           "description": "A constant value in visual domain.",
           "type": "string"
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalValueDef<TextFieldDef,ValueDef<(string|number|boolean)>>": {
+      "additionalProperties": false,
+      "description": "A ValueDef with Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/Condition<(TextFieldDef|ValueDef<(string|number|boolean)>)>"
+        },
+        "value": {
+          "description": "A constant value in visual domain.",
+          "type": [
+            "string",
+            "number",
+            "boolean"
+          ]
         }
       },
       "required": [
@@ -1492,14 +1738,7 @@
       "additionalProperties": false,
       "properties": {
         "color": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/LegendFieldDef<Field,string>"
-            },
-            {
-              "$ref": "#/definitions/ConditionalValueDef<string>"
-            }
-          ],
+          "$ref": "#/definitions/Conditional<LegendFieldDef<Field,string>,ValueDef<string>>",
           "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
         },
         "detail": {
@@ -1517,14 +1756,7 @@
           "description": "Additional levels of detail for grouping data in aggregate views and\nin line and area marks without mapping data to a specific visual channel."
         },
         "opacity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/LegendFieldDef<Field,number>"
-            },
-            {
-              "$ref": "#/definitions/ConditionalValueDef<number>"
-            }
-          ],
+          "$ref": "#/definitions/Conditional<LegendFieldDef<Field,number>,ValueDef<number>>",
           "description": "Opacity of the marks – either can be a value or a range."
         },
         "order": {
@@ -1542,47 +1774,19 @@
           "description": "stack order for stacked marks or order of data points in line marks."
         },
         "shape": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/LegendFieldDef<Field,string>"
-            },
-            {
-              "$ref": "#/definitions/ConditionalValueDef<string>"
-            }
-          ],
+          "$ref": "#/definitions/Conditional<LegendFieldDef<Field,string>,ValueDef<string>>",
           "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
         },
         "size": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/LegendFieldDef<Field,number>"
-            },
-            {
-              "$ref": "#/definitions/ConditionalValueDef<number>"
-            }
-          ],
+          "$ref": "#/definitions/Conditional<LegendFieldDef<Field,number>,ValueDef<number>>",
           "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
         },
         "text": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TextFieldDef"
-            },
-            {
-              "$ref": "#/definitions/ConditionalValueDef<(string|number|boolean)>"
-            }
-          ],
+          "$ref": "#/definitions/Conditional<TextFieldDef,ValueDef<(string|number|boolean)>>",
           "description": "Text of the `text` mark."
         },
         "tooltip": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TextFieldDef"
-            },
-            {
-              "$ref": "#/definitions/ConditionalValueDef<string>"
-            }
-          ],
+          "$ref": "#/definitions/Conditional<TextFieldDef,ValueDef<(string|number|boolean)>>",
           "description": "The tooltip text to show upon mouse hover."
         },
         "x": {
@@ -1636,14 +1840,7 @@
       "additionalProperties": false,
       "properties": {
         "color": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/LegendFieldDef<Field,string>"
-            },
-            {
-              "$ref": "#/definitions/ConditionalValueDef<string>"
-            }
-          ],
+          "$ref": "#/definitions/Conditional<LegendFieldDef<Field,string>,ValueDef<string>>",
           "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
         },
         "column": {
@@ -1665,14 +1862,7 @@
           "description": "Additional levels of detail for grouping data in aggregate views and\nin line and area marks without mapping data to a specific visual channel."
         },
         "opacity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/LegendFieldDef<Field,number>"
-            },
-            {
-              "$ref": "#/definitions/ConditionalValueDef<number>"
-            }
-          ],
+          "$ref": "#/definitions/Conditional<LegendFieldDef<Field,number>,ValueDef<number>>",
           "description": "Opacity of the marks – either can be a value or a range."
         },
         "order": {
@@ -1694,47 +1884,19 @@
           "description": "Vertical facets for trellis plots."
         },
         "shape": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/LegendFieldDef<Field,string>"
-            },
-            {
-              "$ref": "#/definitions/ConditionalValueDef<string>"
-            }
-          ],
+          "$ref": "#/definitions/Conditional<LegendFieldDef<Field,string>,ValueDef<string>>",
           "description": "The symbol's shape (only for `point` marks). The supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string."
         },
         "size": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/LegendFieldDef<Field,number>"
-            },
-            {
-              "$ref": "#/definitions/ConditionalValueDef<number>"
-            }
-          ],
+          "$ref": "#/definitions/Conditional<LegendFieldDef<Field,number>,ValueDef<number>>",
           "description": "Size of the mark.\n- For `point`, `square` and `circle`\n– the symbol size, or pixel area of the mark.\n- For `bar` and `tick` – the bar and tick's size.\n- For `text` – the text's font size.\n- Size is currently unsupported for `line` and `area`."
         },
         "text": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TextFieldDef"
-            },
-            {
-              "$ref": "#/definitions/ConditionalValueDef<(string|number|boolean)>"
-            }
-          ],
+          "$ref": "#/definitions/Conditional<TextFieldDef,ValueDef<(string|number|boolean)>>",
           "description": "Text of the `text` mark."
         },
         "tooltip": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TextFieldDef"
-            },
-            {
-              "$ref": "#/definitions/ConditionalValueDef<string>"
-            }
-          ],
+          "$ref": "#/definitions/Conditional<TextFieldDef,ValueDef<(string|number|boolean)>>",
           "description": "The tooltip text to show upon mouse hover."
         },
         "x": {
@@ -2758,9 +2920,6 @@
           ],
           "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
         },
-        "condition": {
-          "$ref": "#/definitions/Condition<number>"
-        },
         "field": {
           "$ref": "#/definitions/Field",
           "description": "__Required.__ Name of the field from which to pull a data value.\n\n__Note:__ `field` is not required if `aggregate` is `count`."
@@ -2827,9 +2986,6 @@
             }
           ],
           "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
-        },
-        "condition": {
-          "$ref": "#/definitions/Condition<string>"
         },
         "field": {
           "$ref": "#/definitions/Field",
@@ -4408,9 +4564,6 @@
             }
           ],
           "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
-        },
-        "condition": {
-          "$ref": "#/definitions/Condition<(string|number)>"
         },
         "field": {
           "$ref": "#/definitions/Field",

--- a/examples/specs/brush.vl.json
+++ b/examples/specs/brush.vl.json
@@ -12,8 +12,8 @@
     "x": {"field": "Horsepower", "type": "quantitative"},
     "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
     "color": {
-      "condition": {"selection": {"not": "brush"}, "value": "grey"},
-      "field": "Cylinders", "type": "ordinal"
+      "condition": {"selection": "brush", "field": "Cylinders", "type": "ordinal"},
+      "value": "grey"
     }
   }
 }

--- a/examples/specs/interactive_splom.vl.json
+++ b/examples/specs/interactive_splom.vl.json
@@ -31,10 +31,11 @@
         "type": "quantitative"
       },
       "color": {
-        "field": "Origin","type": "nominal",
         "condition": {
-          "selection": {"not": "brush"}, "value": "grey"
-        }
+          "selection": "brush",
+          "field": "Origin","type": "nominal"
+        },
+        "value": "grey"
       }
     }
   }

--- a/examples/specs/layered_selections.vl.json
+++ b/examples/specs/layered_selections.vl.json
@@ -36,8 +36,8 @@
       "x": {"field": "Horsepower", "type": "quantitative"},
       "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
       "color": {
-        "condition": {"selection": {"not": "brush"}, "value": "grey"},
-        "field": "Cylinders", "type": "ordinal"
+        "condition": {"selection": "brush", "field": "Cylinders", "type": "ordinal"},
+        "value": "grey"
       },
       "size": {
         "value": 50,

--- a/examples/specs/query_widgets.vl.json
+++ b/examples/specs/query_widgets.vl.json
@@ -18,8 +18,8 @@
       "x": {"field": "Horsepower", "type": "quantitative"},
       "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
       "color": {
-        "field": "Origin", "type": "nominal",
-        "condition": {"selection": {"not": "CylYr"}, "value": "grey"}
+        "condition": {"selection": "CylYr", "field": "Origin", "type": "nominal"},
+        "value": "grey"
       }
     }
   }, {

--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -344,12 +344,12 @@
                     },
                     "stroke": [
                         {
-                            "test": "!(vlInterval(\"brush_store\", \"\", datum, \"union\", \"all\"))",
-                            "value": "grey"
-                        },
-                        {
+                            "test": "vlInterval(\"brush_store\", \"\", datum, \"union\", \"all\")",
                             "scale": "color",
                             "field": "Cylinders"
+                        },
+                        {
+                            "value": "grey"
                         }
                     ],
                     "fill": {

--- a/examples/vg-specs/interactive_splom.vg.json
+++ b/examples/vg-specs/interactive_splom.vg.json
@@ -505,12 +505,12 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "!(vlInterval(\"brush_store\", \"child_Horsepower_Horsepower_\", datum, \"union\", \"all\"))",
-                                    "value": "grey"
-                                },
-                                {
+                                    "test": "vlInterval(\"brush_store\", \"child_Horsepower_Horsepower_\", datum, \"union\", \"all\")",
                                     "scale": "color",
                                     "field": "Origin"
+                                },
+                                {
+                                    "value": "grey"
                                 }
                             ],
                             "fill": {
@@ -1063,12 +1063,12 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "!(vlInterval(\"brush_store\", \"child_Horsepower_Miles_per_Gallon_\", datum, \"union\", \"all\"))",
-                                    "value": "grey"
-                                },
-                                {
+                                    "test": "vlInterval(\"brush_store\", \"child_Horsepower_Miles_per_Gallon_\", datum, \"union\", \"all\")",
                                     "scale": "color",
                                     "field": "Origin"
+                                },
+                                {
+                                    "value": "grey"
                                 }
                             ],
                             "fill": {
@@ -1622,12 +1622,12 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "!(vlInterval(\"brush_store\", \"child_Acceleration_Horsepower_\", datum, \"union\", \"all\"))",
-                                    "value": "grey"
-                                },
-                                {
+                                    "test": "vlInterval(\"brush_store\", \"child_Acceleration_Horsepower_\", datum, \"union\", \"all\")",
                                     "scale": "color",
                                     "field": "Origin"
+                                },
+                                {
+                                    "value": "grey"
                                 }
                             ],
                             "fill": {
@@ -2181,12 +2181,12 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "!(vlInterval(\"brush_store\", \"child_Acceleration_Miles_per_Gallon_\", datum, \"union\", \"all\"))",
-                                    "value": "grey"
-                                },
-                                {
+                                    "test": "vlInterval(\"brush_store\", \"child_Acceleration_Miles_per_Gallon_\", datum, \"union\", \"all\")",
                                     "scale": "color",
                                     "field": "Origin"
+                                },
+                                {
+                                    "value": "grey"
                                 }
                             ],
                             "fill": {

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -616,12 +616,12 @@
                     },
                     "fill": [
                         {
-                            "test": "!(vlInterval(\"brush_store\", \"layer_1_\", datum, \"union\", \"all\"))",
-                            "value": "grey"
-                        },
-                        {
+                            "test": "vlInterval(\"brush_store\", \"layer_1_\", datum, \"union\", \"all\")",
                             "scale": "color",
                             "field": "Cylinders"
+                        },
+                        {
+                            "value": "grey"
                         }
                     ],
                     "size": [

--- a/examples/vg-specs/query_widgets.vg.json
+++ b/examples/vg-specs/query_widgets.vg.json
@@ -190,12 +190,12 @@
                     },
                     "fill": [
                         {
-                            "test": "!(vlPoint(\"CylYr_store\", \"layer_0_\", datum, \"union\", \"all\"))",
-                            "value": "grey"
-                        },
-                        {
+                            "test": "vlPoint(\"CylYr_store\", \"layer_0_\", datum, \"union\", \"all\")",
                             "scale": "color",
                             "field": "Origin"
+                        },
+                        {
+                            "value": "grey"
                         }
                     ],
                     "shape": {

--- a/scripts/rename-schema.sh
+++ b/scripts/rename-schema.sh
@@ -16,12 +16,12 @@ perl -pi -e s,'ValueDef<\(string\|number\|boolean\)>','TextValueDef',g build/veg
 perl -pi -e s,'ValueDef<string>','StringValueDef',g build/vega-lite-schema.json
 perl -pi -e s,'ValueDef<number>','NumberValueDef',g build/vega-lite-schema.json
 
-perl -pi -e s,'Conditional<TextFieldDef\,TextValueDef>','ConditionTextDefAlias',g build/vega-lite-schema.json
+perl -pi -e s,'Conditional<TextFieldDef\,TextValueDef>','ConditionTextDef',g build/vega-lite-schema.json
 perl -pi -e s,'ConditionalFieldDef<TextFieldDef\,TextValueDef>','ConditionTextFieldDef',g build/vega-lite-schema.json
 perl -pi -e s,'ConditionalValueDef<TextFieldDef\,TextValueDef>','ConditionTextValueDef',g build/vega-lite-schema.json
 perl -pi -e s,'ConditionOnlyDef<TextFieldDef\,TextValueDef>','ConditionOnlyTextDef',g build/vega-lite-schema.json
 
-perl -pi -e s,'Conditional<LegendFieldDef\,','ConditionLegendDefAlias<',g build/vega-lite-schema.json
+perl -pi -e s,'Conditional<LegendFieldDef\,','ConditionLegendDef<',g build/vega-lite-schema.json
 perl -pi -e s,'ConditionalFieldDef<LegendFieldDef\,','ConditionLegendFieldDef<',g build/vega-lite-schema.json
 perl -pi -e s,'ConditionalValueDef<LegendFieldDef\,','ConditionLegendValueDef<',g build/vega-lite-schema.json
 perl -pi -e s,'ConditionOnlyDef<LegendFieldDef\,','ConditionOnlyLegendDef<',g build/vega-lite-schema.json

--- a/scripts/rename-schema.sh
+++ b/scripts/rename-schema.sh
@@ -1,12 +1,31 @@
 perl -pi -e s,'<Field>','',g build/vega-lite-schema.json
+perl -pi -e s,'<Field\,','<',g build/vega-lite-schema.json
+
 perl -pi -e s,'FacetedCompositeUnitSpec','FacetedUnitSpec',g build/vega-lite-schema.json
 perl -pi -e s,'GenericLayerSpec<CompositeUnitSpec>','LayerSpec',g build/vega-lite-schema.json
 perl -pi -e s,'GenericFacetSpec<CompositeUnitSpec>','FacetedSpec',g build/vega-lite-schema.json
 perl -pi -e s,'GenericRepeatSpec<CompositeUnitSpec>','RepeatSpec',g build/vega-lite-schema.json
 perl -pi -e s,'GenericVConcatSpec<CompositeUnitSpec>','VConcatSpec',g build/vega-lite-schema.json
 perl -pi -e s,'GenericHConcatSpec<CompositeUnitSpec>','HConcatSpec',g build/vega-lite-schema.json
+
 perl -pi -e s,'GenericUnitSpec<EncodingWithFacet\,AnyMark>','FacetedCompositeUnitSpecAlias',g build/vega-lite-schema.json
 perl -pi -e s,'GenericUnitSpec<Encoding\,AnyMark>','CompositeUnitSpecAlias',g build/vega-lite-schema.json
+
+
+perl -pi -e s,'ValueDef<\(string\|number\|boolean\)>','TextValueDef',g build/vega-lite-schema.json
+perl -pi -e s,'ValueDef<string>','StringValueDef',g build/vega-lite-schema.json
+perl -pi -e s,'ValueDef<number>','NumberValueDef',g build/vega-lite-schema.json
+
+perl -pi -e s,'Conditional<TextFieldDef\,TextValueDef>','ConditionTextDefAlias',g build/vega-lite-schema.json
+perl -pi -e s,'ConditionalFieldDef<TextFieldDef\,TextValueDef>','ConditionTextFieldDef',g build/vega-lite-schema.json
+perl -pi -e s,'ConditionalValueDef<TextFieldDef\,TextValueDef>','ConditionTextValueDef',g build/vega-lite-schema.json
+perl -pi -e s,'ConditionOnlyDef<TextFieldDef\,TextValueDef>','ConditionOnlyTextDef',g build/vega-lite-schema.json
+
+perl -pi -e s,'Conditional<LegendFieldDef\,','ConditionLegendDefAlias<',g build/vega-lite-schema.json
+perl -pi -e s,'ConditionalFieldDef<LegendFieldDef\,','ConditionLegendFieldDef<',g build/vega-lite-schema.json
+perl -pi -e s,'ConditionalValueDef<LegendFieldDef\,','ConditionLegendValueDef<',g build/vega-lite-schema.json
+perl -pi -e s,'ConditionOnlyDef<LegendFieldDef\,','ConditionOnlyLegendDef<',g build/vega-lite-schema.json
+
 perl -pi -e s,'LogicalOperand<string>','LogicalOperand',g build/vega-lite-schema.json
 perl -pi -e s,'LogicalAnd<string>','LogicalAnd',g build/vega-lite-schema.json
 perl -pi -e s,'LogicalOr<string>','LogicalOr',g build/vega-lite-schema.json

--- a/scripts/rename-schema.sh
+++ b/scripts/rename-schema.sh
@@ -11,6 +11,7 @@ perl -pi -e s,'GenericHConcatSpec<CompositeUnitSpec>','HConcatSpec',g build/vega
 perl -pi -e s,'GenericUnitSpec<EncodingWithFacet\,AnyMark>','FacetedCompositeUnitSpecAlias',g build/vega-lite-schema.json
 perl -pi -e s,'GenericUnitSpec<Encoding\,AnyMark>','CompositeUnitSpecAlias',g build/vega-lite-schema.json
 
+perl -pi -e s,'TopLevel<(.*)>','TopLevel\1',g build/vega-lite-schema.json
 
 perl -pi -e s,'ValueDef<\(string\|number\|boolean\)>','TextValueDef',g build/vega-lite-schema.json
 perl -pi -e s,'ValueDef<string>','StringValueDef',g build/vega-lite-schema.json
@@ -23,10 +24,10 @@ perl -pi -e s,'ConditionalFieldDef<TextFieldDef\,TextValueDef>','ConditionTextFi
 perl -pi -e s,'ConditionalValueDef<TextFieldDef\,TextValueDef>','ConditionTextValueDef',g build/vega-lite-schema.json
 perl -pi -e s,'ConditionOnlyDef<TextFieldDef\,TextValueDef>','ConditionOnlyTextDef',g build/vega-lite-schema.json
 
-perl -pi -e s,'Conditional<LegendFieldDef\,','ConditionLegendDef<',g build/vega-lite-schema.json
-perl -pi -e s,'ConditionalFieldDef<LegendFieldDef\,','ConditionLegendFieldDef<',g build/vega-lite-schema.json
-perl -pi -e s,'ConditionalValueDef<LegendFieldDef\,','ConditionLegendValueDef<',g build/vega-lite-schema.json
-perl -pi -e s,'ConditionOnlyDef<LegendFieldDef\,','ConditionOnlyLegendDef<',g build/vega-lite-schema.json
+perl -pi -e s,'Conditional<LegendFieldDef\,(.*)ValueDef>','Condition\1LegendDef',g build/vega-lite-schema.json
+perl -pi -e s,'ConditionalFieldDef<LegendFieldDef\,(.*)ValueDef>','Condition\1LegendFieldDef',g build/vega-lite-schema.json
+perl -pi -e s,'ConditionalValueDef<LegendFieldDef\,(.*)ValueDef>','Condition\1LegendValueDef',g build/vega-lite-schema.json
+perl -pi -e s,'ConditionOnlyDef<LegendFieldDef\,(.*)ValueDef>','ConditionOnly\1LegendDef',g build/vega-lite-schema.json
 
 perl -pi -e s,'LogicalOperand<string>','LogicalOperand',g build/vega-lite-schema.json
 perl -pi -e s,'LogicalAnd<string>','LogicalAnd',g build/vega-lite-schema.json

--- a/scripts/rename-schema.sh
+++ b/scripts/rename-schema.sh
@@ -16,6 +16,8 @@ perl -pi -e s,'ValueDef<\(string\|number\|boolean\)>','TextValueDef',g build/veg
 perl -pi -e s,'ValueDef<string>','StringValueDef',g build/vega-lite-schema.json
 perl -pi -e s,'ValueDef<number>','NumberValueDef',g build/vega-lite-schema.json
 
+perl -pi -e s,'Condition<(.*)>','Condition\1',g build/vega-lite-schema.json
+
 perl -pi -e s,'Conditional<TextFieldDef\,TextValueDef>','ConditionTextDef',g build/vega-lite-schema.json
 perl -pi -e s,'ConditionalFieldDef<TextFieldDef\,TextValueDef>','ConditionTextFieldDef',g build/vega-lite-schema.json
 perl -pi -e s,'ConditionalValueDef<TextFieldDef\,TextValueDef>','ConditionTextValueDef',g build/vega-lite-schema.json

--- a/scripts/rename-schema.sh
+++ b/scripts/rename-schema.sh
@@ -19,14 +19,14 @@ perl -pi -e s,'ValueDef<number>','NumberValueDef',g build/vega-lite-schema.json
 
 perl -pi -e s,'Condition<(.*)>','Condition\1',g build/vega-lite-schema.json
 
-perl -pi -e s,'Conditional<TextFieldDef\,TextValueDef>','ConditionTextDef',g build/vega-lite-schema.json
-perl -pi -e s,'ConditionalFieldDef<TextFieldDef\,TextValueDef>','ConditionTextFieldDef',g build/vega-lite-schema.json
-perl -pi -e s,'ConditionalValueDef<TextFieldDef\,TextValueDef>','ConditionTextValueDef',g build/vega-lite-schema.json
+perl -pi -e s,'Conditional<TextFieldDef\,TextValueDef>','ConditionalTextDef',g build/vega-lite-schema.json
+perl -pi -e s,'ConditionalFieldDef<TextFieldDef\,TextValueDef>','ConditionalTextFieldDef',g build/vega-lite-schema.json
+perl -pi -e s,'ConditionalValueDef<TextFieldDef\,TextValueDef>','ConditionalTextValueDef',g build/vega-lite-schema.json
 perl -pi -e s,'ConditionOnlyDef<TextFieldDef\,TextValueDef>','ConditionOnlyTextDef',g build/vega-lite-schema.json
 
-perl -pi -e s,'Conditional<LegendFieldDef\,(.*)ValueDef>','Condition\1LegendDef',g build/vega-lite-schema.json
-perl -pi -e s,'ConditionalFieldDef<LegendFieldDef\,(.*)ValueDef>','Condition\1LegendFieldDef',g build/vega-lite-schema.json
-perl -pi -e s,'ConditionalValueDef<LegendFieldDef\,(.*)ValueDef>','Condition\1LegendValueDef',g build/vega-lite-schema.json
+perl -pi -e s,'Conditional<LegendFieldDef\,(.*)ValueDef>','Conditional\1LegendDef',g build/vega-lite-schema.json
+perl -pi -e s,'ConditionalFieldDef<LegendFieldDef\,(.*)ValueDef>','Conditional\1LegendFieldDef',g build/vega-lite-schema.json
+perl -pi -e s,'ConditionalValueDef<LegendFieldDef\,(.*)ValueDef>','Conditional\1LegendValueDef',g build/vega-lite-schema.json
 perl -pi -e s,'ConditionOnlyDef<LegendFieldDef\,(.*)ValueDef>','ConditionOnly\1LegendDef',g build/vega-lite-schema.json
 
 perl -pi -e s,'LogicalOperand<string>','LogicalOperand',g build/vega-lite-schema.json

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -55,6 +55,10 @@ export const TOOLTIP = Channel.TOOLTIP;
 export const CHANNELS = [X, Y, X2, Y2, ROW, COLUMN, SIZE, SHAPE, COLOR, ORDER, OPACITY, TEXT, DETAIL, TOOLTIP];
 const CHANNEL_INDEX = toSet(CHANNELS);
 
+export const SINGLE_DEF_CHANNELS = [X, Y, X2, Y2, ROW, COLUMN, SIZE, SHAPE, COLOR, OPACITY, TEXT, TOOLTIP];
+
+export type SingleDefChannel = typeof SINGLE_DEF_CHANNELS[0];
+
 export function isChannel(str: string): str is Channel {
   return !!CHANNEL_INDEX[str];
 }

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -57,7 +57,10 @@ const CHANNEL_INDEX = toSet(CHANNELS);
 
 export const SINGLE_DEF_CHANNELS = [X, Y, X2, Y2, ROW, COLUMN, SIZE, SHAPE, COLOR, OPACITY, TEXT, TOOLTIP];
 
-export type SingleDefChannel = typeof SINGLE_DEF_CHANNELS[0];
+// export type SingleDefChannel = typeof SINGLE_DEF_CHANNELS[0];
+// FIXME somehow the typeof above leads to the following error when running npm run schema
+// UnknownNodeError: Unknown node "SingleDefChannel" (ts.SyntaxKind = 171) at /Users/kanitw/Documents/_code/_idl/_visrec/vega-lite/src/selection.ts(17,14)
+export type SingleDefChannel = 'x' | 'y' | 'x2' | 'y2' | 'row' | 'column' | 'size' | 'shape' | 'color' | 'opacity' | 'text' | 'tooltip';
 
 export function isChannel(str: string): str is Channel {
   return !!CHANNEL_INDEX[str];

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -55,6 +55,14 @@ export const TOOLTIP = Channel.TOOLTIP;
 export const CHANNELS = [X, Y, X2, Y2, ROW, COLUMN, SIZE, SHAPE, COLOR, ORDER, OPACITY, TEXT, DETAIL, TOOLTIP];
 const CHANNEL_INDEX = toSet(CHANNELS);
 
+/**
+ * Channels cannot have an array of channelDef.
+ * model.fieldDef, getFieldDef only work for these channels.
+ *
+ * (The only two channels that can have an array of channelDefs are "detail" and "order".
+ * Since there can be multiple fieldDefs for detail and order, getFieldDef/model.fieldDef
+ * are not applicable for them.  Similarly, selection projecttion won't work with "detail" and "order".)
+ */
 export const SINGLE_DEF_CHANNELS = [X, Y, X2, Y2, ROW, COLUMN, SIZE, SHAPE, COLOR, OPACITY, TEXT, TOOLTIP];
 
 // export type SingleDefChannel = typeof SINGLE_DEF_CHANNELS[0];

--- a/src/compile/axis/encode.ts
+++ b/src/compile/axis/encode.ts
@@ -1,4 +1,4 @@
-import {Channel, X} from '../../channel';
+import {Channel, SpatialScaleChannel, X} from '../../channel';
 import {NOMINAL, ORDINAL, TEMPORAL} from '../../type';
 import {contains, extend, keys} from '../../util';
 import {VgAxis} from '../../vega.schema';
@@ -7,8 +7,13 @@ import {ScaleType} from '../../scale';
 import {timeFormatExpression} from '../common';
 import {UnitModel} from '../unit';
 
-export function labels(model: UnitModel, channel: Channel, labelsSpec: any, def: VgAxis) {
-  const fieldDef = model.fieldDef(channel);
+export function labels(model: UnitModel, channel: SpatialScaleChannel, labelsSpec: any, def: VgAxis) {
+  const fieldDef = model.fieldDef(channel) ||
+    (
+      channel === 'x' ? model.fieldDef('x2') :
+      channel === 'y' ? model.fieldDef('y2') :
+      undefined
+    );
   const axis = model.axis(channel);
   const config = model.config;
 

--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -1,5 +1,5 @@
 import {Axis, AXIS_PROPERTIES} from '../../axis';
-import {Channel} from '../../channel';
+import {Channel, SpatialScaleChannel} from '../../channel';
 import {VgAxis} from '../../vega.schema';
 
 import * as encode from './encode';
@@ -12,7 +12,7 @@ import {AxisComponent, AxisComponentIndex} from './component';
 type AxisPart = 'domain' | 'grid' | 'labels' | 'ticks' | 'title';
 const AXIS_PARTS: AxisPart[] = ['domain', 'grid', 'labels', 'ticks', 'title'];
 
-export function parseAxisComponent(model: UnitModel, axisChannels: Channel[]): AxisComponentIndex {
+export function parseAxisComponent(model: UnitModel, axisChannels: SpatialScaleChannel[]): AxisComponentIndex {
   return axisChannels.reduce(function(axis, channel) {
     const axisComponent: AxisComponent = {axes:[], gridAxes: []};
     if (model.axis(channel)) {
@@ -58,16 +58,16 @@ function hasAxisPart(axis: VgAxis, part: AxisPart) {
 /**
  * Make an inner axis for showing grid for shared axis.
  */
-export function parseGridAxis(channel: Channel, model: UnitModel): VgAxis {
+export function parseGridAxis(channel: SpatialScaleChannel, model: UnitModel): VgAxis {
   // FIXME: support adding ticks for grid axis that are inner axes of faceted plots.
   return parseAxis(channel, model, true);
 }
 
-export function parseMainAxis(channel: Channel, model: UnitModel) {
+export function parseMainAxis(channel: SpatialScaleChannel, model: UnitModel) {
   return parseAxis(channel, model, false);
 }
 
-function parseAxis(channel: Channel, model: UnitModel, isGridAxis: boolean): VgAxis {
+function parseAxis(channel: SpatialScaleChannel, model: UnitModel, isGridAxis: boolean): VgAxis {
   const axis = model.axis(channel);
 
   const vgAxis: VgAxis = {
@@ -114,7 +114,7 @@ function parseAxis(channel: Channel, model: UnitModel, isGridAxis: boolean): VgA
   return vgAxis;
 }
 
-function getSpecifiedOrDefaultValue(property: keyof VgAxis, specifiedAxis: Axis, channel: Channel, model: UnitModel, isGridAxis: boolean) {
+function getSpecifiedOrDefaultValue(property: keyof VgAxis, specifiedAxis: Axis, channel: SpatialScaleChannel, model: UnitModel, isGridAxis: boolean) {
   const fieldDef = model.fieldDef(channel);
 
   switch (property) {

--- a/src/compile/axis/rules.ts
+++ b/src/compile/axis/rules.ts
@@ -1,7 +1,7 @@
 import * as log from '../../log';
 
 import {Axis} from '../../axis';
-import {Channel, COLUMN, ROW, X, Y} from '../../channel';
+import {Channel, COLUMN, ROW, SpatialScaleChannel, X, Y} from '../../channel';
 import {Config} from '../../config';
 import {DateTime, dateTimeExpr, isDateTime} from '../../datetime';
 import {FieldDef, title as fieldDefTitle} from '../../fielddef';
@@ -20,7 +20,7 @@ export function format(specifiedAxis: Axis, channel: Channel, fieldDef: FieldDef
  * Default rules for whether to show a grid should be shown for a channel.
  * If `grid` is unspecified, the default value is `true` for ordinal scales that are not binned
  */
-export function gridShow(model: UnitModel, channel: Channel) {
+export function gridShow(model: UnitModel, channel: SpatialScaleChannel) {
   const grid = model.axis(channel).grid;
   if (grid !== undefined) {
     return grid;
@@ -29,12 +29,7 @@ export function gridShow(model: UnitModel, channel: Channel) {
   return !model.hasDiscreteDomain(channel) && !model.fieldDef(channel).bin;
 }
 
-export function grid(model: UnitModel, channel: Channel, isGridAxis: boolean) {
-  if (channel === ROW || channel === COLUMN) {
-    // never apply grid for ROW and COLUMN since we manually create rule-group for them
-    return false;
-  }
-
+export function grid(model: UnitModel, channel: SpatialScaleChannel, isGridAxis: boolean) {
   if (!isGridAxis) {
     return undefined;
   }

--- a/src/compile/data/bin.ts
+++ b/src/compile/data/bin.ts
@@ -74,7 +74,7 @@ export class BinNode extends DataFlowNode {
 
   public static makeBinFromEncoding(model: ModelWithField) {
     const bins = model.reduceFieldDef((binComponent: Dict<BinComponent>, fieldDef, channel) => {
-      const fieldDefBin = model.fieldDef(channel).bin;
+      const fieldDefBin = fieldDef.bin;
       if (fieldDefBin) {
         const bin = normalizeBin(fieldDefBin, undefined) || {};
         const key = binKey(fieldDefBin, fieldDef.field);

--- a/src/compile/data/nonpositivefilter.ts
+++ b/src/compile/data/nonpositivefilter.ts
@@ -1,3 +1,4 @@
+import {SCALE_CHANNELS} from '../../channel';
 import {ScaleType} from '../../scale';
 import {Dict, duplicate, extend, keys} from '../../util';
 import {VgFilterTransform, VgTransform} from '../../vega.schema';
@@ -18,7 +19,7 @@ export class NonPositiveFilterNode extends DataFlowNode {
   }
 
   public static make(model: UnitModel) {
-    const filter = model.channels().reduce(function(nonPositiveComponent, channel) {
+    const filter = SCALE_CHANNELS.reduce(function(nonPositiveComponent, channel) {
       const scale = model.getScaleComponent(channel);
       if (!scale || !model.field(channel)) {
         // don't set anything

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -307,10 +307,6 @@ export class FacetModel extends ModelWithField {
     return marks;
   }
 
-  public channels() {
-    return [ROW, COLUMN];
-  }
-
   protected getMapping() {
     return this.facet;
   }

--- a/src/compile/legend/parse.ts
+++ b/src/compile/legend/parse.ts
@@ -1,4 +1,4 @@
-import {Channel, COLOR, OPACITY, SHAPE, SIZE} from '../../channel';
+import {Channel, COLOR, NonspatialScaleChannel, OPACITY, SHAPE, SIZE} from '../../channel';
 import {Legend, LEGEND_PROPERTIES} from '../../legend';
 import {Dict, keys} from '../../util';
 import {VgLegend} from '../../vega.schema';
@@ -36,7 +36,7 @@ function getLegendDefWithScale(model: UnitModel, channel: Channel): LegendCompon
   return null;
 }
 
-export function parseLegend(model: UnitModel, channel: Channel): LegendComponent {
+export function parseLegend(model: UnitModel, channel: NonspatialScaleChannel): LegendComponent {
   const fieldDef = model.fieldDef(channel);
   const legend = model.legend(channel);
 
@@ -64,7 +64,7 @@ export function parseLegend(model: UnitModel, channel: Channel): LegendComponent
   return def;
 }
 
-function getSpecifiedOrDefaultValue(property: keyof VgLegend, specifiedLegend: Legend, channel: Channel, model: UnitModel) {
+function getSpecifiedOrDefaultValue(property: keyof VgLegend, specifiedLegend: Legend, channel: NonspatialScaleChannel, model: UnitModel) {
   const fieldDef = model.fieldDef(channel);
 
   switch (property) {

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -18,8 +18,7 @@ import {UnitModel} from '../unit';
 
 import {isArray} from 'vega-util';
 import {X, Y} from '../../channel';
-import {getFieldDef} from '../../encoding';
-import {field} from '../../fielddef';
+import {field, getFieldDef} from '../../fielddef';
 import {isSelectionDomain} from '../../scale';
 
 const markCompiler: {[type: string]: MarkCompiler} = {
@@ -131,7 +130,7 @@ function detailFields(model: UnitModel): string[] {
         });
       }
     } else {
-      const fieldDef = getFieldDef(encoding, channel);
+      const fieldDef = getFieldDef<string>(encoding[channel]);
       if (fieldDef && !fieldDef.aggregate) {
         details.push(field(fieldDef, {binSuffix: 'start'}));
       }

--- a/src/compile/mark/mixins.ts
+++ b/src/compile/mark/mixins.ts
@@ -8,7 +8,7 @@ import {UnitModel} from '../unit';
 import * as ref from './valueref';
 
 import {NONSPATIAL_SCALE_CHANNELS} from '../../channel';
-import {Condition, FieldDef, isFieldDef, isValueDef} from '../../fielddef';
+import {Condition, FieldDef, getFieldDef, isValueDef} from '../../fielddef';
 import {predicate} from '../selection/selection';
 
 export function color(model: UnitModel) {
@@ -63,6 +63,7 @@ export function nonPosition(channel: typeof NONSPATIAL_SCALE_CHANNELS[0], model:
  * Return a mixin that include a Vega production rule for a Vega-Lite conditional channel definition.
  * or a simple mixin if channel def has no condition.
  */
+// FIXME support ConditionFieldDef
 function wrapCondition(model: UnitModel, condition: Condition<any>, vgChannel: string, valueRef: VgValueRef): VgEncodeEntry {
   if (condition) {
     const {selection, value} = condition;
@@ -77,6 +78,7 @@ function wrapCondition(model: UnitModel, condition: Condition<any>, vgChannel: s
   }
 }
 
+// FIXME support ConditionFieldDef
 export function text(model: UnitModel, vgChannel: 'text' | 'tooltip' = 'text') {
   const channelDef = model.encoding[vgChannel];
   const valueRef = (vgChannel === 'tooltip' && !channelDef) ? undefined : ref.text(channelDef, model.config);
@@ -96,7 +98,7 @@ export function bandPosition(fieldDef: FieldDef<string>, channel: 'x'|'y', model
         [channel+'c']: ref.fieldRef(fieldDef, scaleName, {}, {band: 0.5})
       };
 
-      if (isFieldDef(model.encoding.size)) {
+      if (getFieldDef(model.encoding.size)) {
         log.warn(log.message.cannotUseSizeFieldWithBandSize(channel));
         // TODO: apply size to band and set scale range to some values between 0-1.
         // return {

--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -4,7 +4,7 @@
 
 import {Channel, X, X2, Y, Y2} from '../../channel';
 import {Config} from '../../config';
-import {ChannelDef, field, FieldDef, FieldRefOption, isFieldDef, TextFieldDef, ValueDef} from '../../fielddef';
+import {ChannelDef, Conditional, field, FieldDef, FieldRefOption, isFieldDef, isValueDef, TextFieldDef, ValueDef} from '../../fielddef';
 import {hasDiscreteDomain, isBinScale, ScaleType} from '../../scale';
 import {StackProperties} from '../../stack';
 import {contains} from '../../util';
@@ -113,7 +113,7 @@ export function midPoint(channel: Channel, channelDef: ChannelDef<string>, scale
       } else {
         return fieldRef(channelDef, scaleName, {}); // no need for bin suffix
       }
-    } else if (channelDef.value !== undefined) {
+    } else if (isValueDef(channelDef)) {
       return {value: channelDef.value};
     } else {
       throw new Error('FieldDef without field or value.'); // FIXME add this to log.message
@@ -142,12 +142,12 @@ export function midPoint(channel: Channel, channelDef: ChannelDef<string>, scale
   return defaultRef;
 }
 
-export function text(textDef: TextFieldDef<string> | ValueDef<any>, config: Config): VgValueRef {
+export function text(textDef: Conditional<TextFieldDef<string>, ValueDef<any>>, config: Config): VgValueRef {
   // text
   if (textDef) {
     if (isFieldDef(textDef)) {
       return formatSignalRef(textDef, textDef.format, 'datum', config);
-    } else if (textDef.value) {
+    } else if (isValueDef(textDef)) {
       return {value: textDef.value};
     }
   }

--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -93,6 +93,7 @@ export function midPoint(channel: Channel, channelDef: ChannelDef<string>, scale
 
   if (channelDef) {
     /* istanbul ignore else */
+
     if (isFieldDef(channelDef)) {
       if (isBinScale(scale.type)) {
         // Use middle only for x an y to place marks in the center between start and end of the bin range.

--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -151,7 +151,7 @@ export function text(textDef: Conditional<TextFieldDef<string>, ValueDef<any>>, 
       return {value: textDef.value};
     }
   }
-  return {value: config.text.text};
+  return undefined;
 }
 
 export function midX(width: number, config: Config): VgValueRef {

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -1,5 +1,5 @@
 import {Axis} from '../axis';
-import {Channel, COLUMN, isChannel, NonspatialScaleChannel, ScaleChannel, X} from '../channel';
+import {Channel, COLUMN, isChannel, NonspatialScaleChannel, ScaleChannel, SingleDefChannel, X} from '../channel';
 import {CellConfig, Config} from '../config';
 import {Data, DataSourceType, MAIN, RAW} from '../data';
 import {forEach, reduce} from '../encoding';
@@ -376,10 +376,10 @@ export abstract class Model {
 
 /** Abstract class for UnitModel and FacetModel.  Both of which can contain fieldDefs as a part of its own specification. */
 export abstract class ModelWithField extends Model {
-  public abstract fieldDef(channel: Channel): FieldDef<string>;
+  public abstract fieldDef(channel: SingleDefChannel): FieldDef<string>;
 
   /** Get "field" reference for vega */
-  public field(channel: Channel, opt: FieldRefOption = {}) {
+  public field(channel: SingleDefChannel, opt: FieldRefOption = {}) {
     const fieldDef = this.fieldDef(channel);
 
     if (fieldDef.bin) { // bin has default suffix that depends on scaleType

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -394,7 +394,6 @@ export abstract class ModelWithField extends Model {
   public abstract hasDiscreteDomain(channel: Channel): boolean;
 
 
-  public abstract channels(): Channel[];
 
   protected abstract getMapping(): {[key: string]: any};
 

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -3,7 +3,7 @@ import {Channel, COLUMN, isChannel, NonspatialScaleChannel, ScaleChannel, X} fro
 import {CellConfig, Config} from '../config';
 import {Data, DataSourceType, MAIN, RAW} from '../data';
 import {forEach, reduce} from '../encoding';
-import {ChannelDef, field, FieldDef, FieldRefOption, isFieldDef, isRepeatRef} from '../fielddef';
+import {ChannelDef, field, FieldDef, FieldRefOption, getFieldDef, isFieldDef, isRepeatRef} from '../fielddef';
 import {Legend} from '../legend';
 import {hasDiscreteDomain, Scale} from '../scale';
 import {SortField, SortOrder} from '../sort';
@@ -400,14 +400,19 @@ export abstract class ModelWithField extends Model {
 
   public reduceFieldDef<T, U>(f: (acc: U, fd: FieldDef<string>, c: Channel) => U, init: T, t?: any) {
     return reduce(this.getMapping(), (acc:U , cd: ChannelDef<string>, c: Channel) => {
-      return isFieldDef(cd) ? f(acc, cd, c) : acc;
+      const fieldDef = getFieldDef(cd);
+      if (fieldDef) {
+        return f(acc, fieldDef, c);
+      }
+      return acc;
     }, init, t);
   }
 
   public forEachFieldDef(f: (fd: FieldDef<string>, c: Channel) => void, t?: any) {
     forEach(this.getMapping(), (cd: ChannelDef<string>, c: Channel) => {
-      if (isFieldDef(cd)) {
-        f(cd, c);
+      const fieldDef = getFieldDef(cd);
+      if (fieldDef) {
+        f(fieldDef, c);
       }
     }, t);
   }

--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -1,6 +1,6 @@
 import {SHARED_DOMAIN_OP_INDEX} from '../../aggregate';
 import {binToString} from '../../bin';
-import {Channel} from '../../channel';
+import {Channel, ScaleChannel} from '../../channel';
 import {MAIN, RAW} from '../../data';
 import {DateTime, dateTimeExpr, isDateTime} from '../../datetime';
 import {FieldDef} from '../../fielddef';
@@ -42,7 +42,7 @@ export function initDomain(domain: Domain, fieldDef: FieldDef<string>, scale: Sc
 
 // FIXME(https://github.com/vega/vega-lite/issues/2251#issuecomment-306683920)
 // parseDomain must be called separately after parseScale
-export function parseDomain(model: UnitModel, channel: Channel): VgDomain {
+export function parseDomain(model: UnitModel, channel: ScaleChannel): VgDomain {
   // FIXME replace this with getScaleComponent once parseScaleDomain a separate parseStep from scale
   const scaleType = model.scale(channel).type;
   const domain = model.scaleDomain(channel);
@@ -64,7 +64,7 @@ export function parseDomain(model: UnitModel, channel: Channel): VgDomain {
   return parseSingleChannelDomain(scaleType, domain, model, channel);
 }
 
-function parseSingleChannelDomain(scaleType: ScaleType, domain: Domain, model: UnitModel, channel:Channel): VgDomain {
+function parseSingleChannelDomain(scaleType: ScaleType, domain: Domain, model: UnitModel, channel: ScaleChannel | 'x2' | 'y2'): VgDomain {
   const fieldDef = model.fieldDef(channel);
 
   if (domain && domain !== 'unaggregated' && !isSelectionDomain(domain)) { // explicit value

--- a/src/compile/scale/parse.ts
+++ b/src/compile/scale/parse.ts
@@ -1,4 +1,4 @@
-import {Channel} from '../../channel';
+import {Channel, SCALE_CHANNELS, ScaleChannel} from '../../channel';
 import {isSelectionDomain, Scale} from '../../scale';
 import {isSortField} from '../../sort';
 import {Dict} from '../../util';
@@ -17,8 +17,7 @@ import {SELECTION_DOMAIN} from '../selection/selection';
  * Parse scales for all channels of a model.
  */
 export default function parseScaleComponent(model: UnitModel): ScaleComponentIndex {
-  // TODO: should model.channels() inlcude X2/Y2?
-  return model.channels().reduce(function(scaleComponentsIndex: ScaleComponentIndex, channel: Channel) {
+  return SCALE_CHANNELS.reduce(function(scaleComponentsIndex: ScaleComponentIndex, channel: ScaleChannel) {
     const scaleComponents = parseScale(model, channel);
     if (scaleComponents) {
       scaleComponentsIndex[channel] = scaleComponents;
@@ -40,7 +39,7 @@ export const NON_TYPE_DOMAIN_RANGE_VEGA_SCALE_PROPERTIES: (keyof Scale)[] = [
 /**
  * Parse scales for a single channel of a model.
  */
-export function parseScale(model: UnitModel, channel: Channel) {
+export function parseScale(model: UnitModel, channel: ScaleChannel) {
   if (!model.scale(channel)) {
     return null;
   }

--- a/src/compile/selection/multi.ts
+++ b/src/compile/selection/multi.ts
@@ -15,8 +15,10 @@ const multi:SelectionCompiler = {
     const fields = proj.map((p) => stringValue(p.field)).join(', ');
     const values = proj.map((p) => {
       const channel = p.encoding;
+      const fieldDef = model.fieldDef(channel);
       // Binned fields should capture extents, for a range test against the raw field.
-      return model.fieldDef(channel).bin ? (bins[p.field] = 1,
+      // FIXME: Arvind -- please log proper warning when the specified encoding channel has no field
+      return (fieldDef && fieldDef.bin) ? (bins[p.field] = 1,
         `[${datum}[${stringValue(model.field(channel, {binSuffix: 'start'}))}], ` +
             `${datum}[${stringValue(model.field(channel, {binSuffix: 'end'}))}]]`) :
         `${datum}[${stringValue(p.field)}]`;

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -1,5 +1,5 @@
 import {selector as parseSelector} from 'vega-event-selector';
-import {Channel} from '../../channel';
+import {Channel, SingleDefChannel} from '../../channel';
 import {warn} from '../../log';
 import {LogicalOperand} from '../../logical';
 import {SelectionDomain} from '../../scale';
@@ -40,7 +40,7 @@ export interface SelectionComponent {
 
 export interface ProjectComponent {
   field?: string;
-  encoding?: Channel;
+  encoding?: SingleDefChannel;
 }
 
 export interface SelectionCompiler {

--- a/src/compile/selection/transforms/project.ts
+++ b/src/compile/selection/transforms/project.ts
@@ -1,4 +1,5 @@
-import {Channel} from '../../../channel';
+import {Channel, SingleDefChannel} from '../../../channel';
+import * as log from '../../../log';
 import {SelectionDef} from '../../../selection';
 import {TransformCompiler} from './transforms';
 
@@ -11,12 +12,16 @@ const project:TransformCompiler = {
     let fields = {};
     // TODO: find a possible channel mapping for these fields.
     (selDef.fields || []).forEach((field) => fields[field] = null);
-    (selDef.encodings || []).forEach((channel: Channel) => {
+    (selDef.encodings || []).forEach((channel: SingleDefChannel) => {
       const fieldDef = model.fieldDef(channel);
-      if (fieldDef.timeUnit) {
-        fields[model.field(channel)] = channel;
+      if (fieldDef) {
+        if (fieldDef.timeUnit) {
+          fields[model.field(channel)] = channel;
+        } else {
+          fields[fieldDef.field] = channel;
+        }
       } else {
-        fields[fieldDef.field] = channel;
+        log.warn(log.message.cannotProjectOnChannelWithoutField(channel));
       }
     });
 

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -338,10 +338,6 @@ export class UnitModel extends ModelWithField {
     };
   }
 
-  public channels() {
-    return UNIT_CHANNELS;
-  }
-
   protected getMapping() {
     return this.encoding;
   }

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -1,9 +1,9 @@
 import {Axis} from '../axis';
-import {Channel, NONSPATIAL_SCALE_CHANNELS, UNIT_CHANNELS, UNIT_SCALE_CHANNELS, X, X2, Y, Y2} from '../channel';
+import {Channel, NONSPATIAL_SCALE_CHANNELS, SingleDefChannel, UNIT_CHANNELS, UNIT_SCALE_CHANNELS, X, X2, Y, Y2} from '../channel';
 import {CellConfig, Config} from '../config';
 import {Encoding, normalizeEncoding} from '../encoding';
 import * as vlEncoding from '../encoding'; // TODO: remove
-import {field, FieldDef, FieldRefOption, getFieldDef, isConditionalDef, isFieldDef} from '../fielddef';
+import {ChannelDef, field, FieldDef, FieldRefOption, getFieldDef, isConditionalDef, isFieldDef} from '../fielddef';
 import {Legend} from '../legend';
 import {FILL_STROKE_CONFIG, isMarkDef, Mark, MarkDef, TEXT as TEXT_MARK} from '../mark';
 import {defaultScaleConfig, Domain, hasDiscreteDomain, Scale} from '../scale';
@@ -375,15 +375,18 @@ export class UnitModel extends ModelWithField {
     return vlEncoding.channelHasField(this.encoding, channel);
   }
 
-  public fieldDef(channel: Channel): FieldDef<string> {
-    // TODO: remove this || {}
-    // Currently we have it to prevent null pointer exception.
-    return this.encoding[channel] || {};
+  public fieldDef(channel: SingleDefChannel): FieldDef<string> {
+    const channelDef = this.encoding[channel] as ChannelDef<string>;
+    return getFieldDef(channelDef);
   }
 
   /** Get "field" reference for vega */
-  public field(channel: Channel, opt: FieldRefOption = {}) {
+  public field(channel: SingleDefChannel, opt: FieldRefOption = {}) {
     const fieldDef = this.fieldDef(channel);
+
+    if (!fieldDef) {
+      return undefined;
+    }
 
     if (fieldDef.bin) { // bin has default suffix that depends on scaleType
       opt = extend({

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -19,7 +19,7 @@ import {
   PositionDef,
   ValueDef
 } from './fielddef';
-import {getFieldDef, hasConditionFieldDef} from './fielddef';
+import {getFieldDef, hasConditionFieldDef, isConditionalDef} from './fielddef';
 import * as log from './log';
 import {Mark} from './mark';
 import {isArray, some} from './util';
@@ -169,7 +169,7 @@ export function normalizeEncoding(encoding: Encoding<string>, mark: Mark): Encod
     } else {
       // FIXME: remove this casting.  (I don't know why Typescript doesn't infer this correctly here.)
       const channelDef = encoding[channel] as ChannelDef<string>;
-      if (!isFieldDef(channelDef) && !isValueDef(channelDef)) {
+      if (!isFieldDef(channelDef) && !isValueDef(channelDef) && !isConditionalDef(channelDef)) {
         log.warn(log.message.emptyFieldDef(channelDef, channel));
         return normalizedEncoding;
       }

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -17,7 +17,7 @@ import {
   TextFieldDef,
   ValueDef
 } from './fielddef';
-import {normalizeFieldDef} from './fielddef';
+import {Conditional, normalizeFieldDef} from './fielddef';
 import * as log from './log';
 import {Mark} from './mark';
 import {isArray, some} from './util';
@@ -56,12 +56,12 @@ export interface Encoding<F> {
    * (By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /
    * stroke color for `line` and `point`.)
    */
-  color?: LegendFieldDef<F, string> | ConditionalValueDef<string>;
+  color?: Conditional<LegendFieldDef<F, string>, ValueDef<string>>;
 
   /**
    * Opacity of the marks – either can be a value or a range.
    */
-  opacity?: LegendFieldDef<F, number> | ConditionalValueDef<number>;
+  opacity?: Conditional<LegendFieldDef<F, number>, ValueDef<number>>;
 
   /**
    * Size of the mark.
@@ -71,14 +71,14 @@ export interface Encoding<F> {
    * - For `text` – the text's font size.
    * - Size is currently unsupported for `line` and `area`.
    */
-  size?: LegendFieldDef<F, number> | ConditionalValueDef<number>;
+  size?: Conditional<LegendFieldDef<F, number>, ValueDef<number>>;
 
   /**
    * The symbol's shape (only for `point` marks). The supported values are
    * `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,
    * or `"triangle-down"`, or else a custom SVG path string.
    */
-  shape?: LegendFieldDef<F, string> | ConditionalValueDef<string>; // TODO: maybe distinguish ordinal-only
+  shape?: Conditional<LegendFieldDef<F, string>, ValueDef<string>>; // TODO: maybe distinguish ordinal-only
 
   /**
    * Additional levels of detail for grouping data in aggregate views and
@@ -89,12 +89,12 @@ export interface Encoding<F> {
   /**
    * Text of the `text` mark.
    */
-  text?: TextFieldDef<F> | ConditionalValueDef<string|number|boolean>;
+  text?: Conditional<TextFieldDef<F>, ValueDef<string|number|boolean>>;
 
   /**
    * The tooltip text to show upon mouse hover.
    */
-  tooltip?: TextFieldDef<F> | ConditionalValueDef<string>;
+  tooltip?: Conditional<TextFieldDef<F>, ValueDef<string|number|boolean>>;
 
   /**
    * stack order for stacked marks or order of data points in line marks.

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -6,20 +6,22 @@ import {Facet} from './facet';
 import {
   ChannelDef,
   Condition,
-  ConditionalLegendDef,
-  ConditionalTextDef,
-  ConditionalValueDef,
+  Conditional,
   Field,
   FieldDef,
+  getFieldDef,
+  hasConditionFieldDef,
+  isConditionalDef,
   isFieldDef,
   isValueDef,
+  LegendFieldDef,
   normalize,
   normalizeFieldDef,
   OrderFieldDef,
-  PositionDef,
+  PositionFieldDef,
+  TextFieldDef,
   ValueDef
 } from './fielddef';
-import {getFieldDef, hasConditionFieldDef, isConditionalDef} from './fielddef';
 import * as log from './log';
 import {Mark} from './mark';
 import {isArray, some} from './util';
@@ -32,14 +34,14 @@ export interface Encoding<F> {
    * `line`, `rule`, `text`, and `tick`
    * (or to width and height for `bar` and `area` marks).
    */
-  x?: PositionDef<F>;
+  x?: PositionFieldDef<F> | ValueDef<number>;
 
   /**
    * Y coordinates for `point`, `circle`, `square`,
    * `line`, `rule`, `text`, and `tick`
    * (or to width and height for `bar` and `area` marks).
    */
-  y?: PositionDef<F>;
+  y?: PositionFieldDef<F> | ValueDef<number>;
 
   /**
    * X2 coordinates for ranged `bar`, `rule`, `area`.
@@ -58,12 +60,12 @@ export interface Encoding<F> {
    * (By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /
    * stroke color for `line` and `point`.)
    */
-  color?: ConditionalLegendDef<F, string>;
+  color?: Conditional<LegendFieldDef<F>, ValueDef<string>>;
 
   /**
    * Opacity of the marks – either can be a value or a range.
    */
-  opacity?: ConditionalLegendDef<F, number>;
+  opacity?: Conditional<LegendFieldDef<F>, ValueDef<number>>;
 
   /**
    * Size of the mark.
@@ -73,14 +75,14 @@ export interface Encoding<F> {
    * - For `text` – the text's font size.
    * - Size is currently unsupported for `line` and `area`.
    */
-  size?: ConditionalLegendDef<F, number>;
+  size?: Conditional<LegendFieldDef<F>, ValueDef<number>>;
 
   /**
    * The symbol's shape (only for `point` marks). The supported values are
    * `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,
    * or `"triangle-down"`, or else a custom SVG path string.
    */
-  shape?: ConditionalLegendDef<F, string>; // TODO: maybe distinguish ordinal-only
+  shape?: Conditional<LegendFieldDef<F>, ValueDef<string>>; // TODO: maybe distinguish ordinal-only
 
   /**
    * Additional levels of detail for grouping data in aggregate views and
@@ -91,12 +93,12 @@ export interface Encoding<F> {
   /**
    * Text of the `text` mark.
    */
-  text?: ConditionalTextDef<F>;
+  text?: Conditional<TextFieldDef<F>, ValueDef<string|number|boolean>>;
 
   /**
    * The tooltip text to show upon mouse hover.
    */
-  tooltip?: ConditionalTextDef<F>;
+  tooltip?: Conditional<TextFieldDef<F>, ValueDef<string|number|boolean>>;
 
   /**
    * stack order for stacked marks or order of data points in line marks.

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -17,7 +17,7 @@ import {
   TextFieldDef,
   ValueDef
 } from './fielddef';
-import {Conditional, normalizeFieldDef} from './fielddef';
+import {Conditional, ConditionalLegendDef, ConditionalTextDef, normalizeFieldDef, PositionDef} from './fielddef';
 import * as log from './log';
 import {Mark} from './mark';
 import {isArray, some} from './util';
@@ -30,14 +30,14 @@ export interface Encoding<F> {
    * `line`, `rule`, `text`, and `tick`
    * (or to width and height for `bar` and `area` marks).
    */
-  x?: PositionFieldDef<F> | ValueDef<number>;
+  x?: PositionDef<F>;
 
   /**
    * Y coordinates for `point`, `circle`, `square`,
    * `line`, `rule`, `text`, and `tick`
    * (or to width and height for `bar` and `area` marks).
    */
-  y?: PositionFieldDef<F> | ValueDef<number>;
+  y?: PositionDef<F>;
 
   /**
    * X2 coordinates for ranged `bar`, `rule`, `area`.
@@ -56,12 +56,12 @@ export interface Encoding<F> {
    * (By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /
    * stroke color for `line` and `point`.)
    */
-  color?: Conditional<LegendFieldDef<F, string>, ValueDef<string>>;
+  color?: ConditionalLegendDef<F, string>;
 
   /**
    * Opacity of the marks – either can be a value or a range.
    */
-  opacity?: Conditional<LegendFieldDef<F, number>, ValueDef<number>>;
+  opacity?: ConditionalLegendDef<F, number>;
 
   /**
    * Size of the mark.
@@ -71,14 +71,14 @@ export interface Encoding<F> {
    * - For `text` – the text's font size.
    * - Size is currently unsupported for `line` and `area`.
    */
-  size?: Conditional<LegendFieldDef<F, number>, ValueDef<number>>;
+  size?: ConditionalLegendDef<F, number>;
 
   /**
    * The symbol's shape (only for `point` marks). The supported values are
    * `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`,
    * or `"triangle-down"`, or else a custom SVG path string.
    */
-  shape?: Conditional<LegendFieldDef<F, string>, ValueDef<string>>; // TODO: maybe distinguish ordinal-only
+  shape?: ConditionalLegendDef<F, string>; // TODO: maybe distinguish ordinal-only
 
   /**
    * Additional levels of detail for grouping data in aggregate views and
@@ -89,12 +89,12 @@ export interface Encoding<F> {
   /**
    * Text of the `text` mark.
    */
-  text?: Conditional<TextFieldDef<F>, ValueDef<string|number|boolean>>;
+  text?: ConditionalTextDef<F>;
 
   /**
    * The tooltip text to show upon mouse hover.
    */
-  tooltip?: Conditional<TextFieldDef<F>, ValueDef<string|number|boolean>>;
+  tooltip?: ConditionalTextDef<F>;
 
   /**
    * stack order for stacked marks or order of data points in line marks.

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -143,12 +143,17 @@ export interface PositionFieldDef<F> extends ScaleFieldDef<F> {
    */
   stack?: StackOffset;
 }
+
+export type PositionDef<F> = PositionFieldDef<F> | ValueDef<number>;
+
 export interface LegendFieldDef<F, T> extends ScaleFieldDef<F> {
    /**
     * @nullable
     */
   legend?: Legend;
 }
+
+export type ConditionalLegendDef<F, T> = Conditional<LegendFieldDef<F, T>, ValueDef<T>>;
 
 // Detail
 
@@ -165,6 +170,8 @@ export interface TextFieldDef<F> extends FieldDef<F> {
    */
   format?: string;
 }
+
+export type ConditionalTextDef<F> = Conditional<TextFieldDef<F>, ValueDef<string|number|boolean>>;
 
 export type ChannelDef<F> = FieldDef<F> | ValueDef<any>;
 

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -49,7 +49,7 @@ export type Condition<T> = {
 export type ConditionalFieldDef<F extends FieldDef<any>, V extends ValueDef<any>> = F & {condition?: Condition<V>};
 
 export interface ConditionOnlyDef <F extends FieldDef<any>, V extends ValueDef<any>> {
-  condition: Condition<F | V>;
+  condition: Condition<F> | Condition<V>;
 }
 
 
@@ -60,7 +60,7 @@ export interface ConditionOnlyDef <F extends FieldDef<any>, V extends ValueDef<a
  *   value: ...,
  * }
  */
-export type ConditionalValueDef<F extends FieldDef<any>, V extends ValueDef<any>> = V & {condition?: Condition<F | V>;};
+export type ConditionalValueDef<F extends FieldDef<any>, V extends ValueDef<any>> = V & {condition?: Condition<F> | Condition<V>;};
 
 /**
  * Reference to a repeated value.

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -149,16 +149,12 @@ export interface PositionFieldDef<F> extends ScaleFieldDef<F> {
   stack?: StackOffset;
 }
 
-export type PositionDef<F> = PositionFieldDef<F> | ValueDef<number>;
-
 export interface LegendFieldDef<F> extends ScaleFieldDef<F> {
    /**
     * @nullable
     */
   legend?: Legend;
 }
-
-export type ConditionalLegendDef<F, T> = Conditional<LegendFieldDef<F>, ValueDef<T>>;
 
 // Detail
 
@@ -175,8 +171,6 @@ export interface TextFieldDef<F> extends FieldDef<F> {
    */
   format?: string;
 }
-
-export type ConditionalTextDef<F> = Conditional<TextFieldDef<F>, ValueDef<string|number|boolean>>;
 
 export type ChannelDef<F> = Conditional<FieldDef<F>, ValueDef<any>>;
 

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -27,9 +27,35 @@ export interface ValueDef<T> {
   value: T;
 }
 
-export interface ConditionalValueDef<T> extends ValueDef<T> {
-  condition?: Condition<T>;
-}
+/**
+ * Generic type for conditional channelDef.
+ * F defines the underlying FieldDef type while V defines the underlying ValueDef type.
+ */
+export type Conditional<F extends FieldDef<any>, V extends ValueDef<any>> = ConditionalFieldDef<F, V> | ConditionalValueDef<F, V>;
+
+
+export type Condition<T> = {
+  selection: LogicalOperand<string>;
+} & T;
+
+/**
+ * A FieldDef with Condition<ValueDef>
+ * {
+ *   condition: {value: ...},
+ *   field: ...,
+ *   ...
+ * }
+ */
+export type ConditionalFieldDef<F, V> = F & {condition?: Condition<V>};
+
+/**
+ * A ValueDef with Condition<ValueDef | FieldDef>
+ * {
+ *   condition: {field: ...} | {value: ...},
+ *   value: ...,
+ * }
+ */
+export type ConditionalValueDef<F, V> = V & {condition?: Condition<F | V>};
 
 /**
  * Reference to a repeated value.
@@ -92,11 +118,6 @@ export interface FieldDef<F> extends FieldDefBase<F> {
   type: Type;
 }
 
-export interface Condition<T> {
-  selection: LogicalOperand<string>;
-  value: T;
-}
-
 export interface ScaleFieldDef<F> extends FieldDef<F> {
   scale?: Scale;
   /**
@@ -127,8 +148,6 @@ export interface LegendFieldDef<F, T> extends ScaleFieldDef<F> {
     * @nullable
     */
   legend?: Legend;
-
-  condition?: Condition<T>;
 }
 
 // Detail
@@ -141,8 +160,6 @@ export interface OrderFieldDef<F> extends FieldDef<F> {
 
 export interface TextFieldDef<F> extends FieldDef<F> {
   // FIXME: add more reference to Vega's format pattern or d3's format pattern.
-  condition?: Condition<string|number>;
-
   /**
    * The formatting pattern for text value. If not defined, this will be determined automatically.
    */

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -151,14 +151,14 @@ export interface PositionFieldDef<F> extends ScaleFieldDef<F> {
 
 export type PositionDef<F> = PositionFieldDef<F> | ValueDef<number>;
 
-export interface LegendFieldDef<F, T> extends ScaleFieldDef<F> {
+export interface LegendFieldDef<F> extends ScaleFieldDef<F> {
    /**
     * @nullable
     */
   legend?: Legend;
 }
 
-export type ConditionalLegendDef<F, T> = Conditional<LegendFieldDef<F, T>, ValueDef<T>>;
+export type ConditionalLegendDef<F, T> = Conditional<LegendFieldDef<F>, ValueDef<T>>;
 
 // Detail
 
@@ -191,7 +191,7 @@ export function hasConditionFieldDef<F>(channelDef: ChannelDef<F>): channelDef i
   return !!channelDef && !!channelDef.condition && isFieldDef(channelDef.condition);
 }
 
-export function isFieldDef<F>(channelDef: ChannelDef<F>): channelDef is FieldDef<F> | PositionFieldDef<F> | LegendFieldDef<F, any> | OrderFieldDef<F> | TextFieldDef<F> {
+export function isFieldDef<F>(channelDef: ChannelDef<F>): channelDef is FieldDef<F> | PositionFieldDef<F> | LegendFieldDef<F> | OrderFieldDef<F> | TextFieldDef<F> {
   return !!channelDef && (!!channelDef['field'] || channelDef['aggregate'] === 'count');
 }
 

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -31,7 +31,7 @@ export interface ValueDef<T> {
  * Generic type for conditional channelDef.
  * F defines the underlying FieldDef type while V defines the underlying ValueDef type.
  */
-export type Conditional<F extends FieldDef<any>, V extends ValueDef<any>> = ConditionalFieldDef<F, V> | ConditionalValueDef<F, V>;
+export type Conditional<F extends FieldDef<any>, V extends ValueDef<any>> = ConditionalFieldDef<F, V> | ConditionalValueDef<F, V> | ConditionOnlyDef<F, V>;
 
 
 export type Condition<T> = {
@@ -48,6 +48,11 @@ export type Condition<T> = {
  */
 export type ConditionalFieldDef<F extends FieldDef<any>, V extends ValueDef<any>> = F & {condition?: Condition<V>};
 
+export interface ConditionOnlyDef <F extends FieldDef<any>, V extends ValueDef<any>> {
+  condition: Condition<F | V>;
+}
+
+
 /**
  * A ValueDef with Condition<ValueDef | FieldDef>
  * {
@@ -55,7 +60,7 @@ export type ConditionalFieldDef<F extends FieldDef<any>, V extends ValueDef<any>
  *   value: ...,
  * }
  */
-export type ConditionalValueDef<F extends FieldDef<any>, V extends ValueDef<any>> = V & {condition?: Condition<F | V>};
+export type ConditionalValueDef<F extends FieldDef<any>, V extends ValueDef<any>> = V & {condition?: Condition<F | V>;};
 
 /**
  * Reference to a repeated value.

--- a/src/log.ts
+++ b/src/log.ts
@@ -99,6 +99,11 @@ export function debug(..._: any[]) {
 export namespace message {
   export const INVALID_SPEC = 'Invalid spec';
 
+  // SELECTION
+  export function cannotProjectOnChannelWithoutField(channel: Channel) {
+    return `Cannot project a selection on encoding channel ${channel}, which has no field.`;
+  }
+
   // REPEAT
   export function noSuchRepeatedValue(field: string) {
     return `Unknown repeated value "${field}".`;

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,3 +1,4 @@
+import {SingleDefChannel} from './channel';
 import {VgBinding} from './vega.schema';
 
 export type SelectionTypes = 'single' | 'multi' | 'interval';
@@ -13,7 +14,7 @@ export interface BaseSelectionDef {
 
   // Transforms
   fields?: string[];
-  encodings?: string[];
+  encodings?: SingleDefChannel[];
   toggle?: string | boolean;
   translate?: string | boolean;
   zoom?: string | boolean;

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -3,7 +3,7 @@ import * as log from './log';
 import {SUM_OPS} from './aggregate';
 import {Channel, STACK_GROUP_CHANNELS, X, X2, Y, Y2} from './channel';
 import {channelHasField, Encoding, isAggregate} from './encoding';
-import {Field, FieldDef, isFieldDef, PositionFieldDef} from './fielddef';
+import {Field, FieldDef, getFieldDef, isFieldDef, PositionFieldDef} from './fielddef';
 import {AREA, BAR, CIRCLE, isMarkDef, LINE, Mark, MarkDef, POINT, RULE, SQUARE, TEXT, TICK} from './mark';
 import {ScaleType} from './scale';
 import {contains, isArray} from './util';
@@ -57,8 +57,9 @@ export function stack(m: Mark | MarkDef, encoding: Encoding<Field>, stackConfig:
   const stackBy = STACK_GROUP_CHANNELS.reduce((sc, channel) => {
     if (channelHasField(encoding, channel)) {
       const channelDef = encoding[channel];
-      (isArray(channelDef) ? channelDef : [channelDef]).forEach((fieldDef) => {
-        if (isFieldDef(fieldDef) && !fieldDef.aggregate) {
+      (isArray(channelDef) ? channelDef : [channelDef]).forEach((cDef) => {
+        const fieldDef = getFieldDef(cDef);
+        if (!fieldDef.aggregate) {
           sc.push({
             channel: channel,
             fieldDef: fieldDef

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import {Channel, hasScale, rangeType, supportScaleType} from '../src/channel';
+import {Channel, hasScale, rangeType, SINGLE_DEF_CHANNELS, supportScaleType} from '../src/channel';
 import {CHANNELS, NONSPATIAL_CHANNELS, NONSPATIAL_SCALE_CHANNELS, SCALE_CHANNELS, UNIT_CHANNELS, UNIT_SCALE_CHANNELS} from '../src/channel';
 import {SCALE_TYPES, ScaleType} from '../src/scale';
 import {some, without} from '../src/util';
@@ -9,6 +9,12 @@ describe('channel', () => {
   describe('UNIT_CHANNELS', () => {
     it('should be CHANNELS without row and column', () => {
       assert.deepEqual(UNIT_CHANNELS, without(CHANNELS, ['row', 'column']));
+    });
+  });
+
+  describe('SINGLE_DEF_CHANNELS', () => {
+    it('should be CHANNELS without detail and order', () => {
+      assert.deepEqual(SINGLE_DEF_CHANNELS, without(CHANNELS, ['detail', 'order']));
     });
   });
 

--- a/test/compile/axis/rules.test.ts
+++ b/test/compile/axis/rules.test.ts
@@ -25,27 +25,9 @@ describe('compile/axis', ()=> {
           }
         }), X, true);
       assert.deepEqual(grid, true);
+
     });
 
-    it('should return undefined for COLUMN', function () {
-      const grid = rules.grid(parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: 'a', type: 'quantitative'}
-          }
-        }), COLUMN, true);
-      assert.deepEqual(grid, false);
-    });
-
-    it('should return undefined for ROW', function () {
-      const grid = rules.grid(parseUnitModel({
-          mark: "point",
-          encoding: {
-            x: {field: 'a', type: 'quantitative'}
-          }
-        }), ROW, true);
-      assert.deepEqual(grid, false);
-    });
     it('should return undefined for non-gridAxis', function () {
       const grid = rules.grid(parseUnitModel({
           mark: "point",

--- a/test/compile/data/aggregate.test.ts
+++ b/test/compile/data/aggregate.test.ts
@@ -3,6 +3,7 @@
 import {assert} from 'chai';
 
 import {AggregateNode} from '../../../src/compile/data/aggregate';
+import {Condition} from '../../../src/fielddef';
 import {SummarizeTransform} from '../../../src/transform';
 import {StringSet} from '../../../src/util';
 import {VgAggregateTransform} from '../../../src/vega.schema';
@@ -73,6 +74,28 @@ describe('compile/data/summary', function () {
       assert.deepEqual<VgAggregateTransform>(agg.assemble(), {
         type: 'aggregate',
         groupby: ['Origin', 'Cylinders'],
+        ops: ['mean'],
+        fields: ['Displacement'],
+        as: ['mean_Displacement']
+      });
+    });
+
+    it('should include conditional field in the summary component', function() {
+      const model = parseUnitModel({
+        mark: "point",
+        encoding: {
+          'x': {'aggregate': 'mean', 'field': 'Displacement', 'type': "quantitative"},
+          color: {
+            condition: {selection: 'a', field: 'Origin', 'type': "ordinal"},
+            value: 'red'
+          }
+        }
+      });
+
+      const agg = AggregateNode.makeFromEncoding(model);
+      assert.deepEqual<VgAggregateTransform>(agg.assemble(), {
+        type: 'aggregate',
+        groupby: ['Origin'],
         ops: ['mean'],
         fields: ['Displacement'],
         as: ['mean_Displacement']

--- a/test/compile/scale/domain.test.ts
+++ b/test/compile/scale/domain.test.ts
@@ -44,6 +44,20 @@ describe('compile/scale', () => {
       assert.deepEqual(xDomain, {data: 'main', field: 'a'});
     });
 
+    it('should have correct domain for color ConditionField', function() {
+      const model = parseUnitModel({
+          mark: 'bar',
+          encoding: {
+            color: {
+              condition: {selection: 'sel', field: 'a', type: 'quantitative'}
+            }
+          }
+        });
+
+      const xDomain = parseDomain(model, 'color');
+      assert.deepEqual(xDomain, {data: 'main', field: 'a'});
+    });
+
     it('should return domain for stack', function() {
       const model = parseUnitModel({
         mark: "bar",


### PR DESCRIPTION
Follow up from https://github.com/vega/vega-lite/pull/1971. 

It's probably more natural to do the following way in many cases:

```
x: {
  condition: { selection: <name>,  field: ..., type: ...},
  value: ...
}
```

Currently this PR only contains interface changes, but haven't make it work.  

This will require a major refactor since we can no longer just refer to
`encoding.<channel>.field` for accessing field, so I'm gonna punt on it for now.

- [x] initScale
- [x] initLegend
- [x] fieldDef
  - [x] channelHasField
  - [x] getFieldDef
- [x] aggregate
- [x] mixins of marks 
- [x] schema rename script