### PR TITLE
Initial interactive examples.

### DIFF
--- a/examples/specs/brush.vl.json
+++ b/examples/specs/brush.vl.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+  "description": "Drag out a rectangular brush to highlight points.",
+  "data": {"url": "data/cars.json"},
+  "selection": {
+    "brush": {
+      "type": "interval"
+    }
+  },
+  "mark": "point",
+  "encoding": {
+    "x": {"field": "Horsepower", "type": "quantitative"},
+    "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
+    "color": {
+      "field": "Cylinders", "type": "ordinal",
+      "condition": {
+        "selection": "!brush",
+        "value": "grey"
+      }
+    }
+  }
+}

--- a/examples/specs/paintbrush.vl.json
+++ b/examples/specs/paintbrush.vl.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+  "description": "Select multiple points with the shift key.",
+  "data": {"url": "data/cars.json"},
+  "selection": {
+    "paintbrush": {
+      "type": "multi", "on": "mouseover",
+      "nearest": true
+    }
+  },
+  "mark": "point",
+  "encoding": {
+    "x": {"field": "Horsepower", "type": "quantitative"},
+    "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
+    "size": {
+      "value": 50,
+      "condition": {
+        "selection": "paintbrush",
+        "value": 300
+      }
+    }
+  }
+}

--- a/examples/specs/panzoom_scatter.vl.json
+++ b/examples/specs/panzoom_scatter.vl.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+  "data": {"url": "data/cars.json"},
+  "selection": {
+    "grid": {
+      "type": "interval", "bind": "scales"
+    }
+  },
+  "mark": "circle",
+  "encoding": {
+    "x": {
+      "field": "Horsepower", "type": "quantitative",
+      "scale": {"domain": [75, 150]}
+    },
+    "y": {
+      "field": "Miles_per_Gallon", "type": "quantitative",
+      "scale": {"domain": [20, 40]}
+    },
+    "size": {"field": "Cylinders", "type": "ordinal"}
+  }
+}

--- a/examples/specs/query_widgets.vl.json
+++ b/examples/specs/query_widgets.vl.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+  "description": "Drag the sliders to highlight points.",
+  "data": {"url": "data/cars.json"},
+  "transform": {
+    "calculate": [{"as": "Year", "expr": "year(datum.Year)"}]
+  },
+  "selection": {
+    "CylYr": {
+      "type": "single", "fields": ["Cylinders", "Year"],
+      "bind": {
+        "Cylinders": {"input": "range", "min": 3, "max": 8, "step": 1},
+        "Year": {"input": "range", "min": 1969, "max": 1981, "step": 1}
+      }
+    }
+  },
+  "mark": "circle",
+  "encoding": {
+    "x": {"field": "Horsepower", "type": "quantitative"},
+    "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
+    "color": {
+      "field": "Origin", "type": "nominal",
+      "condition": {
+        "selection": "!CylYr",
+        "value": "grey"
+      }
+    }
+  }
+}

--- a/examples/vl-examples.json
+++ b/examples/vl-examples.json
@@ -236,5 +236,23 @@
         "backgroundPosition": "30% 0%"
       }
     }
+  ],
+  "Interactive": [
+    {
+      "name": "brush",
+      "title": "Rectangular Brush"
+    },
+    {
+      "name": "paintbrush",
+      "title": "Paintbrush Highlight"
+    },
+    {
+      "name": "panzoom_scatter",
+      "title": "Scatterplot Pan & Zoom"
+    },
+    {
+      "name": "query_widgets",
+      "title": "Query Widgets"
+    }
   ]
 }

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,5 +1,4 @@
 import {VgBinding} from './vega.schema';
-import {Dict} from './util';
 
 export type SelectionTypes = 'single' | 'multi' | 'interval';
 export type SelectionDomain = 'data' | 'visual';
@@ -10,7 +9,7 @@ export interface BaseSelectionDef {
   // domain?: SelectionDomain;
   on?: any;
   // predicate?: string;
-  bind?: 'scales' | VgBinding | Dict<VgBinding>;
+  bind?: 'scales' | VgBinding | {[key: string]: VgBinding};
 
   // Transforms
   fields?: string[];

--- a/vega-lite-schema.json
+++ b/vega-lite-schema.json
@@ -592,7 +592,121 @@
                             "type": "object"
                         },
                         {
-                            "$ref": "#/definitions/Dict<VgBinding>"
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "element": {
+                                                "type": "string"
+                                            },
+                                            "input": {
+                                                "enum": [
+                                                    "checkbox"
+                                                ],
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "input"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "element": {
+                                                "type": "string"
+                                            },
+                                            "input": {
+                                                "enum": [
+                                                    "radio"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "options": {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "input",
+                                            "options"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "element": {
+                                                "type": "string"
+                                            },
+                                            "input": {
+                                                "enum": [
+                                                    "select"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "options": {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "input",
+                                            "options"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "element": {
+                                                "type": "string"
+                                            },
+                                            "input": {
+                                                "enum": [
+                                                    "range"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "max": {
+                                                "type": "number"
+                                            },
+                                            "min": {
+                                                "type": "number"
+                                            },
+                                            "step": {
+                                                "type": "number"
+                                            }
+                                        },
+                                        "required": [
+                                            "input"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "element": {
+                                                "type": "string"
+                                            },
+                                            "input": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "input"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "type": "object"
                         },
                         {
                             "enum": [
@@ -1098,12 +1212,6 @@
                     "description": "Integer value representing the year.",
                     "type": "integer"
                 }
-            },
-            "type": "object"
-        },
-        "Dict<VgBinding>": {
-            "additionalProperties": {
-                "$ref": "#/definitions/T"
             },
             "type": "object"
         },
@@ -2982,7 +3090,121 @@
                             "type": "object"
                         },
                         {
-                            "$ref": "#/definitions/Dict<VgBinding>"
+                            "additionalProperties": {
+                                "anyOf": [
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "element": {
+                                                "type": "string"
+                                            },
+                                            "input": {
+                                                "enum": [
+                                                    "checkbox"
+                                                ],
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "input"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "element": {
+                                                "type": "string"
+                                            },
+                                            "input": {
+                                                "enum": [
+                                                    "radio"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "options": {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "input",
+                                            "options"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "element": {
+                                                "type": "string"
+                                            },
+                                            "input": {
+                                                "enum": [
+                                                    "select"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "options": {
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "type": "array"
+                                            }
+                                        },
+                                        "required": [
+                                            "input",
+                                            "options"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "element": {
+                                                "type": "string"
+                                            },
+                                            "input": {
+                                                "enum": [
+                                                    "range"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "max": {
+                                                "type": "number"
+                                            },
+                                            "min": {
+                                                "type": "number"
+                                            },
+                                            "step": {
+                                                "type": "number"
+                                            }
+                                        },
+                                        "required": [
+                                            "input"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    {
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "element": {
+                                                "type": "string"
+                                            },
+                                            "input": {
+                                                "type": "string"
+                                            }
+                                        },
+                                        "required": [
+                                            "input"
+                                        ],
+                                        "type": "object"
+                                    }
+                                ]
+                            },
+                            "type": "object"
                         },
                         {
                             "enum": [
@@ -3245,12 +3467,6 @@
                     "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the x and y properties. Values for theta follow the same convention of arc mark startAngle and endAngle properties: angles are measured in radians, with 0 indicating \"north\".",
                     "type": "number"
                 }
-            },
-            "type": "object"
-        },
-        "T": {
-            "additionalProperties": false,
-            "properties": {
             },
             "type": "object"
         },


### PR DESCRIPTION
Four interactive examples to kick us off:

1. Rectangular brush:
![brush](https://cloud.githubusercontent.com/assets/42262/23326697/5908aa2e-fab5-11e6-9a69-3b899ebc475f.gif)

2. Paintbrush
![paintbrush](https://cloud.githubusercontent.com/assets/42262/23326698/5d150af4-fab5-11e6-9450-fab055ebadc5.gif)

3. Pan & Zoom a Scatterplot
![panzoom_scatter](https://cloud.githubusercontent.com/assets/42262/23326705/68ccfe6a-fab5-11e6-9ec4-a5ff4b26858c.gif)

4. Dynamic query widgets -- this one would greatly benefit from `zindex` support (#1684).
![query_widgets](https://cloud.githubusercontent.com/assets/42262/23326711/7c53f2a4-fab5-11e6-8b47-3db1da54ee16.gif)
