### PR TITLE
Allow users to customize role

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -2305,6 +2305,10 @@
                     "$ref": "#/definitions/Orient",
                     "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
                 },
+                "role": {
+                    "description": "A metadata string indicating the role of the mark.\nThis allows users to use `config.<role-name>.*` to customize properties of marks with specific roles.\nIn addition, SVG renderers will add this role value (prepended with the prefix role-) as a CSS class name on the enclosing SVG group (g) element containing the mark instances.",
+                    "type": "string"
+                },
                 "tension": {
                     "description": "Depending on the interpolation type, sets the tension parameter (for line and area marks).",
                     "maximum": 1,

--- a/src/compile/mark/area.ts
+++ b/src/compile/mark/area.ts
@@ -5,7 +5,7 @@ import {MarkCompiler} from './base';
 
 export const area: MarkCompiler = {
   vgMark: 'area',
-  role: undefined,
+  defaultRole: undefined,
   encodeEntry: (model: UnitModel) => {
     const orient = model.markDef.orient;
 

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -15,7 +15,7 @@ import * as ref from './valueref';
 
 export const bar: MarkCompiler = {
   vgMark: 'rect',
-  role: 'bar',
+  defaultRole: 'bar',
   encodeEntry: (model: UnitModel) => {
     const stack = model.stack;
     return {

--- a/src/compile/mark/base.ts
+++ b/src/compile/mark/base.ts
@@ -14,6 +14,6 @@ export interface MarkCompiler {
    * Vega's Mark role, which enables use to use config.<vega-lite>.* in parser.
    * Basically for marks that are not Vega marks, we output roles for all of them.
    */
-  role: 'bar' | 'point' | 'circle' | 'square' | 'tick' | undefined;
+  defaultRole: 'bar' | 'point' | 'circle' | 'square' | 'tick' | undefined;
   encodeEntry: (model: UnitModel) => VgEncodeEntry;
 }

--- a/src/compile/mark/line.ts
+++ b/src/compile/mark/line.ts
@@ -5,7 +5,7 @@ import {MarkCompiler} from './base';
 
 export const line: MarkCompiler = {
   vgMark: 'line',
-  role: undefined,
+  defaultRole: undefined,
   encodeEntry: (model: UnitModel) => {
     return {
       ...mixins.pointPosition('x', model, 'zeroOrMin'),

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -95,7 +95,7 @@ function parsePathMark(model: UnitModel) {
 function parseNonPathMark(model: UnitModel) {
   const mark = model.mark();
 
-  const role = markCompiler[mark].role;
+  const role = model.markDef.role || markCompiler[mark].defaultRole;
 
   let marks: any[] = []; // TODO: vgMarks
 

--- a/src/compile/mark/point.ts
+++ b/src/compile/mark/point.ts
@@ -31,7 +31,7 @@ export function shapeMixins(model: UnitModel, config: Config, fixedShape?: 'circ
 
 export const point: MarkCompiler = {
   vgMark: 'symbol',
-  role: 'point',
+  defaultRole: 'point',
   encodeEntry: (model: UnitModel) => {
     return encodeEntry(model);
   }
@@ -39,7 +39,7 @@ export const point: MarkCompiler = {
 
 export const circle: MarkCompiler = {
   vgMark: 'symbol',
-  role: 'circle',
+  defaultRole: 'circle',
   encodeEntry: (model: UnitModel) => {
     return encodeEntry(model, 'circle');
   }
@@ -47,7 +47,7 @@ export const circle: MarkCompiler = {
 
 export const square: MarkCompiler = {
   vgMark: 'symbol',
-  role: 'square',
+  defaultRole: 'square',
   encodeEntry: (model: UnitModel) => {
     return encodeEntry(model, 'square');
   }

--- a/src/compile/mark/rect.ts
+++ b/src/compile/mark/rect.ts
@@ -11,7 +11,7 @@ import {MarkCompiler} from './base';
 
 export const rect: MarkCompiler = {
   vgMark: 'rect',
-  role: undefined,
+  defaultRole: undefined,
   encodeEntry: (model: UnitModel) => {
     return {
       ...x(model),

--- a/src/compile/mark/rule.ts
+++ b/src/compile/mark/rule.ts
@@ -4,7 +4,7 @@ import * as mixins from './mixins';
 
 export const rule: MarkCompiler = {
   vgMark: 'rule',
-  role: undefined,
+  defaultRole: undefined,
   encodeEntry: (model: UnitModel) => {
     return {
       ...mixins.pointPosition('x', model, 'zeroOrMin'),

--- a/src/compile/mark/text.ts
+++ b/src/compile/mark/text.ts
@@ -14,7 +14,7 @@ import {Encoding, channelHasField} from '../../encoding';
 
 export const text: MarkCompiler = {
   vgMark: 'text',
-  role: undefined,
+  defaultRole: undefined,
 
   encodeEntry: (model: UnitModel) => {
     const {config, encoding} = model;

--- a/src/compile/mark/tick.ts
+++ b/src/compile/mark/tick.ts
@@ -8,7 +8,7 @@ import * as ref from './valueref';
 
 export const tick: MarkCompiler = {
   vgMark: 'rect',
-  role: 'tick',
+  defaultRole: 'tick',
 
   encodeEntry: (model: UnitModel) => {
     const {config, markDef} = model;

--- a/src/config.ts
+++ b/src/config.ts
@@ -218,6 +218,13 @@ export interface Config {
 
   /** Selection Config */
   selection?: SelectionConfig;
+
+  // Support arbitrary key for role config
+  // Note: Technically, the type for role config should be `MarkConfig`.
+  // However, Typescript requires that the index type must be compatible with all other properties.
+  // Basically, it will complain that `legend: LegendConfig` is not an instance of `MarkConfig`
+  // Thus, we have to use `any` here.
+  [role: string]: any;
 }
 
 export const defaultConfig: Config = {

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -44,6 +44,13 @@ export interface MarkDef {
   type: Mark;
 
   /**
+   * A metadata string indicating the role of the mark.
+   * This allows users to use `config.<role-name>.*` to customize properties of marks with specific roles.
+   * In addition, SVG renderers will add this role value (prepended with the prefix role-) as a CSS class name on the enclosing SVG group (g) element containing the mark instances.
+   */
+  role?: string;
+
+  /**
    * The orientation of a non-stacked bar, tick, area, and line charts.
    * The value is either horizontal (default) or vertical.
    * - For bar, rule and tick, this determines whether the size of the bar and tick

--- a/test/compile/common.test.ts
+++ b/test/compile/common.test.ts
@@ -50,16 +50,16 @@ describe('Common', function() {
     });
 
     it('should use format if provided', function() {
-      assert.equal(numberFormat({field: 'a', type: QUANTITATIVE}, 'a', 'd', X), 'a');
+      assert.equal(numberFormat({field: 'a', type: QUANTITATIVE}, 'a', {}, X), 'a');
     });
 
     it('should not use number format for binned quantitative scale', function() {
-      assert.equal(numberFormat({bin: true, field: 'a', type: QUANTITATIVE}, undefined, 'd', X), undefined);
+      assert.equal(numberFormat({bin: true, field: 'a', type: QUANTITATIVE}, undefined, {}, X), undefined);
     });
 
     it('should not use number format for non-quantitative scale', function() {
       for (let type of [TEMPORAL, NOMINAL, ORDINAL]) {
-        assert.equal(numberFormat({bin: true, field: 'a', type: type}, undefined, 'd', X), undefined);
+        assert.equal(numberFormat({bin: true, field: 'a', type: type}, undefined, {}, X), undefined);
       }
     });
   });


### PR DESCRIPTION
This will be useful for composite marks.  For example, box plot may use bar to implement upper and lower boxes, but config.bar.* should not be applied to these boxes as they represent semantically different things.

Instead, users should able to use role config such as `config.box, config.upperBox, config.lowerBox, config.whisker, config.upper/lowerWhisker` for customizing parts of composite marks.

cc: @mattwchun