### PR TITLE
Differentiate top-level spec from normal spec.

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -2,13 +2,334 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "anyOf": [
         {
-            "$ref": "#/definitions/GenericUnitSpec<string | MarkDef, EncodingWithFacet>"
+            "additionalProperties": false,
+            "properties": {
+                "$schema": {
+                    "description": "URL to JSON schema for this Vega-Lite specification.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "background": {
+                    "description": "CSS color property to use as background of visualization. Default is `\"transparent\"`.",
+                    "type": "string"
+                },
+                "config": {
+                    "$ref": "#/definitions/Config",
+                    "description": "Configuration object"
+                },
+                "data": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/UrlData"
+                        },
+                        {
+                            "$ref": "#/definitions/InlineData"
+                        },
+                        {
+                            "$ref": "#/definitions/NamedData"
+                        }
+                    ],
+                    "description": "An object describing the data source"
+                },
+                "description": {
+                    "description": "An optional description of this mark for commenting purpose.\nThis property has no effect on the output visualization.",
+                    "type": "string"
+                },
+                "encoding": {
+                    "$ref": "#/definitions/EncodingWithFacet",
+                    "description": "A key-value mapping between encoding channels and definition of fields."
+                },
+                "height": {
+                    "type": "number"
+                },
+                "mark": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/MarkDef"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ],
+                    "description": "The mark type.\nOne of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, and `\"text\"`."
+                },
+                "name": {
+                    "description": "Name of the visualization for later reference.",
+                    "type": "string"
+                },
+                "padding": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "bottom": {
+                                    "type": "number"
+                                },
+                                "left": {
+                                    "type": "number"
+                                },
+                                "right": {
+                                    "type": "number"
+                                },
+                                "top": {
+                                    "type": "number"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `\"top\"`, `\"left\"`, `\"right\"`, `\"bottom\"` properties.\n\n__Default value__: `5`",
+                    "minimum": 0
+                },
+                "selection": {
+                    "additionalProperties": {
+                        "$ref": "#/definitions/SelectionDef"
+                    },
+                    "description": "A key-value mapping between selection names and definitions.",
+                    "type": "object"
+                },
+                "transform": {
+                    "description": "An object describing filter and new field calculation.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/FilterTransform"
+                            },
+                            {
+                                "$ref": "#/definitions/CalculateTransform"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "viewport": {
+                    "description": "The width and height of the on-screen viewport, in pixels. If necessary, clipping and scrolling will be applied.",
+                    "type": "number"
+                },
+                "width": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "encoding",
+                "mark"
+            ],
+            "type": "object"
         },
         {
-            "$ref": "#/definitions/GenericFacetSpec<GenericUnitSpec<string | MarkDef, EncodingWithFacet>>"
+            "additionalProperties": false,
+            "properties": {
+                "$schema": {
+                    "description": "URL to JSON schema for this Vega-Lite specification.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "background": {
+                    "description": "CSS color property to use as background of visualization. Default is `\"transparent\"`.",
+                    "type": "string"
+                },
+                "config": {
+                    "$ref": "#/definitions/Config",
+                    "description": "Configuration object"
+                },
+                "data": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/UrlData"
+                        },
+                        {
+                            "$ref": "#/definitions/InlineData"
+                        },
+                        {
+                            "$ref": "#/definitions/NamedData"
+                        }
+                    ],
+                    "description": "An object describing the data source"
+                },
+                "description": {
+                    "description": "An optional description of this mark for commenting purpose.\nThis property has no effect on the output visualization.",
+                    "type": "string"
+                },
+                "facet": {
+                    "$ref": "#/definitions/Facet"
+                },
+                "name": {
+                    "description": "Name of the visualization for later reference.",
+                    "type": "string"
+                },
+                "padding": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "bottom": {
+                                    "type": "number"
+                                },
+                                "left": {
+                                    "type": "number"
+                                },
+                                "right": {
+                                    "type": "number"
+                                },
+                                "top": {
+                                    "type": "number"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `\"top\"`, `\"left\"`, `\"right\"`, `\"bottom\"` properties.\n\n__Default value__: `5`",
+                    "minimum": 0
+                },
+                "spec": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/GenericUnitSpec<string | MarkDef, EncodingWithFacet>"
+                        },
+                        {
+                            "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<string | MarkDef, EncodingWithFacet>>"
+                        }
+                    ]
+                },
+                "transform": {
+                    "description": "An object describing filter and new field calculation.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/FilterTransform"
+                            },
+                            {
+                                "$ref": "#/definitions/CalculateTransform"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "viewport": {
+                    "description": "The width and height of the on-screen viewport, in pixels. If necessary, clipping and scrolling will be applied.",
+                    "type": "number"
+                }
+            },
+            "required": [
+                "facet",
+                "spec"
+            ],
+            "type": "object"
         },
         {
-            "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<string | MarkDef, EncodingWithFacet>>"
+            "additionalProperties": false,
+            "properties": {
+                "$schema": {
+                    "description": "URL to JSON schema for this Vega-Lite specification.",
+                    "format": "uri",
+                    "type": "string"
+                },
+                "background": {
+                    "description": "CSS color property to use as background of visualization. Default is `\"transparent\"`.",
+                    "type": "string"
+                },
+                "config": {
+                    "$ref": "#/definitions/Config",
+                    "description": "Configuration object"
+                },
+                "data": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/UrlData"
+                        },
+                        {
+                            "$ref": "#/definitions/InlineData"
+                        },
+                        {
+                            "$ref": "#/definitions/NamedData"
+                        }
+                    ],
+                    "description": "An object describing the data source"
+                },
+                "description": {
+                    "description": "An optional description of this mark for commenting purpose.\nThis property has no effect on the output visualization.",
+                    "type": "string"
+                },
+                "height": {
+                    "type": "number"
+                },
+                "layer": {
+                    "description": "Unit specs that will be layered.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/GenericUnitSpec<string | MarkDef, EncodingWithFacet>"
+                            },
+                            {
+                                "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<string | MarkDef, EncodingWithFacet>>"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "description": "Name of the visualization for later reference.",
+                    "type": "string"
+                },
+                "padding": {
+                    "anyOf": [
+                        {
+                            "additionalProperties": false,
+                            "properties": {
+                                "bottom": {
+                                    "type": "number"
+                                },
+                                "left": {
+                                    "type": "number"
+                                },
+                                "right": {
+                                    "type": "number"
+                                },
+                                "top": {
+                                    "type": "number"
+                                }
+                            },
+                            "type": "object"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ],
+                    "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `\"top\"`, `\"left\"`, `\"right\"`, `\"bottom\"` properties.\n\n__Default value__: `5`",
+                    "minimum": 0
+                },
+                "transform": {
+                    "description": "An object describing filter and new field calculation.",
+                    "items": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/definitions/FilterTransform"
+                            },
+                            {
+                                "$ref": "#/definitions/CalculateTransform"
+                            }
+                        ]
+                    },
+                    "type": "array"
+                },
+                "viewport": {
+                    "description": "The width and height of the on-screen viewport, in pixels. If necessary, clipping and scrolling will be applied.",
+                    "type": "number"
+                },
+                "width": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "layer"
+            ],
+            "type": "object"
         }
     ],
     "definitions": {
@@ -1044,7 +1365,8 @@
                             "type": "number"
                         }
                     ],
-                    "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `\"top\"`, `\"left\"`, `\"right\"`, `\"bottom\"` properties.\n\n__Default value__: `5`\n\n* @minimum 0"
+                    "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `\"top\"`, `\"left\"`, `\"right\"`, `\"bottom\"` properties.\n\n__Default value__: `5`",
+                    "minimum": 0
                 },
                 "point": {
                     "$ref": "#/definitions/MarkConfig",
@@ -1571,113 +1893,9 @@
             ],
             "type": "string"
         },
-        "GenericFacetSpec<GenericUnitSpec<string | MarkDef, EncodingWithFacet>>": {
-            "additionalProperties": false,
-            "properties": {
-                "$schema": {
-                    "description": "URL to JSON schema for this Vega-Lite specification.",
-                    "format": "uri",
-                    "type": "string"
-                },
-                "config": {
-                    "$ref": "#/definitions/Config",
-                    "description": "Configuration object"
-                },
-                "data": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/UrlData"
-                        },
-                        {
-                            "$ref": "#/definitions/InlineData"
-                        },
-                        {
-                            "$ref": "#/definitions/NamedData"
-                        }
-                    ],
-                    "description": "An object describing the data source"
-                },
-                "description": {
-                    "description": "An optional description of this mark for commenting purpose.\nThis property has no effect on the output visualization.",
-                    "type": "string"
-                },
-                "facet": {
-                    "$ref": "#/definitions/Facet"
-                },
-                "name": {
-                    "description": "Name of the visualization for later reference.",
-                    "type": "string"
-                },
-                "padding": {
-                    "anyOf": [
-                        {
-                            "additionalProperties": false,
-                            "properties": {
-                                "bottom": {
-                                    "type": "number"
-                                },
-                                "left": {
-                                    "type": "number"
-                                },
-                                "right": {
-                                    "type": "number"
-                                },
-                                "top": {
-                                    "type": "number"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "type": "number"
-                        }
-                    ],
-                    "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `\"top\"`, `\"left\"`, `\"right\"`, `\"bottom\"` properties.\n\n__Default value__: `5`",
-                    "minimum": 0
-                },
-                "spec": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/GenericUnitSpec<string | MarkDef, EncodingWithFacet>"
-                        },
-                        {
-                            "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<string | MarkDef, EncodingWithFacet>>"
-                        }
-                    ]
-                },
-                "transform": {
-                    "description": "An array of transforms.",
-                    "items": {
-                        "anyOf": [
-                            {
-                                "$ref": "#/definitions/FilterTransform"
-                            },
-                            {
-                                "$ref": "#/definitions/CalculateTransform"
-                            }
-                        ]
-                    },
-                    "type": "array"
-                }
-            },
-            "required": [
-                "facet",
-                "spec"
-            ],
-            "type": "object"
-        },
         "GenericLayerSpec<GenericUnitSpec<string | MarkDef, EncodingWithFacet>>": {
             "additionalProperties": false,
             "properties": {
-                "$schema": {
-                    "description": "URL to JSON schema for this Vega-Lite specification.",
-                    "format": "uri",
-                    "type": "string"
-                },
-                "config": {
-                    "$ref": "#/definitions/Config",
-                    "description": "Configuration object"
-                },
                 "data": {
                     "anyOf": [
                         {
@@ -1717,35 +1935,8 @@
                     "description": "Name of the visualization for later reference.",
                     "type": "string"
                 },
-                "padding": {
-                    "anyOf": [
-                        {
-                            "additionalProperties": false,
-                            "properties": {
-                                "bottom": {
-                                    "type": "number"
-                                },
-                                "left": {
-                                    "type": "number"
-                                },
-                                "right": {
-                                    "type": "number"
-                                },
-                                "top": {
-                                    "type": "number"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "type": "number"
-                        }
-                    ],
-                    "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `\"top\"`, `\"left\"`, `\"right\"`, `\"bottom\"` properties.\n\n__Default value__: `5`",
-                    "minimum": 0
-                },
                 "transform": {
-                    "description": "An array of transforms.",
+                    "description": "An object describing filter and new field calculation.",
                     "items": {
                         "anyOf": [
                             {
@@ -1770,15 +1961,6 @@
         "GenericUnitSpec<string | MarkDef, EncodingWithFacet>": {
             "additionalProperties": false,
             "properties": {
-                "$schema": {
-                    "description": "URL to JSON schema for this Vega-Lite specification.",
-                    "format": "uri",
-                    "type": "string"
-                },
-                "config": {
-                    "$ref": "#/definitions/Config",
-                    "description": "Configuration object"
-                },
                 "data": {
                     "anyOf": [
                         {
@@ -1819,33 +2001,6 @@
                     "description": "Name of the visualization for later reference.",
                     "type": "string"
                 },
-                "padding": {
-                    "anyOf": [
-                        {
-                            "additionalProperties": false,
-                            "properties": {
-                                "bottom": {
-                                    "type": "number"
-                                },
-                                "left": {
-                                    "type": "number"
-                                },
-                                "right": {
-                                    "type": "number"
-                                },
-                                "top": {
-                                    "type": "number"
-                                }
-                            },
-                            "type": "object"
-                        },
-                        {
-                            "type": "number"
-                        }
-                    ],
-                    "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `\"top\"`, `\"left\"`, `\"right\"`, `\"bottom\"` properties.\n\n__Default value__: `5`",
-                    "minimum": 0
-                },
                 "selection": {
                     "additionalProperties": {
                         "$ref": "#/definitions/SelectionDef"
@@ -1854,7 +2009,7 @@
                     "type": "object"
                 },
                 "transform": {
-                    "description": "An array of transforms.",
+                    "description": "An object describing filter and new field calculation.",
                     "items": {
                         "anyOf": [
                             {

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -105,10 +105,6 @@
                     },
                     "type": "array"
                 },
-                "viewport": {
-                    "description": "The width and height of the on-screen viewport, in pixels. If necessary, clipping and scrolling will be applied.",
-                    "type": "number"
-                },
                 "width": {
                     "type": "number"
                 }
@@ -210,10 +206,6 @@
                         ]
                     },
                     "type": "array"
-                },
-                "viewport": {
-                    "description": "The width and height of the on-screen viewport, in pixels. If necessary, clipping and scrolling will be applied.",
-                    "type": "number"
                 }
             },
             "required": [
@@ -317,10 +309,6 @@
                         ]
                     },
                     "type": "array"
-                },
-                "viewport": {
-                    "description": "The width and height of the on-screen viewport, in pixels. If necessary, clipping and scrolling will be applied.",
-                    "type": "number"
                 },
                 "width": {
                     "type": "number"
@@ -1457,10 +1445,6 @@
                 "timeFormat": {
                     "description": "Default datetime format for axis and legend labels. The format can be set directly on each axis and legend.",
                     "type": "string"
-                },
-                "viewport": {
-                    "description": "The width and height of the on-screen viewport, in pixels. If necessary, clipping and scrolling will be applied.",
-                    "type": "number"
                 }
             },
             "type": "object"

--- a/examples/examples.test.ts
+++ b/examples/examples.test.ts
@@ -1,7 +1,7 @@
+import * as Ajv from 'ajv';
 import {assert} from 'chai';
 import {compile} from '../src/compile/compile';
-import {ExtendedSpec} from '../src/spec';
-import * as Ajv from 'ajv';
+import {ExtendedSpec, TopLevel} from '../src/spec';
 
 const inspect = require('util').inspect;
 const fs = require('fs');
@@ -18,7 +18,7 @@ const ajv = new Ajv({
 const validateVl = ajv.compile(vlSchema);
 const validateVg = ajv.compile(vgSchema);
 
-function validateVL(spec: ExtendedSpec) {
+function validateVL(spec: TopLevel<ExtendedSpec>) {
   const valid = validateVl(spec);
   const errors = validateVl.errors;
   if (!valid) {
@@ -29,7 +29,7 @@ function validateVL(spec: ExtendedSpec) {
   assert.equal(spec.$schema, 'https://vega.github.io/schema/vega-lite/v2.json');
 }
 
-function validateVega(spec: ExtendedSpec) {
+function validateVega(spec: TopLevel<ExtendedSpec>) {
   const vegaSpec = compile(spec).spec;
 
   const valid = validateVg(vegaSpec);

--- a/examples/specs/layer_line_color_rule.vl.json
+++ b/examples/specs/layer_line_color_rule.vl.json
@@ -19,9 +19,9 @@
           "aggregate": "mean"
         },
         "size": {"value": 2},
-        "color": {"field": "symbol","type": "nominal"}
-      },
-      "config": {"mark": {"opacity": 0.5}}
+        "color": {"field": "symbol","type": "nominal"},
+        "opacity": {"value": 0.5}
+      }
     }
   ]
 }

--- a/examples/specs/overlay_area_full.vl.json
+++ b/examples/specs/overlay_area_full.vl.json
@@ -23,8 +23,8 @@
       "encoding": {
         "x": {"field": "date","type": "temporal"},
         "y": {"field": "price","type": "quantitative"}
-      },
-      "config": {"mark": {"filled": true}}
+      }
     }
-  ]
+  ],
+  "config": {"mark": {"filled": true}}
 }

--- a/examples/specs/overlay_line_full.vl.json
+++ b/examples/specs/overlay_line_full.vl.json
@@ -17,8 +17,8 @@
       "encoding": {
         "x": {"field": "date","type": "temporal"},
         "y": {"field": "price","type": "quantitative"}
-      },
-      "config": {"mark": {"filled": true}}
+      }
     }
-  ]
+  ],
+  "config": {"mark": {"filled": true}}
 }

--- a/examples/vg-specs/area.vg.json
+++ b/examples/vg-specs/area.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/area_vertical.vg.json
+++ b/examples/vg-specs/area_vertical.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bar.vg.json
+++ b/examples/vg-specs/bar.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bar_1d.vg.json
+++ b/examples/vg-specs/bar_1d.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bar_1d_rangestep_config.vg.json
+++ b/examples/vg-specs/bar_1d_rangestep_config.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bar_aggregate.vg.json
+++ b/examples/vg-specs/bar_aggregate.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bar_aggregate_size.vg.json
+++ b/examples/vg-specs/bar_aggregate_size.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bar_aggregate_vertical.vg.json
+++ b/examples/vg-specs/bar_aggregate_vertical.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bar_filter_calc.vg.json
+++ b/examples/vg-specs/bar_filter_calc.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bar_grouped.vg.json
+++ b/examples/vg-specs/bar_grouped.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bar_grouped_horizontal.vg.json
+++ b/examples/vg-specs/bar_grouped_horizontal.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bar_layered_transparent.vg.json
+++ b/examples/vg-specs/bar_layered_transparent.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bar_size_default.vg.json
+++ b/examples/vg-specs/bar_size_default.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bar_size_explicit.vg.json
+++ b/examples/vg-specs/bar_size_explicit.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bar_size_explicit_bad.vg.json
+++ b/examples/vg-specs/bar_size_explicit_bad.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bar_size_fit.vg.json
+++ b/examples/vg-specs/bar_size_fit.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bar_size_rangestep_small.vg.json
+++ b/examples/vg-specs/bar_size_rangestep_small.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bar_yearmonth.vg.json
+++ b/examples/vg-specs/bar_yearmonth.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/box_plot.vg.json
+++ b/examples/vg-specs/box_plot.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/bubble_health_income.vg.json
+++ b/examples/vg-specs/bubble_health_income.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/circle.vg.json
+++ b/examples/vg-specs/circle.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/diverging_color_points.vg.json
+++ b/examples/vg-specs/diverging_color_points.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/errorbar_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_aggregate.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/field_spaces.vg.json
+++ b/examples/vg-specs/field_spaces.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/github_punchcard.vg.json
+++ b/examples/vg-specs/github_punchcard.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/histogram.vg.json
+++ b/examples/vg-specs/histogram.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/histogram_nospacing.vg.json
+++ b/examples/vg-specs/histogram_nospacing.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/layer_bar_line.vg.json
+++ b/examples/vg-specs/layer_bar_line.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/layer_bar_line_union.vg.json
+++ b/examples/vg-specs/layer_bar_line_union.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/layer_histogram.vg.json
+++ b/examples/vg-specs/layer_histogram.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/layer_line_color_rule.vg.json
+++ b/examples/vg-specs/layer_line_color_rule.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",
@@ -195,6 +195,9 @@
                             "stroke": {
                                 "scale": "color",
                                 "field": "symbol"
+                            },
+                            "opacity": {
+                                "value": 0.5
                             },
                             "strokeWidth": {
                                 "value": 2

--- a/examples/vg-specs/line.vg.json
+++ b/examples/vg-specs/line.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/line_color.vg.json
+++ b/examples/vg-specs/line_color.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/line_detail.vg.json
+++ b/examples/vg-specs/line_detail.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/line_monotone.vg.json
+++ b/examples/vg-specs/line_monotone.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/line_month.vg.json
+++ b/examples/vg-specs/line_month.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/line_quarter.vg.json
+++ b/examples/vg-specs/line_quarter.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/line_quarter_legend.vg.json
+++ b/examples/vg-specs/line_quarter_legend.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/line_slope.vg.json
+++ b/examples/vg-specs/line_slope.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/line_step.vg.json
+++ b/examples/vg-specs/line_step.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/minimal.vg.json
+++ b/examples/vg-specs/minimal.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/overlay_area_full.vg.json
+++ b/examples/vg-specs/overlay_area_full.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",
@@ -162,7 +162,7 @@
                                 "scale": "y",
                                 "field": "price"
                             },
-                            "stroke": {
+                            "fill": {
                                 "value": "#4c78a8"
                             }
                         }

--- a/examples/vg-specs/overlay_area_short.vg.json
+++ b/examples/vg-specs/overlay_area_short.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",
@@ -185,8 +185,11 @@
                                 "scale": "y",
                                 "field": "price"
                             },
-                            "fill": {
+                            "stroke": {
                                 "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
                             },
                             "opacity": {
                                 "value": 0.7

--- a/examples/vg-specs/overlay_line_full.vg.json
+++ b/examples/vg-specs/overlay_line_full.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",
@@ -122,7 +122,7 @@
                                 "scale": "y",
                                 "field": "price"
                             },
-                            "stroke": {
+                            "fill": {
                                 "value": "#4c78a8"
                             }
                         }

--- a/examples/vg-specs/overlay_line_short.vg.json
+++ b/examples/vg-specs/overlay_line_short.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",
@@ -146,8 +146,11 @@
                                 "scale": "y",
                                 "field": "price"
                             },
-                            "fill": {
+                            "stroke": {
                                 "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
                             },
                             "opacity": {
                                 "value": 0.7

--- a/examples/vg-specs/paintbrush.vg.json
+++ b/examples/vg-specs/paintbrush.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/panzoom_scatter.vg.json
+++ b/examples/vg-specs/panzoom_scatter.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/point_1d.vg.json
+++ b/examples/vg-specs/point_1d.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/point_color.vg.json
+++ b/examples/vg-specs/point_color.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/point_dot_timeunit_color.vg.json
+++ b/examples/vg-specs/point_dot_timeunit_color.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/point_filled.vg.json
+++ b/examples/vg-specs/point_filled.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/point_ordinal_color.vg.json
+++ b/examples/vg-specs/point_ordinal_color.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/query_widgets.vg.json
+++ b/examples/vg-specs/query_widgets.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/rect_heatmap.vg.json
+++ b/examples/vg-specs/rect_heatmap.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter.vg.json
+++ b/examples/vg-specs/scatter.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter_aggregate_detail.vg.json
+++ b/examples/vg-specs/scatter_aggregate_detail.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter_binned.vg.json
+++ b/examples/vg-specs/scatter_binned.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter_binned_color.vg.json
+++ b/examples/vg-specs/scatter_binned_color.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter_binned_opacity.vg.json
+++ b/examples/vg-specs/scatter_binned_opacity.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter_binned_size.vg.json
+++ b/examples/vg-specs/scatter_binned_size.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter_bubble.vg.json
+++ b/examples/vg-specs/scatter_bubble.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter_color.vg.json
+++ b/examples/vg-specs/scatter_color.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter_color_custom.vg.json
+++ b/examples/vg-specs/scatter_color_custom.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter_color_ordinal.vg.json
+++ b/examples/vg-specs/scatter_color_ordinal.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter_color_ordinal_custom.vg.json
+++ b/examples/vg-specs/scatter_color_ordinal_custom.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter_color_quantitative.vg.json
+++ b/examples/vg-specs/scatter_color_quantitative.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter_color_shape_constant.vg.json
+++ b/examples/vg-specs/scatter_color_shape_constant.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter_colored_with_shape.vg.json
+++ b/examples/vg-specs/scatter_colored_with_shape.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter_connected.vg.json
+++ b/examples/vg-specs/scatter_connected.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",
@@ -146,8 +146,11 @@
                                 "scale": "y",
                                 "field": "gas"
                             },
-                            "fill": {
+                            "stroke": {
                                 "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
                             },
                             "opacity": {
                                 "value": 0.7

--- a/examples/vg-specs/scatter_log.vg.json
+++ b/examples/vg-specs/scatter_log.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter_opacity.vg.json
+++ b/examples/vg-specs/scatter_opacity.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/scatter_shape_custom.vg.json
+++ b/examples/vg-specs/scatter_shape_custom.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/square.vg.json
+++ b/examples/vg-specs/square.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/stacked_area.vg.json
+++ b/examples/vg-specs/stacked_area.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/stacked_area_binned.vg.json
+++ b/examples/vg-specs/stacked_area_binned.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/stacked_area_normalize.vg.json
+++ b/examples/vg-specs/stacked_area_normalize.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/stacked_area_ordinal.vg.json
+++ b/examples/vg-specs/stacked_area_ordinal.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/stacked_area_stream.vg.json
+++ b/examples/vg-specs/stacked_area_stream.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/stacked_bar_1d.vg.json
+++ b/examples/vg-specs/stacked_bar_1d.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/stacked_bar_h.vg.json
+++ b/examples/vg-specs/stacked_bar_h.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/stacked_bar_h_order.vg.json
+++ b/examples/vg-specs/stacked_bar_h_order.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/stacked_bar_normalize.vg.json
+++ b/examples/vg-specs/stacked_bar_normalize.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/stacked_bar_population.vg.json
+++ b/examples/vg-specs/stacked_bar_population.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/stacked_bar_size.vg.json
+++ b/examples/vg-specs/stacked_bar_size.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/stacked_bar_sum_opacity.vg.json
+++ b/examples/vg-specs/stacked_bar_sum_opacity.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/stacked_bar_v.vg.json
+++ b/examples/vg-specs/stacked_bar_v.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/stacked_bar_weather.vg.json
+++ b/examples/vg-specs/stacked_bar_weather.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/text_scatter_colored.vg.json
+++ b/examples/vg-specs/text_scatter_colored.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/tick_dot.vg.json
+++ b/examples/vg-specs/tick_dot.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/tick_dot_thickness.vg.json
+++ b/examples/vg-specs/tick_dot_thickness.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/tick_strip.vg.json
+++ b/examples/vg-specs/tick_strip.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/trellis_anscombe.vg.json
+++ b/examples/vg-specs/trellis_anscombe.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/trellis_bar.vg.json
+++ b/examples/vg-specs/trellis_bar.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/trellis_bar_histogram.vg.json
+++ b/examples/vg-specs/trellis_bar_histogram.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/trellis_barley.vg.json
+++ b/examples/vg-specs/trellis_barley.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/trellis_row_column.vg.json
+++ b/examples/vg-specs/trellis_row_column.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/trellis_scatter.vg.json
+++ b/examples/vg-specs/trellis_scatter.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/trellis_scatter_binned_row.vg.json
+++ b/examples/vg-specs/trellis_scatter_binned_row.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/examples/vg-specs/trellis_stacked_bar.vg.json
+++ b/examples/vg-specs/trellis_stacked_bar.vg.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
-    "padding": 5,
     "autosize": "pad",
+    "padding": 5,
     "signals": [
         {
             "name": "width",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "poststart": "rm examples/all-examples.json",
 
     "preschema": "npm run prebuild",
-    "schema": "typescript-json-schema --required true --noExtraProps true src/spec.ts ExtendedSpec > build/vega-lite-schema.json",
+    "schema": "typescript-json-schema --required true --noExtraProps true src/spec.ts TopLevelExtendedSpec > build/vega-lite-schema.json",
 
     "presite": "npm run build && npm run data && npm run build:site && npm run build:toc && npm run build:versions",
     "site": "bundle exec jekyll serve",

--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -16,17 +16,17 @@ import {LayerModel} from './layer';
 import {Model} from './model';
 import {UnitModel} from './unit';
 
-export function buildModel(spec: Spec, parent: Model, parentGivenName: string): Model {
+export function buildModel(spec: Spec, parent: Model, parentGivenName: string, config: Config): Model {
   if (isFacetSpec(spec)) {
-    return new FacetModel(spec, parent, parentGivenName);
+    return new FacetModel(spec, parent, parentGivenName, config);
   }
 
   if (isLayerSpec(spec)) {
-    return new LayerModel(spec, parent, parentGivenName);
+    return new LayerModel(spec, parent, parentGivenName, config);
   }
 
   if (isUnitSpec(spec)) {
-    return new UnitModel(spec, parent, parentGivenName);
+    return new UnitModel(spec, parent, parentGivenName, config);
   }
 
   throw new Error(log.message.INVALID_SPEC);

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -1,6 +1,6 @@
 import {Axis} from '../axis';
 import {Channel, COLUMN, ROW, X, Y} from '../channel';
-import {Config, defaultConfig} from '../config';
+import {Config} from '../config';
 import {forEach} from '../encoding';
 import {Facet} from '../facet';
 import {FieldDef, normalize} from '../fielddef';
@@ -9,7 +9,7 @@ import * as log from '../log';
 import {Scale} from '../scale';
 import {FacetSpec} from '../spec';
 import {StackProperties} from '../stack';
-import {contains, Dict, duplicate, extend, flatten, keys, mergeDeep, vals} from '../util';
+import {contains, Dict, duplicate, extend, flatten, keys, vals} from '../util';
 import {VgData, VgEncodeEntry} from '../vega.schema';
 
 import {parseAxisComponent, parseGridAxis, parseMainAxis} from './axis/parse';
@@ -54,24 +54,18 @@ export class FacetModel extends Model {
     column?: number;
   } = {};
 
-  constructor(spec: FacetSpec, parent: Model, parentGivenName: string) {
-    super(spec, parent, parentGivenName);
+  constructor(spec: FacetSpec, parent: Model, parentGivenName: string, config: Config) {
+    super(spec, parent, parentGivenName, config);
 
-    // Config must be initialized before child as it gets cascaded to the child
-    const config = this.config = this.initConfig(spec.config, parent);
-
-    const child  = this.child = buildModel(spec.spec, this, this.getName('child'));
+    const child  = this.child = buildModel(spec.spec, this, this.getName('child'), config);
     this.children = [child];
 
     const facet  = this.facet = this.initFacet(spec.facet);
-    this.scales  = this.initScalesAndSpacing(facet, config);
-    this.axes   = this.initAxis(facet, config, child);
+    this.scales  = this.initScalesAndSpacing(facet, this.config);
+    this.axes   = this.initAxis(facet, this.config, child);
     this.legends = {};
   }
 
-  private initConfig(specConfig: Config, parent: Model) {
-    return mergeDeep(duplicate(defaultConfig), parent ? parent.config : {}, specConfig);
-  }
 
   private initFacet(facet: Facet) {
     // clone to prevent side effect to the original spec

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -1,6 +1,6 @@
 import {Axis} from '../axis';
 import {Channel} from '../channel';
-import {CellConfig, Config, defaultConfig} from '../config';
+import {CellConfig, Config} from '../config';
 import {isUrlData} from '../data';
 import {FieldDef} from '../fielddef';
 import {Legend} from '../legend';
@@ -8,7 +8,7 @@ import {FILL_STROKE_CONFIG} from '../mark';
 import {Scale} from '../scale';
 import {LayerSpec} from '../spec';
 import {StackProperties} from '../stack';
-import {Dict, duplicate, flatten, keys, mergeDeep} from '../util';
+import {Dict, flatten, keys} from '../util';
 import {isSignalRefDomain, VgData, VgEncodeEntry, VgScale} from '../vega.schema';
 
 import {applyConfig, buildModel} from './common';
@@ -47,21 +47,17 @@ export class LayerModel extends Model {
    */
   public readonly height: number;
 
-  constructor(spec: LayerSpec, parent: Model, parentGivenName: string) {
-    super(spec, parent, parentGivenName);
+  constructor(spec: LayerSpec, parent: Model, parentGivenName: string, config: Config) {
+    super(spec, parent, parentGivenName, config);
 
     this.width = spec.width;
     this.height = spec.height;
 
-    this.config = this.initConfig(spec.config, parent);
     this.children = spec.layer.map((layer, i) => {
+      // FIXME: this is not always the case
       // we know that the model has to be a unit model because we pass in a unit spec
-      return buildModel(layer, this, this.getName('layer_' + i)) as UnitModel;
+      return buildModel(layer, this, this.getName('layer_' + i), config) as UnitModel;
     });
-  }
-
-  private initConfig(specConfig: Config, parent: Model) {
-    return mergeDeep(duplicate(defaultConfig), specConfig, parent ? parent.config : {});
   }
 
   public channelHasField(channel: Channel): boolean {

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -9,7 +9,7 @@ import {ChannelDef, field, FieldDef, FieldRefOption, isFieldDef} from '../fieldd
 import {Legend} from '../legend';
 import {hasDiscreteDomain, Scale} from '../scale';
 import {SortField, SortOrder} from '../sort';
-import {BaseSpec, Padding} from '../spec';
+import {BaseSpec} from '../spec';
 import {Transform} from '../transform';
 import {Dict, extend, vals} from '../util';
 import {VgAxis, VgData, VgEncodeEntry, VgLegend, VgScale} from '../vega.schema';
@@ -83,7 +83,6 @@ export abstract class Model {
   public readonly parent: Model;
   protected readonly name: string;
   public readonly description: string;
-  public readonly padding: Padding;
 
   public readonly data: Data;
   public readonly transforms: Transform[];
@@ -98,13 +97,13 @@ export abstract class Model {
   protected sizeNameMap: NameMapInterface;
 
   protected readonly transform: Transform;
-  protected abstract readonly scales: Dict<Scale> = {};
+  protected readonly scales: Dict<Scale> = {};
 
-  protected abstract readonly axes: Dict<Axis> = {};
+  protected readonly axes: Dict<Axis> = {};
 
-  protected abstract readonly legends: Dict<Legend> = {};
+  protected readonly legends: Dict<Legend> = {};
 
-  public abstract readonly config: Config;
+  public readonly config: Config;
 
   public component: Component;
 
@@ -112,8 +111,9 @@ export abstract class Model {
 
   public abstract stack: StackProperties;
 
-  constructor(spec: BaseSpec, parent: Model, parentGivenName: string) {
+  constructor(spec: BaseSpec, parent: Model, parentGivenName: string, config: Config) {
     this.parent = parent;
+    this.config = config;
 
     // If name is not provided, always use parent's givenName to avoid name conflicts.
     this.name = spec.name || parentGivenName;
@@ -126,12 +126,10 @@ export abstract class Model {
     this.data = spec.data;
 
     this.description = spec.description;
-    this.padding = spec.padding;
     this.transforms = spec.transform || [];
 
     this.component = {data: null, layout: null, mark: null, scales: null, axes: null, axisGroups: null, gridGroups: null, legends: null, selection: null};
   }
-
 
   public parse() {
     this.parseData();

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,8 +4,9 @@ import {BarConfig, MarkConfig, TextConfig, TickConfig} from './mark';
 import * as mark from './mark';
 import {defaultScaleConfig, ScaleConfig} from './scale';
 import {defaultConfig as defaultSelectionConfig, SelectionConfig} from './selection';
-import {Padding} from './spec';
 import {StackOffset} from './stack';
+import {TopLevelProperties} from './toplevelprops';
+import {duplicate, mergeDeep} from './util';
 import {VgRangeScheme} from './vega.schema';
 
 export interface CellConfig {
@@ -111,28 +112,10 @@ export const defaultOverlayConfig: OverlayConfig = {
 
 export type RangeConfig = (number|string)[] | VgRangeScheme | {step: number};
 
-export interface Config {
+export interface Config  extends TopLevelProperties {
   // TODO: add this back once we have top-down layout approach
   // width?: number;
   // height?: number;
-  // padding?: number|string;
-  /**
-   * The width and height of the on-screen viewport, in pixels. If necessary, clipping and scrolling will be applied.
-   */
-  viewport?: number;
-  /**
-   * CSS color property to use as background of visualization. Default is `"transparent"`.
-   */
-  background?: string;
-
-  /**
-   * The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `"top"`, `"left"`, `"right"`, `"bottom"` properties.
-   *
-   * __Default value__: `5`
-   *
-   * * @minimum 0
-   */
-  padding?: Padding;
 
   /**
    * D3 Number format for axis labels and text tables. For example "s" for SI units.
@@ -301,3 +284,7 @@ export const defaultConfig: Config = {
 
   selection: defaultSelectionConfig,
 };
+
+export function initConfig(config: Config) {
+  return mergeDeep(duplicate(defaultConfig), config);
+}

--- a/src/toplevelprops.ts
+++ b/src/toplevelprops.ts
@@ -1,0 +1,40 @@
+
+export type Padding = number | {top?: number, bottom?: number, left?: number, right?: number};
+export interface TopLevelProperties {
+
+  // Current we don't support autosize yet.  Once we do, we have to modify compile.ts to fix this.
+  // autosize?: ...;
+
+  /**
+   * The width and height of the on-screen viewport, in pixels. If necessary, clipping and scrolling will be applied.
+   */
+  viewport?: number;
+  /**
+   * CSS color property to use as background of visualization. Default is `"transparent"`.
+   */
+  background?: string;
+
+  /**
+   * The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `"top"`, `"left"`, `"right"`, `"bottom"` properties.
+   *
+   * __Default value__: `5`
+   *
+   * @minimum 0
+   */
+  padding?: Padding;
+
+
+}
+
+const TOP_LEVEL_PROPERTIES: (keyof TopLevelProperties)[] = [
+  'viewport', 'background', 'padding'
+];
+
+export function extractTopLevelProperties<T extends TopLevelProperties>(t: T) {
+  return TOP_LEVEL_PROPERTIES.reduce((o, p) => {
+    if (t && t[p] !== undefined) {
+      o[p] = t[p];
+    }
+    return o;
+  }, {});
+}

--- a/src/toplevelprops.ts
+++ b/src/toplevelprops.ts
@@ -1,14 +1,9 @@
 
 export type Padding = number | {top?: number, bottom?: number, left?: number, right?: number};
 export interface TopLevelProperties {
-
   // Current we don't support autosize yet.  Once we do, we have to modify compile.ts to fix this.
   // autosize?: ...;
 
-  /**
-   * The width and height of the on-screen viewport, in pixels. If necessary, clipping and scrolling will be applied.
-   */
-  viewport?: number;
   /**
    * CSS color property to use as background of visualization. Default is `"transparent"`.
    */
@@ -22,12 +17,10 @@ export interface TopLevelProperties {
    * @minimum 0
    */
   padding?: Padding;
-
-
 }
 
 const TOP_LEVEL_PROPERTIES: (keyof TopLevelProperties)[] = [
-  'viewport', 'background', 'padding'
+  'background', 'padding'
 ];
 
 export function extractTopLevelProperties<T extends TopLevelProperties>(t: T) {

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -16,7 +16,7 @@ describe('Compile', function() {
   });
 
   describe('compile', () => {
-    it('should return a spec with basic top-level properties, size signals, data and marks', () => {
+    it('should return a spec with default top-level properties, size signals, data and marks', () => {
       const spec = compile({
         "data": {
           "values": [{"a": "A","b": 28}]
@@ -26,6 +26,38 @@ describe('Compile', function() {
       }).spec;
 
       assert.equal(spec.padding, 5);
+      assert.equal(spec.autosize, 'pad');
+      assert.deepEqual(spec.signals, [
+        {
+          name: 'width',
+          update: "data('layout')[0].width"
+        },
+        {
+          name: 'height',
+          update: "data('layout')[0].height"
+        },
+        {
+          name: 'unit',
+          value: {},
+          on: [{events: 'mousemove', update: 'group()._id ? group() : unit'}]
+        }
+      ]);
+
+      assert.equal(spec.data.length, 2); // just source and layout
+      assert.equal(spec.marks.length, 1); // just the root group
+    });
+
+    it('should return a spec with specified top-level properties, size signals, data and marks', () => {
+      const spec = compile({
+        "padding": 123,
+        "data": {
+          "values": [{"a": "A","b": 28}]
+        },
+        "mark": "point",
+        "encoding": {}
+      }).spec;
+
+      assert.equal(spec.padding, 123);
       assert.equal(spec.autosize, 'pad');
       assert.deepEqual(spec.signals, [
         {

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -5,21 +5,22 @@ import {assert} from 'chai';
 import * as log from '../../src/log';
 
 import {ROW, SHAPE} from '../../src/channel';
-import {FacetModel} from '../../src/compile/facet';
 import * as facet from '../../src/compile/facet';
 import {defaultConfig} from '../../src/config';
 import {Facet} from '../../src/facet';
 import {POINT} from '../../src/mark';
-import {FacetSpec} from '../../src/spec';
 import {ORDINAL} from '../../src/type';
 import {parseFacetModel} from '../util';
 
 describe('FacetModel', function() {
   it('should say it is facet', function() {
-    const model = new FacetModel({facet: {}, spec: {
-      mark: POINT,
-      encoding: {}
-    }} as FacetSpec, null, null);
+    const model = parseFacetModel({
+      facet: {},
+      spec: {
+        mark: POINT,
+        encoding: {}
+      }
+    });
     assert(!model.isUnit());
     assert(model.isFacet());
     assert(!model.isLayer());

--- a/test/compile/layer.test.ts
+++ b/test/compile/layer.test.ts
@@ -6,7 +6,7 @@ import {parseLayerModel} from '../util';
 
 describe('Layer', function() {
   it('should say it is layer', function() {
-    const model = new LayerModel({layer: []} as LayerSpec, null, null);
+    const model = new LayerModel({layer: []} as LayerSpec, null, null, {});
     assert(!model.isUnit());
     assert(!model.isFacet());
     assert(model.isLayer());

--- a/test/compile/unit.test.ts
+++ b/test/compile/unit.test.ts
@@ -1,16 +1,14 @@
 import {assert} from 'chai';
 
 import {DETAIL, SHAPE, X} from '../../src/channel';
-import {UnitModel} from '../../src/compile/unit';
 import * as log from '../../src/log';
 import {BAR} from '../../src/mark';
-import {UnitSpec} from '../../src/spec';
 import {QUANTITATIVE} from '../../src/type';
 import {parseUnitModel} from '../util';
 
 describe('UnitModel', function() {
   it('should say it is unit', function() {
-    const model = new UnitModel({mark: 'point'} as UnitSpec, null, null);
+    const model = parseUnitModel({mark: 'point', encoding: {}});
     assert(model.isUnit());
     assert(!model.isFacet());
     assert(!model.isLayer());

--- a/test/stack.test.ts
+++ b/test/stack.test.ts
@@ -8,7 +8,7 @@ import {AggregateOp} from '../src/aggregate';
 import {DETAIL, X, Y} from '../src/channel';
 import {AREA, BAR, PRIMITIVE_MARKS, RECT} from '../src/mark';
 import {ScaleType} from '../src/scale';
-import {isStacked, UnitSpec} from '../src/spec';
+import {isStacked, TopLevel, UnitSpec} from '../src/spec';
 import {stack, STACK_BY_DEFAULT_MARKS, STACKABLE_MARKS, StackOffset} from '../src/stack';
 
 describe('stack', () => {
@@ -17,7 +17,7 @@ describe('stack', () => {
   it('should be disabled for non-stackable marks with at least of of the stack channel', () => {
     [undefined, 'center', 'none', 'zero', 'normalize'].forEach((stacked: StackOffset) => {
       NON_STACKABLE_MARKS.forEach((nonStackableMark) => {
-        const spec: UnitSpec = {
+        const spec: TopLevel<UnitSpec> = {
           "data": {"url": "data/barley.json"},
           "mark": nonStackableMark,
           "encoding": {
@@ -38,7 +38,7 @@ describe('stack', () => {
   it('should always be disabled for raw plot', () => {
     [undefined, 'center', 'none', 'zero', 'normalize'].forEach((stacked: StackOffset) => {
       PRIMITIVE_MARKS.forEach((mark) => {
-        const spec: UnitSpec = {
+        const spec: TopLevel<UnitSpec> = {
           "data": {"url": "data/barley.json"},
           "mark": mark,
           "encoding": {
@@ -59,7 +59,7 @@ describe('stack', () => {
   it('should always be disabled if there is no stackby channel', () => {
     [undefined, 'center', 'none', 'zero', 'normalize'].forEach((stacked: StackOffset) => {
       PRIMITIVE_MARKS.forEach((mark) => {
-        const spec: UnitSpec = {
+        const spec: TopLevel<UnitSpec> = {
           "data": {"url": "data/barley.json"},
           "mark": mark,
           "encoding": {
@@ -79,7 +79,7 @@ describe('stack', () => {
   it('should always be disabled if the stackby channel is aggregated', () => {
     [undefined, 'center', 'none', 'zero', 'normalize'].forEach((stacked: StackOffset) => {
       PRIMITIVE_MARKS.forEach((mark) => {
-        const spec: UnitSpec = {
+        const spec: TopLevel<UnitSpec> = {
           "data": {"url": "data/barley.json"},
           "mark": mark,
           "encoding": {
@@ -101,7 +101,7 @@ describe('stack', () => {
     [undefined, 'center', 'zero', 'normalize'].forEach((stacked: StackOffset) => {
       const marks = stacked === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
       marks.forEach((mark) => {
-        const spec: UnitSpec = {
+        const spec: TopLevel<UnitSpec> = {
           "data": {"url": "data/barley.json"},
           "mark": mark,
           "encoding": {
@@ -126,7 +126,7 @@ describe('stack', () => {
     [undefined, 'center', 'zero', 'normalize'].forEach((stacked: StackOffset) => {
       const marks = stacked === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
       marks.forEach((mark) => {
-        const spec: UnitSpec = {
+        const spec: TopLevel<UnitSpec> = {
           "data": {"url": "data/barley.json"},
           "mark": mark,
           "encoding": {
@@ -148,7 +148,7 @@ describe('stack', () => {
   it('should always be disabled if both x and y are aggregate', () => {
     [undefined, 'center', 'none', 'zero', 'normalize'].forEach((stacked: StackOffset) => {
       PRIMITIVE_MARKS.forEach((mark) => {
-        const spec: UnitSpec = {
+        const spec: TopLevel<UnitSpec> = {
           "data": {"url": "data/barley.json"},
           "mark": mark,
           "encoding": {
@@ -169,7 +169,7 @@ describe('stack', () => {
   it('should always be disabled if neither x nor y is aggregate', () => {
     [undefined, 'center', 'none', 'zero', 'normalize'].forEach((stacked: StackOffset) => {
       PRIMITIVE_MARKS.forEach((mark) => {
-        const spec: UnitSpec = {
+        const spec: TopLevel<UnitSpec> = {
           "data": {"url": "data/barley.json"},
           "mark": mark,
           "encoding": {
@@ -192,7 +192,7 @@ describe('stack', () => {
       const marks = stacked === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
       marks.forEach((mark) => {
         log.runLocalLogger((localLogger) => {
-          const spec: UnitSpec = {
+          const spec: TopLevel<UnitSpec> = {
             "mark": mark,
             "encoding": {
               "x": {"field": "a", "type": "quantitative", "aggregate": "sum"},
@@ -219,7 +219,7 @@ describe('stack', () => {
       const marks = stacked === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
       marks.forEach((mark) => {
         log.runLocalLogger((localLogger) => {
-          const spec: UnitSpec = {
+          const spec: TopLevel<UnitSpec> = {
             "mark": mark,
             "encoding": {
               "y": {"field": "a", "type": "quantitative", "aggregate": "sum"},
@@ -247,7 +247,7 @@ describe('stack', () => {
         const marks = stacked === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
         marks.forEach((mark) => {
           log.runLocalLogger((localLogger) => {
-            const spec: UnitSpec = {
+            const spec: TopLevel<UnitSpec> = {
               "data": {"url": "data/barley.json"},
               "mark": mark,
               "encoding": {
@@ -274,7 +274,7 @@ describe('stack', () => {
         const marks = stacked === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
         marks.forEach((mark) => {
           log.runLocalLogger((localLogger) => {
-            const spec: UnitSpec = {
+            const spec: TopLevel<UnitSpec> = {
               "data": {"url": "data/barley.json"},
               "mark": mark,
               "encoding": {
@@ -298,7 +298,7 @@ describe('stack', () => {
   describe('stack().groupbyChannel, .fieldChannel', () => {
     it('should be correct for horizontal', () => {
       [BAR, AREA].forEach((stackableMark) => {
-        const spec: UnitSpec = {
+        const spec: TopLevel<UnitSpec> = {
           "data": {"url": "data/barley.json"},
           "mark": stackableMark,
           "encoding": {
@@ -316,7 +316,7 @@ describe('stack', () => {
 
     it('should be correct for horizontal (single)', () => {
       [BAR, AREA].forEach((stackableMark) => {
-        const spec: UnitSpec = {
+        const spec: TopLevel<UnitSpec> = {
           "data": {"url": "data/barley.json"},
           "mark": stackableMark,
           "encoding": {
@@ -333,7 +333,7 @@ describe('stack', () => {
 
     it('should be correct for vertical', () => {
       [BAR, AREA].forEach((stackableMark) => {
-        const spec: UnitSpec = {
+        const spec: TopLevel<UnitSpec> = {
           "data": {"url": "data/barley.json"},
           "mark": stackableMark,
           "encoding": {
@@ -351,7 +351,7 @@ describe('stack', () => {
 
     it('should be correct for vertical (single)', () => {
       [BAR, AREA].forEach((stackableMark) => {
-        const spec: UnitSpec = {
+        const spec: TopLevel<UnitSpec> = {
           "data": {"url": "data/barley.json"},
           "mark": stackableMark,
           "encoding": {
@@ -370,7 +370,7 @@ describe('stack', () => {
   describe('stack().offset', () => {
     it('should be zero for stackable marks with at least of of the stack channel if stacked is unspecified', () => {
       [BAR, AREA].forEach((stackableMark) => {
-        const spec: UnitSpec = {
+        const spec: TopLevel<UnitSpec> = {
           "data": {"url": "data/barley.json"},
           "mark": stackableMark,
           "encoding": {
@@ -387,7 +387,7 @@ describe('stack', () => {
     it('should be the specified stacked for stackable marks with at least one of the stack channel', () => {
       ['center', 'zero', 'normalize'].forEach((stacked: StackOffset) => {
         [BAR, AREA].forEach((stackableMark) => {
-          const spec: UnitSpec = {
+          const spec: TopLevel<UnitSpec> = {
             "data": {"url": "data/barley.json"},
             "mark": stackableMark,
             "encoding": {

--- a/test/util.ts
+++ b/test/util.ts
@@ -3,21 +3,22 @@ import {FacetModel} from '../src/compile/facet';
 import {LayerModel} from '../src/compile/layer';
 import {Model} from '../src/compile/model';
 import {UnitModel} from '../src/compile/unit';
-import {ExtendedSpec, FacetSpec, LayerSpec, normalize, UnitSpec} from '../src/spec';
+import {initConfig} from '../src/config';
+import {ExtendedSpec, FacetSpec, LayerSpec, normalize, TopLevel, UnitSpec} from '../src/spec';
 
-export function parseModel(inputSpec: ExtendedSpec): Model {
+export function parseModel(inputSpec: TopLevel<ExtendedSpec>): Model {
   const spec = normalize(inputSpec);
-  return buildModel(spec, null, '');
+  return buildModel(spec, null, '', initConfig(inputSpec.config));
 }
 
-export function parseUnitModel(spec: UnitSpec) {
-  return new UnitModel(spec, null, '');
+export function parseUnitModel(spec: TopLevel<UnitSpec>) {
+  return new UnitModel(spec, null, '', initConfig(spec.config));
 }
 
-export function parseLayerModel(spec: LayerSpec) {
-  return new LayerModel(spec, null, '');
+export function parseLayerModel(spec: TopLevel<LayerSpec>) {
+  return new LayerModel(spec, null, '', initConfig(spec.config));
 }
 
-export function parseFacetModel(spec: FacetSpec) {
-  return new FacetModel(spec, null, '');
+export function parseFacetModel(spec: TopLevel<FacetSpec>) {
+  return new FacetModel(spec, null, '', initConfig(spec.config));
 }


### PR DESCRIPTION
This PR differentiates top-level specs from normal specs.
Basically, normal (internal) specs should not have top-level properties such as `padding`,`$schema`, `config`. etc.

- Add `toplevel.ts` that `spec.ts` and `config.ts` can import (avoid circular dependencies)
- Add new `TopLevelExtendedSpec = TopLevel<ExtendedSpec>` that we will build schema from

- Rewrite how we assemble top-level properties in `compile.ts`
- Remove the old config cascading logic (Config is now always at the top-level and thus there is no cascading anymore -- we can now initialize config once in compile.ts and in our test utility)

- for `unit.ts`, avoid passing around config for the class method as they can just use `this.config`
