### PR TITLE
Fix the bug labelAngle cannot be applied when labelAngle == 0

### DIFF
--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -121,10 +121,10 @@ export class FacetModel extends Model {
 
           if (channel === ROW) {
             const yAxis: any = child.axis(Y);
-            if (yAxis && yAxis.orient !== 'right' && !modelAxis.orient) {
+            if (yAxis && yAxis.orient !== 'right' && modelAxis.orient === undefined) {
               modelAxis.orient = 'right';
             }
-            if (model.hasDescendantWithFieldOnChannel(X) && !modelAxis.labelAngle) {
+            if (model.hasDescendantWithFieldOnChannel(X) && modelAxis.labelAngle === undefined) {
               modelAxis.labelAngle = modelAxis.orient === 'right' ? 90 : 270;
             }
           }

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -396,6 +396,44 @@ describe('compile/facet', () => {
       });
       assert.deepEqual(model.axis(ROW), {"orient": "right", "labelAngle": 90});
     });
+
+    it('should set the labelAngle if specified', () => {
+      const model = parseFacetModel({
+        facet: {
+          row: {field: 'c', type: 'ordinal', "axis": {"labelAngle": 0}}
+        },
+        spec: {
+          mark: 'point',
+          encoding: {
+            "x": {"aggregate": "sum", "field": "yield", "type": "quantitative"},
+            "y": {"field": "variety", "type": "nominal"}
+          },
+        }
+      });
+      assert.deepEqual(model.axis(ROW), {"orient": "right", "labelAngle": 0});
+    });
+
+    it('should set the labelAngle if labelAngle is not specified', () => {
+      const model = parseFacetModel({
+        facet: {
+          row: {field: 'a', type: 'ordinal'}
+        },
+        spec: {
+          mark: 'point',
+          encoding: {
+            "x": {"aggregate": "sum", "field": "yield", "type": "quantitative"},
+            "y": {"field": "variety", "type": "nominal"},
+            "row": {
+              "field": "c", "type": "nominal",
+              "axis": {
+                  "title": "title"
+              }
+            }
+          },
+        }
+      });
+      assert.deepEqual(model.axis(ROW), {"orient": "right", "labelAngle": 90});
+    });
   });
 });
 


### PR DESCRIPTION
Fix #1664 
```
{
    "data": {"values": [
      {"a": "A","b": 28, "c": "A"}, 
      {"a": "B","b": 55, "c": "A"}, 
      {"a": "C","b": 43, "c": "A"}
    ]},
    "mark": "bar",
    "encoding": {
        "x": {
            "field": "b", "type": "quantitative", "axis": false
        },
        "y": {
            "field": "a", "type": "nominal", "axis": false
        },
        "row": {
            "field": "c", "type": "nominal",
            "axis": {
                "title": "", "labelAngle": 0
            }
        }
    }
}
```

<img width="267" alt="screen shot 2017-04-03 at 10 08 39 am" src="https://cloud.githubusercontent.com/assets/11696585/24621200/8a68304a-1855-11e7-912b-c7f67ad8a0ec.png">
