### PR TITLE
fix bug parallel build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,3 @@ notifications:
 cache:
   directories:
   - $HOME/.yarn-cache
-
-before_install:
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get update -q
-  - sudo apt-get install parallel -y

--- a/scripts/build-examples.sh
+++ b/scripts/build-examples.sh
@@ -10,13 +10,13 @@ mkdir $dir
 
 if type parallel >/dev/null 2>&1
 then
+  echo "Using parallel to generate vega specs from examples in parallel."
+  ls examples/specs/*.vl.json | parallel  --plus --halt 1 "bin/vl2vg -p {} > examples/vg-specs/{/..}.vg.json"
+else
   echo "Parallel not found! Sequentially generate vega specs from examples."
   for file in examples/specs/*.vl.json; do
     filename=$(basename "$file")
     name="${filename%.vl.json}"
     bin/vl2vg -p $file > $dir/$name.vg.json
   done
-else
-  echo "Using parallel to generate vega specs from examples in parallel."
-  ls examples/specs/*.vl.json | parallel  --plus --halt 1 "bin/vl2vg -p {} > examples/vg-specs/{/..}.vg.json"
 fi


### PR DESCRIPTION
Fix part of #2068 
If user have GNU parallel installed on their own, build:examples should work in parallel now