### PR TITLE
make `fieldDef.normalize` drops invalid aggregate

### DIFF
--- a/src/aggregate.ts
+++ b/src/aggregate.ts
@@ -1,4 +1,4 @@
-
+import {toSet} from './util';
 export type AggregateOp = 'argmax' | 'argmin' | 'average' | 'count'
   | 'distinct' | 'max' | 'mean' | 'median' | 'min' | 'missing' | 'modeskew'
   | 'q1' | 'q3' | 'ci0' | 'ci1' | 'stdev' | 'stdevp' | 'sum' | 'valid' | 'values' | 'variance'
@@ -28,6 +28,8 @@ export const AGGREGATE_OPS: AggregateOp[] = [
     'argmin',
     'argmax',
 ];
+
+export const AGGREGATE_OP_INDEX = toSet(AGGREGATE_OPS);
 
 /** Additive-based aggregation operations.  These can be applied to stack. */
 export const SUM_OPS: AggregateOp[] = [

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -1,7 +1,7 @@
 
 // utility for a field definition object
 
-import {AggregateOp} from './aggregate';
+import {AGGREGATE_OP_INDEX, AggregateOp} from './aggregate';
 import {Axis} from './axis';
 import {autoMaxBins, Bin, binToString} from './bin';
 import {Channel, rangeType} from './channel';
@@ -253,6 +253,13 @@ export function normalize(channelDef: ChannelDef, channel: Channel) {
   // If a fieldDef contains a field, we need type.
   if (isFieldDef(channelDef)) { // TODO: or datum
     let fieldDef: FieldDef = channelDef;
+
+    // Drop invalid aggregate
+    if (fieldDef.aggregate && !AGGREGATE_OP_INDEX[fieldDef.aggregate]) {
+      let {aggregate, ...fieldDefWithoutAggregate} = fieldDef;
+      log.warn(log.message.invalidAggregate(fieldDef.aggregate));
+      fieldDef = fieldDefWithoutAggregate;
+    }
 
     // Normalize bin
     if (fieldDef.bin) {

--- a/src/log.ts
+++ b/src/log.ts
@@ -103,6 +103,9 @@ export namespace message {
   export function invalidFieldType(type: Type) {
     return `Invalid field type "${type}"`;
   }
+  export function invalidAggregate(aggregate: AggregateOp | string) {
+    return `Invalid aggregation operator "${aggregate}"`;
+  }
 
   export function emptyOrInvalidFieldType(type: Type | string, channel: Channel, newType: Type) {
     return `Invalid field type (${type}) for channel ${channel}, using ${newType} instead.`;

--- a/test/fielddef.test.ts
+++ b/test/fielddef.test.ts
@@ -40,6 +40,12 @@ describe('fieldDef', () => {
       assert.deepEqual(normalize(fieldDef, 'x'), {field: 'a', type: 'quantitative'});
       assert.equal(localLogger.warns[0], log.message.emptyOrInvalidFieldType(undefined, 'x', 'quantitative'));
     }));
+
+    it('should drop invalid aggregate ops and throw warning.', log.wrap((localLogger) => {
+      const fieldDef = {aggregate: 'boxplot', field: 'a', type: 'quantitative'};
+      assert.deepEqual(normalize(fieldDef, 'x'), {field: 'a', type: 'quantitative'});
+      assert.equal(localLogger.warns[0], log.message.invalidAggregate('boxplot'));
+    }));
   });
 
   describe('channelCompatability', () => {


### PR DESCRIPTION
cc: @mattwchun -- this will allow you to make `aggregate: AggregateOp | 'box plot'` in encoding.ts without causing any bugs

  
