### PR TITLE
[WIP] Edit Axis Docs

### DIFF
--- a/site/docs/axis.md
+++ b/site/docs/axis.md
@@ -7,7 +7,14 @@ permalink: /docs/axis.html
 
 Axes provide axis lines, ticks and labels to convey how a spatial range represents a data range. Simply put, axes visualize scales.
 
-By default, Vega-Lite automatically creates axes for `x`, `y`, `row`, and `column` channels when they are encoded. Axis can be customized via the `axis` property of a channel definition.
+By default, Vega-Lite automatically creates axes for `x`, `y`, `row`, and `column` channels when they are encoded.
+
+Axis can be customized via the `axis` property of a channel definition.
+The field's axis can be removed by setting `axis` to `false`. If `axis` is `true`, default axis properties are applied.
+As described below, `axis` can also be an [object that defines its properties](#axis-properties).
+
+Besides `axis` property of each individual encoding channel, the configuration object ([`config`](config.html)) also provides [axis config](#axis-config) (`config: {axis: {...}}`) for setting default axis properties for all axes.
+
 
 {: .suppress-error}
 ```json
@@ -36,55 +43,49 @@ By default, Vega-Lite automatically creates axes for `x`, `y`, `row`, and `colum
 }
 ```
 
-## Customizing Axis
-
-The field's axis can be removed by setting `axis` to `false`. If `axis` is `true`, default axis properties are applied.
-
-Either Axis properties or Axis Config can be customized. To customize Axis properties, you need to set `axis` to an axis property object. To customize Axis Config, you need set config properties by specifying `config: {axis: {...}}`.
-
 <!--TODO: add default behavior for each property -->
 
-### Axis Properties
+## Axis Properties
 
-Axis properties will apply to the current encoding channel only. Axis properties can be customized by setting `axis` to an axis property object. The `axis` property object supports the following properties:
+To customize axis, an `axis` object can contain the following groups of properties:
 
-#### General
+### General
 
 {% include table.html props="domain,orient,offset,position,zindex" source="Axis" %}
 
-#### Labels
+### Labels
 
 {% include table.html props="labels,format,labelAngle" source= "Axis" %}
 
-#### Ticks
+### Ticks
 
 {% include table.html props="ticks,labelPadding,tickCount,tickSize,values" source="Axis" %}
 
-#### Title
+### Title
 
 {% include table.html props="title,maxExtent,minExtent" source="Axis" %}
 
 
-### Axis Config
+## Axis Config
 
-Axis Config will apply to the all encoding channel has `axis`. Axis Config can be customized by setting `config: {axis: {...}}`. Axis Config supports the following configurations:
+To provide themes for all axes, the axis config `config: {axis: {...}}` can contain the following properties:
 
-#### General
+### General
 
 {% include table.html props="domain,domainColor,domainWidth" source="AxisConfig" %}
 
-#### Grid
+### Grid
 
 {% include table.html props="grid,gridColor,gridDash,gridOpacity,gridWidth" source="AxisConfig" %}
 
-#### Labels
+### Labels
 
 {% include table.html props="shortTimeLabels" source="AxisConfig" %}
 
-#### Ticks
+### Ticks
 
 {% include table.html props="tickColor,labelColor,labelFont,labelFontSize,labelLimit,tickWidth" source="AxisConfig" %}
 
-#### Title
+### Title
 
 {% include table.html props="titleColor,titleFont,titleLimit,titleFontWeight,titleFontSize,titlePadding,titleMaxLength" source="AxisConfig" %}

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -283,11 +283,10 @@ For a full list of scale configuration and their default values, please see the 
 {:#axis-config}
 ## Axis Configuration  (`config.axis.*`)
 
-Axis configuration determines default properties for `x` and `y` [axes](axis.html). (For `row` and `column` axes, see [facet axis configuration](#facet-axis-config)).
+Axis configuration determines default properties for `x` and `y` [axes](axis.html).
+For a full list of axis configuration, please see the [Axis Config section in the axis page](axis.html#axis-config).
 
-<span class="note-line">__See Code:__
-For a full list of axis configuration and their default values, please see the `AxisConfig` interface and `defaultAxisConfig` in [axis.ts](https://github.com/vega/vega-lite/blob/master/src/axis.ts).
-</span>
+(For `row` and `column` axes, see [facet axis configuration](#facet-axis-config)).
 
 {:#legend-config}
 ## Legend Configuration  (`config.legend.*`)


### PR DESCRIPTION
@YuhanLu  I make further edits to axis.md page.  

I think we reduce the number of heading levels a bit.  The `## Customizing Axis` part isn't really necessary and is, in fact, redundant with the page's intro.

Could you please double check this apply a similar change to `legend.md`.  

Btw, you might find grammarly.com useful as a spell checker. 