### PR TITLE
enable auto-generation for config.md

### DIFF
--- a/_includes/type-anyof.html
+++ b/_includes/type-anyof.html
@@ -10,7 +10,7 @@
       {% assign element = type.items.type | append: "[]" | capitalize %}
       {{element}}
     {% endif %}
-  {% else if type.type != nil }
+  {% else %}
     {% assign element = type.type | capitalize %}
     {{element}}
   {% endif %}

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -10,7 +10,7 @@
                     "type": "string"
                 },
                 "background": {
-                    "description": "CSS color property to use as background of visualization. Default is `\"transparent\"`.",
+                    "description": "CSS color property to use as background of visualization.\n\n__Default value:__ none (transparent)",
                     "type": "string"
                 },
                 "config": {
@@ -124,7 +124,7 @@
                     "type": "string"
                 },
                 "background": {
-                    "description": "CSS color property to use as background of visualization. Default is `\"transparent\"`.",
+                    "description": "CSS color property to use as background of visualization.\n\n__Default value:__ none (transparent)",
                     "type": "string"
                 },
                 "config": {
@@ -223,7 +223,7 @@
                     "type": "string"
                 },
                 "background": {
-                    "description": "CSS color property to use as background of visualization. Default is `\"transparent\"`.",
+                    "description": "CSS color property to use as background of visualization.\n\n__Default value:__ none (transparent)",
                     "type": "string"
                 },
                 "config": {
@@ -610,7 +610,7 @@
             "properties": {
                 "align": {
                     "$ref": "#/definitions/HorizontalAlign",
-                    "description": "The horizontal alignment of the text. One of left, right, center."
+                    "description": "The horizontal alignment of the text. One of `\"left\"`, `\"right\"`, `\"center\"`."
                 },
                 "angle": {
                     "description": "The rotation angle of the text, in degrees.",
@@ -620,19 +620,19 @@
                 },
                 "baseline": {
                     "$ref": "#/definitions/VerticalAlign",
-                    "description": "The vertical alignment of the text. One of top, middle, bottom."
+                    "description": "The vertical alignment of the text. One of `\"top\"`, `\"middle\"`, `\"bottom\"`.\n\n__Default value:__ `\"middle\"`"
                 },
                 "binSpacing": {
-                    "description": "Offset between bar for binned field.  Ideal value for this is either 0 (Preferred by statisticians) or 1 (Vega-Lite Default, D3 example style).",
+                    "description": "Offset between bar for binned field.  Ideal value for this is either 0 (Preferred by statisticians) or 1 (Vega-Lite Default, D3 example style).\n\n__Default value:__ `1`",
                     "minimum": 0,
                     "type": "number"
                 },
                 "color": {
-                    "description": "Default color.",
+                    "description": "Default color.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`",
                     "type": "string"
                 },
                 "continuousBandSize": {
-                    "description": "Default size of the bars on continuous scales.",
+                    "description": "Default size of the bars on continuous scales.\n\n__Default value:__ `2`",
                     "minimum": 0,
                     "type": "number"
                 },
@@ -642,28 +642,29 @@
                     "type": "number"
                 },
                 "dx": {
-                    "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the angle property.",
+                    "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
                     "type": "number"
                 },
                 "dy": {
-                    "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the angle property.",
+                    "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
                     "type": "number"
                 },
                 "fill": {
-                    "description": "Default Fill Color.  This has higher precedence than config.color",
+                    "description": "Default Fill Color.  This has higher precedence than config.color\n\n__Default value:__ (None)",
                     "type": "string"
                 },
                 "fillOpacity": {
+                    "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ `1`",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
                 },
                 "filled": {
-                    "description": "Whether the mark's color should be used as fill color instead of stroke color.\nAll marks except \"point\", \"line\", and \"rule\" are filled by default.",
+                    "description": "Whether the mark's color should be used as fill color instead of stroke color.\n\n__Default value:__ `true` for all marks except `point` and `false` for `point`.\n\n__Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.",
                     "type": "boolean"
                 },
                 "font": {
-                    "description": "The typeface to set the text in (e.g., Helvetica Neue).",
+                    "description": "The typeface to set the text in (e.g., `\"Helvetica Neue\"`).",
                     "minimum": 0,
                     "type": "string"
                 },
@@ -674,7 +675,7 @@
                 },
                 "fontStyle": {
                     "$ref": "#/definitions/FontStyle",
-                    "description": "The font style (e.g., italic)."
+                    "description": "The font style (e.g., `\"italic\"`)."
                 },
                 "fontWeight": {
                     "anyOf": [
@@ -689,13 +690,14 @@
                             "type": "number"
                         }
                     ],
-                    "description": "The font weight (e.g., `\"normal\"`, `\"bold\"`, `900`)."
+                    "description": "The font weight (e.g., `\"bold\"`)."
                 },
                 "interpolate": {
                     "$ref": "#/definitions/Interpolate",
                     "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
                 },
                 "opacity": {
+                    "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or [layered `bar` charts](http://vega.github.io/vega-editor/?mode=vega-lite&spec=bar_layered_transparent&showEditor=1) and `1` otherwise.",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
@@ -705,21 +707,21 @@
                     "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
                 },
                 "radius": {
-                    "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the x and y properties.",
+                    "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the `x` and `y` properties.",
                     "minimum": 0,
                     "type": "number"
                 },
                 "shape": {
-                    "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.",
+                    "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.\n\n__Default value:__ `\"circle\"`",
                     "type": "string"
                 },
                 "size": {
-                    "description": "The pixel area each the point/circle/square.\nFor example: in the case of circles, the radius is determined in part by the square root of the size value.",
+                    "description": "The pixel area each the point/circle/square.\nFor example: in the case of circles, the radius is determined in part by the square root of the size value.\n\n__Default value:__ `30`",
                     "minimum": 0,
                     "type": "number"
                 },
                 "stroke": {
-                    "description": "Default Stroke Color.  This has higher precedence than config.color",
+                    "description": "Default Stroke Color.  This has higher precedence than config.color\n\n__Default value:__ (None)",
                     "type": "string"
                 },
                 "strokeDash": {
@@ -734,11 +736,13 @@
                     "type": "number"
                 },
                 "strokeOpacity": {
+                    "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
                 },
                 "strokeWidth": {
+                    "description": "The stroke width, in pixels.",
                     "minimum": 0,
                     "type": "number"
                 },
@@ -749,11 +753,11 @@
                     "type": "number"
                 },
                 "text": {
-                    "description": "Placeholder Text",
+                    "description": "Placeholder text if the `text` channel is not specified",
                     "type": "string"
                 },
                 "theta": {
-                    "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the x and y properties. Values for theta follow the same convention of arc mark startAngle and endAngle properties: angles are measured in radians, with 0 indicating \"north\".",
+                    "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
                     "type": "number"
                 }
             },
@@ -1112,43 +1116,46 @@
             "additionalProperties": false,
             "properties": {
                 "clip": {
+                    "description": "Whether the view should be clipped.",
                     "type": "boolean"
                 },
                 "fill": {
-                    "description": "The fill color.",
+                    "description": "The fill color.\n\n__Default value:__ (none)",
                     "type": "string"
                 },
                 "fillOpacity": {
-                    "description": "The fill opacity (value between [0,1]).",
+                    "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ (none)",
                     "type": "number"
                 },
                 "height": {
+                    "description": "The default height of the single plot or each plot in a trellis plot when the visualization has a continuous (non-ordinal) y-scale with `rangeStep` = `null`.\n\n__Default value:__ `200`",
                     "type": "number"
                 },
                 "stroke": {
-                    "description": "The stroke color.",
+                    "description": "The stroke color.\n\n__Default value:__ (none)",
                     "type": "string"
                 },
                 "strokeDash": {
-                    "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.",
+                    "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.\n\n__Default value:__ (none)",
                     "items": {
                         "type": "number"
                     },
                     "type": "array"
                 },
                 "strokeDashOffset": {
-                    "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
+                    "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.\n\n__Default value:__ (none)",
                     "type": "number"
                 },
                 "strokeOpacity": {
-                    "description": "The stroke opacity (value between [0,1]).",
+                    "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ (none)",
                     "type": "number"
                 },
                 "strokeWidth": {
-                    "description": "The stroke width, in pixels.",
+                    "description": "The stroke width, in pixels.\n\n__Default value:__ (none)",
                     "type": "number"
                 },
                 "width": {
+                    "description": "The default width of the single plot or each plot in a trellis plot when the visualization has a continuous (non-ordinal) x-scale or ordinal x-scale with `rangeStep` = `null`.\n\n__Default value:__ `200`",
                     "type": "number"
                 }
             },
@@ -1308,7 +1315,7 @@
                     "description": "Specific axis config for x-axis along the bottom edge of the chart."
                 },
                 "background": {
-                    "description": "CSS color property to use as background of visualization. Default is `\"transparent\"`.",
+                    "description": "CSS color property to use as background of visualization.\n\n__Default value:__ none (transparent)",
                     "type": "string"
                 },
                 "bar": {
@@ -1324,7 +1331,7 @@
                     "description": "Circle-Specific Config"
                 },
                 "countTitle": {
-                    "description": "Default axis and legend title for count fields.",
+                    "description": "Default axis and legend title for count fields.\n\n__Default value:__ `'Number of Records'`.",
                     "type": "string"
                 },
                 "facet": {
@@ -1348,7 +1355,7 @@
                     "description": "Mark Config"
                 },
                 "numberFormat": {
-                    "description": "D3 Number format for axis labels and text tables. For example \"s\" for SI units.",
+                    "description": "D3 Number format for axis labels and text tables. For example \"s\" for SI units.(in the form of [D3 number format pattern](https://github.com/mbostock/d3/wiki/Formatting)).\n\n__Default value:__ `\"s\"` (except for text marks that encode a count field, the default value is `\"d\"`).",
                     "type": "string"
                 },
                 "overlay": {
@@ -1469,7 +1476,7 @@
                     "description": "Tick-Specific Config"
                 },
                 "timeFormat": {
-                    "description": "Default datetime format for axis and legend labels. The format can be set directly on each axis and legend.",
+                    "description": "Default datetime format for axis and legend labels. The format can be set directly on each axis and legend. [D3 time format pattern](https://github.com/mbostock/d3/wiki/Time-Formatting)).\n\n__Default value:__ `'%b %d, %Y'`.",
                     "type": "string"
                 }
             },
@@ -1802,12 +1809,15 @@
             "additionalProperties": false,
             "properties": {
                 "color": {
+                    "description": "Color of the grid between facets.",
                     "type": "string"
                 },
                 "offset": {
+                    "description": "Offset for grid between facets.",
                     "type": "number"
                 },
                 "opacity": {
+                    "description": "Opacity of the grid between facets.",
                     "type": "number"
                 }
             },
@@ -2437,7 +2447,7 @@
             "properties": {
                 "align": {
                     "$ref": "#/definitions/HorizontalAlign",
-                    "description": "The horizontal alignment of the text. One of left, right, center."
+                    "description": "The horizontal alignment of the text. One of `\"left\"`, `\"right\"`, `\"center\"`."
                 },
                 "angle": {
                     "description": "The rotation angle of the text, in degrees.",
@@ -2447,35 +2457,36 @@
                 },
                 "baseline": {
                     "$ref": "#/definitions/VerticalAlign",
-                    "description": "The vertical alignment of the text. One of top, middle, bottom."
+                    "description": "The vertical alignment of the text. One of `\"top\"`, `\"middle\"`, `\"bottom\"`.\n\n__Default value:__ `\"middle\"`"
                 },
                 "color": {
-                    "description": "Default color.",
+                    "description": "Default color.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`",
                     "type": "string"
                 },
                 "dx": {
-                    "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the angle property.",
+                    "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
                     "type": "number"
                 },
                 "dy": {
-                    "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the angle property.",
+                    "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
                     "type": "number"
                 },
                 "fill": {
-                    "description": "Default Fill Color.  This has higher precedence than config.color",
+                    "description": "Default Fill Color.  This has higher precedence than config.color\n\n__Default value:__ (None)",
                     "type": "string"
                 },
                 "fillOpacity": {
+                    "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ `1`",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
                 },
                 "filled": {
-                    "description": "Whether the mark's color should be used as fill color instead of stroke color.\nAll marks except \"point\", \"line\", and \"rule\" are filled by default.",
+                    "description": "Whether the mark's color should be used as fill color instead of stroke color.\n\n__Default value:__ `true` for all marks except `point` and `false` for `point`.\n\n__Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.",
                     "type": "boolean"
                 },
                 "font": {
-                    "description": "The typeface to set the text in (e.g., Helvetica Neue).",
+                    "description": "The typeface to set the text in (e.g., `\"Helvetica Neue\"`).",
                     "minimum": 0,
                     "type": "string"
                 },
@@ -2486,7 +2497,7 @@
                 },
                 "fontStyle": {
                     "$ref": "#/definitions/FontStyle",
-                    "description": "The font style (e.g., italic)."
+                    "description": "The font style (e.g., `\"italic\"`)."
                 },
                 "fontWeight": {
                     "anyOf": [
@@ -2501,13 +2512,14 @@
                             "type": "number"
                         }
                     ],
-                    "description": "The font weight (e.g., `\"normal\"`, `\"bold\"`, `900`)."
+                    "description": "The font weight (e.g., `\"bold\"`)."
                 },
                 "interpolate": {
                     "$ref": "#/definitions/Interpolate",
                     "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
                 },
                 "opacity": {
+                    "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or [layered `bar` charts](http://vega.github.io/vega-editor/?mode=vega-lite&spec=bar_layered_transparent&showEditor=1) and `1` otherwise.",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
@@ -2517,21 +2529,21 @@
                     "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
                 },
                 "radius": {
-                    "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the x and y properties.",
+                    "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the `x` and `y` properties.",
                     "minimum": 0,
                     "type": "number"
                 },
                 "shape": {
-                    "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.",
+                    "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.\n\n__Default value:__ `\"circle\"`",
                     "type": "string"
                 },
                 "size": {
-                    "description": "The pixel area each the point/circle/square.\nFor example: in the case of circles, the radius is determined in part by the square root of the size value.",
+                    "description": "The pixel area each the point/circle/square.\nFor example: in the case of circles, the radius is determined in part by the square root of the size value.\n\n__Default value:__ `30`",
                     "minimum": 0,
                     "type": "number"
                 },
                 "stroke": {
-                    "description": "Default Stroke Color.  This has higher precedence than config.color",
+                    "description": "Default Stroke Color.  This has higher precedence than config.color\n\n__Default value:__ (None)",
                     "type": "string"
                 },
                 "strokeDash": {
@@ -2546,11 +2558,13 @@
                     "type": "number"
                 },
                 "strokeOpacity": {
+                    "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
                 },
                 "strokeWidth": {
+                    "description": "The stroke width, in pixels.",
                     "minimum": 0,
                     "type": "number"
                 },
@@ -2561,11 +2575,11 @@
                     "type": "number"
                 },
                 "text": {
-                    "description": "Placeholder Text",
+                    "description": "Placeholder text if the `text` channel is not specified",
                     "type": "string"
                 },
                 "theta": {
-                    "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the x and y properties. Values for theta follow the same convention of arc mark startAngle and endAngle properties: angles are measured in radians, with 0 indicating \"north\".",
+                    "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
                     "type": "number"
                 }
             },
@@ -2580,7 +2594,7 @@
                 },
                 "interpolate": {
                     "$ref": "#/definitions/Interpolate",
-                    "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+                    "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y.\nFor more information about each interpolation method, please see [D3's line interpolation](https://github.com/mbostock/d3/wiki/SVG-Shapes#line_interpolate)."
                 },
                 "orient": {
                     "$ref": "#/definitions/Orient",
@@ -2591,7 +2605,7 @@
                     "type": "string"
                 },
                 "tension": {
-                    "description": "Depending on the interpolation type, sets the tension parameter (for line and area marks).",
+                    "description": "Depending on the interpolation type, sets the tension parameter (for line and area marks).(See [D3's line interpolation](https://github.com/mbostock/d3/wiki/SVG-Shapes#line_interpolate).)",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
@@ -2710,7 +2724,7 @@
                     "description": "Type of overlay for area mark (line or linepoint)"
                 },
                 "line": {
-                    "description": "Whether to overlay line with point.",
+                    "description": "Whether to overlay line with point.\n\n__Default value:__ `false`",
                     "type": "boolean"
                 }
             },
@@ -2968,7 +2982,7 @@
             "additionalProperties": false,
             "properties": {
                 "bandPaddingInner": {
-                    "description": "Default inner padding for `x` and `y` band-ordinal scales.",
+                    "description": "Default inner padding for `x` and `y` band-ordinal scales.\n\n__Default value:__ `0.1`",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
@@ -2984,7 +2998,7 @@
                     "type": "boolean"
                 },
                 "facetSpacing": {
-                    "description": "Default spacing between faceted plots.",
+                    "description": "Default spacing between faceted plots.\n\n__Default value:__ `16`",
                     "minimum": 0,
                     "type": "integer"
                 },
@@ -2994,12 +3008,12 @@
                     "type": "number"
                 },
                 "maxFontSize": {
-                    "description": "The default max value for mapping quantitative fields to text's size/fontSize.\nIf undefined (default), we will use bandSize - 1.",
+                    "description": "The default max value for mapping quantitative fields to text's size/fontSize.\nIf undefined (default), we will use bandSize - 1.\n\n__Default value:__ `40`",
                     "minimum": 0,
                     "type": "number"
                 },
                 "maxOpacity": {
-                    "description": "Default max opacity for mapping a field to opacity.",
+                    "description": "Default max opacity for mapping a field to opacity.\n\n__Default value:__ `0.8`",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
@@ -3010,7 +3024,7 @@
                     "type": "number"
                 },
                 "maxStrokeWidth": {
-                    "description": "Default max strokeWidth for strokeWidth  (or rule/line's size) scale.",
+                    "description": "Default max strokeWidth for strokeWidth  (or rule/line's size) scale.\n\n__Default value:__ `4`",
                     "minimum": 0,
                     "type": "number"
                 },
@@ -3020,28 +3034,28 @@
                     "type": "number"
                 },
                 "minFontSize": {
-                    "description": "The default min value for mapping quantitative fields to tick's size/fontSize scale with zero=false",
+                    "description": "The default min value for mapping quantitative fields to tick's size/fontSize scale with zero=false\n\n__Default value:__ `8`",
                     "minimum": 0,
                     "type": "number"
                 },
                 "minOpacity": {
-                    "description": "Default minimum opacity for mapping a field to opacity.",
+                    "description": "Default minimum opacity for mapping a field to opacity.\n\n__Default value:__ `0.3`",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
                 },
                 "minSize": {
-                    "description": "Default minimum value for point size scale with zero=false.",
+                    "description": "Default minimum value for point size scale with zero=false.\n\n__Default value:__ `9`",
                     "minimum": 0,
                     "type": "number"
                 },
                 "minStrokeWidth": {
-                    "description": "Default minimum strokeWidth for strokeWidth (or rule/line's size) scale with zero=false.",
+                    "description": "Default minimum strokeWidth for strokeWidth (or rule/line's size) scale with zero=false.\n\n__Default value:__ `1`",
                     "minimum": 0,
                     "type": "number"
                 },
                 "pointPadding": {
-                    "description": "Default outer padding for `x` and `y` point-ordinal scales.",
+                    "description": "Default outer padding for `x` and `y` point-ordinal scales.\n\n__Default value:__ `0.5`",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
@@ -3049,7 +3063,7 @@
                 "rangeStep": {
                     "anyOf": [
                         {
-                            "description": "Default range step for (1) `y` ordinal scale,\nand (2) `x` ordinal scale when the mark is not `text`.",
+                            "description": "Default range step for (1) `y` ordinal scale,\nand (2) `x` ordinal scale when the mark is not `text`.\n\n__Default value:__ `21`",
                             "minimum": 0,
                             "type": "number"
                         },
@@ -3063,14 +3077,14 @@
                     "type": "boolean"
                 },
                 "shapes": {
-                    "description": "The default collection of symbol shapes for mapping nominal fields to shapes of point marks (i.e., range of a `shape` scale).\nEach value should be one of: `\"circle\"`, `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.",
+                    "description": "The default collection of symbol shapes for mapping nominal fields to shapes of point marks (i.e., range of a `shape` scale).\nEach value should be one of: `\"circle\"`, `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.\n\n__Default value:__ `[\"circle\", \"square\", \"cross\", \"diamond\", \"triangle-up\", \"triangle-down\"]`",
                     "items": {
                         "type": "string"
                     },
                     "type": "array"
                 },
                 "textXRangeStep": {
-                    "description": "Default range step for `x` ordinal scale when is mark is `text`.",
+                    "description": "Default range step for `x` ordinal scale when is mark is `text`.\n\n__Default value:__ `90`",
                     "minimum": 0,
                     "type": "number"
                 },
@@ -3452,7 +3466,7 @@
             "properties": {
                 "align": {
                     "$ref": "#/definitions/HorizontalAlign",
-                    "description": "The horizontal alignment of the text. One of left, right, center."
+                    "description": "The horizontal alignment of the text. One of `\"left\"`, `\"right\"`, `\"center\"`."
                 },
                 "angle": {
                     "description": "The rotation angle of the text, in degrees.",
@@ -3462,35 +3476,36 @@
                 },
                 "baseline": {
                     "$ref": "#/definitions/VerticalAlign",
-                    "description": "The vertical alignment of the text. One of top, middle, bottom."
+                    "description": "The vertical alignment of the text. One of `\"top\"`, `\"middle\"`, `\"bottom\"`.\n\n__Default value:__ `\"middle\"`"
                 },
                 "color": {
-                    "description": "Default color.",
+                    "description": "Default color.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`",
                     "type": "string"
                 },
                 "dx": {
-                    "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the angle property.",
+                    "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
                     "type": "number"
                 },
                 "dy": {
-                    "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the angle property.",
+                    "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
                     "type": "number"
                 },
                 "fill": {
-                    "description": "Default Fill Color.  This has higher precedence than config.color",
+                    "description": "Default Fill Color.  This has higher precedence than config.color\n\n__Default value:__ (None)",
                     "type": "string"
                 },
                 "fillOpacity": {
+                    "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ `1`",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
                 },
                 "filled": {
-                    "description": "Whether the mark's color should be used as fill color instead of stroke color.\nAll marks except \"point\", \"line\", and \"rule\" are filled by default.",
+                    "description": "Whether the mark's color should be used as fill color instead of stroke color.\n\n__Default value:__ `true` for all marks except `point` and `false` for `point`.\n\n__Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.",
                     "type": "boolean"
                 },
                 "font": {
-                    "description": "The typeface to set the text in (e.g., Helvetica Neue).",
+                    "description": "The typeface to set the text in (e.g., `\"Helvetica Neue\"`).",
                     "minimum": 0,
                     "type": "string"
                 },
@@ -3501,7 +3516,7 @@
                 },
                 "fontStyle": {
                     "$ref": "#/definitions/FontStyle",
-                    "description": "The font style (e.g., italic)."
+                    "description": "The font style (e.g., `\"italic\"`)."
                 },
                 "fontWeight": {
                     "anyOf": [
@@ -3516,13 +3531,14 @@
                             "type": "number"
                         }
                     ],
-                    "description": "The font weight (e.g., `\"normal\"`, `\"bold\"`, `900`)."
+                    "description": "The font weight (e.g., `\"bold\"`)."
                 },
                 "interpolate": {
                     "$ref": "#/definitions/Interpolate",
                     "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
                 },
                 "opacity": {
+                    "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or [layered `bar` charts](http://vega.github.io/vega-editor/?mode=vega-lite&spec=bar_layered_transparent&showEditor=1) and `1` otherwise.",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
@@ -3532,12 +3548,12 @@
                     "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
                 },
                 "radius": {
-                    "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the x and y properties.",
+                    "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the `x` and `y` properties.",
                     "minimum": 0,
                     "type": "number"
                 },
                 "shape": {
-                    "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.",
+                    "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.\n\n__Default value:__ `\"circle\"`",
                     "type": "string"
                 },
                 "shortTimeLabels": {
@@ -3545,12 +3561,12 @@
                     "type": "boolean"
                 },
                 "size": {
-                    "description": "The pixel area each the point/circle/square.\nFor example: in the case of circles, the radius is determined in part by the square root of the size value.",
+                    "description": "The pixel area each the point/circle/square.\nFor example: in the case of circles, the radius is determined in part by the square root of the size value.\n\n__Default value:__ `30`",
                     "minimum": 0,
                     "type": "number"
                 },
                 "stroke": {
-                    "description": "Default Stroke Color.  This has higher precedence than config.color",
+                    "description": "Default Stroke Color.  This has higher precedence than config.color\n\n__Default value:__ (None)",
                     "type": "string"
                 },
                 "strokeDash": {
@@ -3565,11 +3581,13 @@
                     "type": "number"
                 },
                 "strokeOpacity": {
+                    "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
                 },
                 "strokeWidth": {
+                    "description": "The stroke width, in pixels.",
                     "minimum": 0,
                     "type": "number"
                 },
@@ -3580,11 +3598,11 @@
                     "type": "number"
                 },
                 "text": {
-                    "description": "Placeholder Text",
+                    "description": "Placeholder text if the `text` channel is not specified",
                     "type": "string"
                 },
                 "theta": {
-                    "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the x and y properties. Values for theta follow the same convention of arc mark startAngle and endAngle properties: angles are measured in radians, with 0 indicating \"north\".",
+                    "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
                     "type": "number"
                 }
             },
@@ -3639,7 +3657,7 @@
             "properties": {
                 "align": {
                     "$ref": "#/definitions/HorizontalAlign",
-                    "description": "The horizontal alignment of the text. One of left, right, center."
+                    "description": "The horizontal alignment of the text. One of `\"left\"`, `\"right\"`, `\"center\"`."
                 },
                 "angle": {
                     "description": "The rotation angle of the text, in degrees.",
@@ -3654,35 +3672,36 @@
                 },
                 "baseline": {
                     "$ref": "#/definitions/VerticalAlign",
-                    "description": "The vertical alignment of the text. One of top, middle, bottom."
+                    "description": "The vertical alignment of the text. One of `\"top\"`, `\"middle\"`, `\"bottom\"`.\n\n__Default value:__ `\"middle\"`"
                 },
                 "color": {
-                    "description": "Default color.",
+                    "description": "Default color.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`",
                     "type": "string"
                 },
                 "dx": {
-                    "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the angle property.",
+                    "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
                     "type": "number"
                 },
                 "dy": {
-                    "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the angle property.",
+                    "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
                     "type": "number"
                 },
                 "fill": {
-                    "description": "Default Fill Color.  This has higher precedence than config.color",
+                    "description": "Default Fill Color.  This has higher precedence than config.color\n\n__Default value:__ (None)",
                     "type": "string"
                 },
                 "fillOpacity": {
+                    "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ `1`",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
                 },
                 "filled": {
-                    "description": "Whether the mark's color should be used as fill color instead of stroke color.\nAll marks except \"point\", \"line\", and \"rule\" are filled by default.",
+                    "description": "Whether the mark's color should be used as fill color instead of stroke color.\n\n__Default value:__ `true` for all marks except `point` and `false` for `point`.\n\n__Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.",
                     "type": "boolean"
                 },
                 "font": {
-                    "description": "The typeface to set the text in (e.g., Helvetica Neue).",
+                    "description": "The typeface to set the text in (e.g., `\"Helvetica Neue\"`).",
                     "minimum": 0,
                     "type": "string"
                 },
@@ -3693,7 +3712,7 @@
                 },
                 "fontStyle": {
                     "$ref": "#/definitions/FontStyle",
-                    "description": "The font style (e.g., italic)."
+                    "description": "The font style (e.g., `\"italic\"`)."
                 },
                 "fontWeight": {
                     "anyOf": [
@@ -3708,13 +3727,14 @@
                             "type": "number"
                         }
                     ],
-                    "description": "The font weight (e.g., `\"normal\"`, `\"bold\"`, `900`)."
+                    "description": "The font weight (e.g., `\"bold\"`)."
                 },
                 "interpolate": {
                     "$ref": "#/definitions/Interpolate",
                     "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
                 },
                 "opacity": {
+                    "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or [layered `bar` charts](http://vega.github.io/vega-editor/?mode=vega-lite&spec=bar_layered_transparent&showEditor=1) and `1` otherwise.",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
@@ -3724,21 +3744,21 @@
                     "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
                 },
                 "radius": {
-                    "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the x and y properties.",
+                    "description": "Polar coordinate radial offset, in pixels, of the text label from the origin determined by the `x` and `y` properties.",
                     "minimum": 0,
                     "type": "number"
                 },
                 "shape": {
-                    "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.",
+                    "description": "The default symbol shape to use. One of: `\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, or `\"triangle-down\"`, or a custom SVG path.\n\n__Default value:__ `\"circle\"`",
                     "type": "string"
                 },
                 "size": {
-                    "description": "The pixel area each the point/circle/square.\nFor example: in the case of circles, the radius is determined in part by the square root of the size value.",
+                    "description": "The pixel area each the point/circle/square.\nFor example: in the case of circles, the radius is determined in part by the square root of the size value.\n\n__Default value:__ `30`",
                     "minimum": 0,
                     "type": "number"
                 },
                 "stroke": {
-                    "description": "Default Stroke Color.  This has higher precedence than config.color",
+                    "description": "Default Stroke Color.  This has higher precedence than config.color\n\n__Default value:__ (None)",
                     "type": "string"
                 },
                 "strokeDash": {
@@ -3753,11 +3773,13 @@
                     "type": "number"
                 },
                 "strokeOpacity": {
+                    "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
                     "maximum": 1,
                     "minimum": 0,
                     "type": "number"
                 },
                 "strokeWidth": {
+                    "description": "The stroke width, in pixels.",
                     "minimum": 0,
                     "type": "number"
                 },
@@ -3768,15 +3790,15 @@
                     "type": "number"
                 },
                 "text": {
-                    "description": "Placeholder Text",
+                    "description": "Placeholder text if the `text` channel is not specified",
                     "type": "string"
                 },
                 "theta": {
-                    "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the x and y properties. Values for theta follow the same convention of arc mark startAngle and endAngle properties: angles are measured in radians, with 0 indicating \"north\".",
+                    "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
                     "type": "number"
                 },
                 "thickness": {
-                    "description": "Thickness of the tick mark.",
+                    "description": "Thickness of the tick mark.\n\n__Default value:__  `1`",
                     "minimum": 0,
                     "type": "number"
                 }

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -41,13 +41,7 @@ A Vega-Lite `config` object can have the following top-level properties:
 
 {:#format}
 
-| Property      | Type          | Description    |
-| :------------ |:-------------:| :------------- |
-| viewport      | Integer[]     | The width and height of the on-screen viewport, in pixels. If necessary, clipping and scrolling will be applied. <span class="note-line">__Default value:__ (none)</span> |
-| background    | String        | CSS color property to use as background of visualization. <span class="note-line">__Default value:__ (none)</span> |
-| countTitle    | String      | The default title for count field (`{field:'*', aggregate:'count', type: 'QUANTITATIVE'}`). <span class="note-line">__Default value:__ `'Number of Records'`.</span>|
-| numberFormat  | String      | The default number format pattern for text and labels of axes and legends (in the form of [D3 number format pattern](https://github.com/mbostock/d3/wiki/Formatting)). <span class="note-line">__Default value:__ `"s"` (except for text marks that encode a count field, the default value is `"d"`).</span>|
-| timeFormat    | String     | The default time format pattern for temporal field without time unit in the text mark and labels of axes and legends (in the form of [D3 time format pattern](https://github.com/mbostock/d3/wiki/Time-Formatting)). <span class="note-line">__Default value:__ `'%b %d, %Y'`.</span>|
+{% include table.html props="background,countTitle,numberFormat,timeFormat" source="Config" %}
 
 <!-- TODO: consider adding width, height, numberFormat, timeFormat  -->
 
@@ -61,25 +55,13 @@ Each plot in either a single plot or a trellis plot is called a _cell_. Cell con
 
 `width` and `height` property of the cell configuration determine the width of a visualization with a continuous x-scale and the height of a visualization with a continuous y-scale respectively.
 
-| Property      | Type          | Description    |
-| :------------ |:-------------:| :------------- |
-| width         | Integer       | The default width of the single plot or each plot in a trellis plot when the visualization has a continuous (non-ordinal) x-scale or ordinal x-scale with `rangeStep` = `"fit"`. <span class="note-line">__Default value:__ `200`</span> |
-| height        | Integer       | The default height of the single plot or each plot in a trellis plot when the visualization has a continuous (non-ordinal) y-scale with `rangeStep` = `"fit"`. <span class="note-line">__Default value:__ `200`</span> |
+{% include table.html props="width,height" source="CellConfig" %}
 
 **For more information about visualization's size, please see [Customizing Size](size.html) page.**
 
 ### Cell Style Configuration
 
-| Property      | Type          | Description    |
-| :------------ |:-------------:| :------------- |
-| clip          | boolean       | Whether the view should be clipped. |
-| fill          | Color         | The fill color. <span class="note-line">__Default value:__ (none)</span> |
-| fillOpacity   | Number        | The fill opacity (value between [0,1]). <span class="note-line">__Default value:__ (none)</span>|
-| stroke        | Color         | The stroke color. <span class="note-line">__Default value:__ (none)</span>|
-| strokeOpacity | Number        | The stroke opacity (value between [0,1]). <span class="note-line">__Default value:__ (none)</span>|
-| strokeWidth   | Number        | The stroke width, in pixels. <span class="note-line">__Default value:__ (none)</span>|
-| strokeDash    | Number[]      | An array of alternating stroke, space lengths for creating dashed or dotted lines. <span class="note-line">__Default value:__ (none)</span>|
-| strokeDashOffset  | Number    | The offset (in pixels) into which to begin drawing with the stroke dash array. <span class="note-line">__Default value:__ (none)</span>|
+{% include table.html props="clip,fill,fillOpacity,stroke,strokeOpacity,strokeWidth,strokeDash,strokeDashOffset" source="CellConfig" %}
 
 
 {:#mark-config}
@@ -91,12 +73,7 @@ A mark config object can have the following properties:
 
 #### Color
 
-| Property      | Type          | Description    |
-| :------------ |:-------------:| :------------- |
-| filled        | Boolean        | Whether the shape\'s color should be used as fill color instead of stroke color. See [mark](mark.html#scatter_filled) for a usage example. <span class="note-line">__Default value:__ `true` for all marks except `point` and `false` for `point`.</span><span class="note-line">__Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.</span> |
-| color         | color         | The color of the mark – either fill or stroke color based on the `filled` mark config. <span class="note-line">__Default value:__ <span style="color: #4682b4;">&#9632;</span> blue (`""#4682b4"`)</span>  |
-| fill          | Color         | The fill color. This config will be overridden by `color` channel's specified or mapped values if `filled` is `true`. <span class="note-line">__Default value:__ (None) </span>  |
-| stroke        | Color         | The stroke color. This config will be overridden by `color` channel's specified or mapped values if `filled` is `false`. <span class="note-line">__Default value:__ (None) </span> |
+{% include table.html props="filled,color,fill,stroke" source="MarkConfig" %}
 
 <!-- Linked from another page. Don't remove!-->
 
@@ -110,38 +87,19 @@ By default, `point` marks have filled borders and are transparent inside. Settin
 
 #### Opacity
 
-| Property      | Type          | Description    |
-| :------------ |:-------------:| :------------- |
-| opacity       | Number        | The overall opacity (value between [0,1]). <span class="note-line">__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or [layered `bar` charts](http://vega.github.io/vega-editor/?mode=vega-lite&spec=bar_layered_transparent&showEditor=1) and `1` otherwise. </span>|
-| fillOpacity   | Number        | The fill opacity (value between [0,1]). <span class="note-line">__Default value:__ `1` </span>|
-| strokeOpacity | Number        | The stroke opacity (value between [0,1]). <span class="note-line">__Default value:__ `1` </span> |
+{% include table.html props="opacity,fillOpacity,strokeOpacity" source="MarkConfig" %}
+
 
 #### Stroke Style
 
-| Property      | Type          | Description    |
-| :------------ |:-------------:| :------------- |
-| strokeWidth   | Number        | The stroke width, in pixels. |
-| strokeDash    | Number[]      | An array of alternating stroke, space lengths for creating dashed or dotted lines. |
-| strokeDashOffset  | Number    | The offset (in pixels) into which to begin drawing with the stroke dash array. |
+{% include table.html props="strokeWidth,strokeDash,strokeDashOffset" source="MarkConfig" %}
 
 <!-- one example for custom fill/stroke -->
-
-{:#stacked}
-### Stacking (for Bar and Area)
-
-<!-- TODO: -->
-
-| Property      | Type          | Description    |
-| :------------ |:-------------:| :------------- |
-| stacked       | string        | Modes for stacking marks. <br/> • `zero` - stacking with baseline offset at zero value of the scale (for creating typical stacked [bar](mark.html#stacked-bar-chart) and [area](mark.html#stacked-area-chart) chart). <br/> • `normalize` - stacking with normalized domain (for creating normalized stacked [bar](mark.html#normalized-stacked-bar-chart) and [area](mark.html#normalized-stacked-area-chart) chart). <br/> • `center` - stacking with center baseline (for [streamgraph](mark.html#streamgraph)). <br/> • `none` - No-stacking. This will produce layered [bar](mark.html#layered-bar-chart) and area chart. <span class="note-line">__Default value:__ `zero` for plots with all of the following conditions: (1) `bar` or `area` marks (2) `color`, `opacity`, `size`, or `detail` channel mapped to a group-by field (3) One ordinal or nominal axis, and (4) one quantitative axis with linear scale and summative aggregation function (e.g., `sum`, `count`).</span>|
 
 {:#interpolate}
 ### Interpolation (for Line and Area Marks)
 
-| Property      | Type          | Description    |
-| :------------ |:-------------:| :------------- |
-| interpolate   | String        | The line interpolation method to use. One of `"linear"`, `"step-before"`, `"step-after"`, `"basis"`, `"basis-open"`, `"basis-closed"`, `"bundle"`, `"cardinal"`, `"cardinal-open"`, `"cardinal-closed"`, `"monotone"`. For more information about each interpolation method, please see [D3's line interpolation](https://github.com/mbostock/d3/wiki/SVG-Shapes#line_interpolate). |
-| tension       | Number        | Depending on the interpolation type, sets the tension parameter. (See [D3's line interpolation](https://github.com/mbostock/d3/wiki/SVG-Shapes#line_interpolate).) |
+{% include table.html props="interpolate,tension" source="MarkConfig" %}
 
 #### Example: interpolate with `monotone`
 
@@ -155,9 +113,7 @@ By default, `point` marks have filled borders and are transparent inside. Settin
 {:#orient}
 ### Orientation (for Bar, Tick, Line, and Area Marks)
 
-| Property      | Type          | Description    |
-| :------------ |:-------------:| :------------- |
-| orient        | String        | The orientation of a non-stacked bar, area, and line charts. The value is either `"horizontal"`, or `"vertical"` (default). For bar and tick, this determines whether the size of the bar and tick should be applied to x or y dimension. For area, this property determines the orient property of the Vega output. For line, this property determines the path order of the points in the line if `path` channel is not specified. For stacked charts, this is always determined by the orientation of the stack; therefore explicitly specified value will be ignored. |
+{% include table.html props="orient" source="MarkConfig" %}
 
 <!-- TODO: write better explanation for default behavior -->
 
@@ -199,10 +155,8 @@ vg.embed('#horizontal_line', {
 
 ### Bar Config
 
-| Property      | Type          | Description    |
-| :------------ |:-------------:| :------------- |
-| barBinSpacing | Number        | Spacing between bars of binned quantitative fields.  <span class="note-line">__Default value:__  `1`. </span> |
-| barSize       | Number        | The size of the bars (width for vertical bar charts and height for horizontal bar chart). <span class="note-line">__Default value:__  `rangeStep-1` if  the bar's x or y axis is an ordinal scale. (This provides 1 pixel offset between bars.) and `2` for if both x and y scales have linear scales. </span>  |
+{% include table.html props="binSpacing,continuousBandSize,discreteBandSize" source="BarConfig" %}
+
 
 #### Example: Histogram without Spacing between bars
 
@@ -210,26 +164,20 @@ vg.embed('#horizontal_line', {
 
 ### Point Config
 
-| Property            | Type                | Description  |
-| :------------------ |:-------------------:| :------------|
-| shape               | Number              | The symbol shape to use. One of `"circle"`, `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or else a custom SVG path string.<span class="note-line">__Default value:__ `"circle"` </span> |
+{% include table.html props="shape" source="MarkConfig" %}
 
 
 ### Point Size Config (for Point, Circle, and Square Marks)
 
-| Property            | Type                | Description  |
-| :------------------ |:-------------------:| :------------|
-| size                | Number              | The pixel area each the point. For example: in the case of circles, the radius is determined in part by the square root of the size value.<span class="note-line">__Default value:__ `30` </span> |
+{% include table.html props="size" source="MarkConfig" %}
 
 
 ### Tick Config
 
 {:#tick-thickness}
 
-| Property            | Type                | Description  |
-| :------------------ |:-------------------:| :------------|
-| tickSize           | Number        | The size of the ticks  (height of the ticks for horizontal dot plots and strip plots and width of the ticks for vertical dot plots and strip plots). <span class="note-line">__Default value:__ `2/3*rangeStep` (This will provide offset between band equals to the width of the tick.) </span>|
-| tickThickness           | Number              | Thickness of the tick mark. <span class="note-line">__Default value:__ `1` </span> |
+{% include table.html props="bandSize,thickness" source="TickConfig" %}
+
 
 #### Example Customizing Tick's Size and Thickness
 
@@ -241,32 +189,17 @@ vg.embed('#horizontal_line', {
 
 #### Text Position
 
-| Property            | Type                | Description  |
-| :------------------ |:-------------------:| :------------|
-| angle               | Number  | The rotation angle of the text, in degrees.|
-| align               | String  | The horizontal alignment of the text. One of `left`, `right`, `center`.|
-| baseline            | String  | The vertical alignment of the text. One of `top`, `middle`, `bottom`.|
-| dx                  | Number  | The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.|
-| dy                  | Number  | The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.|
-| radius              | Number  | Polar coordinate radial offset, in pixels, of the text label from the origin determined by the `x` and `y` properties.|
-| theta               | Number  | Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating "north".|
+{% include table.html props="angle,align,baseline,dx,dy,radius,theta" source="MarkConfig" %}
+
 
 #### Font Style
 
-| Property            | Type                | Description  |
-| :------------------ |:-------------------:| :------------|
-| font                | String  | The typeface to set the text in (e.g., `Helvetica Neue`).|
-| fontSize            | Number  | The font size, in pixels. The default value is 10. |
-| fontStyle           | String  | The font style (e.g., `italic`).|
-| fontWeight          | String  | The font weight (e.g., `bold`).|
+{% include table.html props="font,fontSize,fontStyle,fontWeight" source="MarkConfig" %}
 
-#### Text Value and Format
+#### Text Value
 
-| Property            | Type                | Description  |
-| :------------------ |:-------------------:| :------------|
-| text                | String |  Placeholder text if the `text` channel is not specified (`"Abc"` by default). |
-| format              | String  | The formatting pattern for text value. If not defined, this will be determined automatically |
-| shortTimeLabels     | Boolean | Whether year, month names, and weekday names should be abbreviated.  <span class="note-line">__Default Behavior:__ Only month is shortened by default.</span>  |
+{% include table.html props="text" source="MarkConfig" %}
+
 
 <!-- TODO: expand format detail -->
 <!-- TODO: example of customized text -->
@@ -308,11 +241,7 @@ Facet cell configuration overrides [cell config](#cell-config) for faceted (trel
 {:#facet-grid-config}
 ### Facet Grid Configuration (`config.facet.grid.*`)
 
-| Property      | Type          | Description    |
-| :------------ |:-------------:| :------------- |
-| color         | Color         | Color of the grid between facets. |
-| opacity       | Number        | Opacity of the grid between facets. |
-| offset        | Number        | Offset for grid between facets. |
+{% include table.html props="color,opacity,offset" source="FacetGridConfig" %}
 
 {:#facet-axis-config}
 ### Facet Axis Configuration (`config.facet.axis.*`)

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,33 +10,82 @@ import {duplicate, mergeDeep} from './util';
 import {VgRangeScheme} from './vega.schema';
 
 export interface CellConfig {
+  /**
+   * The default width of the single plot or each plot in a trellis plot when the visualization has a continuous (non-ordinal) x-scale or ordinal x-scale with `rangeStep` = `null`.
+   *
+   * __Default value:__ `200`
+   *
+   */
   width?: number;
+
+  /**
+   * The default height of the single plot or each plot in a trellis plot when the visualization has a continuous (non-ordinal) y-scale with `rangeStep` = `null`.
+   *
+   * __Default value:__ `200`
+   *
+   */
   height?: number;
 
+  /**
+   * Whether the view should be clipped.
+   */
   clip?: boolean;
 
   // FILL_STROKE_CONFIG
   /**
    * The fill color.
+   *
+   * __Default value:__ (none)
+   *
    */
   fill?: string;
 
-  /** The fill opacity (value between [0,1]). */
+  /**
+   * The fill opacity (value between [0,1]).
+   *
+   * __Default value:__ (none)
+   *
+   */
   fillOpacity?: number;
 
-  /** The stroke color. */
+  /**
+   * The stroke color.
+   *
+   * __Default value:__ (none)
+   *
+   */
   stroke?: string;
 
-  /** The stroke opacity (value between [0,1]). */
+  /**
+   * The stroke opacity (value between [0,1]).
+   *
+   * __Default value:__ (none)
+   *
+   */
   strokeOpacity?: number;
 
-  /** The stroke width, in pixels. */
+  /**
+   * The stroke width, in pixels.
+   *
+   * __Default value:__ (none)
+   *
+   */
   strokeWidth?: number;
 
-  /** An array of alternating stroke, space lengths for creating dashed or dotted lines. */
+  /**
+   * An array of alternating stroke, space lengths for creating dashed or dotted lines.
+   *
+   * __Default value:__ (none)
+   *
+   */
   strokeDash?: number[];
 
-  /** The offset (in pixels) into which to begin drawing with the stroke dash array. */
+  /**
+   * The offset (in pixels) into which to begin drawing with the stroke dash array.
+   *
+   * __Default value:__ (none)
+   *
+   */
   strokeDashOffset?: number;
 }
 
@@ -63,8 +112,18 @@ export interface FacetConfig {
 }
 
 export interface FacetGridConfig {
+  /**
+   * Color of the grid between facets.
+   */
   color?: string;
+
+  /**
+   * Opacity of the grid between facets.
+   */
   opacity?: number;
+  /**
+   * Offset for grid between facets.
+   */
   offset?: number;
 }
 
@@ -85,6 +144,8 @@ export type AreaOverlay = 'line' | 'linepoint' | 'none';
 export interface OverlayConfig {
   /**
    * Whether to overlay line with point.
+   *
+   * __Default value:__ `false`
    */
   line?: boolean;
 
@@ -106,17 +167,26 @@ export interface Config  extends TopLevelProperties {
   // height?: number;
 
   /**
-   * D3 Number format for axis labels and text tables. For example "s" for SI units.
+   * D3 Number format for axis labels and text tables. For example "s" for SI units.(in the form of [D3 number format pattern](https://github.com/mbostock/d3/wiki/Formatting)).
+   *
+   * __Default value:__ `"s"` (except for text marks that encode a count field, the default value is `"d"`).
+   *
    */
   numberFormat?: string;
 
   /**
-   * Default datetime format for axis and legend labels. The format can be set directly on each axis and legend.
+   * Default datetime format for axis and legend labels. The format can be set directly on each axis and legend. [D3 time format pattern](https://github.com/mbostock/d3/wiki/Time-Formatting)).
+   *
+   * __Default value:__ `'%b %d, %Y'`.
+   *
    */
   timeFormat?: string;
 
   /**
    * Default axis and legend title for count fields.
+   *
+   * __Default value:__ `'Number of Records'`.
+   *
    * @type {string}
    */
   countTitle?: string;

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -84,11 +84,12 @@ export interface MarkDef {
    * - `"cardinal-closed"`: a closed Cardinal spline, as in a loop.
    * - `"bundle"`: equivalent to basis, except the tension parameter is used to straighten the spline.
    * - `"monotone"`: cubic interpolation that preserves monotonicity in y.
+   * For more information about each interpolation method, please see [D3's line interpolation](https://github.com/mbostock/d3/wiki/SVG-Shapes#line_interpolate).
    */
   interpolate?: Interpolate;
 
   /**
-   * Depending on the interpolation type, sets the tension parameter (for line and area marks).
+   * Depending on the interpolation type, sets the tension parameter (for line and area marks).(See [D3's line interpolation](https://github.com/mbostock/d3/wiki/SVG-Shapes#line_interpolate).)
    * @minimum 0
    * @maximum 1
    */
@@ -118,13 +119,19 @@ export interface MarkConfig extends VgMarkConfig {
   // ---------- Color ----------
   /**
    * Whether the mark's color should be used as fill color instead of stroke color.
-   * All marks except "point", "line", and "rule" are filled by default.
+   *
+   * __Default value:__ `true` for all marks except `point` and `false` for `point`.
+   *
+   * __Applicable for:__ `bar`, `point`, `circle`, `square`, and `area` marks.
+   *
    */
   filled?: boolean;
 
   // TODO: remove this once we correctly integrate theme
   /**
    * Default color.
+   *
+   * __Default value:__ <span style="color: #4682b4;">&#9632;</span> `"#4682b4"`
    */
   color?: string;
 }
@@ -136,11 +143,17 @@ export const defaultMarkConfig: MarkConfig = {
 export interface BarConfig extends MarkConfig {
   /**
    * Offset between bar for binned field.  Ideal value for this is either 0 (Preferred by statisticians) or 1 (Vega-Lite Default, D3 example style).
+   *
+   * __Default value:__ `1`
+   *
    * @minimum 0
    */
   binSpacing?: number;
   /**
    * Default size of the bars on continuous scales.
+   *
+   * __Default value:__ `2`
+   *
    * @minimum 0
    */
   continuousBandSize?: number;
@@ -179,6 +192,9 @@ export interface TickConfig extends MarkConfig {
 
   /**
    * Thickness of the tick mark.
+   *
+   * __Default value:__  `1`
+   *
    * @minimum 0
    */
   thickness?: number;

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -92,12 +92,17 @@ export interface ScaleConfig {
   clamp?: boolean;
   /**
    *  Default range step for `x` ordinal scale when is mark is `text`.
+   *
+   * __Default value:__ `90`
+   *
    *  @minimum 0
    */
   textXRangeStep?: number; // FIXME: consider if we will rename this "tableColumnWidth"
   /**
    * Default range step for (1) `y` ordinal scale,
    * and (2) `x` ordinal scale when the mark is not `text`.
+   *
+   * __Default value:__ `21`
    *
    * @minimum 0
    * @nullable
@@ -106,6 +111,9 @@ export interface ScaleConfig {
 
   /**
    * Default inner padding for `x` and `y` band-ordinal scales.
+   *
+   * __Default value:__ `0.1`
+   *
    * @minimum 0
    * @maximum 1
    */
@@ -121,6 +129,9 @@ export interface ScaleConfig {
 
   /**
    * Default outer padding for `x` and `y` point-ordinal scales.
+   *
+   * __Default value:__ `0.5`
+   *
    * @minimum 0
    * @maximum 1
    */
@@ -128,6 +139,9 @@ export interface ScaleConfig {
 
   /**
    * Default spacing between faceted plots.
+   *
+   * __Default value:__ `16`
+   *
    * @TJS-type integer
    * @minimum 0
    */
@@ -162,18 +176,27 @@ export interface ScaleConfig {
   /**
    * The default max value for mapping quantitative fields to text's size/fontSize.
    * If undefined (default), we will use bandSize - 1.
+   *
+   * __Default value:__ `40`
+   *
    * @minimum 0
    */
   maxFontSize?: number;
 
   /**
    * The default min value for mapping quantitative fields to tick's size/fontSize scale with zero=false
+   *
+   * __Default value:__ `8`
+   *
    * @minimum 0
    */
   minFontSize?: number;
 
   /**
    * Default minimum opacity for mapping a field to opacity.
+   *
+   * __Default value:__ `0.3`
+   *
    * @minimum 0
    * @maximum 1
    */
@@ -181,6 +204,9 @@ export interface ScaleConfig {
 
   /**
    * Default max opacity for mapping a field to opacity.
+   *
+   * __Default value:__ `0.8`
+   *
    * @minimum 0
    * @maximum 1
    */
@@ -189,6 +215,9 @@ export interface ScaleConfig {
 
   /**
    * Default minimum value for point size scale with zero=false.
+   *
+   * __Default value:__ `9`
+   *
    * @minimum 0
    */
   minSize?: number;
@@ -201,12 +230,18 @@ export interface ScaleConfig {
 
   /**
    * Default minimum strokeWidth for strokeWidth (or rule/line's size) scale with zero=false.
+   *
+   * __Default value:__ `1`
+   *
    * @minimum 0
    */
   minStrokeWidth?: number;
 
   /**
    * Default max strokeWidth for strokeWidth  (or rule/line's size) scale.
+   *
+   * __Default value:__ `4`
+   *
    * @minimum 0
    */
   maxStrokeWidth?: number;
@@ -214,6 +249,9 @@ export interface ScaleConfig {
   /**
    * The default collection of symbol shapes for mapping nominal fields to shapes of point marks (i.e., range of a `shape` scale).
    * Each value should be one of: `"circle"`, `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
+   *
+   * __Default value:__ `["circle", "square", "cross", "diamond", "triangle-up", "triangle-down"]`
+   *
    */
   shapes?: string[];
 }

--- a/src/toplevelprops.ts
+++ b/src/toplevelprops.ts
@@ -5,7 +5,9 @@ export interface TopLevelProperties {
   // autosize?: ...;
 
   /**
-   * CSS color property to use as background of visualization. Default is `"transparent"`.
+   * CSS color property to use as background of visualization.
+   *
+   * __Default value:__ none (transparent)
    */
   background?: string;
 

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -603,16 +603,26 @@ export interface VgMarkConfig {
 
   /**
    * Default Fill Color.  This has higher precedence than config.color
+   *
+   * __Default value:__ (None)
+   *
    */
   fill?: string;
 
   /**
    * Default Stroke Color.  This has higher precedence than config.color
+   *
+   * __Default value:__ (None)
+   *
    */
   stroke?: string;
 
   // ---------- Opacity ----------
   /**
+   * The overall opacity (value between [0,1]).
+   *
+   * __Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or [layered `bar` charts](http://vega.github.io/vega-editor/?mode=vega-lite&spec=bar_layered_transparent&showEditor=1) and `1` otherwise.
+   *
    * @minimum 0
    * @maximum 1
    */
@@ -620,12 +630,20 @@ export interface VgMarkConfig {
 
 
   /**
+   * The fill opacity (value between [0,1]).
+   *
+   * __Default value:__ `1`
+   *
    * @minimum 0
    * @maximum 1
    */
   fillOpacity?: number;
 
   /**
+   * The stroke opacity (value between [0,1]).
+   *
+   * __Default value:__ `1`
+   *
    * @minimum 0
    * @maximum 1
    */
@@ -633,6 +651,8 @@ export interface VgMarkConfig {
 
   // ---------- Stroke Style ----------
   /**
+   * The stroke width, in pixels.
+   *
    * @minimum 0
    */
   strokeWidth?: number;
@@ -688,12 +708,18 @@ export interface VgMarkConfig {
 
   /**
    * The default symbol shape to use. One of: `"circle"` (default), `"square"`, `"cross"`, `"diamond"`, `"triangle-up"`, or `"triangle-down"`, or a custom SVG path.
+   *
+   * __Default value:__ `"circle"`
+   *
    */
   shape?: string;
 
   /**
    * The pixel area each the point/circle/square.
    * For example: in the case of circles, the radius is determined in part by the square root of the size value.
+   *
+   * __Default value:__ `30`
+   *
    * @minimum 0
    */
   size?: number;
@@ -701,7 +727,7 @@ export interface VgMarkConfig {
   // Text / Label Mark Config
 
   /**
-   * The horizontal alignment of the text. One of left, right, center.
+   * The horizontal alignment of the text. One of `"left"`, `"right"`, `"center"`.
    */
   align?: HorizontalAlign;
 
@@ -713,33 +739,36 @@ export interface VgMarkConfig {
   angle?: number;
 
   /**
-   * The vertical alignment of the text. One of top, middle, bottom.
+   * The vertical alignment of the text. One of `"top"`, `"middle"`, `"bottom"`.
+   *
+   * __Default value:__ `"middle"`
+   *
    */
   baseline?: VerticalAlign;
 
   /**
-   * The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the angle property.
+   * The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.
    */
   dx?: number;
 
   /**
-   * The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the angle property.
+   * The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.
    */
   dy?: number;
 
   /**
-   * Polar coordinate radial offset, in pixels, of the text label from the origin determined by the x and y properties.
+   * Polar coordinate radial offset, in pixels, of the text label from the origin determined by the `x` and `y` properties.
    * @minimum 0
    */
   radius?: number;
 
   /**
-   * Polar coordinate angle, in radians, of the text label from the origin determined by the x and y properties. Values for theta follow the same convention of arc mark startAngle and endAngle properties: angles are measured in radians, with 0 indicating "north".
+   * Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating "north".
    */
   theta?: number;
 
   /**
-   * The typeface to set the text in (e.g., Helvetica Neue).
+   * The typeface to set the text in (e.g., `"Helvetica Neue"`).
    * @minimum 0
    */
   font?: string;
@@ -751,16 +780,16 @@ export interface VgMarkConfig {
   fontSize?: number;
 
   /**
-   * The font style (e.g., italic).
+   * The font style (e.g., `"italic"`).
    */
   fontStyle?: FontStyle;
   /**
-   * The font weight (e.g., `"normal"`, `"bold"`, `900`).
+   * The font weight (e.g., `"bold"`).
    */
   fontWeight?: FontWeight | FontWeightNumber;
 
   /**
-   * Placeholder Text
+   * Placeholder text if the `text` channel is not specified
    */
   text?: string;
 }


### PR DESCRIPTION
Fix part of #1723 

Enable auto generation for config.md

But I have some properties not sure if they are removed. `viewport`, `stacked`, `format`, `shortTimeLabels`.

And there might be some help with adding missing properties for this doc as well. #2114
