### PR TITLE
Support selections with layered specs

### DIFF
--- a/examples/specs/layered_selections.vl.json
+++ b/examples/specs/layered_selections.vl.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+  "description": "Drag out a rectangular brush to highlight points.",
+  "data": {"url": "data/cars.json"},
+  "layer": [{
+    "selection": {
+      "grid": {
+        "type": "interval", "bind": "scales",
+        "translate": "[mousedown[!event.shiftKey], mouseup] > mousemove"
+      },
+      "cyl": {
+        "type": "single", "fields": ["Cylinders"],
+        "bind": {"input": "range", "min": 3, "max": 8, "step": 1}
+      }
+    },
+    "mark": "point",
+    "encoding": {
+      "x": {"field": "Horsepower", "type": "quantitative"},
+      "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
+      "color": {
+        "condition": {"selection": "brush", "value": "grey"},
+        "field": "Cylinders", "type": "ordinal"
+      },
+      "size": {"value": 100}
+    }
+  }, {
+    "mark": "square",
+      "selection": {
+      "brush": {
+        "type": "interval",
+        "on": "[mousedown[event.shiftKey], mouseup] > mousemove",
+        "translate": "[mousedown[event.shiftKey], mouseup] > mousemove"
+      }
+    },
+    "encoding": {
+      "x": {"field": "Horsepower", "type": "quantitative"},
+      "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
+      "color": {
+        "condition": {"selection": "!brush", "value": "grey"},
+        "field": "Cylinders", "type": "ordinal"
+      },
+      "size": {
+        "value": 50,
+        "condition": {
+          "selection": "cyl", "value": 150
+        }
+      }
+    }
+  }]
+}

--- a/examples/vg-specs/box_plot.vg.json
+++ b/examples/vg-specs/box_plot.vg.json
@@ -197,147 +197,172 @@
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rule",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "min_people"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "max_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "rect",
-                    "role": "tick",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "min_people"
-                            },
+                        "enter": {
                             "width": {
-                                "value": 5
+                                "field": {
+                                    "group": "width"
+                                }
                             },
                             "height": {
-                                "value": 1
+                                "field": {
+                                    "group": "height"
+                                }
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_2_marks",
-                    "type": "rect",
-                    "role": "tick",
-                    "from": {
-                        "data": "data_2"
                     },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rule",
+                            "from": {
+                                "data": "data_0"
                             },
-                            "yc": {
-                                "scale": "y",
-                                "field": "max_people"
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "min_people"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "max_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "rect",
+                            "role": "tick",
+                            "from": {
+                                "data": "data_1"
                             },
-                            "width": {
-                                "value": 5
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "min_people"
+                                    },
+                                    "width": {
+                                        "value": 5
+                                    },
+                                    "height": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_2_marks",
+                            "type": "rect",
+                            "role": "tick",
+                            "from": {
+                                "data": "data_2"
                             },
-                            "height": {
-                                "value": 1
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "max_people"
+                                    },
+                                    "width": {
+                                        "value": 5
+                                    },
+                                    "height": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_3_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "data_3"
                             },
-                            "fill": {
-                                "value": "#4c78a8"
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "width": {
+                                        "value": 5
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "q1_people"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "q3_people"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_4_marks",
+                            "type": "rect",
+                            "role": "tick",
+                            "from": {
+                                "data": "data_4"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "median_people"
+                                    },
+                                    "width": {
+                                        "value": 5
+                                    },
+                                    "height": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "white"
+                                    }
+                                }
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_3_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "data_3"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "width": {
-                                "value": 5
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "q1_people"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "q3_people"
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_4_marks",
-                    "type": "rect",
-                    "role": "tick",
-                    "from": {
-                        "data": "data_4"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "median_people"
-                            },
-                            "width": {
-                                "value": 5
-                            },
-                            "height": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "white"
-                            }
-                        }
-                    }
+                    ]
                 }
             ],
             "scales": [

--- a/examples/vg-specs/errorbar_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_aggregate.vg.json
@@ -178,117 +178,142 @@
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rule",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "min_people"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "max_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "rect",
-                    "role": "tick",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "min_people"
-                            },
+                        "enter": {
                             "width": {
-                                "value": 5
+                                "field": {
+                                    "group": "width"
+                                }
                             },
                             "height": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_2_marks",
-                    "type": "rect",
-                    "role": "tick",
-                    "from": {
-                        "data": "data_2"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "max_people"
-                            },
-                            "width": {
-                                "value": 5
-                            },
-                            "height": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_3_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_3"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "mean_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
+                                "field": {
+                                    "group": "height"
+                                }
                             },
                             "fill": {
                                 "value": "transparent"
                             },
-                            "size": {
-                                "value": 2
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rule",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "min_people"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "max_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "rect",
+                            "role": "tick",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "min_people"
+                                    },
+                                    "width": {
+                                        "value": 5
+                                    },
+                                    "height": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_2_marks",
+                            "type": "rect",
+                            "role": "tick",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "max_people"
+                                    },
+                                    "width": {
+                                        "value": 5
+                                    },
+                                    "height": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_3_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_3"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "mean_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "size": {
+                                        "value": 2
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ],
             "scales": [

--- a/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
@@ -178,117 +178,142 @@
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rule",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "min_people"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "age"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "field": "max_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "rect",
-                    "role": "tick",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "min_people"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "age"
+                        "enter": {
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
                             "height": {
-                                "value": 5
-                            },
-                            "width": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_2_marks",
-                    "type": "rect",
-                    "role": "tick",
-                    "from": {
-                        "data": "data_2"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "max_people"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "age"
-                            },
-                            "height": {
-                                "value": 5
-                            },
-                            "width": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_3_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_3"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "mean_people"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "age"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
+                                "field": {
+                                    "group": "height"
+                                }
                             },
                             "fill": {
                                 "value": "transparent"
                             },
-                            "size": {
-                                "value": 2
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rule",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "min_people"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "age"
+                                    },
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "max_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "rect",
+                            "role": "tick",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "min_people"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "age"
+                                    },
+                                    "height": {
+                                        "value": 5
+                                    },
+                                    "width": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_2_marks",
+                            "type": "rect",
+                            "role": "tick",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "max_people"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "age"
+                                    },
+                                    "height": {
+                                        "value": 5
+                                    },
+                                    "width": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_3_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_3"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "mean_people"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "age"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "size": {
+                                        "value": 2
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ],
             "scales": [

--- a/examples/vg-specs/layer_bar_line.vg.json
+++ b/examples/vg-specs/layer_bar_line.vg.json
@@ -146,56 +146,81 @@
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "a"
-                            },
+                        "enter": {
                             "width": {
-                                "value": 20
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "b"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "line",
-                    "from": {
-                        "data": "data_1"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "a"
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "data_0"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "b"
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "a"
+                                    },
+                                    "width": {
+                                        "value": 20
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "b"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "line",
+                            "from": {
+                                "data": "data_1"
                             },
-                            "stroke": {
-                                "value": "red"
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "a"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "b"
+                                    },
+                                    "stroke": {
+                                        "value": "red"
+                                    }
+                                }
                             }
                         }
-                    }
+                    ]
                 }
             ],
             "scales": [

--- a/examples/vg-specs/layer_bar_line_union.vg.json
+++ b/examples/vg-specs/layer_bar_line_union.vg.json
@@ -155,56 +155,81 @@
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "a"
-                            },
+                        "enter": {
                             "width": {
-                                "value": 20
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "c"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "line",
-                    "from": {
-                        "data": "data_1"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "b"
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "data_0"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "c"
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "a"
+                                    },
+                                    "width": {
+                                        "value": 20
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "c"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "line",
+                            "from": {
+                                "data": "data_1"
                             },
-                            "stroke": {
-                                "value": "red"
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "b"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "c"
+                                    },
+                                    "stroke": {
+                                        "value": "red"
+                                    }
+                                }
                             }
                         }
-                    }
+                    ]
                 }
             ],
             "scales": [

--- a/examples/vg-specs/layer_histogram.vg.json
+++ b/examples/vg-specs/layer_histogram.vg.json
@@ -163,68 +163,93 @@
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x2": {
-                                "scale": "layer_0_x",
-                                "field": "bin_maxbins_10_distance_start",
-                                "offset": 1
+                        "enter": {
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "x": {
-                                "scale": "layer_0_x",
-                                "field": "bin_maxbins_10_distance_end"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "count_*"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "data_1"
                     },
-                    "encode": {
-                        "update": {
-                            "x2": {
-                                "scale": "layer_1_x",
-                                "field": "bin_maxbins_10_distance_start",
-                                "offset": 1
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "data_0"
                             },
-                            "x": {
-                                "scale": "layer_1_x",
-                                "field": "bin_maxbins_10_distance_end"
+                            "encode": {
+                                "update": {
+                                    "x2": {
+                                        "scale": "layer_0_x",
+                                        "field": "bin_maxbins_10_distance_start",
+                                        "offset": 1
+                                    },
+                                    "x": {
+                                        "scale": "layer_0_x",
+                                        "field": "bin_maxbins_10_distance_end"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "count_*"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "data_1"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "count_*"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "goldenrod"
+                            "encode": {
+                                "update": {
+                                    "x2": {
+                                        "scale": "layer_1_x",
+                                        "field": "bin_maxbins_10_distance_start",
+                                        "offset": 1
+                                    },
+                                    "x": {
+                                        "scale": "layer_1_x",
+                                        "field": "bin_maxbins_10_distance_end"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "count_*"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "goldenrod"
+                                    }
+                                }
                             }
                         }
-                    }
+                    ]
                 }
             ],
             "scales": [

--- a/examples/vg-specs/layer_line_color_rule.vg.json
+++ b/examples/vg-specs/layer_line_color_rule.vg.json
@@ -115,19 +115,9 @@
             },
             "marks": [
                 {
-                    "name": "layer_0_pathgroup",
                     "type": "group",
-                    "from": {
-                        "facet": {
-                            "name": "faceted-path-layer_0_main",
-                            "data": "data_0",
-                            "groupby": [
-                                "symbol"
-                            ]
-                        }
-                    },
                     "encode": {
-                        "update": {
+                        "enter": {
                             "width": {
                                 "field": {
                                     "group": "width"
@@ -137,67 +127,102 @@
                                 "field": {
                                     "group": "height"
                                 }
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
                             }
                         }
                     },
                     "marks": [
                         {
-                            "name": "layer_0_marks",
-                            "type": "line",
+                            "name": "layer_0_pathgroup",
+                            "type": "group",
                             "from": {
-                                "data": "faceted-path-layer_0_main"
+                                "facet": {
+                                    "name": "faceted-path-layer_0_main",
+                                    "data": "data_0",
+                                    "groupby": [
+                                        "symbol"
+                                    ]
+                                }
+                            },
+                            "encode": {
+                                "update": {
+                                    "width": {
+                                        "field": {
+                                            "group": "width"
+                                        }
+                                    },
+                                    "height": {
+                                        "field": {
+                                            "group": "height"
+                                        }
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "name": "layer_0_marks",
+                                    "type": "line",
+                                    "from": {
+                                        "data": "faceted-path-layer_0_main"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "date"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "price"
+                                            },
+                                            "stroke": {
+                                                "scale": "color",
+                                                "field": "symbol"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "rule",
+                            "from": {
+                                "data": "data_1"
                             },
                             "encode": {
                                 "update": {
                                     "x": {
-                                        "scale": "x",
-                                        "field": "date"
+                                        "value": 0
                                     },
                                     "y": {
                                         "scale": "y",
-                                        "field": "price"
+                                        "field": "mean_price"
+                                    },
+                                    "x2": {
+                                        "field": {
+                                            "group": "width"
+                                        }
                                     },
                                     "stroke": {
                                         "scale": "color",
                                         "field": "symbol"
+                                    },
+                                    "opacity": {
+                                        "value": 0.5
+                                    },
+                                    "strokeWidth": {
+                                        "value": 2
                                     }
                                 }
                             }
                         }
                     ]
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "rule",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "value": 0
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "mean_price"
-                            },
-                            "x2": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "symbol"
-                            },
-                            "opacity": {
-                                "value": 0.5
-                            },
-                            "strokeWidth": {
-                                "value": 2
-                            }
-                        }
-                    }
                 }
             ],
             "scales": [

--- a/examples/vg-specs/layer_overlay.vg.json
+++ b/examples/vg-specs/layer_overlay.vg.json
@@ -181,94 +181,169 @@
             },
             "marks": [
                 {
-                    "name": "layer_0_layer_0_marks",
-                    "type": "line",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Cylinders"
+                        "enter": {
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "max_Horsepower"
-                            },
-                            "stroke": {
-                                "value": "darkred"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_0_layer_1_marks",
-                    "type": "symbol",
-                    "role": "pointOverlay",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Cylinders"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "max_Horsepower"
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             },
                             "fill": {
-                                "value": "darkred"
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_1_layer_0_marks",
-                    "type": "line",
-                    "from": {
-                        "data": "data_2"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Cylinders"
+                    "marks": [
+                        {
+                            "type": "group",
+                            "encode": {
+                                "enter": {
+                                    "width": {
+                                        "field": {
+                                            "group": "width"
+                                        }
+                                    },
+                                    "height": {
+                                        "field": {
+                                            "group": "height"
+                                        }
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "clip": {
+                                        "value": true
+                                    }
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "min_Horsepower"
+                            "marks": [
+                                {
+                                    "name": "layer_0_layer_0_marks",
+                                    "type": "line",
+                                    "from": {
+                                        "data": "data_0"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "Cylinders"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "max_Horsepower"
+                                            },
+                                            "stroke": {
+                                                "value": "darkred"
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "name": "layer_0_layer_1_marks",
+                                    "type": "symbol",
+                                    "role": "pointOverlay",
+                                    "from": {
+                                        "data": "data_1"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "Cylinders"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "max_Horsepower"
+                                            },
+                                            "fill": {
+                                                "value": "darkred"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "type": "group",
+                            "encode": {
+                                "enter": {
+                                    "width": {
+                                        "field": {
+                                            "group": "width"
+                                        }
+                                    },
+                                    "height": {
+                                        "field": {
+                                            "group": "height"
+                                        }
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "clip": {
+                                        "value": true
+                                    }
+                                }
                             },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
+                            "marks": [
+                                {
+                                    "name": "layer_1_layer_0_marks",
+                                    "type": "line",
+                                    "from": {
+                                        "data": "data_2"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "Cylinders"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "min_Horsepower"
+                                            },
+                                            "stroke": {
+                                                "value": "#4c78a8"
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "name": "layer_1_layer_1_marks",
+                                    "type": "symbol",
+                                    "role": "pointOverlay",
+                                    "from": {
+                                        "data": "data_3"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "Cylinders"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "min_Horsepower"
+                                            },
+                                            "fill": {
+                                                "value": "#4c78a8"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
                         }
-                    }
-                },
-                {
-                    "name": "layer_1_layer_1_marks",
-                    "type": "symbol",
-                    "role": "pointOverlay",
-                    "from": {
-                        "data": "data_3"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Cylinders"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "min_Horsepower"
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
+                    ]
                 }
             ],
             "scales": [

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -1,0 +1,842 @@
+{
+    "$schema": "http://vega.github.io/schema/vega/v3.0.json",
+    "autosize": "pad",
+    "padding": 5,
+    "signals": [
+        {
+            "name": "width",
+            "update": "data('layout')[0].width"
+        },
+        {
+            "name": "height",
+            "update": "data('layout')[0].height"
+        },
+        {
+            "name": "layer_0_cyl_Cylinders",
+            "value": "",
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "click"
+                        }
+                    ],
+                    "update": "(item().isVoronoi ? datum.datum : datum)[\"Cylinders\"]"
+                }
+            ],
+            "bind": {
+                "input": "range",
+                "min": 3,
+                "max": 8,
+                "step": 1
+            }
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        },
+        {
+            "name": "layer_0_grid_x"
+        },
+        {
+            "name": "layer_0_grid_y"
+        },
+        {
+            "name": "layer_0_cyl",
+            "update": "data(\"layer_0_cyl_store\")[0]"
+        }
+    ],
+    "data": [
+        {
+            "name": "source_0",
+            "url": "data/cars.json",
+            "format": {
+                "type": "json",
+                "parse": {
+                    "Horsepower": "number",
+                    "Miles_per_Gallon": "number"
+                }
+            },
+            "transform": []
+        },
+        {
+            "name": "data_0",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "filter",
+                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
+                }
+            ]
+        },
+        {
+            "name": "data_1",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "filter",
+                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
+                }
+            ]
+        },
+        {
+            "name": "layout",
+            "values": [
+                {}
+            ],
+            "transform": [
+                {
+                    "type": "formula",
+                    "as": "width",
+                    "expr": "200"
+                },
+                {
+                    "type": "formula",
+                    "as": "height",
+                    "expr": "200"
+                }
+            ]
+        },
+        {
+            "name": "layer_0_grid_store"
+        },
+        {
+            "name": "layer_0_cyl_store"
+        },
+        {
+            "name": "layer_1_brush_store"
+        }
+    ],
+    "marks": [
+        {
+            "name": "main-group",
+            "type": "group",
+            "description": "Drag out a rectangular brush to highlight points.",
+            "from": {
+                "data": "layout"
+            },
+            "encode": {
+                "update": {
+                    "width": {
+                        "field": "width"
+                    },
+                    "height": {
+                        "field": "height"
+                    },
+                    "fill": {
+                        "value": "transparent"
+                    }
+                }
+            },
+            "signals": [
+                {
+                    "name": "layer_0_grid_x",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "layer_0_grid_translate_delta"
+                            },
+                            "update": "[layer_0_grid_translate_anchor.extent_x[0] - abs(span(layer_0_grid_translate_anchor.extent_x)) * layer_0_grid_translate_delta.x / layer_0_grid_translate_anchor.width, layer_0_grid_translate_anchor.extent_x[1] - abs(span(layer_0_grid_translate_anchor.extent_x)) * layer_0_grid_translate_delta.x / layer_0_grid_translate_anchor.width]"
+                        },
+                        {
+                            "events": {
+                                "signal": "layer_0_grid_zoom_delta"
+                            },
+                            "update": "[layer_0_grid_zoom_anchor.x + (domain(\"x\")[0] - layer_0_grid_zoom_anchor.x) * layer_0_grid_zoom_delta, layer_0_grid_zoom_anchor.x + (domain(\"x\")[1] - layer_0_grid_zoom_anchor.x) * layer_0_grid_zoom_delta]"
+                        }
+                    ],
+                    "push": "outer"
+                },
+                {
+                    "name": "layer_0_grid_y",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "layer_0_grid_translate_delta"
+                            },
+                            "update": "[layer_0_grid_translate_anchor.extent_y[0] + abs(span(layer_0_grid_translate_anchor.extent_y)) * layer_0_grid_translate_delta.y / layer_0_grid_translate_anchor.height, layer_0_grid_translate_anchor.extent_y[1] + abs(span(layer_0_grid_translate_anchor.extent_y)) * layer_0_grid_translate_delta.y / layer_0_grid_translate_anchor.height]"
+                        },
+                        {
+                            "events": {
+                                "signal": "layer_0_grid_zoom_delta"
+                            },
+                            "update": "[layer_0_grid_zoom_anchor.y + (domain(\"y\")[0] - layer_0_grid_zoom_anchor.y) * layer_0_grid_zoom_delta, layer_0_grid_zoom_anchor.y + (domain(\"y\")[1] - layer_0_grid_zoom_anchor.y) * layer_0_grid_zoom_delta]"
+                        }
+                    ],
+                    "push": "outer"
+                },
+                {
+                    "name": "layer_0_grid",
+                    "update": "[{field: \"Horsepower\", extent: layer_0_grid_x}, {field: \"Miles_per_Gallon\", extent: layer_0_grid_y}]"
+                },
+                {
+                    "name": "layer_0_grid_translate_anchor",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousedown",
+                                    "filter": [
+                                        "!event.shiftKey"
+                                    ]
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_0_grid_translate_delta",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousemove",
+                                    "between": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
+                                        },
+                                        {
+                                            "source": "scope",
+                                            "type": "mouseup"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "update": "{x: x(unit) - layer_0_grid_translate_anchor.x, y: y(unit) - layer_0_grid_translate_anchor.y}"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_0_grid_zoom_anchor",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel"
+                                }
+                            ],
+                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_0_grid_zoom_delta",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel"
+                                }
+                            ],
+                            "force": true,
+                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_0_grid_tuple",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "layer_0_grid"
+                            },
+                            "update": "{unit: unit.datum && unit.datum._id, intervals: layer_0_grid}"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_0_grid_modify",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "layer_0_grid"
+                            },
+                            "update": "modify(\"layer_0_grid_store\", layer_0_grid_tuple, {unit: layer_0_grid_tuple.unit})"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_0_cyl",
+                    "update": "{fields: [\"Cylinders\"], values: [layer_0_cyl_Cylinders]}"
+                },
+                {
+                    "name": "layer_0_cyl_tuple",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "layer_0_cyl"
+                            },
+                            "update": "{unit: unit.datum && unit.datum._id, fields: layer_0_cyl.fields, values: layer_0_cyl.values, Cylinders: layer_0_cyl.values[0]}"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_0_cyl_modify",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "layer_0_cyl"
+                            },
+                            "update": "modify(\"layer_0_cyl_store\", layer_0_cyl_tuple, true)"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_1_brush_x",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "event.shiftKey",
+                                    "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                                ]
+                            },
+                            "update": "invert(\"x\", [x(unit), x(unit)])"
+                        },
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousemove",
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "event.shiftKey",
+                                            "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                                        ]
+                                    },
+                                    {
+                                        "source": "scope",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "[layer_1_brush_x[0], invert(\"x\", clamp(x(unit), 0, width))]"
+                        },
+                        {
+                            "events": {
+                                "signal": "layer_1_brush_translate_delta"
+                            },
+                            "update": "clampRange([layer_1_brush_translate_anchor.extent_x[0] + abs(span(layer_1_brush_translate_anchor.extent_x)) * layer_1_brush_translate_delta.x / layer_1_brush_translate_anchor.width, layer_1_brush_translate_anchor.extent_x[1] + abs(span(layer_1_brush_translate_anchor.extent_x)) * layer_1_brush_translate_delta.x / layer_1_brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+                        },
+                        {
+                            "events": {
+                                "signal": "layer_1_brush_zoom_delta"
+                            },
+                            "update": "clampRange([layer_1_brush_zoom_anchor.x + (layer_1_brush_x[0] - layer_1_brush_zoom_anchor.x) * layer_1_brush_zoom_delta, layer_1_brush_zoom_anchor.x + (layer_1_brush_x[1] - layer_1_brush_zoom_anchor.x) * layer_1_brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_1_brush_y",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "event.shiftKey",
+                                    "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                                ]
+                            },
+                            "update": "invert(\"y\", [y(unit), y(unit)])"
+                        },
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousemove",
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "event.shiftKey",
+                                            "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                                        ]
+                                    },
+                                    {
+                                        "source": "scope",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "[layer_1_brush_y[0], invert(\"y\", clamp(y(unit), 0, height))]"
+                        },
+                        {
+                            "events": {
+                                "signal": "layer_1_brush_translate_delta"
+                            },
+                            "update": "clampRange([layer_1_brush_translate_anchor.extent_y[0] - abs(span(layer_1_brush_translate_anchor.extent_y)) * layer_1_brush_translate_delta.y / layer_1_brush_translate_anchor.height, layer_1_brush_translate_anchor.extent_y[1] - abs(span(layer_1_brush_translate_anchor.extent_y)) * layer_1_brush_translate_delta.y / layer_1_brush_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
+                        },
+                        {
+                            "events": {
+                                "signal": "layer_1_brush_zoom_delta"
+                            },
+                            "update": "clampRange([layer_1_brush_zoom_anchor.y + (layer_1_brush_y[0] - layer_1_brush_zoom_anchor.y) * layer_1_brush_zoom_delta, layer_1_brush_zoom_anchor.y + (layer_1_brush_y[1] - layer_1_brush_zoom_anchor.y) * layer_1_brush_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_1_brush_size",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "event.shiftKey",
+                                    "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                                ]
+                            },
+                            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
+                        },
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousemove",
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "event.shiftKey",
+                                            "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                                        ]
+                                    },
+                                    {
+                                        "source": "scope",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "{x: layer_1_brush_size.x, y: layer_1_brush_size.y, width: abs(x(unit) - layer_1_brush_size.x), height: abs(y(unit) - layer_1_brush_size.y)}"
+                        },
+                        {
+                            "events": {
+                                "signal": "layer_1_brush_zoom_delta"
+                            },
+                            "update": "{x: layer_1_brush_size.x, y: layer_1_brush_size.y, width: layer_1_brush_size.width * layer_1_brush_zoom_delta , height: layer_1_brush_size.height * layer_1_brush_zoom_delta}"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_1_brush",
+                    "update": "[{field: \"Horsepower\", extent: layer_1_brush_x}, {field: \"Miles_per_Gallon\", extent: layer_1_brush_y}]"
+                },
+                {
+                    "name": "layer_1_brush_translate_anchor",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousedown",
+                                    "filter": [
+                                        "event.shiftKey"
+                                    ],
+                                    "markname": "layer_1_brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit), width: layer_1_brush_size.width, height: layer_1_brush_size.height, extent_x: slice(layer_1_brush_x), extent_y: slice(layer_1_brush_y), }"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_1_brush_translate_delta",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousemove",
+                                    "between": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
+                                            "markname": "layer_1_brush_brush"
+                                        },
+                                        {
+                                            "source": "scope",
+                                            "type": "mouseup"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "update": "{x: x(unit) - layer_1_brush_translate_anchor.x, y: y(unit) - layer_1_brush_translate_anchor.y}"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_1_brush_zoom_anchor",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "markname": "layer_1_brush_brush"
+                                }
+                            ],
+                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_1_brush_zoom_delta",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "markname": "layer_1_brush_brush"
+                                }
+                            ],
+                            "force": true,
+                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_1_brush_tuple",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "layer_1_brush"
+                            },
+                            "update": "{unit: unit.datum && unit.datum._id, intervals: layer_1_brush}"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_1_brush_modify",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "layer_1_brush"
+                            },
+                            "update": "modify(\"layer_1_brush_store\", layer_1_brush_tuple, {unit: layer_1_brush_tuple.unit})"
+                        }
+                    ]
+                }
+            ],
+            "marks": [
+                {
+                    "type": "group",
+                    "encode": {
+                        "enter": {
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
+                            },
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "type": "rect",
+                            "encode": {
+                                "enter": {
+                                    "fill": {
+                                        "value": "#eee"
+                                    }
+                                },
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "signal": "layer_1_brush[0].extent[0]"
+                                    },
+                                    "x2": {
+                                        "scale": "x",
+                                        "signal": "layer_1_brush[0].extent[1]"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "signal": "layer_1_brush[1].extent[0]"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "signal": "layer_1_brush[1].extent[1]"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_0_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "Horsepower"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "Miles_per_Gallon"
+                                    },
+                                    "stroke": [
+                                        {
+                                            "test": "vlInterval(\"layer_1_brush_store\", parent._id, datum, \"union\", \"all\")",
+                                            "value": "grey"
+                                        },
+                                        {
+                                            "scale": "color",
+                                            "field": "Cylinders"
+                                        }
+                                    ],
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "size": {
+                                        "value": 100
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "symbol",
+                            "role": "square",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "Horsepower"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "Miles_per_Gallon"
+                                    },
+                                    "fill": [
+                                        {
+                                            "test": "!vlInterval(\"layer_1_brush_store\", parent._id, datum, \"union\", \"all\")",
+                                            "value": "grey"
+                                        },
+                                        {
+                                            "scale": "color",
+                                            "field": "Cylinders"
+                                        }
+                                    ],
+                                    "size": [
+                                        {
+                                            "test": "vlPoint(\"layer_0_cyl_store\", parent._id, datum, \"union\", \"all\")",
+                                            "value": 150
+                                        },
+                                        {
+                                            "value": 50
+                                        }
+                                    ],
+                                    "shape": {
+                                        "value": "square"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_brush_brush",
+                            "type": "rect",
+                            "encode": {
+                                "enter": {
+                                    "fill": {
+                                        "value": "transparent"
+                                    }
+                                },
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "signal": "layer_1_brush[0].extent[0]"
+                                    },
+                                    "x2": {
+                                        "scale": "x",
+                                        "signal": "layer_1_brush[0].extent[1]"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "signal": "layer_1_brush[1].extent[0]"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "signal": "layer_1_brush[1].extent[1]"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                }
+            ],
+            "scales": [
+                {
+                    "name": "x",
+                    "type": "linear",
+                    "domain": {
+                        "fields": [
+                            {
+                                "data": "data_0",
+                                "field": "Horsepower"
+                            },
+                            {
+                                "data": "data_1",
+                                "field": "Horsepower"
+                            }
+                        ],
+                        "sort": true
+                    },
+                    "range": [
+                        0,
+                        200
+                    ],
+                    "round": true,
+                    "nice": true,
+                    "zero": true,
+                    "domainRaw": {
+                        "signal": "layer_0_grid_x"
+                    }
+                },
+                {
+                    "name": "y",
+                    "type": "linear",
+                    "domain": {
+                        "fields": [
+                            {
+                                "data": "data_0",
+                                "field": "Miles_per_Gallon"
+                            },
+                            {
+                                "data": "data_1",
+                                "field": "Miles_per_Gallon"
+                            }
+                        ],
+                        "sort": true
+                    },
+                    "range": [
+                        200,
+                        0
+                    ],
+                    "round": true,
+                    "nice": true,
+                    "zero": true,
+                    "domainRaw": {
+                        "signal": "layer_0_grid_y"
+                    }
+                },
+                {
+                    "name": "color",
+                    "type": "ordinal",
+                    "domain": {
+                        "fields": [
+                            {
+                                "data": "data_0",
+                                "field": "Cylinders"
+                            },
+                            {
+                                "data": "data_1",
+                                "field": "Cylinders"
+                            }
+                        ],
+                        "sort": true
+                    },
+                    "range": "ordinal"
+                }
+            ],
+            "axes": [
+                {
+                    "scale": "x",
+                    "format": "s",
+                    "orient": "bottom",
+                    "tickCount": 5,
+                    "title": "Horsepower",
+                    "zindex": 1
+                },
+                {
+                    "scale": "x",
+                    "domain": false,
+                    "format": "s",
+                    "grid": true,
+                    "labels": false,
+                    "orient": "bottom",
+                    "tickCount": 5,
+                    "ticks": false,
+                    "zindex": 0,
+                    "gridScale": "y"
+                },
+                {
+                    "scale": "y",
+                    "format": "s",
+                    "orient": "left",
+                    "title": "Miles_per_Gallon",
+                    "zindex": 1
+                },
+                {
+                    "scale": "y",
+                    "domain": false,
+                    "format": "s",
+                    "grid": true,
+                    "labels": false,
+                    "orient": "left",
+                    "ticks": false,
+                    "zindex": 0,
+                    "gridScale": "x"
+                }
+            ],
+            "legends": [
+                {
+                    "stroke": "color",
+                    "title": "Cylinders"
+                }
+            ]
+        }
+    ]
+}

--- a/examples/vg-specs/overlay_area_full.vg.json
+++ b/examples/vg-specs/overlay_area_full.vg.json
@@ -126,81 +126,106 @@
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "area",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
+                        "enter": {
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
                             },
-                            "orient": {
-                                "value": "vertical"
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "line",
-                    "from": {
-                        "data": "data_1"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "area",
+                            "from": {
+                                "data": "data_0"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "orient": {
+                                        "value": "vertical"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "line",
+                            "from": {
+                                "data": "data_1"
                             },
-                            "fill": {
-                                "value": "#4c78a8"
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_2_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_2_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_2"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
+                    ]
                 }
             ],
             "scales": [

--- a/examples/vg-specs/overlay_area_short.vg.json
+++ b/examples/vg-specs/overlay_area_short.vg.json
@@ -126,81 +126,106 @@
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "area",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
+                        "enter": {
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
                             },
-                            "orient": {
-                                "value": "vertical"
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "line",
-                    "from": {
-                        "data": "data_1"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "area",
+                            "from": {
+                                "data": "data_0"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "orient": {
+                                        "value": "vertical"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "line",
+                            "from": {
+                                "data": "data_1"
                             },
-                            "stroke": {
-                                "value": "#4c78a8"
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_2_marks",
+                            "type": "symbol",
+                            "role": "pointOverlay",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_2_marks",
-                    "type": "symbol",
-                    "role": "pointOverlay",
-                    "from": {
-                        "data": "data_2"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
+                    ]
                 }
             ],
             "scales": [

--- a/examples/vg-specs/overlay_line_full.vg.json
+++ b/examples/vg-specs/overlay_line_full.vg.json
@@ -108,52 +108,77 @@
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "line",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
+                        "enter": {
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
                             },
-                            "opacity": {
-                                "value": 0.7
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "line",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ],
             "scales": [

--- a/examples/vg-specs/overlay_line_short.vg.json
+++ b/examples/vg-specs/overlay_line_short.vg.json
@@ -109,52 +109,77 @@
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "line",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
+                        "enter": {
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "symbol",
-                    "role": "pointOverlay",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
                             },
-                            "opacity": {
-                                "value": 0.7
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "line",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "symbol",
+                            "role": "pointOverlay",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ],
             "scales": [

--- a/examples/vg-specs/scatter_connected.vg.json
+++ b/examples/vg-specs/scatter_connected.vg.json
@@ -108,52 +108,77 @@
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "line",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "miles"
+                        "enter": {
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "gas"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "symbol",
-                    "role": "pointOverlay",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "miles"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "gas"
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
                             },
-                            "opacity": {
-                                "value": 0.7
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "line",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "miles"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "gas"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "symbol",
+                            "role": "pointOverlay",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "miles"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "gas"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ],
             "scales": [

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -71,8 +71,13 @@ export class LayerModel extends Model {
   }
 
   public parseSelection() {
-    // TODO: @arvind can write this
-    // We might need to split this into compileSelectionData and compileSelectionSignals?
+    this.component.selection = {};
+    this.children.forEach(child => {
+      child.parseSelection();
+      keys(child.component.selection).forEach((key) => {
+        this.component.selection[key] = child.component.selection[key];
+      });
+    });
   }
 
   public parseLayoutData() {
@@ -174,12 +179,13 @@ export class LayerModel extends Model {
     return applyConfig({}, cellConfig, FILL_STROKE_CONFIG.concat(['clip']));
   }
 
+  // TODO: Support same named selections across children.
   public assembleSignals(signals: any[]): any[] {
-    return [];
+    return this.children.reduce((signals, child) => child.assembleSignals(signals), []);
   }
 
   public assembleSelectionData(data: VgData[]): VgData[] {
-    return [];
+    return this.children.reduce((data, child) => child.assembleSelectionData(data), []);
   }
 
   public assembleData(): VgData[] {

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -17,7 +17,7 @@ import {assembleLayout, parseLayerLayout} from './layout';
 import {Model} from './model';
 import {unionDomains} from './scale/domain';
 import {UnitModel} from './unit';
-
+import {assembleLayerMarks} from './selection/selection';
 
 export class LayerModel extends Model {
   public readonly children: UnitModel[];
@@ -213,9 +213,9 @@ export class LayerModel extends Model {
 
   public assembleMarks(): any[] {
     // only children have marks
-    return flatten(this.children.map((child) => {
+    return assembleLayerMarks(this, flatten(this.children.map((child) => {
       return child.assembleMarks();
-    }));
+    })));
   }
 
   public channels(): Channel[] {

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -16,7 +16,7 @@ import {parseData} from './data/parse';
 import {assembleLayout, parseLayerLayout} from './layout';
 import {Model} from './model';
 import {unionDomains} from './scale/domain';
-import {assembleLayerMarks} from './selection/selection';
+import {assembleLayerMarks as assembleLayeredSelectionMarks} from './selection/selection';
 import {UnitModel} from './unit';
 
 export class LayerModel extends Model {
@@ -71,6 +71,9 @@ export class LayerModel extends Model {
   }
 
   public parseSelection() {
+    // Merge selections up the hierarchy so that they may be referenced
+    // across unit specs. Persist their definitions within each child
+    // to assemble signals which remain within output Vega unit groups.
     this.component.selection = {};
     this.children.forEach(child => {
       child.parseSelection();
@@ -212,8 +215,7 @@ export class LayerModel extends Model {
   }
 
   public assembleMarks(): any[] {
-    // only children have marks
-    return assembleLayerMarks(this, flatten(this.children.map((child) => {
+    return assembleLayeredSelectionMarks(this, flatten(this.children.map((child) => {
       return child.assembleMarks();
     })));
   }

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -16,8 +16,8 @@ import {parseData} from './data/parse';
 import {assembleLayout, parseLayerLayout} from './layout';
 import {Model} from './model';
 import {unionDomains} from './scale/domain';
-import {UnitModel} from './unit';
 import {assembleLayerMarks} from './selection/selection';
+import {UnitModel} from './unit';
 
 export class LayerModel extends Model {
   public readonly children: UnitModel[];
@@ -181,11 +181,11 @@ export class LayerModel extends Model {
 
   // TODO: Support same named selections across children.
   public assembleSignals(signals: any[]): any[] {
-    return this.children.reduce((signals, child) => child.assembleSignals(signals), []);
+    return this.children.reduce((sg, child) => child.assembleSignals(sg), []);
   }
 
   public assembleSelectionData(data: VgData[]): VgData[] {
-    return this.children.reduce((data, child) => child.assembleSelectionData(data), []);
+    return this.children.reduce((db, child) => child.assembleSelectionData(db), []);
   }
 
   public assembleData(): VgData[] {

--- a/src/compile/mark/mixins.ts
+++ b/src/compile/mark/mixins.ts
@@ -79,7 +79,7 @@ function wrapCondition(model: UnitModel, condition: Condition<any>, vgChannel: s
 function selectionTest(model: UnitModel, selectionName: string) {
   const negate = selectionName.charAt(0) === '!',
     name = negate ? selectionName.slice(1) : selectionName;
-  return (negate ? '!' : '') + predicate(model.component.selection[name]);
+  return (negate ? '!' : '') + predicate(model.getComponent('selection', name));
 }
 
 export function text(model: UnitModel) {

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -368,4 +368,13 @@ export abstract class Model {
 
     return mark;
   }
+
+  /**
+   * Traverse a model's hierarchy to get the specified component.
+   * @param type Scales or Selection
+   * @param name Name of the component
+   */
+  public getComponent(type: 'scales' | 'selection', name: string): any {
+    return this.component[type][name] || this.parent.getComponent(type, name);
+  }
 }

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -12,9 +12,9 @@ import {SelectionComponent} from './selection';
 import singleCompiler from './single';
 import {forEachTransform} from './transforms/transforms';
 
-export const STORE = '_store',
-  TUPLE  = '_tuple',
-  MODIFY = '_modify';
+export const STORE = '_store';
+export const TUPLE  = '_tuple';
+export const MODIFY = '_modify';
 
 export interface SelectionComponent {
   name: string;
@@ -83,7 +83,7 @@ export function parseUnitSelection(model: UnitModel, selDefs: Dict<SelectionDef>
       resolve: 'union' as SelectionResolutions
     }) as SelectionComponent;
 
-    forEachTransform(selCmpt, function(txCompiler) {
+    forEachTransform(selCmpt, txCompiler => {
       if (txCompiler.parse) {
         txCompiler.parse(model, selDef, selCmpt);
       }
@@ -94,14 +94,14 @@ export function parseUnitSelection(model: UnitModel, selDefs: Dict<SelectionDef>
 }
 
 export function assembleUnitSignals(model: UnitModel, signals: any[]) {
-  forEachSelection(model, function(selCmpt, selCompiler) {
+  forEachSelection(model, (selCmpt, selCompiler) => {
     const name = selCmpt.name,
         tupleExpr = selCompiler.tupleExpr(model, selCmpt);
     let modifyExpr = selCompiler.modifyExpr(model, selCmpt);
 
     signals.push.apply(signals, selCompiler.signals(model, selCmpt));
 
-    forEachTransform(selCmpt, function(txCompiler) {
+    forEachTransform(selCmpt, txCompiler => {
       if (txCompiler.signals) {
         signals = txCompiler.signals(model, selCmpt, signals);
       }
@@ -135,12 +135,12 @@ export function assembleTopLevelSignals(model: Model) {
     on: [{events: 'mousemove', update: 'group()._id ? group() : unit'}]
   }];
 
-  forEachSelection(model, function(selCmpt, selCompiler) {
+  forEachSelection(model, (selCmpt, selCompiler) => {
     if (selCompiler.topLevelSignals) {
       signals.push.apply(signals, selCompiler.topLevelSignals(model, selCmpt));
     }
 
-    forEachTransform(selCmpt, function(txCompiler) {
+    forEachTransform(selCmpt, txCompiler => {
       if (txCompiler.topLevelSignals) {
         signals = txCompiler.topLevelSignals(model, selCmpt, signals);
       }
@@ -151,8 +151,8 @@ export function assembleTopLevelSignals(model: Model) {
 }
 
 export function assembleUnitData(model: UnitModel, data: VgData[]): VgData[] {
-  forEachSelection(model, function(selCmpt, _) {
-    data.push.apply(data, [{name: selCmpt.name + STORE}]);
+  forEachSelection(model, selCmpt => {
+    data.push({name: selCmpt.name + STORE});
   });
 
   return data;
@@ -161,9 +161,9 @@ export function assembleUnitData(model: UnitModel, data: VgData[]): VgData[] {
 export function assembleUnitMarks(model: UnitModel, marks: any[]): any[] {
   let clipGroup = false,
       selMarks = marks;
-  forEachSelection(model, function(selCmpt, selCompiler) {
+  forEachSelection(model, (selCmpt, selCompiler) => {
     selMarks = selCompiler.marks ? selCompiler.marks(model, selCmpt, selMarks) : selMarks;
-    forEachTransform(selCmpt, function(txCompiler) {
+    forEachTransform(selCmpt, (txCompiler) => {
       clipGroup = clipGroup || txCompiler.clipGroup;
       if (txCompiler.marks) {
         selMarks = txCompiler.marks(model, selCmpt, marks, selMarks);
@@ -180,7 +180,7 @@ export function assembleUnitMarks(model: UnitModel, marks: any[]): any[] {
 
 export function assembleLayerMarks(model: LayerModel, marks: any[]): any[] {
   let clipGroup = false;
-  model.children.forEach((child) => {
+  model.children.forEach(child => {
     const unit = assembleUnitMarks(child, marks);
     marks = unit[0];
     clipGroup = clipGroup || unit[1];

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -3,9 +3,9 @@ import {Channel} from '../../channel';
 import {SelectionDef, SelectionDomain, SelectionResolutions, SelectionTypes} from '../../selection';
 import {Dict, extend, isString, stringValue} from '../../util';
 import {VgBinding, VgData} from '../../vega.schema';
+import {LayerModel} from '../layer';
 import {Model} from '../model';
 import {UnitModel} from '../unit';
-import {LayerModel} from '../layer';
 import intervalCompiler from './interval';
 import multiCompiler from './multi';
 import {SelectionComponent} from './selection';
@@ -181,7 +181,7 @@ export function assembleUnitMarks(model: UnitModel, marks: any[]): any[] {
 export function assembleLayerMarks(model: LayerModel, marks: any[]): any[] {
   let clipGroup = false;
   model.children.forEach((child) => {
-    let unit = assembleUnitMarks(child, marks);
+    const unit = assembleUnitMarks(child, marks);
     marks = unit[0];
     clipGroup = clipGroup || unit[1];
   });
@@ -249,5 +249,5 @@ function clippedGroup(model: Model, marks: any[]): any[] {
       }
     },
     marks: marks.map(model.correctDataNames)
-  }]
+  }];
 }

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -150,11 +150,11 @@ export function assembleTopLevelSignals(model: Model) {
 }
 
 export function assembleUnitData(model: UnitModel, data: VgData[]): VgData[] {
-  return data
-    .concat(Object.keys(model.component.selection)
-      .map(function(k: string) {
-        return {name: k + STORE};
-      }));
+  forEachSelection(model, function(selCmpt, _) {
+    data.push.apply(data, [{name: selCmpt.name + STORE}]);
+  });
+
+  return data;
 }
 
 export function assembleUnitMarks(model: UnitModel, marks: any[]): any[] {

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -171,6 +171,9 @@ export function assembleUnitMarks(model: UnitModel, marks: any[]): any[] {
     });
   });
 
+  // In a layered spec, we want to clip all layers together rather than
+  // only the layer within which the selection is defined. Propagate
+  // our assembled state up and let the LayerModel make the right call.
   if (model.parent && model.parent instanceof LayerModel) {
     return [selMarks, clippedGroup];
   } else {

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -171,7 +171,7 @@ export function assembleUnitMarks(model: UnitModel, marks: any[]): any[] {
     });
   });
 
-  if (model.parent && model.parent.isLayer()) {
+  if (model.parent && model.parent instanceof LayerModel) {
     return [selMarks, clippedGroup];
   } else {
     return clipGroup ? clippedGroup(model, selMarks) : selMarks;

--- a/src/compile/selection/transforms/scales.ts
+++ b/src/compile/selection/transforms/scales.ts
@@ -15,12 +15,11 @@ const scaleBindings:TransformCompiler = {
   },
 
   parse: function(model, selDef, selCmpt) {
-    const scales = model.component.scales;
     const bound:Channel[] = selCmpt.scales = [];
 
     selCmpt.project.forEach(function(p) {
       const channel = p.encoding;
-      const scale = scales[channel];
+      const scale = model.getComponent('scales', channel);
 
       if (!scale || !hasContinuousDomain(scale.type)) {
         warn('Scale bindings are currently only supported for scales with continuous domains.');

--- a/src/compile/selection/transforms/scales.ts
+++ b/src/compile/selection/transforms/scales.ts
@@ -8,7 +8,7 @@ import {channelSignalName, MODIFY, TUPLE} from '../selection';
 import {TransformCompiler} from './transforms';
 
 const scaleBindings:TransformCompiler = {
-  clippedGroup: true,
+  clipGroup: true,
 
   has: function(selCmpt) {
     return selCmpt.type === 'interval' && selCmpt.bind && selCmpt.bind === 'scales';

--- a/src/compile/selection/transforms/transforms.ts
+++ b/src/compile/selection/transforms/transforms.ts
@@ -12,7 +12,7 @@ export interface TransformCompiler {
   // tupleExpr?: (model: UnitModel, selCmpt: SelectionComponent, expr: string) => string;
   modifyExpr?: (model: UnitModel, selCmpt: SelectionComponent, expr: string) => string;
   marks?: (model: UnitModel, selCmpt:SelectionComponent, marks: any[], selMarks: any[]) => any[];
-  clippedGroup?: boolean;
+  clipGroup?: boolean;
 }
 
 import inputs from './inputs';

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -17,6 +17,7 @@ import {applyConfig} from './common';
 import {assembleData} from './data/assemble';
 import {parseData} from './data/parse';
 import {FacetModel} from './facet';
+import {LayerModel} from './layer';
 import {assembleLayout, parseUnitLayout} from './layout';
 import {parseLegendComponent} from './legend/parse';
 import {initEncoding, initMarkDef} from './mark/init';
@@ -259,7 +260,7 @@ export class UnitModel extends Model {
 
   public assembleMarks() {
     let marks = this.component.mark || [];
-    if (!this.parent || !this.parent.isLayer()) {
+    if (!this.parent || !(this.parent instanceof LayerModel)) {
       marks = assembleSelectionMarks(this, marks);
     }
 

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -25,7 +25,7 @@ import {parseMark} from './mark/mark';
 import {Model} from './model';
 import initScale from './scale/init';
 import parseScaleComponent from './scale/parse';
-import {assembleUnitData as assembleSelectionData, assembleUnitMarks as assembleSelectionMarks, assembleUnitSignals, parseUnitSelection} from './selection/selection';
+import {assembleUnitData as assembleSelectionData, assembleUnitMarks as assembleUnitSelectionMarks, assembleUnitSignals, parseUnitSelection} from './selection/selection';
 
 /**
  * Internal model of Vega-Lite specification for the compiler.
@@ -260,8 +260,12 @@ export class UnitModel extends Model {
 
   public assembleMarks() {
     let marks = this.component.mark || [];
+
+    // If this unit is part of a layer, selections should augment
+    // all in concert rather than each unit individually. This
+    // ensures correct interleaving of clipping and brushed marks.
     if (!this.parent || !(this.parent instanceof LayerModel)) {
-      marks = assembleSelectionMarks(this, marks);
+      marks = assembleUnitSelectionMarks(this, marks);
     }
 
     return marks.map(this.correctDataNames);

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -259,7 +259,9 @@ export class UnitModel extends Model {
 
   public assembleMarks() {
     let marks = this.component.mark || [];
-    marks = assembleSelectionMarks(this, marks);
+    if (!this.parent || !this.parent.isLayer()) {
+      marks = assembleSelectionMarks(this, marks);
+    }
 
     return marks.map(this.correctDataNames);
   }

--- a/test/compile/selection/layers.test.ts
+++ b/test/compile/selection/layers.test.ts
@@ -1,0 +1,198 @@
+/* tslint:disable quotemark */
+
+import {assert} from 'chai';
+import multi from '../../../src/compile/selection/multi';
+import * as selection from '../../../src/compile/selection/selection';
+import {parseLayerModel} from '../../util';
+
+describe('Layered Selections', function() {
+  const layers = parseLayerModel({
+    layer: [{
+      "selection": {
+        "brush": {"type": "interval"}
+      },
+      "mark": "circle",
+      "encoding": {
+        "x": {"field": "Horsepower","type": "quantitative"},
+        "y": {"field": "Miles_per_Gallon","type": "quantitative"},
+        "color": {"field": "Origin", "type": "N"}
+      }
+    }, {
+      "selection": {
+        "grid": {"type": "interval", "bind": "scales"}
+      },
+      "mark": "square",
+      "encoding": {
+        "x": {"field": "Horsepower","type": "quantitative"},
+        "y": {"field": "Miles_per_Gallon","type": "quantitative"},
+        "color": {"field": "Origin", "type": "N"}
+      }
+    }]
+  });
+
+  layers.parseScale();
+  layers.parseSelection();
+  layers.parseMark();
+
+  // Selections should augment layered marks together, rather than each
+  // mark individually. This ensures correct interleaving of brush and
+  // clipping marks (e.g., that the brush mark appears above all layers
+  // and thus can be moved around).
+  it('should pass through unit mark assembly', function() {
+    assert.sameDeepMembers(layers.children[0].assembleMarks(), [{
+      "name": "layer_0_marks",
+      "type": "symbol",
+      "role": "circle",
+      "from": {
+        "data": "layer_0_main"
+      },
+      "encode": {
+        "update": {
+          "x": {
+            "scale": "x",
+            "field": "Horsepower"
+          },
+          "y": {
+            "scale": "y",
+            "field": "Miles_per_Gallon"
+          },
+          "fill": {
+            "scale": "color",
+            "field": "Origin"
+          },
+          "shape": {
+            "value": "circle"
+          },
+          "opacity": {
+            "value": 0.7
+          }
+        }
+      }
+    }]);
+
+    assert.sameDeepMembers(layers.children[1].assembleMarks(), [{
+      "name": "layer_1_marks",
+      "type": "symbol",
+      "role": "square",
+      "from": {
+        "data": "layer_1_main"
+      },
+      "encode": {
+        "update": {
+          "x": {
+            "scale": "x",
+            "field": "Horsepower"
+          },
+          "y": {
+            "scale": "y",
+            "field": "Miles_per_Gallon"
+          },
+          "fill": {
+            "scale": "color",
+            "field": "Origin"
+          },
+          "shape": {
+            "value": "square"
+          },
+          "opacity": {
+            "value": 0.7
+          }
+        }
+      }
+    }]);
+  });
+
+  it('should assemble selection marks across layers', function() {
+    const child0 = layers.children[0].assembleMarks()[0],
+          child1 = layers.children[1].assembleMarks()[0];
+
+    assert.sameDeepMembers(layers.assembleMarks(), [{
+      // Clipping mark introduced by "grid" selection.
+      "type": "group",
+      "encode": {
+        "enter": {
+          "width": {
+            "field": {
+              "group": "width"
+            }
+          },
+          "height": {
+            "field": {
+              "group": "height"
+            }
+          },
+          "fill": {
+            "value": "transparent"
+          },
+          "clip": {
+            "value": true
+          }
+        }
+      },
+      "marks": [
+        // Background brush mark for "brush" selection.
+        {
+          "name": undefined,
+          "type": "rect",
+          "encode": {
+            "enter": {
+              "fill": {
+                "value": "#eee"
+              }
+            },
+            "update": {
+              "x": {
+                "scale": "x",
+                "signal": "layer_0_brush[0].extent[0]"
+              },
+              "x2": {
+                "scale": "x",
+                "signal": "layer_0_brush[0].extent[1]"
+              },
+              "y": {
+                "scale": "y",
+                "signal": "layer_0_brush[1].extent[0]"
+              },
+              "y2": {
+                "scale": "y",
+                "signal": "layer_0_brush[1].extent[1]"
+              }
+            }
+          }
+        },
+        // Layer marks
+        child0, child1,
+        // Foreground brush mark for "brush" selection.
+        {
+          "name": "layer_0_brush_brush",
+          "type": "rect",
+          "encode": {
+            "enter": {
+              "fill": {
+                "value": "transparent"
+              }
+            },
+            "update": {
+              "x": {
+                "scale": "x",
+                "signal": "layer_0_brush[0].extent[0]"
+              },
+              "x2": {
+                "scale": "x",
+                "signal": "layer_0_brush[0].extent[1]"
+              },
+              "y": {
+                "scale": "y",
+                "signal": "layer_0_brush[1].extent[0]"
+              },
+              "y2": {
+                "scale": "y",
+                "signal": "layer_0_brush[1].extent[1]"
+              }
+            }
+          }
+        }
+      ]
+    }]);
+  });
+});


### PR DESCRIPTION
Fixes #2146. The following spec demonstrates selections defined in both layers and used across them. 

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "description": "Drag out a rectangular brush to highlight points.",
  "data": {"url": "data/cars.json"},
  "layer": [{
    "selection": {
      "grid": {
        "type": "interval", "bind": "scales",
        "translate": "[mousedown[!event.shiftKey], mouseup] > mousemove"
      }
    },
    "mark": "point",
    "encoding": {
      "x": {"field": "Horsepower", "type": "quantitative"},
      "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
      "color": {
        "condition": {"selection": "brush", "value": "grey"},
        "field": "Cylinders", "type": "ordinal"
      },
      "size": {"value": 100}
    }
  }, {
    "mark": "square",
      "selection": {
      "brush": {
        "type": "interval",
        "on": "[mousedown[event.shiftKey], mouseup] > mousemove",
        "translate": "[mousedown[event.shiftKey], mouseup] > mousemove"
      }
    },
    "encoding": {
      "x": {"field": "Horsepower", "type": "quantitative"},
      "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
      "color": {
        "condition": {"selection": "!brush", "value": "grey"},
        "field": "Cylinders", "type": "ordinal"
      }
    }
  }]
}
```