### PR TITLE
Support selections with faceted specs

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1020,6 +1020,9 @@
                 },
                 "on": {
                 },
+                "resolve": {
+                    "$ref": "#/definitions/SelectionResolutions"
+                },
                 "toggle": {
                     "type": [
                         "string",
@@ -3401,6 +3404,9 @@
                 },
                 "on": {
                 },
+                "resolve": {
+                    "$ref": "#/definitions/SelectionResolutions"
+                },
                 "toggle": {
                     "type": [
                         "string",
@@ -3427,6 +3433,17 @@
                 "type"
             ],
             "type": "object"
+        },
+        "SelectionResolutions": {
+            "enum": [
+                "global",
+                "independent",
+                "intersect",
+                "intersect_others",
+                "union",
+                "union_others"
+            ],
+            "type": "string"
         },
         "SelectionTypes": {
             "enum": [

--- a/examples/specs/faceted_selections.vl.json
+++ b/examples/specs/faceted_selections.vl.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+  "description": "Anscombe's Quartet",
+  "data": {"url": "data/anscombe.json"},
+  "mark": "circle",
+  "selection": {
+    "brush": {
+      "type": "interval", "resolve": "intersect",
+      "encodings": ["x"]
+    },
+    "grid": {
+      "type": "interval", "resolve": "global",
+      "bind": "scales",
+      "translate": "[mousedown[event.shiftKey], mouseup] > mousemove"
+    },
+    "xenc": {
+      "type": "single", "resolve": "global",
+      "on": "mouseover", "nearest": true,
+      "fields": ["X"], "bind": {"input": "number"}
+    }
+  },
+  "encoding": {
+    "column": {"field": "Series","type": "nominal"},
+    "x": {
+      "field": "X",
+      "type": "quantitative",
+      "scale": {"zero": false}
+    },
+    "y": {
+      "field": "Y",
+      "type": "quantitative",
+      "scale": {"zero": false}
+    },
+    "size": {
+      "value": 100,
+      "condition": {"selection": "brush","value": 250}
+    },
+    "color": {
+      "value": "steelblue",
+      "condition": {
+        "selection": "xenc",
+        "value": "red"
+      }
+    }
+  },
+  "config": {"mark": {"opacity": 1}}
+}

--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -321,7 +321,7 @@
                             "events": {
                                 "signal": "brush"
                             },
-                            "update": "modify(\"brush_store\", brush_tuple, {unit: brush_tuple.unit})"
+                            "update": "modify(\"brush_store\", brush_tuple, true)"
                         }
                     ]
                 }
@@ -336,22 +336,46 @@
                             }
                         },
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "signal": "brush[0].extent[0]"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "signal": "brush[0].extent[1]"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "signal": "brush[1].extent[0]"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "signal": "brush[1].extent[1]"
-                            }
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "scale": "x",
+                                    "signal": "brush[0].extent[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "scale": "x",
+                                    "signal": "brush[0].extent[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "scale": "y",
+                                    "signal": "brush[1].extent[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "scale": "y",
+                                    "signal": "brush[1].extent[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ]
                         }
                     }
                 },
@@ -401,22 +425,46 @@
                             }
                         },
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "signal": "brush[0].extent[0]"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "signal": "brush[0].extent[1]"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "signal": "brush[1].extent[0]"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "signal": "brush[1].extent[1]"
-                            }
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "scale": "x",
+                                    "signal": "brush[0].extent[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "scale": "x",
+                                    "signal": "brush[0].extent[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "scale": "y",
+                                    "signal": "brush[1].extent[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "scale": "y",
+                                    "signal": "brush[1].extent[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ]
                         }
                     }
                 }

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -1,0 +1,865 @@
+{
+    "$schema": "http://vega.github.io/schema/vega/v3.0.json",
+    "autosize": "pad",
+    "padding": 5,
+    "signals": [
+        {
+            "name": "width",
+            "update": "data('layout')[0].width"
+        },
+        {
+            "name": "height",
+            "update": "data('layout')[0].height"
+        },
+        {
+            "name": "child_xenc_X",
+            "value": "",
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "mouseover"
+                        }
+                    ],
+                    "update": "(item().isVoronoi ? datum.datum : datum)[\"X\"]"
+                }
+            ],
+            "bind": {
+                "input": "number"
+            }
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        },
+        {
+            "name": "child_grid_x"
+        },
+        {
+            "name": "child_grid_y"
+        },
+        {
+            "name": "child_xenc",
+            "update": "data(\"child_xenc_store\")[0]"
+        }
+    ],
+    "data": [
+        {
+            "name": "source_0",
+            "url": "data/anscombe.json",
+            "format": {
+                "type": "json",
+                "parse": {
+                    "X": "number",
+                    "Y": "number"
+                }
+            },
+            "transform": [
+                {
+                    "type": "filter",
+                    "expr": "datum[\"X\"] !== null && !isNaN(datum[\"X\"]) && datum[\"Y\"] !== null && !isNaN(datum[\"Y\"])"
+                }
+            ]
+        },
+        {
+            "name": "column",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "aggregate",
+                    "groupby": [
+                        "Series"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "layout",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "aggregate",
+                    "fields": [
+                        "Series"
+                    ],
+                    "ops": [
+                        "distinct"
+                    ]
+                },
+                {
+                    "type": "formula",
+                    "as": "child_width",
+                    "expr": "200"
+                },
+                {
+                    "type": "formula",
+                    "as": "width",
+                    "expr": "(datum[\"child_width\"] + 16) * datum[\"distinct_Series\"]"
+                },
+                {
+                    "type": "formula",
+                    "as": "child_height",
+                    "expr": "200"
+                },
+                {
+                    "type": "formula",
+                    "as": "height",
+                    "expr": "datum[\"child_height\"] + 16"
+                }
+            ]
+        },
+        {
+            "name": "child_brush_store"
+        },
+        {
+            "name": "child_grid_store"
+        },
+        {
+            "name": "child_xenc_store"
+        }
+    ],
+    "marks": [
+        {
+            "name": "main-group",
+            "type": "group",
+            "description": "Anscombe's Quartet",
+            "from": {
+                "data": "layout"
+            },
+            "encode": {
+                "update": {
+                    "width": {
+                        "field": "width"
+                    },
+                    "height": {
+                        "field": "height"
+                    }
+                }
+            },
+            "marks": [
+                {
+                    "name": "x-axes",
+                    "type": "group",
+                    "from": {
+                        "data": "column"
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "field": {
+                                    "parent": "child_width"
+                                }
+                            },
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
+                            },
+                            "x": {
+                                "scale": "column",
+                                "field": "Series",
+                                "offset": 8
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "X",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "y-axes",
+                    "type": "group",
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
+                            },
+                            "height": {
+                                "field": {
+                                    "parent": "child_height"
+                                }
+                            },
+                            "y": {
+                                "value": 8
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Y",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "Series"
+                            ]
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "column",
+                                "field": "Series",
+                                "offset": 8
+                            },
+                            "y": {
+                                "value": 8
+                            },
+                            "width": {
+                                "field": {
+                                    "parent": "child_width"
+                                }
+                            },
+                            "height": {
+                                "field": {
+                                    "parent": "child_height"
+                                }
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "signals": [
+                        {
+                            "name": "child_brush_x",
+                            "value": [],
+                            "on": [
+                                {
+                                    "events": {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
+                                        ]
+                                    },
+                                    "update": "invert(\"x\", [x(unit), x(unit)])"
+                                },
+                                {
+                                    "events": {
+                                        "source": "window",
+                                        "type": "mousemove",
+                                        "consume": true,
+                                        "between": [
+                                            {
+                                                "source": "scope",
+                                                "type": "mousedown",
+                                                "filter": [
+                                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
+                                                ]
+                                            },
+                                            {
+                                                "source": "window",
+                                                "type": "mouseup"
+                                            }
+                                        ]
+                                    },
+                                    "update": "[child_brush_x[0], invert(\"x\", clamp(x(unit), 0, width))]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "child_brush_translate_delta"
+                                    },
+                                    "update": "clampRange([child_brush_translate_anchor.extent_x[0] + abs(span(child_brush_translate_anchor.extent_x)) * child_brush_translate_delta.x / child_brush_translate_anchor.width, child_brush_translate_anchor.extent_x[1] + abs(span(child_brush_translate_anchor.extent_x)) * child_brush_translate_delta.x / child_brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "child_brush_zoom_delta"
+                                    },
+                                    "update": "clampRange([child_brush_zoom_anchor.x + (child_brush_x[0] - child_brush_zoom_anchor.x) * child_brush_zoom_delta, child_brush_zoom_anchor.x + (child_brush_x[1] - child_brush_zoom_anchor.x) * child_brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_size",
+                            "value": [],
+                            "on": [
+                                {
+                                    "events": {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
+                                        ]
+                                    },
+                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
+                                },
+                                {
+                                    "events": {
+                                        "source": "window",
+                                        "type": "mousemove",
+                                        "consume": true,
+                                        "between": [
+                                            {
+                                                "source": "scope",
+                                                "type": "mousedown",
+                                                "filter": [
+                                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
+                                                ]
+                                            },
+                                            {
+                                                "source": "window",
+                                                "type": "mouseup"
+                                            }
+                                        ]
+                                    },
+                                    "update": "{x: child_brush_size.x, y: child_brush_size.y, width: abs(x(unit) - child_brush_size.x), height: abs(y(unit) - child_brush_size.y)}"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "child_brush_zoom_delta"
+                                    },
+                                    "update": "{x: child_brush_size.x, y: child_brush_size.y, width: child_brush_size.width * child_brush_zoom_delta , height: child_brush_size.height * child_brush_zoom_delta}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush",
+                            "update": "[{field: \"X\", extent: child_brush_x}]"
+                        },
+                        {
+                            "name": "child_brush_translate_anchor",
+                            "value": {},
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "markname": "child_brush_brush"
+                                        }
+                                    ],
+                                    "update": "{x: x(unit), y: y(unit), width: child_brush_size.width, height: child_brush_size.height, extent_x: slice(child_brush_x), }"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_translate_delta",
+                            "value": {},
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "window",
+                                            "type": "mousemove",
+                                            "consume": true,
+                                            "between": [
+                                                {
+                                                    "source": "scope",
+                                                    "type": "mousedown",
+                                                    "markname": "child_brush_brush"
+                                                },
+                                                {
+                                                    "source": "window",
+                                                    "type": "mouseup"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "update": "{x: x(unit) - child_brush_translate_anchor.x, y: y(unit) - child_brush_translate_anchor.y}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_zoom_anchor",
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "wheel",
+                                            "markname": "child_brush_brush"
+                                        }
+                                    ],
+                                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_zoom_delta",
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "wheel",
+                                            "markname": "child_brush_brush"
+                                        }
+                                    ],
+                                    "force": true,
+                                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_tuple",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_brush"
+                                    },
+                                    "update": "{unit: unit.datum && unit.datum._id, intervals: child_brush}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_modify",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_brush"
+                                    },
+                                    "update": "modify(\"child_brush_store\", child_brush_tuple, {unit: child_brush_tuple.unit})"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_x",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_grid_translate_delta"
+                                    },
+                                    "update": "[child_grid_translate_anchor.extent_x[0] - abs(span(child_grid_translate_anchor.extent_x)) * child_grid_translate_delta.x / child_grid_translate_anchor.width, child_grid_translate_anchor.extent_x[1] - abs(span(child_grid_translate_anchor.extent_x)) * child_grid_translate_delta.x / child_grid_translate_anchor.width]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "child_grid_zoom_delta"
+                                    },
+                                    "update": "[child_grid_zoom_anchor.x + (domain(\"x\")[0] - child_grid_zoom_anchor.x) * child_grid_zoom_delta, child_grid_zoom_anchor.x + (domain(\"x\")[1] - child_grid_zoom_anchor.x) * child_grid_zoom_delta]"
+                                }
+                            ],
+                            "push": "outer"
+                        },
+                        {
+                            "name": "child_grid_y",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_grid_translate_delta"
+                                    },
+                                    "update": "[child_grid_translate_anchor.extent_y[0] + abs(span(child_grid_translate_anchor.extent_y)) * child_grid_translate_delta.y / child_grid_translate_anchor.height, child_grid_translate_anchor.extent_y[1] + abs(span(child_grid_translate_anchor.extent_y)) * child_grid_translate_delta.y / child_grid_translate_anchor.height]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "child_grid_zoom_delta"
+                                    },
+                                    "update": "[child_grid_zoom_anchor.y + (domain(\"y\")[0] - child_grid_zoom_anchor.y) * child_grid_zoom_delta, child_grid_zoom_anchor.y + (domain(\"y\")[1] - child_grid_zoom_anchor.y) * child_grid_zoom_delta]"
+                                }
+                            ],
+                            "push": "outer"
+                        },
+                        {
+                            "name": "child_grid",
+                            "update": "[{field: \"X\", extent: child_grid_x}, {field: \"Y\", extent: child_grid_y}]"
+                        },
+                        {
+                            "name": "child_grid_translate_anchor",
+                            "value": {},
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ]
+                                        }
+                                    ],
+                                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_translate_delta",
+                            "value": {},
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousemove",
+                                            "between": [
+                                                {
+                                                    "source": "scope",
+                                                    "type": "mousedown",
+                                                    "filter": [
+                                                        "event.shiftKey"
+                                                    ]
+                                                },
+                                                {
+                                                    "source": "scope",
+                                                    "type": "mouseup"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "update": "{x: x(unit) - child_grid_translate_anchor.x, y: y(unit) - child_grid_translate_anchor.y}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_zoom_anchor",
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "wheel"
+                                        }
+                                    ],
+                                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_zoom_delta",
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "wheel"
+                                        }
+                                    ],
+                                    "force": true,
+                                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_tuple",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_grid"
+                                    },
+                                    "update": "{unit: unit.datum && unit.datum._id, intervals: child_grid}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_modify",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_grid"
+                                    },
+                                    "update": "modify(\"child_grid_store\", child_grid_tuple, true)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_xenc",
+                            "update": "{fields: [\"X\"], values: [child_xenc_X]}"
+                        },
+                        {
+                            "name": "child_xenc_tuple",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_xenc"
+                                    },
+                                    "update": "{unit: unit.datum && unit.datum._id, fields: child_xenc.fields, values: child_xenc.values, X: child_xenc.values[0]}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_xenc_modify",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_xenc"
+                                    },
+                                    "update": "modify(\"child_xenc_store\", child_xenc_tuple, true)"
+                                }
+                            ]
+                        }
+                    ],
+                    "marks": [
+                        {
+                            "type": "group",
+                            "encode": {
+                                "enter": {
+                                    "width": {
+                                        "field": {
+                                            "group": "width"
+                                        }
+                                    },
+                                    "height": {
+                                        "field": {
+                                            "group": "height"
+                                        }
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "clip": {
+                                        "value": true
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "type": "rect",
+                                    "encode": {
+                                        "enter": {
+                                            "fill": {
+                                                "value": "#eee"
+                                            }
+                                        },
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "signal": "child_brush[0].extent[0]"
+                                            },
+                                            "x2": {
+                                                "scale": "x",
+                                                "signal": "child_brush[0].extent[1]"
+                                            },
+                                            "y": {
+                                                "value": 0
+                                            },
+                                            "y2": {
+                                                "field": {
+                                                    "group": "height"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "name": "child_marks",
+                                    "type": "symbol",
+                                    "role": "circle",
+                                    "from": {
+                                        "data": "facet"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "X"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "Y"
+                                            },
+                                            "fill": [
+                                                {
+                                                    "test": "vlPoint(\"child_xenc_store\", parent._id, datum, \"union\", \"all\")",
+                                                    "value": "red"
+                                                },
+                                                {
+                                                    "value": "steelblue"
+                                                }
+                                            ],
+                                            "size": [
+                                                {
+                                                    "test": "vlInterval(\"child_brush_store\", parent._id, datum, \"intersect\", \"all\")",
+                                                    "value": 250
+                                                },
+                                                {
+                                                    "value": 100
+                                                }
+                                            ],
+                                            "shape": {
+                                                "value": "circle"
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "name": "child_voronoi",
+                                    "type": "path",
+                                    "from": {
+                                        "data": "child_marks"
+                                    },
+                                    "encode": {
+                                        "enter": {
+                                            "fill": {
+                                                "value": "transparent"
+                                            },
+                                            "strokeWidth": {
+                                                "value": 0.35
+                                            },
+                                            "stroke": {
+                                                "value": "transparent"
+                                            },
+                                            "isVoronoi": {
+                                                "value": true
+                                            }
+                                        }
+                                    },
+                                    "transform": [
+                                        {
+                                            "type": "voronoi",
+                                            "x": "datum.x",
+                                            "y": "datum.y",
+                                            "size": [
+                                                {
+                                                    "signal": "width"
+                                                },
+                                                {
+                                                    "signal": "height"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "child_brush_brush",
+                                    "type": "rect",
+                                    "encode": {
+                                        "enter": {
+                                            "fill": {
+                                                "value": "transparent"
+                                            }
+                                        },
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "signal": "child_brush[0].extent[0]"
+                                            },
+                                            "x2": {
+                                                "scale": "x",
+                                                "signal": "child_brush[0].extent[1]"
+                                            },
+                                            "y": {
+                                                "value": 0
+                                            },
+                                            "y2": {
+                                                "field": {
+                                                    "group": "height"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "y"
+                        },
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
+                        }
+                    ]
+                }
+            ],
+            "scales": [
+                {
+                    "name": "column",
+                    "type": "band",
+                    "domain": {
+                        "data": "source_0",
+                        "field": "Series",
+                        "sort": true
+                    },
+                    "range": "width",
+                    "round": true
+                },
+                {
+                    "name": "x",
+                    "type": "linear",
+                    "domain": {
+                        "data": "source_0",
+                        "field": "X"
+                    },
+                    "range": [
+                        0,
+                        200
+                    ],
+                    "round": true,
+                    "nice": true,
+                    "zero": false,
+                    "domainRaw": {
+                        "signal": "child_grid_x"
+                    }
+                },
+                {
+                    "name": "y",
+                    "type": "linear",
+                    "domain": {
+                        "data": "source_0",
+                        "field": "Y"
+                    },
+                    "range": [
+                        200,
+                        0
+                    ],
+                    "round": true,
+                    "nice": true,
+                    "zero": false,
+                    "domainRaw": {
+                        "signal": "child_grid_y"
+                    }
+                }
+            ],
+            "axes": [
+                {
+                    "scale": "column",
+                    "domain": false,
+                    "grid": false,
+                    "orient": "top",
+                    "ticks": false,
+                    "title": "Series",
+                    "zindex": 1
+                }
+            ]
+        }
+    ]
+}

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -269,7 +269,7 @@
                             "events": {
                                 "signal": "layer_0_grid"
                             },
-                            "update": "modify(\"layer_0_grid_store\", layer_0_grid_tuple, {unit: layer_0_grid_tuple.unit})"
+                            "update": "modify(\"layer_0_grid_store\", layer_0_grid_tuple, true)"
                         }
                     ]
                 },
@@ -544,7 +544,7 @@
                             "events": {
                                 "signal": "layer_1_brush"
                             },
-                            "update": "modify(\"layer_1_brush_store\", layer_1_brush_tuple, {unit: layer_1_brush_tuple.unit})"
+                            "update": "modify(\"layer_1_brush_store\", layer_1_brush_tuple, true)"
                         }
                     ]
                 }
@@ -582,22 +582,46 @@
                                     }
                                 },
                                 "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "signal": "layer_1_brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "x",
-                                        "signal": "layer_1_brush[0].extent[1]"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "signal": "layer_1_brush[1].extent[0]"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "signal": "layer_1_brush[1].extent[1]"
-                                    }
+                                    "x": [
+                                        {
+                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                            "scale": "x",
+                                            "signal": "layer_1_brush[0].extent[0]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                            "scale": "x",
+                                            "signal": "layer_1_brush[0].extent[1]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "y": [
+                                        {
+                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                            "scale": "y",
+                                            "signal": "layer_1_brush[1].extent[0]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "y2": [
+                                        {
+                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                            "scale": "y",
+                                            "signal": "layer_1_brush[1].extent[1]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ]
                                 }
                             }
                         },
@@ -695,22 +719,46 @@
                                     }
                                 },
                                 "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "signal": "layer_1_brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "x",
-                                        "signal": "layer_1_brush[0].extent[1]"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "signal": "layer_1_brush[1].extent[0]"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "signal": "layer_1_brush[1].extent[1]"
-                                    }
+                                    "x": [
+                                        {
+                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                            "scale": "x",
+                                            "signal": "layer_1_brush[0].extent[0]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                            "scale": "x",
+                                            "signal": "layer_1_brush[0].extent[1]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "y": [
+                                        {
+                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                            "scale": "y",
+                                            "signal": "layer_1_brush[1].extent[0]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "y2": [
+                                        {
+                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                            "scale": "y",
+                                            "signal": "layer_1_brush[1].extent[1]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ]
                                 }
                             }
                         }

--- a/examples/vg-specs/panzoom_scatter.vg.json
+++ b/examples/vg-specs/panzoom_scatter.vg.json
@@ -218,7 +218,7 @@
                             "events": {
                                 "signal": "grid"
                             },
-                            "update": "modify(\"grid_store\", grid_tuple, {unit: grid_tuple.unit})"
+                            "update": "modify(\"grid_store\", grid_tuple, true)"
                         }
                     ]
                 }

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -134,8 +134,8 @@ export class FacetModel extends Model {
   }
 
   public parseSelection() {
-    // TODO: @arvind can write this
-    // We might need to split this into compileSelectionData and compileSelectionSignals?
+    this.child.parseSelection();
+    this.component.selection = this.child.component.selection;
   }
 
   public parseLayoutData() {
@@ -253,7 +253,7 @@ export class FacetModel extends Model {
   }
 
   public assembleSelectionData(data: VgData[]): VgData[] {
-    return [];
+    return this.child.assembleSelectionData(data);
   }
 
   public assembleLayout(layoutData: VgData[]): VgData[] {

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -134,6 +134,9 @@ export class FacetModel extends Model {
   }
 
   public parseSelection() {
+    // As a facet has a single child, the selection components are the same.
+    // The child maintains its selections to assemble signals, which remain
+    // within its unit.
     this.child.parseSelection();
     this.component.selection = this.child.component.selection;
   }

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -1,8 +1,8 @@
 import {Channel, X, Y} from '../../channel';
 import {warn} from '../../log';
-import {extend, stringValue, keys} from '../../util';
+import {extend, keys, stringValue} from '../../util';
 import {UnitModel} from '../unit';
-import {channelSignalName, invert as invertFn, SelectionCompiler, SelectionComponent, TUPLE, STORE} from './selection';
+import {channelSignalName, invert as invertFn, SelectionCompiler, SelectionComponent, STORE, TUPLE} from './selection';
 import scales from './transforms/scales';
 
 export const BRUSH = '_brush',
@@ -105,7 +105,7 @@ const interval:SelectionCompiler = {
         update[key] = [{
           test: `${store}.length && ${tpl} && ${tpl}.unit === ${store}[0].unit`,
           ...update[key]
-        }, {value: 0}]
+        }, {value: 0}];
       });
     }
 

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -100,6 +100,10 @@ const interval:SelectionCompiler = {
         {field: {group: 'height'}})
     };
 
+    // If the selection is resolved to global, only a single interval is in
+    // the store. Wrap brush mark's encodings with a production rule to test
+    // this based on the `unit` property. Hide the brush mark if it corresponds
+    // to a unit different from the one in the store.
     if (selCmpt.resolve === 'global') {
       keys(update).forEach(function(key) {
         update[key] = [{

--- a/src/compile/selection/multi.ts
+++ b/src/compile/selection/multi.ts
@@ -25,7 +25,9 @@ const multi:SelectionCompiler = {
   },
 
   modifyExpr: function(model, selCmpt) {
-    return selCmpt.name + TUPLE;
+    let tpl = selCmpt.name + TUPLE;
+    return tpl + ', ' +
+      (selCmpt.resolve === 'global' ? 'null' : `{unit: ${tpl}.unit}`);
   }
 };
 

--- a/src/compile/selection/multi.ts
+++ b/src/compile/selection/multi.ts
@@ -25,7 +25,7 @@ const multi:SelectionCompiler = {
   },
 
   modifyExpr: function(model, selCmpt) {
-    let tpl = selCmpt.name + TUPLE;
+    const tpl = selCmpt.name + TUPLE;
     return tpl + ', ' +
       (selCmpt.resolve === 'global' ? 'null' : `{unit: ${tpl}.unit}`);
   }

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -80,7 +80,6 @@ export function parseUnitSelection(model: UnitModel, selDefs: Dict<SelectionDef>
       name: model.getName(name),
       events: isString(selDef.on) ? parseSelector(selDef.on, 'scope') : selDef.on,
       domain: 'data' as SelectionDomain, // TODO: Support def.domain
-      resolve: 'union' as SelectionResolutions
     }) as SelectionComponent;
 
     forEachTransform(selCmpt, txCompiler => {
@@ -192,12 +191,12 @@ export function assembleLayerMarks(model: LayerModel, marks: any[]): any[] {
 }
 
 const PREDICATES_OPS = {
-  'single': '"intersect", "all"',
+  'global': '"union", "all"',
   'independent': '"intersect", "unit"',
   'union': '"union", "all"',
   'union_others': '"union", "others"',
   'intersect': '"intersect", "all"',
-  'intersect_others': '"intersect", "others'
+  'intersect_others': '"intersect", "others"'
 };
 
 export function predicate(selCmpt: SelectionComponent, datum?: string): string {

--- a/src/compile/selection/single.ts
+++ b/src/compile/selection/single.ts
@@ -24,7 +24,9 @@ const single:SelectionCompiler = {
   },
 
   modifyExpr: function(model, selCmpt) {
-    return selCmpt.name + TUPLE + ', true';
+    let tpl = selCmpt.name + TUPLE;
+    return tpl + ', ' +
+      (selCmpt.resolve === 'global' ? 'true' : `{unit: ${tpl}.unit}`);
   }
 };
 

--- a/src/compile/selection/single.ts
+++ b/src/compile/selection/single.ts
@@ -24,7 +24,7 @@ const single:SelectionCompiler = {
   },
 
   modifyExpr: function(model, selCmpt) {
-    let tpl = selCmpt.name + TUPLE;
+    const tpl = selCmpt.name + TUPLE;
     return tpl + ', ' +
       (selCmpt.resolve === 'global' ? 'true' : `{unit: ${tpl}.unit}`);
   }

--- a/src/compile/selection/transforms/inputs.ts
+++ b/src/compile/selection/transforms/inputs.ts
@@ -3,7 +3,8 @@ import {TransformCompiler} from './transforms';
 
 const inputBindings:TransformCompiler = {
   has: function(selCmpt) {
-    return selCmpt.type === 'single' && selCmpt.bind && selCmpt.bind !== 'scales';
+    return selCmpt.type === 'single' && selCmpt.resolve === 'global' &&
+      selCmpt.bind && selCmpt.bind !== 'scales';
   },
 
   topLevelSignals: function(model, selCmpt, signals) {

--- a/src/compile/selection/transforms/scales.ts
+++ b/src/compile/selection/transforms/scales.ts
@@ -11,7 +11,8 @@ const scaleBindings:TransformCompiler = {
   clipGroup: true,
 
   has: function(selCmpt) {
-    return selCmpt.type === 'interval' && selCmpt.bind && selCmpt.bind === 'scales';
+    return selCmpt.type === 'interval' && selCmpt.resolve === 'global' &&
+      selCmpt.bind && selCmpt.bind === 'scales';
   },
 
   parse: function(model, selDef, selCmpt) {

--- a/src/compile/selection/transforms/toggle.ts
+++ b/src/compile/selection/transforms/toggle.ts
@@ -21,7 +21,9 @@ const toggle:TransformCompiler = {
         signal = selCmpt.name + TOGGLE;
 
     return `${signal} ? null : ${tpl}, ` +
-      `${signal} ? null : true, ` +
+      (selCmpt.resolve === 'global' ?
+        `${signal} ? null : true, ` :
+        `${signal} ? null : {unit: ${tpl}.unit}, `) +
       `${signal} ? ${tpl} : null`;
   }
 };

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -1,3 +1,4 @@
+import { LayerModel } from 'vega-lite/build/src/compile/layer';
 import {Axis} from '../axis';
 import {Channel, NONSPATIAL_SCALE_CHANNELS, UNIT_CHANNELS, UNIT_SCALE_CHANNELS, X, X2,  Y, Y2} from '../channel';
 import {CellConfig, Config} from '../config';

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -1,4 +1,3 @@
-import { LayerModel } from 'vega-lite/build/src/compile/layer';
 import {Axis} from '../axis';
 import {Channel, NONSPATIAL_SCALE_CHANNELS, UNIT_CHANNELS, UNIT_SCALE_CHANNELS, X, X2,  Y, Y2} from '../channel';
 import {CellConfig, Config} from '../config';

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -2,11 +2,12 @@ import {VgBinding} from './vega.schema';
 
 export type SelectionTypes = 'single' | 'multi' | 'interval';
 export type SelectionDomain = 'data' | 'visual';
-export type SelectionResolutions = 'single' | 'independent' | 'union' |
+export type SelectionResolutions = 'global' | 'independent' | 'union' |
   'union_others' | 'intersect' | 'intersect_others';
 
 export interface BaseSelectionDef {
   // domain?: SelectionDomain;
+  resolve?: SelectionResolutions;
   on?: any;
   // predicate?: string;
   bind?: 'scales' | VgBinding | {[key: string]: VgBinding};
@@ -31,12 +32,13 @@ export interface SelectionConfig {
 }
 
 export const defaultConfig:SelectionConfig = {
-  single: {on: 'click', fields: ['_id']},
-  multi: {on: 'click', fields: ['_id'], toggle: 'event.shiftKey'},
+  single: {on: 'click', fields: ['_id'], resolve: 'global'},
+  multi: {on: 'click', fields: ['_id'], toggle: 'event.shiftKey', resolve: 'global'},
   interval: {
     on: '[mousedown, window:mouseup] > window:mousemove!',
     encodings: ['x', 'y'],
     translate: '[mousedown, window:mouseup] > window:mousemove!',
-    zoom: 'wheel'
+    zoom: 'wheel',
+    resolve: 'global'
   }
 };

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -196,9 +196,9 @@ function normalizeFacetedUnit(spec: FacetedUnitSpec, config: Config): FacetSpec 
       ...(column ? {column}: {}),
     },
     spec: normalizeNonFacetUnit({
-      selection,
       mark,
-      encoding
+      encoding,
+      ...(selection ? {selection} : {})
     }, config)
   };
 }

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -187,7 +187,7 @@ function normalizeFacetedUnit(spec: FacetedUnitSpec, config: Config): FacetSpec 
   const {row: row, column: column, ...encoding} = spec.encoding;
 
   // Mark and encoding should be moved into the inner spec
-  const {mark: mark, encoding: _, ...outerSpec} = spec;
+  const {mark: mark, selection: selection, encoding: _, ...outerSpec} = spec;
 
   return {
     ...outerSpec,
@@ -196,6 +196,7 @@ function normalizeFacetedUnit(spec: FacetedUnitSpec, config: Config): FacetSpec 
       ...(column ? {column}: {}),
     },
     spec: normalizeNonFacetUnit({
+      selection,
       mark,
       encoding
     }, config)

--- a/test/compile/selection/interval.test.ts
+++ b/test/compile/selection/interval.test.ts
@@ -31,7 +31,8 @@ describe('Interval Selections', function() {
       "type": "interval",
       "on": "[mousedown, mouseup] > mousemove, [keydown, keyup] > keypress",
       "translate": false,
-      "zoom": false
+      "zoom": false,
+      "resolve": "intersect"
     }
   });
 
@@ -224,10 +225,10 @@ describe('Interval Selections', function() {
 
   it('builds modify signals', function() {
     const oneExpr = interval.modifyExpr(model, selCmpts['one']);
-    assert.equal(oneExpr, 'one_tuple, {unit: one_tuple.unit}');
+    assert.equal(oneExpr, 'one_tuple, true');
 
     const twoExpr = interval.modifyExpr(model, selCmpts['two']);
-    assert.equal(twoExpr, 'two_tuple, {unit: two_tuple.unit}');
+    assert.equal(twoExpr, 'two_tuple, true');
 
     const threeExpr = interval.modifyExpr(model, selCmpts['three']);
     assert.equal(threeExpr, 'three_tuple, {unit: three_tuple.unit}');
@@ -273,16 +274,36 @@ describe('Interval Selections', function() {
         "encode": {
           "enter": {"fill": {"value": "#eee"}},
           "update": {
-            "x": {
-              "scale": "x",
-              "signal": "one[0].extent[0]"
-            },
-            "x2": {
-              "scale": "x",
-              "signal": "one[0].extent[1]"
-            },
-            "y": {"value": 0},
-            "y2": {"field": {"group": "height"}}
+            "x": [
+              {
+                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "scale": "x",
+                "signal": "one[0].extent[0]"
+              },
+              {"value": 0}
+            ],
+            "x2": [
+              {
+                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "scale": "x",
+                "signal": "one[0].extent[1]"
+              },
+              {"value": 0}
+            ],
+            "y": [
+              {
+                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "value": 0
+              },
+              {"value": 0}
+            ],
+            "y2": [
+              {
+                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "field": {"group": "height"}
+              },
+              {"value": 0}
+            ]
           }
         }
       },
@@ -293,16 +314,36 @@ describe('Interval Selections', function() {
         "encode": {
           "enter": {"fill": {"value": "transparent"}},
           "update": {
-            "x": {
-              "scale": "x",
-              "signal": "one[0].extent[0]"
-            },
-            "x2": {
-              "scale": "x",
-              "signal": "one[0].extent[1]"
-            },
-            "y": {"value": 0},
-            "y2": {"field": {"group": "height"}}
+            "x": [
+              {
+                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "scale": "x",
+                "signal": "one[0].extent[0]"
+              },
+              {"value": 0}
+            ],
+            "x2": [
+              {
+                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "scale": "x",
+                "signal": "one[0].extent[1]"
+              },
+              {"value": 0}
+            ],
+            "y": [
+              {
+                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "value": 0
+              },
+              {"value": 0}
+            ],
+            "y2": [
+              {
+                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "field": {"group": "height"}
+              },
+              {"value": 0}
+            ]
           }
         }
       }

--- a/test/compile/selection/layers.test.ts
+++ b/test/compile/selection/layers.test.ts
@@ -141,22 +141,46 @@ describe('Layered Selections', function() {
               }
             },
             "update": {
-              "x": {
-                "scale": "x",
-                "signal": "layer_0_brush[0].extent[0]"
-              },
-              "x2": {
-                "scale": "x",
-                "signal": "layer_0_brush[0].extent[1]"
-              },
-              "y": {
-                "scale": "y",
-                "signal": "layer_0_brush[1].extent[0]"
-              },
-              "y2": {
-                "scale": "y",
-                "signal": "layer_0_brush[1].extent[1]"
-              }
+              "x": [
+                {
+                  "test": "data(\"layer_0_brush_store\").length && layer_0_brush_tuple && layer_0_brush_tuple.unit === data(\"layer_0_brush_store\")[0].unit",
+                  "scale": "x",
+                  "signal": "layer_0_brush[0].extent[0]"
+                },
+                {
+                  "value": 0
+                }
+              ],
+              "x2": [
+                {
+                  "test": "data(\"layer_0_brush_store\").length && layer_0_brush_tuple && layer_0_brush_tuple.unit === data(\"layer_0_brush_store\")[0].unit",
+                  "scale": "x",
+                  "signal": "layer_0_brush[0].extent[1]"
+                },
+                {
+                  "value": 0
+                }
+              ],
+              "y": [
+                {
+                  "test": "data(\"layer_0_brush_store\").length && layer_0_brush_tuple && layer_0_brush_tuple.unit === data(\"layer_0_brush_store\")[0].unit",
+                  "scale": "y",
+                  "signal": "layer_0_brush[1].extent[0]"
+                },
+                {
+                  "value": 0
+                }
+              ],
+              "y2": [
+                {
+                  "test": "data(\"layer_0_brush_store\").length && layer_0_brush_tuple && layer_0_brush_tuple.unit === data(\"layer_0_brush_store\")[0].unit",
+                  "scale": "y",
+                  "signal": "layer_0_brush[1].extent[1]"
+                },
+                {
+                  "value": 0
+                }
+              ]
             }
           }
         },
@@ -173,22 +197,46 @@ describe('Layered Selections', function() {
               }
             },
             "update": {
-              "x": {
-                "scale": "x",
-                "signal": "layer_0_brush[0].extent[0]"
-              },
-              "x2": {
-                "scale": "x",
-                "signal": "layer_0_brush[0].extent[1]"
-              },
-              "y": {
-                "scale": "y",
-                "signal": "layer_0_brush[1].extent[0]"
-              },
-              "y2": {
-                "scale": "y",
-                "signal": "layer_0_brush[1].extent[1]"
-              }
+              "x": [
+                {
+                  "test": "data(\"layer_0_brush_store\").length && layer_0_brush_tuple && layer_0_brush_tuple.unit === data(\"layer_0_brush_store\")[0].unit",
+                  "scale": "x",
+                  "signal": "layer_0_brush[0].extent[0]"
+                },
+                {
+                  "value": 0
+                }
+              ],
+              "x2": [
+                {
+                  "test": "data(\"layer_0_brush_store\").length && layer_0_brush_tuple && layer_0_brush_tuple.unit === data(\"layer_0_brush_store\")[0].unit",
+                  "scale": "x",
+                  "signal": "layer_0_brush[0].extent[1]"
+                },
+                {
+                  "value": 0
+                }
+              ],
+              "y": [
+                {
+                  "test": "data(\"layer_0_brush_store\").length && layer_0_brush_tuple && layer_0_brush_tuple.unit === data(\"layer_0_brush_store\")[0].unit",
+                  "scale": "y",
+                  "signal": "layer_0_brush[1].extent[0]"
+                },
+                {
+                  "value": 0
+                }
+              ],
+              "y2": [
+                {
+                  "test": "data(\"layer_0_brush_store\").length && layer_0_brush_tuple && layer_0_brush_tuple.unit === data(\"layer_0_brush_store\")[0].unit",
+                  "scale": "y",
+                  "signal": "layer_0_brush[1].extent[1]"
+                },
+                {
+                  "value": 0
+                }
+              ]
             }
           }
         }


### PR DESCRIPTION
Follows #2160. Here's a test spec:

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "description": "Anscombe's Quartet",
  "data": {"url": "data/anscombe.json"},
  "mark": "circle",
  "selection": {
    "brush": {
      "type": "interval", "resolve": "global",
      "encodings": ["x"]
    }
  },
  "encoding": {
    "column": {"field": "Series","type": "nominal"},
    "x": {
      "field": "X",
      "type": "quantitative",
      "scale": {"zero": false}
    },
    "y": {
      "field": "Y",
      "type": "quantitative",
      "scale": {"zero": false}
    },
    "size": {
      "value": 100,
      "condition": {"selection": "brush","value": 250}
    }
  },
  "config": {"mark": {"opacity": 1}}
}
```

Things to vary:
* Resolution scheme: `global`, `independent`, `union`, `union_others`, `intersect`, `intersect_others`.
* Binding should only work with `global` resolutions. 