### PR TITLE
[WIP] Re-build Facet with the new Layout Operator

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1762,7 +1762,7 @@
                     "description": "Color of the marks – either fill or stroke color based on mark type.\n(By default, fill color for `area`, `bar`, `tick`, `text`, `circle`, and `square` /\nstroke color for `line` and `point`.)"
                 },
                 "column": {
-                    "$ref": "#/definitions/PositionFieldDef",
+                    "$ref": "#/definitions/FieldDef",
                     "description": "Horizontal facets for trellis plots."
                 },
                 "detail": {
@@ -1805,7 +1805,7 @@
                     "description": "stack order for stacked marks or order of data points in line marks."
                 },
                 "row": {
-                    "$ref": "#/definitions/PositionFieldDef",
+                    "$ref": "#/definitions/FieldDef",
                     "description": "Vertical facets for trellis plots."
                 },
                 "shape": {
@@ -1947,11 +1947,11 @@
             "additionalProperties": false,
             "properties": {
                 "column": {
-                    "$ref": "#/definitions/PositionFieldDef",
+                    "$ref": "#/definitions/FieldDef",
                     "description": "Horizontal facets for trellis plots."
                 },
                 "row": {
-                    "$ref": "#/definitions/PositionFieldDef",
+                    "$ref": "#/definitions/FieldDef",
                     "description": "Vertical facets for trellis plots."
                 }
             },
@@ -1960,10 +1960,6 @@
         "FacetConfig": {
             "additionalProperties": false,
             "properties": {
-                "axis": {
-                    "$ref": "#/definitions/AxisConfig",
-                    "description": "Facet Axis Config"
-                },
                 "cell": {
                     "$ref": "#/definitions/CellConfig",
                     "description": "Facet Cell Config"
@@ -3137,10 +3133,6 @@
                     ],
                     "description": "Range scheme (e.g., color schemes such as `\"category10\"` or `\"viridis\"`).\n\n__Default value:__ [scale config](config.html#scale-config)'s `\"nominalColorScheme\"` for nominal field and `\"sequentialColorScheme\"` for other types of fields."
                 },
-                "spacing": {
-                    "description": "(For `row` and `column` only) A pixel value for padding between cells in the trellis plots.\n\n__Default value:__ derived from [scale config](config.html#scale-config)'s `facetSpacing`",
-                    "type": "integer"
-                },
                 "type": {
                     "$ref": "#/definitions/ScaleType",
                     "description": "The type of scale.\n- For a _quantitative_ field, supported quantitative scale types  are `\"linear\"` (default), `\"log\"`, `\"pow\"`, `\"sqrt\"`, `\"quantile\"`, `\"quantize\"`, and `\"threshold\"`.\n- For a _temporal_ field without `timeUnit`, the scale type should be `\"time\"` (default) or `\"ordinal\"`.\n- For _ordinal_ and _nominal_ fields, the type is always `\"ordinal\"`.\nUnsupported values will be ignored."
@@ -3170,11 +3162,6 @@
                 "clamp": {
                     "description": "If true, values that exceed the data domain are clamped to either the minimum or maximum range value",
                     "type": "boolean"
-                },
-                "facetSpacing": {
-                    "description": "Default spacing between faceted plots.\n\n__Default value:__ `16`",
-                    "minimum": 0,
-                    "type": "integer"
                 },
                 "maxBandSize": {
                     "description": "The default max value for mapping quantitative fields to bar's size/bandSize.\nIf undefined (default), we will use bandSize - 1.",

--- a/examples/specs/bar_grouped.vl.json
+++ b/examples/specs/bar_grouped.vl.json
@@ -8,9 +8,7 @@
   "mark": "bar",
   "encoding": {
     "column": {
-      "field": "age", "type": "ordinal",
-      "scale": {"spacing": 4},
-      "axis": {"orient": "bottom", "offset": -8}
+      "field": "age", "type": "ordinal"
     },
     "y": {
       "aggregate": "sum", "field": "people", "type": "quantitative",

--- a/examples/specs/bar_grouped.vl.json
+++ b/examples/specs/bar_grouped.vl.json
@@ -16,8 +16,8 @@
     },
     "x": {
       "field": "gender", "type": "nominal",
-      "scale": {"rangeStep": 6},
-      "axis": null
+      "scale": {"rangeStep": 12},
+      "axis": {"title": ""}
     },
     "color": {
       "field": "gender", "type": "nominal",

--- a/examples/specs/bar_grouped_horizontal.vl.json
+++ b/examples/specs/bar_grouped_horizontal.vl.json
@@ -8,9 +8,7 @@
   "mark": "bar",
   "encoding": {
     "row": {
-      "field": "age", "type": "ordinal",
-      "scale": {"spacing": 4},
-      "axis": {"orient": "left", "offset": -8}
+      "field": "age", "type": "ordinal"
     },
     "x": {
       "aggregate": "sum", "field": "people", "type": "quantitative",

--- a/examples/specs/trellis_barley.vl.json
+++ b/examples/specs/trellis_barley.vl.json
@@ -5,8 +5,7 @@
   "mark": "point",
   "encoding": {
     "row": {
-      "field": "site", "type": "ordinal",
-      "sort": {"op": "median", "field": "yield", "order": "descending"}
+      "field": "site", "type": "ordinal"
     },
     "x": {
       "aggregate": "median", "field": "yield", "type": "quantitative",

--- a/examples/vg-specs/bar_grouped.vg.json
+++ b/examples/vg-specs/bar_grouped.vg.json
@@ -112,12 +112,12 @@
                 {
                     "type": "formula",
                     "as": "child_width",
-                    "expr": "max(datum[\"distinct_gender\"] - 1 + 2*0.5, 0) * 6"
+                    "expr": "max(datum[\"distinct_gender\"] - 1 + 2*0.5, 0) * 12"
                 },
                 {
                     "type": "formula",
                     "as": "width",
-                    "expr": "(datum[\"child_width\"] + 4) * datum[\"distinct_age\"]"
+                    "expr": "(datum[\"child_width\"] + 5) * datum[\"distinct_age\"]"
                 },
                 {
                     "type": "formula",
@@ -127,7 +127,7 @@
                 {
                     "type": "formula",
                     "as": "height",
-                    "expr": "datum[\"child_height\"] + 16"
+                    "expr": "datum[\"child_height\"] + 5"
                 }
             ]
         }
@@ -149,108 +149,227 @@
                     }
                 }
             },
+            "signals": [
+                {
+                    "name": "column",
+                    "update": "data('layout')[0].distinct_age"
+                }
+            ],
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10,
+                    "header": 10
+                },
+                "columns": 1,
+                "bounds": "full"
+            },
             "marks": [
                 {
-                    "name": "y-axes",
                     "type": "group",
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "y": {
-                                "value": 8
-                            }
-                        }
+                    "layout": {
+                        "padding": {
+                            "row": 10,
+                            "column": 10,
+                            "header": 10
+                        },
+                        "columns": {
+                            "signal": "column"
+                        },
+                        "bounds": "full"
                     },
-                    "axes": [
+                    "marks": [
                         {
-                            "scale": "y",
-                            "format": "s",
-                            "orient": "left",
-                            "title": "population",
-                            "zindex": 1
+                            "name": "x-axes",
+                            "type": "group",
+                            "role": "column-footer",
+                            "from": {
+                                "data": "column"
+                            },
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "title": "",
+                                    "zindex": 1,
+                                    "encode": {
+                                        "labels": {
+                                            "update": {
+                                                "angle": {
+                                                    "value": 270
+                                                },
+                                                "align": {
+                                                    "value": "right"
+                                                },
+                                                "baseline": {
+                                                    "value": "middle"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "y-axes",
+                            "type": "group",
+                            "role": "row-header",
+                            "axes": [
+                                {
+                                    "scale": "y",
+                                    "format": "s",
+                                    "orient": "left",
+                                    "title": "population",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "column-labels",
+                            "role": "column-header",
+                            "type": "group",
+                            "from": {
+                                "data": "column"
+                            },
+                            "encode": {
+                                "update": {
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "type": "text",
+                                    "role": "column-labels",
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "field": {
+                                                    "group": "width"
+                                                },
+                                                "mult": 0.5
+                                            },
+                                            "y": {
+                                                "value": -10
+                                            },
+                                            "text": {
+                                                "field": {
+                                                    "parent": "age"
+                                                }
+                                            },
+                                            "align": {
+                                                "value": "center"
+                                            },
+                                            "fill": {
+                                                "value": "black"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cell",
+                            "type": "group",
+                            "from": {
+                                "facet": {
+                                    "name": "facet",
+                                    "data": "source_0",
+                                    "groupby": [
+                                        "age"
+                                    ]
+                                }
+                            },
+                            "encode": {
+                                "update": {
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
+                                    },
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
+                                    },
+                                    "stroke": {
+                                        "value": "#ccc"
+                                    },
+                                    "strokeWidth": {
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "name": "child_marks",
+                                    "type": "rect",
+                                    "role": "bar",
+                                    "from": {
+                                        "data": "facet"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "xc": {
+                                                "scale": "x",
+                                                "field": "gender"
+                                            },
+                                            "width": {
+                                                "value": 11
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "sum_people_end"
+                                            },
+                                            "y2": {
+                                                "scale": "y",
+                                                "field": "sum_people_start"
+                                            },
+                                            "fill": {
+                                                "scale": "color",
+                                                "field": "gender"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
                 {
-                    "name": "cell",
+                    "name": "column-title",
+                    "role": "column-header",
                     "type": "group",
-                    "from": {
-                        "facet": {
-                            "name": "facet",
-                            "data": "source_0",
-                            "groupby": [
-                                "age"
-                            ]
-                        }
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "column",
-                                "field": "age",
-                                "offset": 2
-                            },
-                            "y": {
-                                "value": 8
-                            },
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "stroke": {
-                                "value": "#ccc"
-                            },
-                            "strokeWidth": {
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            }
-                        }
-                    },
                     "marks": [
                         {
-                            "name": "child_marks",
-                            "type": "rect",
-                            "role": "bar",
-                            "from": {
-                                "data": "facet"
-                            },
+                            "type": "text",
+                            "role": "column-labels",
                             "encode": {
                                 "update": {
-                                    "xc": {
-                                        "scale": "x",
-                                        "field": "gender"
+                                    "x": {
+                                        "signal": "0.5 * width"
                                     },
-                                    "width": {
-                                        "value": 5
+                                    "text": {
+                                        "value": "age"
                                     },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "sum_people_end"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "field": "sum_people_start"
+                                    "align": {
+                                        "value": "center"
                                     },
                                     "fill": {
-                                        "scale": "color",
-                                        "field": "gender"
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
                                     }
                                 }
                             }
@@ -260,17 +379,6 @@
             ],
             "scales": [
                 {
-                    "name": "column",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "age",
-                        "sort": true
-                    },
-                    "range": "width",
-                    "round": true
-                },
-                {
                     "name": "x",
                     "type": "point",
                     "domain": {
@@ -279,7 +387,7 @@
                         "sort": true
                     },
                     "range": {
-                        "step": 6
+                        "step": 12
                     },
                     "round": true,
                     "padding": 0.5
@@ -314,18 +422,6 @@
                         "#EA98D2",
                         "#659CCA"
                     ]
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "column",
-                    "domain": false,
-                    "grid": false,
-                    "offset": -8,
-                    "orient": "bottom",
-                    "ticks": false,
-                    "title": "age",
-                    "zindex": 1
                 }
             ],
             "legends": [

--- a/examples/vg-specs/bar_grouped.vg.json
+++ b/examples/vg-specs/bar_grouped.vg.json
@@ -343,7 +343,7 @@
                     "marks": [
                         {
                             "type": "text",
-                            "role": "column-labels",
+                            "role": "column-title",
                             "encode": {
                                 "update": {
                                     "x": {

--- a/examples/vg-specs/bar_grouped.vg.json
+++ b/examples/vg-specs/bar_grouped.vg.json
@@ -139,16 +139,6 @@
             "from": {
                 "data": "layout"
             },
-            "encode": {
-                "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    }
-                }
-            },
             "signals": [
                 {
                     "name": "column",

--- a/examples/vg-specs/bar_grouped_horizontal.vg.json
+++ b/examples/vg-specs/bar_grouped_horizontal.vg.json
@@ -304,7 +304,7 @@
                     "marks": [
                         {
                             "type": "text",
-                            "role": "row-labels",
+                            "role": "row-title",
                             "encode": {
                                 "update": {
                                     "y": {

--- a/examples/vg-specs/bar_grouped_horizontal.vg.json
+++ b/examples/vg-specs/bar_grouped_horizontal.vg.json
@@ -117,7 +117,7 @@
                 {
                     "type": "formula",
                     "as": "width",
-                    "expr": "datum[\"child_width\"] + 16"
+                    "expr": "datum[\"child_width\"] + 5"
                 },
                 {
                     "type": "formula",
@@ -127,7 +127,7 @@
                 {
                     "type": "formula",
                     "as": "height",
-                    "expr": "(datum[\"child_height\"] + 4) * datum[\"distinct_age\"]"
+                    "expr": "(datum[\"child_height\"] + 5) * datum[\"distinct_age\"]"
                 }
             ]
         }
@@ -149,109 +149,191 @@
                     }
                 }
             },
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10,
+                    "header": 10
+                },
+                "columns": 1,
+                "bounds": "full"
+            },
             "marks": [
                 {
-                    "name": "x-axes",
                     "type": "group",
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            },
-                            "x": {
-                                "value": 8
-                            }
-                        }
+                    "layout": {
+                        "padding": {
+                            "row": 10,
+                            "column": 10,
+                            "header": 10
+                        },
+                        "columns": 1,
+                        "bounds": "full"
                     },
-                    "axes": [
+                    "marks": [
                         {
-                            "scale": "x",
-                            "format": "s",
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "title": "population",
-                            "zindex": 1
+                            "name": "x-axes",
+                            "type": "group",
+                            "role": "column-footer",
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "format": "s",
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "title": "population",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "row-labels",
+                            "role": "row-header",
+                            "type": "group",
+                            "from": {
+                                "data": "row"
+                            },
+                            "encode": {
+                                "update": {
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "type": "text",
+                                    "role": "row-labels",
+                                    "encode": {
+                                        "update": {
+                                            "y": {
+                                                "field": {
+                                                    "group": "height"
+                                                },
+                                                "mult": 0.5
+                                            },
+                                            "x": {
+                                                "value": -10
+                                            },
+                                            "text": {
+                                                "field": {
+                                                    "parent": "age"
+                                                }
+                                            },
+                                            "align": {
+                                                "value": "right"
+                                            },
+                                            "fill": {
+                                                "value": "black"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cell",
+                            "type": "group",
+                            "from": {
+                                "facet": {
+                                    "name": "facet",
+                                    "data": "source_0",
+                                    "groupby": [
+                                        "age"
+                                    ]
+                                }
+                            },
+                            "encode": {
+                                "update": {
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
+                                    },
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
+                                    },
+                                    "stroke": {
+                                        "value": "#ccc"
+                                    },
+                                    "strokeWidth": {
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "name": "child_marks",
+                                    "type": "rect",
+                                    "role": "bar",
+                                    "from": {
+                                        "data": "facet"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "sum_people_end"
+                                            },
+                                            "x2": {
+                                                "scale": "x",
+                                                "field": "sum_people_start"
+                                            },
+                                            "yc": {
+                                                "scale": "y",
+                                                "field": "gender"
+                                            },
+                                            "height": {
+                                                "value": 5
+                                            },
+                                            "fill": {
+                                                "scale": "color",
+                                                "field": "gender"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     ]
                 },
                 {
-                    "name": "cell",
+                    "name": "row-title",
+                    "role": "row-header",
                     "type": "group",
-                    "from": {
-                        "facet": {
-                            "name": "facet",
-                            "data": "source_0",
-                            "groupby": [
-                                "age"
-                            ]
-                        }
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "value": 8
-                            },
-                            "y": {
-                                "scale": "row",
-                                "field": "age",
-                                "offset": 2
-                            },
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "stroke": {
-                                "value": "#ccc"
-                            },
-                            "strokeWidth": {
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            }
-                        }
-                    },
                     "marks": [
                         {
-                            "name": "child_marks",
-                            "type": "rect",
-                            "role": "bar",
-                            "from": {
-                                "data": "facet"
-                            },
+                            "type": "text",
+                            "role": "row-labels",
                             "encode": {
                                 "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "sum_people_end"
+                                    "y": {
+                                        "signal": "0.5 * height"
                                     },
-                                    "x2": {
-                                        "scale": "x",
-                                        "field": "sum_people_start"
+                                    "angle": {
+                                        "value": 270
                                     },
-                                    "yc": {
-                                        "scale": "y",
-                                        "field": "gender"
+                                    "text": {
+                                        "value": "age"
                                     },
-                                    "height": {
-                                        "value": 5
+                                    "align": {
+                                        "value": "right"
                                     },
                                     "fill": {
-                                        "scale": "color",
-                                        "field": "gender"
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
                                     }
                                 }
                             }
@@ -260,17 +342,6 @@
                 }
             ],
             "scales": [
-                {
-                    "name": "row",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "age",
-                        "sort": true
-                    },
-                    "range": "height",
-                    "round": true
-                },
                 {
                     "name": "x",
                     "type": "linear",
@@ -315,33 +386,6 @@
                         "#EA98D2",
                         "#659CCA"
                     ]
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "row",
-                    "domain": false,
-                    "grid": false,
-                    "offset": -8,
-                    "orient": "left",
-                    "ticks": false,
-                    "title": "age",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "center"
-                                },
-                                "baseline": {
-                                    "value": "bottom"
-                                }
-                            }
-                        }
-                    }
                 }
             ],
             "legends": [

--- a/examples/vg-specs/bar_grouped_horizontal.vg.json
+++ b/examples/vg-specs/bar_grouped_horizontal.vg.json
@@ -139,16 +139,6 @@
             "from": {
                 "data": "layout"
             },
-            "encode": {
-                "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    }
-                }
-            },
             "layout": {
                 "padding": {
                     "row": 10,

--- a/examples/vg-specs/box_plot.vg.json
+++ b/examples/vg-specs/box_plot.vg.json
@@ -27,8 +27,7 @@
             "name": "source_0",
             "url": "data/population.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         },
         {

--- a/examples/vg-specs/errorbar_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_aggregate.vg.json
@@ -27,8 +27,7 @@
             "name": "source_0",
             "url": "data/population.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             },
             "transform": [
                 {

--- a/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
@@ -27,8 +27,7 @@
             "name": "source_0",
             "url": "data/population.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             },
             "transform": [
                 {

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -133,16 +133,6 @@
             "from": {
                 "data": "layout"
             },
-            "encode": {
-                "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    }
-                }
-            },
             "signals": [
                 {
                     "name": "column",

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -835,7 +835,7 @@
                     "marks": [
                         {
                             "type": "text",
-                            "role": "column-labels",
+                            "role": "column-title",
                             "encode": {
                                 "update": {
                                     "x": {

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -101,7 +101,7 @@
                 {
                     "type": "formula",
                     "as": "width",
-                    "expr": "(datum[\"child_width\"] + 16) * datum[\"distinct_Series\"]"
+                    "expr": "(datum[\"child_width\"] + 5) * datum[\"distinct_Series\"]"
                 },
                 {
                     "type": "formula",
@@ -111,7 +111,7 @@
                 {
                     "type": "formula",
                     "as": "height",
-                    "expr": "datum[\"child_height\"] + 16"
+                    "expr": "datum[\"child_height\"] + 5"
                 }
             ]
         },
@@ -143,675 +143,733 @@
                     }
                 }
             },
+            "signals": [
+                {
+                    "name": "column",
+                    "update": "data('layout')[0].distinct_Series"
+                }
+            ],
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10,
+                    "header": 10
+                },
+                "columns": 1,
+                "bounds": "full"
+            },
             "marks": [
                 {
-                    "name": "x-axes",
                     "type": "group",
-                    "from": {
-                        "data": "column"
+                    "layout": {
+                        "padding": {
+                            "row": 10,
+                            "column": 10,
+                            "header": 10
+                        },
+                        "columns": {
+                            "signal": "column"
+                        },
+                        "bounds": "full"
                     },
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            },
-                            "x": {
-                                "scale": "column",
-                                "field": "Series",
-                                "offset": 8
-                            }
-                        }
-                    },
-                    "axes": [
+                    "marks": [
                         {
-                            "scale": "x",
-                            "format": "s",
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "title": "X",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "y-axes",
-                    "type": "group",
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                            "name": "x-axes",
+                            "type": "group",
+                            "role": "column-footer",
+                            "from": {
+                                "data": "column"
                             },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "y": {
-                                "value": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "y",
-                            "format": "s",
-                            "orient": "left",
-                            "title": "Y",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "cell",
-                    "type": "group",
-                    "from": {
-                        "facet": {
-                            "name": "facet",
-                            "data": "source_0",
-                            "groupby": [
-                                "Series"
-                            ]
-                        }
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "column",
-                                "field": "Series",
-                                "offset": 8
-                            },
-                            "y": {
-                                "value": 8
-                            },
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "stroke": {
-                                "value": "#ccc"
-                            },
-                            "strokeWidth": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            }
-                        }
-                    },
-                    "signals": [
-                        {
-                            "name": "child_brush_x",
-                            "value": [],
-                            "on": [
+                            "axes": [
                                 {
-                                    "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
-                                        ]
-                                    },
-                                    "update": "invert(\"x\", [x(unit), x(unit)])"
-                                },
-                                {
-                                    "events": {
-                                        "source": "window",
-                                        "type": "mousemove",
-                                        "consume": true,
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "window",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "[child_brush_x[0], invert(\"x\", clamp(x(unit), 0, width))]"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "child_brush_translate_delta"
-                                    },
-                                    "update": "clampRange([child_brush_translate_anchor.extent_x[0] + abs(span(child_brush_translate_anchor.extent_x)) * child_brush_translate_delta.x / child_brush_translate_anchor.width, child_brush_translate_anchor.extent_x[1] + abs(span(child_brush_translate_anchor.extent_x)) * child_brush_translate_delta.x / child_brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "child_brush_zoom_delta"
-                                    },
-                                    "update": "clampRange([child_brush_zoom_anchor.x + (child_brush_x[0] - child_brush_zoom_anchor.x) * child_brush_zoom_delta, child_brush_zoom_anchor.x + (child_brush_x[1] - child_brush_zoom_anchor.x) * child_brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+                                    "scale": "x",
+                                    "format": "s",
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "title": "X",
+                                    "zindex": 1
                                 }
                             ]
                         },
                         {
-                            "name": "child_brush_size",
-                            "value": [],
-                            "on": [
+                            "name": "y-axes",
+                            "type": "group",
+                            "role": "row-header",
+                            "axes": [
                                 {
-                                    "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
-                                        ]
-                                    },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                                },
-                                {
-                                    "events": {
-                                        "source": "window",
-                                        "type": "mousemove",
-                                        "consume": true,
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "window",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "{x: child_brush_size.x, y: child_brush_size.y, width: abs(x(unit) - child_brush_size.x), height: abs(y(unit) - child_brush_size.y)}"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "child_brush_zoom_delta"
-                                    },
-                                    "update": "{x: child_brush_size.x, y: child_brush_size.y, width: child_brush_size.width * child_brush_zoom_delta , height: child_brush_size.height * child_brush_zoom_delta}"
+                                    "scale": "y",
+                                    "format": "s",
+                                    "orient": "left",
+                                    "title": "Y",
+                                    "zindex": 1
                                 }
                             ]
                         },
                         {
-                            "name": "child_brush",
-                            "update": "[{field: \"X\", extent: child_brush_x}]"
-                        },
-                        {
-                            "name": "child_brush_translate_anchor",
-                            "value": {},
-                            "on": [
-                                {
-                                    "events": [
-                                        {
-                                            "source": "scope",
-                                            "type": "mousedown",
-                                            "markname": "child_brush_brush"
+                            "name": "column-labels",
+                            "role": "column-header",
+                            "type": "group",
+                            "from": {
+                                "data": "column"
+                            },
+                            "encode": {
+                                "update": {
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
                                         }
-                                    ],
-                                    "update": "{x: x(unit), y: y(unit), width: child_brush_size.width, height: child_brush_size.height, extent_x: slice(child_brush_x), }"
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "type": "text",
+                                    "role": "column-labels",
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "field": {
+                                                    "group": "width"
+                                                },
+                                                "mult": 0.5
+                                            },
+                                            "y": {
+                                                "value": -10
+                                            },
+                                            "text": {
+                                                "field": {
+                                                    "parent": "Series"
+                                                }
+                                            },
+                                            "align": {
+                                                "value": "center"
+                                            },
+                                            "fill": {
+                                                "value": "black"
+                                            }
+                                        }
+                                    }
                                 }
                             ]
                         },
                         {
-                            "name": "child_brush_translate_delta",
-                            "value": {},
-                            "on": [
+                            "name": "cell",
+                            "type": "group",
+                            "from": {
+                                "facet": {
+                                    "name": "facet",
+                                    "data": "source_0",
+                                    "groupby": [
+                                        "Series"
+                                    ]
+                                }
+                            },
+                            "encode": {
+                                "update": {
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
+                                    },
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
+                                    },
+                                    "stroke": {
+                                        "value": "#ccc"
+                                    },
+                                    "strokeWidth": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    }
+                                }
+                            },
+                            "signals": [
                                 {
-                                    "events": [
+                                    "name": "child_brush_x",
+                                    "value": [],
+                                    "on": [
                                         {
-                                            "source": "window",
-                                            "type": "mousemove",
-                                            "consume": true,
-                                            "between": [
+                                            "events": {
+                                                "source": "scope",
+                                                "type": "mousedown",
+                                                "filter": [
+                                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
+                                                ]
+                                            },
+                                            "update": "invert(\"x\", [x(unit), x(unit)])"
+                                        },
+                                        {
+                                            "events": {
+                                                "source": "window",
+                                                "type": "mousemove",
+                                                "consume": true,
+                                                "between": [
+                                                    {
+                                                        "source": "scope",
+                                                        "type": "mousedown",
+                                                        "filter": [
+                                                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "source": "window",
+                                                        "type": "mouseup"
+                                                    }
+                                                ]
+                                            },
+                                            "update": "[child_brush_x[0], invert(\"x\", clamp(x(unit), 0, width))]"
+                                        },
+                                        {
+                                            "events": {
+                                                "signal": "child_brush_translate_delta"
+                                            },
+                                            "update": "clampRange([child_brush_translate_anchor.extent_x[0] + abs(span(child_brush_translate_anchor.extent_x)) * child_brush_translate_delta.x / child_brush_translate_anchor.width, child_brush_translate_anchor.extent_x[1] + abs(span(child_brush_translate_anchor.extent_x)) * child_brush_translate_delta.x / child_brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+                                        },
+                                        {
+                                            "events": {
+                                                "signal": "child_brush_zoom_delta"
+                                            },
+                                            "update": "clampRange([child_brush_zoom_anchor.x + (child_brush_x[0] - child_brush_zoom_anchor.x) * child_brush_zoom_delta, child_brush_zoom_anchor.x + (child_brush_x[1] - child_brush_zoom_anchor.x) * child_brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "child_brush_size",
+                                    "value": [],
+                                    "on": [
+                                        {
+                                            "events": {
+                                                "source": "scope",
+                                                "type": "mousedown",
+                                                "filter": [
+                                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
+                                                ]
+                                            },
+                                            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
+                                        },
+                                        {
+                                            "events": {
+                                                "source": "window",
+                                                "type": "mousemove",
+                                                "consume": true,
+                                                "between": [
+                                                    {
+                                                        "source": "scope",
+                                                        "type": "mousedown",
+                                                        "filter": [
+                                                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
+                                                        ]
+                                                    },
+                                                    {
+                                                        "source": "window",
+                                                        "type": "mouseup"
+                                                    }
+                                                ]
+                                            },
+                                            "update": "{x: child_brush_size.x, y: child_brush_size.y, width: abs(x(unit) - child_brush_size.x), height: abs(y(unit) - child_brush_size.y)}"
+                                        },
+                                        {
+                                            "events": {
+                                                "signal": "child_brush_zoom_delta"
+                                            },
+                                            "update": "{x: child_brush_size.x, y: child_brush_size.y, width: child_brush_size.width * child_brush_zoom_delta , height: child_brush_size.height * child_brush_zoom_delta}"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "child_brush",
+                                    "update": "[{field: \"X\", extent: child_brush_x}]"
+                                },
+                                {
+                                    "name": "child_brush_translate_anchor",
+                                    "value": {},
+                                    "on": [
+                                        {
+                                            "events": [
                                                 {
                                                     "source": "scope",
                                                     "type": "mousedown",
                                                     "markname": "child_brush_brush"
-                                                },
+                                                }
+                                            ],
+                                            "update": "{x: x(unit), y: y(unit), width: child_brush_size.width, height: child_brush_size.height, extent_x: slice(child_brush_x), }"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "child_brush_translate_delta",
+                                    "value": {},
+                                    "on": [
+                                        {
+                                            "events": [
                                                 {
                                                     "source": "window",
-                                                    "type": "mouseup"
+                                                    "type": "mousemove",
+                                                    "consume": true,
+                                                    "between": [
+                                                        {
+                                                            "source": "scope",
+                                                            "type": "mousedown",
+                                                            "markname": "child_brush_brush"
+                                                        },
+                                                        {
+                                                            "source": "window",
+                                                            "type": "mouseup"
+                                                        }
+                                                    ]
                                                 }
-                                            ]
+                                            ],
+                                            "update": "{x: x(unit) - child_brush_translate_anchor.x, y: y(unit) - child_brush_translate_anchor.y}"
                                         }
-                                    ],
-                                    "update": "{x: x(unit) - child_brush_translate_anchor.x, y: y(unit) - child_brush_translate_anchor.y}"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "child_brush_zoom_anchor",
-                            "on": [
-                                {
-                                    "events": [
-                                        {
-                                            "source": "scope",
-                                            "type": "wheel",
-                                            "markname": "child_brush_brush"
-                                        }
-                                    ],
-                                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "child_brush_zoom_delta",
-                            "on": [
-                                {
-                                    "events": [
-                                        {
-                                            "source": "scope",
-                                            "type": "wheel",
-                                            "markname": "child_brush_brush"
-                                        }
-                                    ],
-                                    "force": true,
-                                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "child_brush_tuple",
-                            "on": [
-                                {
-                                    "events": {
-                                        "signal": "child_brush"
-                                    },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: child_brush}"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "child_brush_modify",
-                            "on": [
-                                {
-                                    "events": {
-                                        "signal": "child_brush"
-                                    },
-                                    "update": "modify(\"child_brush_store\", child_brush_tuple, {unit: child_brush_tuple.unit})"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "child_grid_x",
-                            "on": [
-                                {
-                                    "events": {
-                                        "signal": "child_grid_translate_delta"
-                                    },
-                                    "update": "[child_grid_translate_anchor.extent_x[0] - abs(span(child_grid_translate_anchor.extent_x)) * child_grid_translate_delta.x / child_grid_translate_anchor.width, child_grid_translate_anchor.extent_x[1] - abs(span(child_grid_translate_anchor.extent_x)) * child_grid_translate_delta.x / child_grid_translate_anchor.width]"
+                                    ]
                                 },
                                 {
-                                    "events": {
-                                        "signal": "child_grid_zoom_delta"
-                                    },
-                                    "update": "[child_grid_zoom_anchor.x + (domain(\"x\")[0] - child_grid_zoom_anchor.x) * child_grid_zoom_delta, child_grid_zoom_anchor.x + (domain(\"x\")[1] - child_grid_zoom_anchor.x) * child_grid_zoom_delta]"
-                                }
-                            ],
-                            "push": "outer"
-                        },
-                        {
-                            "name": "child_grid_y",
-                            "on": [
-                                {
-                                    "events": {
-                                        "signal": "child_grid_translate_delta"
-                                    },
-                                    "update": "[child_grid_translate_anchor.extent_y[0] + abs(span(child_grid_translate_anchor.extent_y)) * child_grid_translate_delta.y / child_grid_translate_anchor.height, child_grid_translate_anchor.extent_y[1] + abs(span(child_grid_translate_anchor.extent_y)) * child_grid_translate_delta.y / child_grid_translate_anchor.height]"
+                                    "name": "child_brush_zoom_anchor",
+                                    "on": [
+                                        {
+                                            "events": [
+                                                {
+                                                    "source": "scope",
+                                                    "type": "wheel",
+                                                    "markname": "child_brush_brush"
+                                                }
+                                            ],
+                                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                                        }
+                                    ]
                                 },
                                 {
-                                    "events": {
-                                        "signal": "child_grid_zoom_delta"
-                                    },
-                                    "update": "[child_grid_zoom_anchor.y + (domain(\"y\")[0] - child_grid_zoom_anchor.y) * child_grid_zoom_delta, child_grid_zoom_anchor.y + (domain(\"y\")[1] - child_grid_zoom_anchor.y) * child_grid_zoom_delta]"
-                                }
-                            ],
-                            "push": "outer"
-                        },
-                        {
-                            "name": "child_grid",
-                            "update": "[{field: \"X\", extent: child_grid_x}, {field: \"Y\", extent: child_grid_y}]"
-                        },
-                        {
-                            "name": "child_grid_translate_anchor",
-                            "value": {},
-                            "on": [
-                                {
-                                    "events": [
+                                    "name": "child_brush_zoom_delta",
+                                    "on": [
                                         {
-                                            "source": "scope",
-                                            "type": "mousedown",
-                                            "filter": [
-                                                "event.shiftKey"
-                                            ]
+                                            "events": [
+                                                {
+                                                    "source": "scope",
+                                                    "type": "wheel",
+                                                    "markname": "child_brush_brush"
+                                                }
+                                            ],
+                                            "force": true,
+                                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "child_brush_tuple",
+                                    "on": [
+                                        {
+                                            "events": {
+                                                "signal": "child_brush"
+                                            },
+                                            "update": "{unit: unit.datum && unit.datum._id, intervals: child_brush}"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "child_brush_modify",
+                                    "on": [
+                                        {
+                                            "events": {
+                                                "signal": "child_brush"
+                                            },
+                                            "update": "modify(\"child_brush_store\", child_brush_tuple, {unit: child_brush_tuple.unit})"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "child_grid_x",
+                                    "on": [
+                                        {
+                                            "events": {
+                                                "signal": "child_grid_translate_delta"
+                                            },
+                                            "update": "[child_grid_translate_anchor.extent_x[0] - abs(span(child_grid_translate_anchor.extent_x)) * child_grid_translate_delta.x / child_grid_translate_anchor.width, child_grid_translate_anchor.extent_x[1] - abs(span(child_grid_translate_anchor.extent_x)) * child_grid_translate_delta.x / child_grid_translate_anchor.width]"
+                                        },
+                                        {
+                                            "events": {
+                                                "signal": "child_grid_zoom_delta"
+                                            },
+                                            "update": "[child_grid_zoom_anchor.x + (domain(\"x\")[0] - child_grid_zoom_anchor.x) * child_grid_zoom_delta, child_grid_zoom_anchor.x + (domain(\"x\")[1] - child_grid_zoom_anchor.x) * child_grid_zoom_delta]"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "child_grid_translate_delta",
-                            "value": {},
-                            "on": [
+                                    "push": "outer"
+                                },
                                 {
-                                    "events": [
+                                    "name": "child_grid_y",
+                                    "on": [
                                         {
-                                            "source": "scope",
-                                            "type": "mousemove",
-                                            "between": [
+                                            "events": {
+                                                "signal": "child_grid_translate_delta"
+                                            },
+                                            "update": "[child_grid_translate_anchor.extent_y[0] + abs(span(child_grid_translate_anchor.extent_y)) * child_grid_translate_delta.y / child_grid_translate_anchor.height, child_grid_translate_anchor.extent_y[1] + abs(span(child_grid_translate_anchor.extent_y)) * child_grid_translate_delta.y / child_grid_translate_anchor.height]"
+                                        },
+                                        {
+                                            "events": {
+                                                "signal": "child_grid_zoom_delta"
+                                            },
+                                            "update": "[child_grid_zoom_anchor.y + (domain(\"y\")[0] - child_grid_zoom_anchor.y) * child_grid_zoom_delta, child_grid_zoom_anchor.y + (domain(\"y\")[1] - child_grid_zoom_anchor.y) * child_grid_zoom_delta]"
+                                        }
+                                    ],
+                                    "push": "outer"
+                                },
+                                {
+                                    "name": "child_grid",
+                                    "update": "[{field: \"X\", extent: child_grid_x}, {field: \"Y\", extent: child_grid_y}]"
+                                },
+                                {
+                                    "name": "child_grid_translate_anchor",
+                                    "value": {},
+                                    "on": [
+                                        {
+                                            "events": [
                                                 {
                                                     "source": "scope",
                                                     "type": "mousedown",
                                                     "filter": [
                                                         "event.shiftKey"
                                                     ]
-                                                },
-                                                {
-                                                    "source": "scope",
-                                                    "type": "mouseup"
-                                                }
-                                            ]
-                                        }
-                                    ],
-                                    "update": "{x: x(unit) - child_grid_translate_anchor.x, y: y(unit) - child_grid_translate_anchor.y}"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "child_grid_zoom_anchor",
-                            "on": [
-                                {
-                                    "events": [
-                                        {
-                                            "source": "scope",
-                                            "type": "wheel"
-                                        }
-                                    ],
-                                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "child_grid_zoom_delta",
-                            "on": [
-                                {
-                                    "events": [
-                                        {
-                                            "source": "scope",
-                                            "type": "wheel"
-                                        }
-                                    ],
-                                    "force": true,
-                                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "child_grid_tuple",
-                            "on": [
-                                {
-                                    "events": {
-                                        "signal": "child_grid"
-                                    },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: child_grid}"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "child_grid_modify",
-                            "on": [
-                                {
-                                    "events": {
-                                        "signal": "child_grid"
-                                    },
-                                    "update": "modify(\"child_grid_store\", child_grid_tuple, true)"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "child_xenc",
-                            "update": "{fields: [\"X\"], values: [child_xenc_X]}"
-                        },
-                        {
-                            "name": "child_xenc_tuple",
-                            "on": [
-                                {
-                                    "events": {
-                                        "signal": "child_xenc"
-                                    },
-                                    "update": "{unit: unit.datum && unit.datum._id, fields: child_xenc.fields, values: child_xenc.values, X: child_xenc.values[0]}"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "child_xenc_modify",
-                            "on": [
-                                {
-                                    "events": {
-                                        "signal": "child_xenc"
-                                    },
-                                    "update": "modify(\"child_xenc_store\", child_xenc_tuple, true)"
-                                }
-                            ]
-                        }
-                    ],
-                    "marks": [
-                        {
-                            "type": "group",
-                            "encode": {
-                                "enter": {
-                                    "width": {
-                                        "field": {
-                                            "group": "width"
-                                        }
-                                    },
-                                    "height": {
-                                        "field": {
-                                            "group": "height"
-                                        }
-                                    },
-                                    "fill": {
-                                        "value": "transparent"
-                                    },
-                                    "clip": {
-                                        "value": true
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "type": "rect",
-                                    "encode": {
-                                        "enter": {
-                                            "fill": {
-                                                "value": "#eee"
-                                            }
-                                        },
-                                        "update": {
-                                            "x": {
-                                                "scale": "x",
-                                                "signal": "child_brush[0].extent[0]"
-                                            },
-                                            "x2": {
-                                                "scale": "x",
-                                                "signal": "child_brush[0].extent[1]"
-                                            },
-                                            "y": {
-                                                "value": 0
-                                            },
-                                            "y2": {
-                                                "field": {
-                                                    "group": "height"
-                                                }
-                                            }
-                                        }
-                                    }
-                                },
-                                {
-                                    "name": "child_marks",
-                                    "type": "symbol",
-                                    "role": "circle",
-                                    "from": {
-                                        "data": "facet"
-                                    },
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "scale": "x",
-                                                "field": "X"
-                                            },
-                                            "y": {
-                                                "scale": "y",
-                                                "field": "Y"
-                                            },
-                                            "fill": [
-                                                {
-                                                    "test": "vlPoint(\"child_xenc_store\", parent._id, datum, \"union\", \"all\")",
-                                                    "value": "red"
-                                                },
-                                                {
-                                                    "value": "steelblue"
                                                 }
                                             ],
-                                            "size": [
-                                                {
-                                                    "test": "vlInterval(\"child_brush_store\", parent._id, datum, \"intersect\", \"all\")",
-                                                    "value": 250
-                                                },
-                                                {
-                                                    "value": 100
-                                                }
-                                            ],
-                                            "shape": {
-                                                "value": "circle"
-                                            }
-                                        }
-                                    }
-                                },
-                                {
-                                    "name": "child_voronoi",
-                                    "type": "path",
-                                    "from": {
-                                        "data": "child_marks"
-                                    },
-                                    "encode": {
-                                        "enter": {
-                                            "fill": {
-                                                "value": "transparent"
-                                            },
-                                            "strokeWidth": {
-                                                "value": 0.35
-                                            },
-                                            "stroke": {
-                                                "value": "transparent"
-                                            },
-                                            "isVoronoi": {
-                                                "value": true
-                                            }
-                                        }
-                                    },
-                                    "transform": [
-                                        {
-                                            "type": "voronoi",
-                                            "x": "datum.x",
-                                            "y": "datum.y",
-                                            "size": [
-                                                {
-                                                    "signal": "width"
-                                                },
-                                                {
-                                                    "signal": "height"
-                                                }
-                                            ]
+                                            "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
                                         }
                                     ]
                                 },
                                 {
-                                    "name": "child_brush_brush",
-                                    "type": "rect",
+                                    "name": "child_grid_translate_delta",
+                                    "value": {},
+                                    "on": [
+                                        {
+                                            "events": [
+                                                {
+                                                    "source": "scope",
+                                                    "type": "mousemove",
+                                                    "between": [
+                                                        {
+                                                            "source": "scope",
+                                                            "type": "mousedown",
+                                                            "filter": [
+                                                                "event.shiftKey"
+                                                            ]
+                                                        },
+                                                        {
+                                                            "source": "scope",
+                                                            "type": "mouseup"
+                                                        }
+                                                    ]
+                                                }
+                                            ],
+                                            "update": "{x: x(unit) - child_grid_translate_anchor.x, y: y(unit) - child_grid_translate_anchor.y}"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "child_grid_zoom_anchor",
+                                    "on": [
+                                        {
+                                            "events": [
+                                                {
+                                                    "source": "scope",
+                                                    "type": "wheel"
+                                                }
+                                            ],
+                                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "child_grid_zoom_delta",
+                                    "on": [
+                                        {
+                                            "events": [
+                                                {
+                                                    "source": "scope",
+                                                    "type": "wheel"
+                                                }
+                                            ],
+                                            "force": true,
+                                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "child_grid_tuple",
+                                    "on": [
+                                        {
+                                            "events": {
+                                                "signal": "child_grid"
+                                            },
+                                            "update": "{unit: unit.datum && unit.datum._id, intervals: child_grid}"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "child_grid_modify",
+                                    "on": [
+                                        {
+                                            "events": {
+                                                "signal": "child_grid"
+                                            },
+                                            "update": "modify(\"child_grid_store\", child_grid_tuple, true)"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "child_xenc",
+                                    "update": "{fields: [\"X\"], values: [child_xenc_X]}"
+                                },
+                                {
+                                    "name": "child_xenc_tuple",
+                                    "on": [
+                                        {
+                                            "events": {
+                                                "signal": "child_xenc"
+                                            },
+                                            "update": "{unit: unit.datum && unit.datum._id, fields: child_xenc.fields, values: child_xenc.values, X: child_xenc.values[0]}"
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "child_xenc_modify",
+                                    "on": [
+                                        {
+                                            "events": {
+                                                "signal": "child_xenc"
+                                            },
+                                            "update": "modify(\"child_xenc_store\", child_xenc_tuple, true)"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "marks": [
+                                {
+                                    "type": "group",
                                     "encode": {
                                         "enter": {
-                                            "fill": {
-                                                "value": "transparent"
-                                            }
-                                        },
-                                        "update": {
-                                            "x": {
-                                                "scale": "x",
-                                                "signal": "child_brush[0].extent[0]"
+                                            "width": {
+                                                "field": {
+                                                    "group": "width"
+                                                }
                                             },
-                                            "x2": {
-                                                "scale": "x",
-                                                "signal": "child_brush[0].extent[1]"
-                                            },
-                                            "y": {
-                                                "value": 0
-                                            },
-                                            "y2": {
+                                            "height": {
                                                 "field": {
                                                     "group": "height"
                                                 }
+                                            },
+                                            "fill": {
+                                                "value": "transparent"
+                                            },
+                                            "clip": {
+                                                "value": true
                                             }
                                         }
-                                    }
+                                    },
+                                    "marks": [
+                                        {
+                                            "type": "rect",
+                                            "encode": {
+                                                "enter": {
+                                                    "fill": {
+                                                        "value": "#eee"
+                                                    }
+                                                },
+                                                "update": {
+                                                    "x": {
+                                                        "scale": "x",
+                                                        "signal": "child_brush[0].extent[0]"
+                                                    },
+                                                    "x2": {
+                                                        "scale": "x",
+                                                        "signal": "child_brush[0].extent[1]"
+                                                    },
+                                                    "y": {
+                                                        "value": 0
+                                                    },
+                                                    "y2": {
+                                                        "field": {
+                                                            "group": "height"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "name": "child_marks",
+                                            "type": "symbol",
+                                            "role": "circle",
+                                            "from": {
+                                                "data": "facet"
+                                            },
+                                            "encode": {
+                                                "update": {
+                                                    "x": {
+                                                        "scale": "x",
+                                                        "field": "X"
+                                                    },
+                                                    "y": {
+                                                        "scale": "y",
+                                                        "field": "Y"
+                                                    },
+                                                    "fill": [
+                                                        {
+                                                            "test": "vlPoint(\"child_xenc_store\", parent._id, datum, \"union\", \"all\")",
+                                                            "value": "red"
+                                                        },
+                                                        {
+                                                            "value": "steelblue"
+                                                        }
+                                                    ],
+                                                    "size": [
+                                                        {
+                                                            "test": "vlInterval(\"child_brush_store\", parent._id, datum, \"intersect\", \"all\")",
+                                                            "value": 250
+                                                        },
+                                                        {
+                                                            "value": 100
+                                                        }
+                                                    ],
+                                                    "shape": {
+                                                        "value": "circle"
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "name": "child_voronoi",
+                                            "type": "path",
+                                            "from": {
+                                                "data": "child_marks"
+                                            },
+                                            "encode": {
+                                                "enter": {
+                                                    "fill": {
+                                                        "value": "transparent"
+                                                    },
+                                                    "strokeWidth": {
+                                                        "value": 0.35
+                                                    },
+                                                    "stroke": {
+                                                        "value": "transparent"
+                                                    },
+                                                    "isVoronoi": {
+                                                        "value": true
+                                                    }
+                                                }
+                                            },
+                                            "transform": [
+                                                {
+                                                    "type": "voronoi",
+                                                    "x": "datum.x",
+                                                    "y": "datum.y",
+                                                    "size": [
+                                                        {
+                                                            "signal": "width"
+                                                        },
+                                                        {
+                                                            "signal": "height"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "name": "child_brush_brush",
+                                            "type": "rect",
+                                            "encode": {
+                                                "enter": {
+                                                    "fill": {
+                                                        "value": "transparent"
+                                                    }
+                                                },
+                                                "update": {
+                                                    "x": {
+                                                        "scale": "x",
+                                                        "signal": "child_brush[0].extent[0]"
+                                                    },
+                                                    "x2": {
+                                                        "scale": "x",
+                                                        "signal": "child_brush[0].extent[1]"
+                                                    },
+                                                    "y": {
+                                                        "value": 0
+                                                    },
+                                                    "y2": {
+                                                        "field": {
+                                                            "group": "height"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ],
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "domain": false,
+                                    "format": "s",
+                                    "grid": true,
+                                    "labels": false,
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "ticks": false,
+                                    "zindex": 0,
+                                    "gridScale": "y"
+                                },
+                                {
+                                    "scale": "y",
+                                    "domain": false,
+                                    "format": "s",
+                                    "grid": true,
+                                    "labels": false,
+                                    "orient": "left",
+                                    "ticks": false,
+                                    "zindex": 0,
+                                    "gridScale": "x"
                                 }
                             ]
                         }
-                    ],
-                    "axes": [
+                    ]
+                },
+                {
+                    "name": "column-title",
+                    "role": "column-header",
+                    "type": "group",
+                    "marks": [
                         {
-                            "scale": "x",
-                            "domain": false,
-                            "format": "s",
-                            "grid": true,
-                            "labels": false,
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "ticks": false,
-                            "zindex": 0,
-                            "gridScale": "y"
-                        },
-                        {
-                            "scale": "y",
-                            "domain": false,
-                            "format": "s",
-                            "grid": true,
-                            "labels": false,
-                            "orient": "left",
-                            "ticks": false,
-                            "zindex": 0,
-                            "gridScale": "x"
+                            "type": "text",
+                            "role": "column-labels",
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "signal": "0.5 * width"
+                                    },
+                                    "text": {
+                                        "value": "Series"
+                                    },
+                                    "align": {
+                                        "value": "center"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    }
+                                }
+                            }
                         }
                     ]
                 }
             ],
             "scales": [
-                {
-                    "name": "column",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Series",
-                        "sort": true
-                    },
-                    "range": "width",
-                    "round": true
-                },
                 {
                     "name": "x",
                     "type": "linear",
@@ -847,17 +905,6 @@
                     "domainRaw": {
                         "signal": "child_grid_y"
                     }
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "column",
-                    "domain": false,
-                    "grid": false,
-                    "orient": "top",
-                    "ticks": false,
-                    "title": "Series",
-                    "zindex": 1
                 }
             ]
         }

--- a/examples/vg-specs/layer_bar_line.vg.json
+++ b/examples/vg-specs/layer_bar_line.vg.json
@@ -64,8 +64,7 @@
                 }
             ],
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         },
         {

--- a/examples/vg-specs/layer_bar_line_union.vg.json
+++ b/examples/vg-specs/layer_bar_line_union.vg.json
@@ -73,8 +73,7 @@
                 }
             ],
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         },
         {

--- a/examples/vg-specs/layer_histogram.vg.json
+++ b/examples/vg-specs/layer_histogram.vg.json
@@ -27,8 +27,7 @@
             "name": "source_0",
             "url": "data/flights-2k.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         },
         {

--- a/examples/vg-specs/layer_line_color_rule.vg.json
+++ b/examples/vg-specs/layer_line_color_rule.vg.json
@@ -27,8 +27,7 @@
             "name": "source_0",
             "url": "data/stocks.csv",
             "format": {
-                "type": "csv",
-                "parse": {}
+                "type": "csv"
             }
         },
         {

--- a/examples/vg-specs/layer_overlay.vg.json
+++ b/examples/vg-specs/layer_overlay.vg.json
@@ -42,14 +42,20 @@
                 {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
-                },
+                }
+            ]
+        },
+        {
+            "name": "data_1",
+            "source": "data_0",
+            "transform": [
                 {
                     "type": "aggregate",
                     "groupby": [
                         "Cylinders"
                     ],
                     "ops": [
-                        "max"
+                        "min"
                     ],
                     "fields": [
                         "Horsepower"
@@ -61,33 +67,6 @@
                         "field": "Cylinders",
                         "order": "descending"
                     }
-                }
-            ]
-        },
-        {
-            "name": "data_1",
-            "source": "source_0",
-            "transform": [
-                {
-                    "type": "formula",
-                    "expr": "toNumber(datum[\"Horsepower\"])",
-                    "as": "Horsepower"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
-                },
-                {
-                    "type": "aggregate",
-                    "groupby": [
-                        "Cylinders"
-                    ],
-                    "ops": [
-                        "max"
-                    ],
-                    "fields": [
-                        "Horsepower"
-                    ]
                 }
             ]
         },
@@ -103,7 +82,13 @@
                 {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
-                },
+                }
+            ]
+        },
+        {
+            "name": "data_3",
+            "source": "data_2",
+            "transform": [
                 {
                     "type": "aggregate",
                     "groupby": [
@@ -115,18 +100,11 @@
                     "fields": [
                         "Horsepower"
                     ]
-                },
-                {
-                    "type": "collect",
-                    "sort": {
-                        "field": "Cylinders",
-                        "order": "descending"
-                    }
                 }
             ]
         },
         {
-            "name": "data_3",
+            "name": "data_4",
             "source": "source_0",
             "transform": [
                 {
@@ -144,7 +122,41 @@
                         "Cylinders"
                     ],
                     "ops": [
-                        "min"
+                        "max"
+                    ],
+                    "fields": [
+                        "Horsepower"
+                    ]
+                },
+                {
+                    "type": "collect",
+                    "sort": {
+                        "field": "Cylinders",
+                        "order": "descending"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "data_5",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "formula",
+                    "expr": "toNumber(datum[\"Horsepower\"])",
+                    "as": "Horsepower"
+                },
+                {
+                    "type": "filter",
+                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
+                },
+                {
+                    "type": "aggregate",
+                    "groupby": [
+                        "Cylinders"
+                    ],
+                    "ops": [
+                        "max"
                     ],
                     "fields": [
                         "Horsepower"
@@ -249,7 +261,7 @@
                                     "name": "layer_0_layer_0_marks",
                                     "type": "line",
                                     "from": {
-                                        "data": "data_0"
+                                        "data": "data_4"
                                     },
                                     "encode": {
                                         "update": {
@@ -272,7 +284,7 @@
                                     "type": "symbol",
                                     "role": "pointOverlay",
                                     "from": {
-                                        "data": "data_1"
+                                        "data": "data_5"
                                     },
                                     "encode": {
                                         "update": {
@@ -319,7 +331,7 @@
                                     "name": "layer_1_layer_0_marks",
                                     "type": "line",
                                     "from": {
-                                        "data": "data_2"
+                                        "data": "data_1"
                                     },
                                     "encode": {
                                         "update": {
@@ -373,15 +385,15 @@
                         "fields": [
                             {
                                 "field": "Cylinders",
-                                "data": "data_0"
+                                "data": "data_4"
+                            },
+                            {
+                                "field": "Cylinders",
+                                "data": "data_5"
                             },
                             {
                                 "field": "Cylinders",
                                 "data": "data_1"
-                            },
-                            {
-                                "field": "Cylinders",
-                                "data": "data_2"
                             },
                             {
                                 "field": "Cylinders",
@@ -403,15 +415,15 @@
                         "fields": [
                             {
                                 "field": "max_Horsepower",
-                                "data": "data_0"
+                                "data": "data_4"
                             },
                             {
                                 "field": "max_Horsepower",
-                                "data": "data_1"
+                                "data": "data_5"
                             },
                             {
                                 "field": "min_Horsepower",
-                                "data": "data_2"
+                                "data": "data_1"
                             },
                             {
                                 "field": "min_Horsepower",

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -58,8 +58,7 @@
             "name": "source_0",
             "url": "data/cars.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         },
         {

--- a/examples/vg-specs/line_quarter.vg.json
+++ b/examples/vg-specs/line_quarter.vg.json
@@ -342,7 +342,7 @@
                     "marks": [
                         {
                             "type": "text",
-                            "role": "column-labels",
+                            "role": "column-title",
                             "encode": {
                                 "update": {
                                     "x": {

--- a/examples/vg-specs/line_quarter.vg.json
+++ b/examples/vg-specs/line_quarter.vg.json
@@ -103,7 +103,7 @@
                 {
                     "type": "formula",
                     "as": "width",
-                    "expr": "(datum[\"child_width\"] + 16) * datum[\"distinct_year_date\"]"
+                    "expr": "(datum[\"child_width\"] + 5) * datum[\"distinct_year_date\"]"
                 },
                 {
                     "type": "formula",
@@ -113,7 +113,7 @@
                 {
                     "type": "formula",
                     "as": "height",
-                    "expr": "datum[\"child_height\"] + 16"
+                    "expr": "datum[\"child_height\"] + 5"
                 }
             ]
         }
@@ -136,189 +136,247 @@
                     }
                 }
             },
+            "signals": [
+                {
+                    "name": "column",
+                    "update": "data('layout')[0].distinct_year_date"
+                }
+            ],
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10,
+                    "header": 10
+                },
+                "columns": 1,
+                "bounds": "full"
+            },
             "marks": [
                 {
-                    "name": "x-axes",
                     "type": "group",
-                    "from": {
-                        "data": "column"
-                    },
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            },
-                            "x": {
-                                "scale": "column",
-                                "field": "year_date",
-                                "offset": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "x",
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "title": "QUARTER(date)",
-                            "zindex": 1,
-                            "encode": {
-                                "labels": {
-                                    "update": {
-                                        "text": {
-                                            "signal": "'Q' + quarter(datum.value)"
-                                        },
-                                        "angle": {
-                                            "value": 270
-                                        },
-                                        "align": {
-                                            "value": "right"
-                                        },
-                                        "baseline": {
-                                            "value": "middle"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                },
-                {
-                    "name": "y-axes",
-                    "type": "group",
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "y": {
-                                "value": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "y",
-                            "format": "s",
-                            "orient": "left",
-                            "title": "MEAN(price)",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "cell",
-                    "type": "group",
-                    "from": {
-                        "facet": {
-                            "name": "facet",
-                            "data": "source_0",
-                            "groupby": [
-                                "year_date"
-                            ]
-                        }
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "column",
-                                "field": "year_date",
-                                "offset": 8
-                            },
-                            "y": {
-                                "value": 8
-                            },
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "stroke": {
-                                "value": "#ccc"
-                            },
-                            "strokeWidth": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            }
-                        }
+                    "layout": {
+                        "padding": {
+                            "row": 10,
+                            "column": 10,
+                            "header": 10
+                        },
+                        "columns": {
+                            "signal": "column"
+                        },
+                        "bounds": "full"
                     },
                     "marks": [
                         {
-                            "name": "child_marks",
-                            "type": "symbol",
-                            "role": "point",
+                            "name": "x-axes",
+                            "type": "group",
+                            "role": "column-footer",
                             "from": {
-                                "data": "facet"
+                                "data": "column"
+                            },
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "title": "QUARTER(date)",
+                                    "zindex": 1,
+                                    "encode": {
+                                        "labels": {
+                                            "update": {
+                                                "text": {
+                                                    "signal": "'Q' + quarter(datum.value)"
+                                                },
+                                                "angle": {
+                                                    "value": 270
+                                                },
+                                                "align": {
+                                                    "value": "right"
+                                                },
+                                                "baseline": {
+                                                    "value": "middle"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "y-axes",
+                            "type": "group",
+                            "role": "row-header",
+                            "axes": [
+                                {
+                                    "scale": "y",
+                                    "format": "s",
+                                    "orient": "left",
+                                    "title": "MEAN(price)",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "column-labels",
+                            "role": "column-header",
+                            "type": "group",
+                            "from": {
+                                "data": "column"
                             },
                             "encode": {
                                 "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "quarter_date"
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "type": "text",
+                                    "role": "column-labels",
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "field": {
+                                                    "group": "width"
+                                                },
+                                                "mult": 0.5
+                                            },
+                                            "y": {
+                                                "value": -10
+                                            },
+                                            "text": {
+                                                "field": {
+                                                    "parent": "year_date"
+                                                }
+                                            },
+                                            "align": {
+                                                "value": "center"
+                                            },
+                                            "fill": {
+                                                "value": "black"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cell",
+                            "type": "group",
+                            "from": {
+                                "facet": {
+                                    "name": "facet",
+                                    "data": "source_0",
+                                    "groupby": [
+                                        "year_date"
+                                    ]
+                                }
+                            },
+                            "encode": {
+                                "update": {
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
                                     },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "mean_price"
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
                                     },
                                     "stroke": {
-                                        "scale": "color",
-                                        "field": "symbol"
+                                        "value": "#ccc"
+                                    },
+                                    "strokeWidth": {
+                                        "value": 1
                                     },
                                     "fill": {
                                         "value": "transparent"
                                     }
                                 }
-                            }
+                            },
+                            "marks": [
+                                {
+                                    "name": "child_marks",
+                                    "type": "symbol",
+                                    "role": "point",
+                                    "from": {
+                                        "data": "facet"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "quarter_date"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "mean_price"
+                                            },
+                                            "stroke": {
+                                                "scale": "color",
+                                                "field": "symbol"
+                                            },
+                                            "fill": {
+                                                "value": "transparent"
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "axes": [
+                                {
+                                    "scale": "y",
+                                    "domain": false,
+                                    "format": "s",
+                                    "grid": true,
+                                    "labels": false,
+                                    "orient": "left",
+                                    "ticks": false,
+                                    "zindex": 0,
+                                    "gridScale": "x"
+                                }
+                            ]
                         }
-                    ],
-                    "axes": [
+                    ]
+                },
+                {
+                    "name": "column-title",
+                    "role": "column-header",
+                    "type": "group",
+                    "marks": [
                         {
-                            "scale": "y",
-                            "domain": false,
-                            "format": "s",
-                            "grid": true,
-                            "labels": false,
-                            "orient": "left",
-                            "ticks": false,
-                            "zindex": 0,
-                            "gridScale": "x"
+                            "type": "text",
+                            "role": "column-labels",
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "signal": "0.5 * width"
+                                    },
+                                    "text": {
+                                        "value": "YEAR(date)"
+                                    },
+                                    "align": {
+                                        "value": "center"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    }
+                                }
+                            }
                         }
                     ]
                 }
             ],
             "scales": [
-                {
-                    "name": "column",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "year_date",
-                        "sort": true
-                    },
-                    "range": "width",
-                    "round": true
-                },
                 {
                     "name": "x",
                     "type": "point",
@@ -357,26 +415,6 @@
                         "sort": true
                     },
                     "range": "category"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "column",
-                    "domain": false,
-                    "grid": false,
-                    "orient": "top",
-                    "ticks": false,
-                    "title": "YEAR(date)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%Y')"
-                                }
-                            }
-                        }
-                    }
                 }
             ],
             "legends": [

--- a/examples/vg-specs/line_quarter.vg.json
+++ b/examples/vg-specs/line_quarter.vg.json
@@ -126,16 +126,6 @@
             "from": {
                 "data": "layout"
             },
-            "encode": {
-                "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    }
-                }
-            },
             "signals": [
                 {
                     "name": "column",

--- a/examples/vg-specs/overlay_area_full.vg.json
+++ b/examples/vg-specs/overlay_area_full.vg.json
@@ -27,8 +27,7 @@
             "name": "source_0",
             "url": "data/stocks.csv",
             "format": {
-                "type": "csv",
-                "parse": {}
+                "type": "csv"
             },
             "transform": [
                 {

--- a/examples/vg-specs/overlay_area_short.vg.json
+++ b/examples/vg-specs/overlay_area_short.vg.json
@@ -27,8 +27,7 @@
             "name": "source_0",
             "url": "data/stocks.csv",
             "format": {
-                "type": "csv",
-                "parse": {}
+                "type": "csv"
             },
             "transform": [
                 {

--- a/examples/vg-specs/overlay_line_full.vg.json
+++ b/examples/vg-specs/overlay_line_full.vg.json
@@ -27,8 +27,7 @@
             "name": "source_0",
             "url": "data/stocks.csv",
             "format": {
-                "type": "csv",
-                "parse": {}
+                "type": "csv"
             },
             "transform": [
                 {

--- a/examples/vg-specs/overlay_line_short.vg.json
+++ b/examples/vg-specs/overlay_line_short.vg.json
@@ -27,8 +27,7 @@
             "name": "source_0",
             "url": "data/stocks.csv",
             "format": {
-                "type": "csv",
-                "parse": {}
+                "type": "csv"
             },
             "transform": [
                 {

--- a/examples/vg-specs/scatter_connected.vg.json
+++ b/examples/vg-specs/scatter_connected.vg.json
@@ -27,8 +27,7 @@
             "name": "source_0",
             "url": "data/driving.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         },
         {

--- a/examples/vg-specs/trellis_anscombe.vg.json
+++ b/examples/vg-specs/trellis_anscombe.vg.json
@@ -306,7 +306,7 @@
                     "marks": [
                         {
                             "type": "text",
-                            "role": "column-labels",
+                            "role": "column-title",
                             "encode": {
                                 "update": {
                                     "x": {

--- a/examples/vg-specs/trellis_anscombe.vg.json
+++ b/examples/vg-specs/trellis_anscombe.vg.json
@@ -73,7 +73,7 @@
                 {
                     "type": "formula",
                     "as": "width",
-                    "expr": "(datum[\"child_width\"] + 16) * datum[\"distinct_Series\"]"
+                    "expr": "(datum[\"child_width\"] + 5) * datum[\"distinct_Series\"]"
                 },
                 {
                     "type": "formula",
@@ -83,7 +83,7 @@
                 {
                     "type": "formula",
                     "as": "height",
-                    "expr": "datum[\"child_height\"] + 16"
+                    "expr": "datum[\"child_height\"] + 5"
                 }
             ]
         }
@@ -106,183 +106,241 @@
                     }
                 }
             },
+            "signals": [
+                {
+                    "name": "column",
+                    "update": "data('layout')[0].distinct_Series"
+                }
+            ],
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10,
+                    "header": 10
+                },
+                "columns": 1,
+                "bounds": "full"
+            },
             "marks": [
                 {
-                    "name": "x-axes",
                     "type": "group",
-                    "from": {
-                        "data": "column"
-                    },
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            },
-                            "x": {
-                                "scale": "column",
-                                "field": "Series",
-                                "offset": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "x",
-                            "format": "s",
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "title": "X",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "y-axes",
-                    "type": "group",
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "y": {
-                                "value": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "y",
-                            "format": "s",
-                            "orient": "left",
-                            "title": "Y",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "cell",
-                    "type": "group",
-                    "from": {
-                        "facet": {
-                            "name": "facet",
-                            "data": "source_0",
-                            "groupby": [
-                                "Series"
-                            ]
-                        }
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "column",
-                                "field": "Series",
-                                "offset": 8
-                            },
-                            "y": {
-                                "value": 8
-                            },
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "stroke": {
-                                "value": "#ccc"
-                            },
-                            "strokeWidth": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            }
-                        }
+                    "layout": {
+                        "padding": {
+                            "row": 10,
+                            "column": 10,
+                            "header": 10
+                        },
+                        "columns": {
+                            "signal": "column"
+                        },
+                        "bounds": "full"
                     },
                     "marks": [
                         {
-                            "name": "child_marks",
-                            "type": "symbol",
-                            "role": "circle",
+                            "name": "x-axes",
+                            "type": "group",
+                            "role": "column-footer",
                             "from": {
-                                "data": "facet"
+                                "data": "column"
+                            },
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "format": "s",
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "title": "X",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "y-axes",
+                            "type": "group",
+                            "role": "row-header",
+                            "axes": [
+                                {
+                                    "scale": "y",
+                                    "format": "s",
+                                    "orient": "left",
+                                    "title": "Y",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "column-labels",
+                            "role": "column-header",
+                            "type": "group",
+                            "from": {
+                                "data": "column"
                             },
                             "encode": {
                                 "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "X"
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "type": "text",
+                                    "role": "column-labels",
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "field": {
+                                                    "group": "width"
+                                                },
+                                                "mult": 0.5
+                                            },
+                                            "y": {
+                                                "value": -10
+                                            },
+                                            "text": {
+                                                "field": {
+                                                    "parent": "Series"
+                                                }
+                                            },
+                                            "align": {
+                                                "value": "center"
+                                            },
+                                            "fill": {
+                                                "value": "black"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cell",
+                            "type": "group",
+                            "from": {
+                                "facet": {
+                                    "name": "facet",
+                                    "data": "source_0",
+                                    "groupby": [
+                                        "Series"
+                                    ]
+                                }
+                            },
+                            "encode": {
+                                "update": {
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
                                     },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "Y"
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
+                                    },
+                                    "stroke": {
+                                        "value": "#ccc"
+                                    },
+                                    "strokeWidth": {
+                                        "value": 1
                                     },
                                     "fill": {
-                                        "value": "#4c78a8"
+                                        "value": "transparent"
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "name": "child_marks",
+                                    "type": "symbol",
+                                    "role": "circle",
+                                    "from": {
+                                        "data": "facet"
                                     },
-                                    "shape": {
-                                        "value": "circle"
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "X"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "Y"
+                                            },
+                                            "fill": {
+                                                "value": "#4c78a8"
+                                            },
+                                            "shape": {
+                                                "value": "circle"
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "domain": false,
+                                    "format": "s",
+                                    "grid": true,
+                                    "labels": false,
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "ticks": false,
+                                    "zindex": 0,
+                                    "gridScale": "y"
+                                },
+                                {
+                                    "scale": "y",
+                                    "domain": false,
+                                    "format": "s",
+                                    "grid": true,
+                                    "labels": false,
+                                    "orient": "left",
+                                    "ticks": false,
+                                    "zindex": 0,
+                                    "gridScale": "x"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "column-title",
+                    "role": "column-header",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "column-labels",
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "signal": "0.5 * width"
+                                    },
+                                    "text": {
+                                        "value": "Series"
+                                    },
+                                    "align": {
+                                        "value": "center"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
                                     }
                                 }
                             }
-                        }
-                    ],
-                    "axes": [
-                        {
-                            "scale": "x",
-                            "domain": false,
-                            "format": "s",
-                            "grid": true,
-                            "labels": false,
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "ticks": false,
-                            "zindex": 0,
-                            "gridScale": "y"
-                        },
-                        {
-                            "scale": "y",
-                            "domain": false,
-                            "format": "s",
-                            "grid": true,
-                            "labels": false,
-                            "orient": "left",
-                            "ticks": false,
-                            "zindex": 0,
-                            "gridScale": "x"
                         }
                     ]
                 }
             ],
             "scales": [
-                {
-                    "name": "column",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Series",
-                        "sort": true
-                    },
-                    "range": "width",
-                    "round": true
-                },
                 {
                     "name": "x",
                     "type": "linear",
@@ -312,17 +370,6 @@
                     "round": true,
                     "nice": true,
                     "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "column",
-                    "domain": false,
-                    "grid": false,
-                    "orient": "top",
-                    "ticks": false,
-                    "title": "Series",
-                    "zindex": 1
                 }
             ]
         }

--- a/examples/vg-specs/trellis_anscombe.vg.json
+++ b/examples/vg-specs/trellis_anscombe.vg.json
@@ -96,16 +96,6 @@
             "from": {
                 "data": "layout"
             },
-            "encode": {
-                "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    }
-                }
-            },
             "signals": [
                 {
                     "name": "column",

--- a/examples/vg-specs/trellis_bar.vg.json
+++ b/examples/vg-specs/trellis_bar.vg.json
@@ -349,7 +349,7 @@
                     "marks": [
                         {
                             "type": "text",
-                            "role": "row-labels",
+                            "role": "row-title",
                             "encode": {
                                 "update": {
                                     "y": {

--- a/examples/vg-specs/trellis_bar.vg.json
+++ b/examples/vg-specs/trellis_bar.vg.json
@@ -140,16 +140,6 @@
             "from": {
                 "data": "layout"
             },
-            "encode": {
-                "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    }
-                }
-            },
             "layout": {
                 "padding": {
                     "row": 10,

--- a/examples/vg-specs/trellis_bar.vg.json
+++ b/examples/vg-specs/trellis_bar.vg.json
@@ -117,7 +117,7 @@
                 {
                     "type": "formula",
                     "as": "width",
-                    "expr": "datum[\"child_width\"] + 16"
+                    "expr": "datum[\"child_width\"] + 5"
                 },
                 {
                     "type": "formula",
@@ -127,7 +127,7 @@
                 {
                     "type": "formula",
                     "as": "height",
-                    "expr": "(datum[\"child_height\"] + 16) * datum[\"distinct_gender\"]"
+                    "expr": "(datum[\"child_height\"] + 5) * datum[\"distinct_gender\"]"
                 }
             ]
         }
@@ -150,190 +150,243 @@
                     }
                 }
             },
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10,
+                    "header": 10
+                },
+                "columns": 1,
+                "bounds": "full"
+            },
             "marks": [
                 {
-                    "name": "x-axes",
                     "type": "group",
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            },
-                            "x": {
-                                "value": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "x",
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "title": "age",
-                            "zindex": 1,
-                            "encode": {
-                                "labels": {
-                                    "update": {
-                                        "angle": {
-                                            "value": 270
-                                        },
-                                        "align": {
-                                            "value": "right"
-                                        },
-                                        "baseline": {
-                                            "value": "middle"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                },
-                {
-                    "name": "y-axes",
-                    "type": "group",
-                    "from": {
-                        "data": "row"
-                    },
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "y": {
-                                "scale": "row",
-                                "field": "gender",
-                                "offset": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "y",
-                            "format": "s",
-                            "orient": "left",
-                            "title": "population",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "cell",
-                    "type": "group",
-                    "from": {
-                        "facet": {
-                            "name": "facet",
-                            "data": "source_0",
-                            "groupby": [
-                                "gender"
-                            ]
-                        }
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "value": 8
-                            },
-                            "y": {
-                                "scale": "row",
-                                "field": "gender",
-                                "offset": 8
-                            },
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "stroke": {
-                                "value": "#ccc"
-                            },
-                            "strokeWidth": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            }
-                        }
+                    "layout": {
+                        "padding": {
+                            "row": 10,
+                            "column": 10,
+                            "header": 10
+                        },
+                        "columns": 1,
+                        "bounds": "full"
                     },
                     "marks": [
                         {
-                            "name": "child_marks",
-                            "type": "rect",
-                            "role": "bar",
+                            "name": "x-axes",
+                            "type": "group",
+                            "role": "column-footer",
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "title": "age",
+                                    "zindex": 1,
+                                    "encode": {
+                                        "labels": {
+                                            "update": {
+                                                "angle": {
+                                                    "value": 270
+                                                },
+                                                "align": {
+                                                    "value": "right"
+                                                },
+                                                "baseline": {
+                                                    "value": "middle"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "y-axes",
+                            "type": "group",
+                            "role": "row-header",
                             "from": {
-                                "data": "facet"
+                                "data": "row"
+                            },
+                            "axes": [
+                                {
+                                    "scale": "y",
+                                    "format": "s",
+                                    "orient": "left",
+                                    "title": "population",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "row-labels",
+                            "role": "row-header",
+                            "type": "group",
+                            "from": {
+                                "data": "row"
                             },
                             "encode": {
                                 "update": {
-                                    "xc": {
-                                        "scale": "x",
-                                        "field": "age"
-                                    },
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "type": "text",
+                                    "role": "row-labels",
+                                    "encode": {
+                                        "update": {
+                                            "y": {
+                                                "field": {
+                                                    "group": "height"
+                                                },
+                                                "mult": 0.5
+                                            },
+                                            "x": {
+                                                "value": -10
+                                            },
+                                            "text": {
+                                                "field": {
+                                                    "parent": "gender"
+                                                }
+                                            },
+                                            "align": {
+                                                "value": "right"
+                                            },
+                                            "fill": {
+                                                "value": "black"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cell",
+                            "type": "group",
+                            "from": {
+                                "facet": {
+                                    "name": "facet",
+                                    "data": "source_0",
+                                    "groupby": [
+                                        "gender"
+                                    ]
+                                }
+                            },
+                            "encode": {
+                                "update": {
                                     "width": {
-                                        "value": 16
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
                                     },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "sum_people_end"
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
                                     },
-                                    "y2": {
-                                        "scale": "y",
-                                        "field": "sum_people_start"
+                                    "stroke": {
+                                        "value": "#ccc"
+                                    },
+                                    "strokeWidth": {
+                                        "value": 1
                                     },
                                     "fill": {
-                                        "scale": "color",
-                                        "field": "gender"
+                                        "value": "transparent"
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "name": "child_marks",
+                                    "type": "rect",
+                                    "role": "bar",
+                                    "from": {
+                                        "data": "facet"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "xc": {
+                                                "scale": "x",
+                                                "field": "age"
+                                            },
+                                            "width": {
+                                                "value": 16
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "sum_people_end"
+                                            },
+                                            "y2": {
+                                                "scale": "y",
+                                                "field": "sum_people_start"
+                                            },
+                                            "fill": {
+                                                "scale": "color",
+                                                "field": "gender"
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "axes": [
+                                {
+                                    "scale": "y",
+                                    "domain": false,
+                                    "format": "s",
+                                    "grid": true,
+                                    "labels": false,
+                                    "orient": "left",
+                                    "ticks": false,
+                                    "zindex": 0,
+                                    "gridScale": "x"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "row-title",
+                    "role": "row-header",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "row-labels",
+                            "encode": {
+                                "update": {
+                                    "y": {
+                                        "signal": "0.5 * height"
+                                    },
+                                    "angle": {
+                                        "value": 270
+                                    },
+                                    "text": {
+                                        "value": "gender"
+                                    },
+                                    "align": {
+                                        "value": "right"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
                                     }
                                 }
                             }
-                        }
-                    ],
-                    "axes": [
-                        {
-                            "scale": "y",
-                            "domain": false,
-                            "format": "s",
-                            "grid": true,
-                            "labels": false,
-                            "orient": "left",
-                            "ticks": false,
-                            "zindex": 0,
-                            "gridScale": "x"
                         }
                     ]
                 }
             ],
             "scales": [
-                {
-                    "name": "row",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "gender",
-                        "sort": true
-                    },
-                    "range": "height",
-                    "round": true
-                },
                 {
                     "name": "x",
                     "type": "point",
@@ -378,32 +431,6 @@
                         "#EA98D2",
                         "#659CCA"
                     ]
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "row",
-                    "domain": false,
-                    "grid": false,
-                    "orient": "right",
-                    "ticks": false,
-                    "title": "gender",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 90
-                                },
-                                "align": {
-                                    "value": "center"
-                                },
-                                "baseline": {
-                                    "value": "bottom"
-                                }
-                            }
-                        }
-                    }
                 }
             ],
             "legends": [

--- a/examples/vg-specs/trellis_bar_histogram.vg.json
+++ b/examples/vg-specs/trellis_bar_histogram.vg.json
@@ -126,16 +126,6 @@
             "from": {
                 "data": "layout"
             },
-            "encode": {
-                "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    }
-                }
-            },
             "layout": {
                 "padding": {
                     "row": 10,

--- a/examples/vg-specs/trellis_bar_histogram.vg.json
+++ b/examples/vg-specs/trellis_bar_histogram.vg.json
@@ -336,7 +336,7 @@
                     "marks": [
                         {
                             "type": "text",
-                            "role": "row-labels",
+                            "role": "row-title",
                             "encode": {
                                 "update": {
                                     "y": {

--- a/examples/vg-specs/trellis_bar_histogram.vg.json
+++ b/examples/vg-specs/trellis_bar_histogram.vg.json
@@ -104,7 +104,7 @@
                 {
                     "type": "formula",
                     "as": "width",
-                    "expr": "datum[\"child_width\"] + 16"
+                    "expr": "datum[\"child_width\"] + 5"
                 },
                 {
                     "type": "formula",
@@ -114,7 +114,7 @@
                 {
                     "type": "formula",
                     "as": "height",
-                    "expr": "(datum[\"child_height\"] + 16) * datum[\"distinct_Origin\"]"
+                    "expr": "(datum[\"child_height\"] + 5) * datum[\"distinct_Origin\"]"
                 }
             ]
         }
@@ -136,191 +136,244 @@
                     }
                 }
             },
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10,
+                    "header": 10
+                },
+                "columns": 1,
+                "bounds": "full"
+            },
             "marks": [
                 {
-                    "name": "x-axes",
                     "type": "group",
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            },
-                            "x": {
-                                "value": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "x",
-                            "format": "s",
-                            "orient": "bottom",
-                            "title": "BIN(Horsepower)",
-                            "zindex": 1,
-                            "encode": {
-                                "labels": {
-                                    "update": {
-                                        "angle": {
-                                            "value": 270
-                                        },
-                                        "align": {
-                                            "value": "right"
-                                        },
-                                        "baseline": {
-                                            "value": "middle"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                },
-                {
-                    "name": "y-axes",
-                    "type": "group",
-                    "from": {
-                        "data": "row"
-                    },
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "y": {
-                                "scale": "row",
-                                "field": "Origin",
-                                "offset": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "y",
-                            "format": "s",
-                            "orient": "left",
-                            "title": "Number of Records",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "cell",
-                    "type": "group",
-                    "from": {
-                        "facet": {
-                            "name": "facet",
-                            "data": "source_0",
-                            "groupby": [
-                                "Origin"
-                            ]
-                        }
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "value": 8
-                            },
-                            "y": {
-                                "scale": "row",
-                                "field": "Origin",
-                                "offset": 8
-                            },
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "stroke": {
-                                "value": "#ccc"
-                            },
-                            "strokeWidth": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            }
-                        }
+                    "layout": {
+                        "padding": {
+                            "row": 10,
+                            "column": 10,
+                            "header": 10
+                        },
+                        "columns": 1,
+                        "bounds": "full"
                     },
                     "marks": [
                         {
-                            "name": "child_marks",
-                            "type": "rect",
-                            "role": "bar",
+                            "name": "x-axes",
+                            "type": "group",
+                            "role": "column-footer",
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "format": "s",
+                                    "orient": "bottom",
+                                    "title": "BIN(Horsepower)",
+                                    "zindex": 1,
+                                    "encode": {
+                                        "labels": {
+                                            "update": {
+                                                "angle": {
+                                                    "value": 270
+                                                },
+                                                "align": {
+                                                    "value": "right"
+                                                },
+                                                "baseline": {
+                                                    "value": "middle"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "y-axes",
+                            "type": "group",
+                            "role": "row-header",
                             "from": {
-                                "data": "facet"
+                                "data": "row"
+                            },
+                            "axes": [
+                                {
+                                    "scale": "y",
+                                    "format": "s",
+                                    "orient": "left",
+                                    "title": "Number of Records",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "row-labels",
+                            "role": "row-header",
+                            "type": "group",
+                            "from": {
+                                "data": "row"
                             },
                             "encode": {
                                 "update": {
-                                    "x2": {
-                                        "scale": "x",
-                                        "field": "bin_maxbins_15_Horsepower_start",
-                                        "offset": 1
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "type": "text",
+                                    "role": "row-labels",
+                                    "encode": {
+                                        "update": {
+                                            "y": {
+                                                "field": {
+                                                    "group": "height"
+                                                },
+                                                "mult": 0.5
+                                            },
+                                            "x": {
+                                                "value": -10
+                                            },
+                                            "text": {
+                                                "field": {
+                                                    "parent": "Origin"
+                                                }
+                                            },
+                                            "align": {
+                                                "value": "right"
+                                            },
+                                            "fill": {
+                                                "value": "black"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cell",
+                            "type": "group",
+                            "from": {
+                                "facet": {
+                                    "name": "facet",
+                                    "data": "source_0",
+                                    "groupby": [
+                                        "Origin"
+                                    ]
+                                }
+                            },
+                            "encode": {
+                                "update": {
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
                                     },
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "bin_maxbins_15_Horsepower_end"
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
                                     },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "count_*"
+                                    "stroke": {
+                                        "value": "#ccc"
                                     },
-                                    "y2": {
-                                        "scale": "y",
-                                        "value": 0
+                                    "strokeWidth": {
+                                        "value": 1
                                     },
                                     "fill": {
-                                        "value": "#4c78a8"
+                                        "value": "transparent"
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "name": "child_marks",
+                                    "type": "rect",
+                                    "role": "bar",
+                                    "from": {
+                                        "data": "facet"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "x2": {
+                                                "scale": "x",
+                                                "field": "bin_maxbins_15_Horsepower_start",
+                                                "offset": 1
+                                            },
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "bin_maxbins_15_Horsepower_end"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "count_*"
+                                            },
+                                            "y2": {
+                                                "scale": "y",
+                                                "value": 0
+                                            },
+                                            "fill": {
+                                                "value": "#4c78a8"
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "axes": [
+                                {
+                                    "scale": "y",
+                                    "domain": false,
+                                    "format": "s",
+                                    "grid": true,
+                                    "labels": false,
+                                    "orient": "left",
+                                    "ticks": false,
+                                    "zindex": 0,
+                                    "gridScale": "x"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "row-title",
+                    "role": "row-header",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "row-labels",
+                            "encode": {
+                                "update": {
+                                    "y": {
+                                        "signal": "0.5 * height"
+                                    },
+                                    "angle": {
+                                        "value": 270
+                                    },
+                                    "text": {
+                                        "value": "Origin"
+                                    },
+                                    "align": {
+                                        "value": "right"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
                                     }
                                 }
                             }
-                        }
-                    ],
-                    "axes": [
-                        {
-                            "scale": "y",
-                            "domain": false,
-                            "format": "s",
-                            "grid": true,
-                            "labels": false,
-                            "orient": "left",
-                            "ticks": false,
-                            "zindex": 0,
-                            "gridScale": "x"
                         }
                     ]
                 }
             ],
             "scales": [
-                {
-                    "name": "row",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Origin",
-                        "sort": true
-                    },
-                    "range": "height",
-                    "round": true
-                },
                 {
                     "name": "x",
                     "type": "bin-linear",
@@ -348,32 +401,6 @@
                     "round": true,
                     "nice": true,
                     "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "row",
-                    "domain": false,
-                    "grid": false,
-                    "orient": "right",
-                    "ticks": false,
-                    "title": "Origin",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 90
-                                },
-                                "align": {
-                                    "value": "center"
-                                },
-                                "baseline": {
-                                    "value": "bottom"
-                                }
-                            }
-                        }
-                    }
                 }
             ]
         }

--- a/examples/vg-specs/trellis_barley.vg.json
+++ b/examples/vg-specs/trellis_barley.vg.json
@@ -94,7 +94,7 @@
                 {
                     "type": "formula",
                     "as": "width",
-                    "expr": "datum[\"child_width\"] + 16"
+                    "expr": "datum[\"child_width\"] + 5"
                 },
                 {
                     "type": "formula",
@@ -104,7 +104,7 @@
                 {
                     "type": "formula",
                     "as": "height",
-                    "expr": "(datum[\"child_height\"] + 16) * datum[\"distinct_site\"]"
+                    "expr": "(datum[\"child_height\"] + 5) * datum[\"distinct_site\"]"
                 }
             ]
         }
@@ -127,197 +127,246 @@
                     }
                 }
             },
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10,
+                    "header": 10
+                },
+                "columns": 1,
+                "bounds": "full"
+            },
             "marks": [
                 {
-                    "name": "x-axes",
                     "type": "group",
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            },
-                            "x": {
-                                "value": 8
-                            }
-                        }
+                    "layout": {
+                        "padding": {
+                            "row": 10,
+                            "column": 10,
+                            "header": 10
+                        },
+                        "columns": 1,
+                        "bounds": "full"
                     },
-                    "axes": [
-                        {
-                            "scale": "x",
-                            "format": "s",
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "title": "MEDIAN(yield)",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "y-axes",
-                    "type": "group",
-                    "from": {
-                        "data": "row"
-                    },
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "y": {
-                                "scale": "row",
-                                "field": "site",
-                                "offset": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "y",
-                            "orient": "left",
-                            "title": "variety",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "cell",
-                    "type": "group",
-                    "from": {
-                        "facet": {
-                            "name": "facet",
-                            "data": "source_0",
-                            "groupby": [
-                                "site"
-                            ]
-                        }
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "value": 8
-                            },
-                            "y": {
-                                "scale": "row",
-                                "field": "site",
-                                "offset": 8
-                            },
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "stroke": {
-                                "value": "#ccc"
-                            },
-                            "strokeWidth": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            }
-                        }
-                    },
-                    "data": [
-                        {
-                            "source": "facet",
-                            "name": "data_0",
-                            "transform": [
-                                {
-                                    "type": "aggregate",
-                                    "groupby": [
-                                        "variety",
-                                        "year"
-                                    ],
-                                    "ops": [
-                                        "median"
-                                    ],
-                                    "fields": [
-                                        "yield"
-                                    ]
-                                }
-                            ]
-                        }
-                    ],
                     "marks": [
                         {
-                            "name": "child_marks",
-                            "type": "symbol",
-                            "role": "point",
+                            "name": "x-axes",
+                            "type": "group",
+                            "role": "column-footer",
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "format": "s",
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "title": "MEDIAN(yield)",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "y-axes",
+                            "type": "group",
+                            "role": "row-header",
                             "from": {
-                                "data": "data_0"
+                                "data": "row"
+                            },
+                            "axes": [
+                                {
+                                    "scale": "y",
+                                    "orient": "left",
+                                    "title": "variety",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "row-labels",
+                            "role": "row-header",
+                            "type": "group",
+                            "from": {
+                                "data": "row"
                             },
                             "encode": {
                                 "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "median_yield"
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "type": "text",
+                                    "role": "row-labels",
+                                    "encode": {
+                                        "update": {
+                                            "y": {
+                                                "field": {
+                                                    "group": "height"
+                                                },
+                                                "mult": 0.5
+                                            },
+                                            "x": {
+                                                "value": -10
+                                            },
+                                            "text": {
+                                                "field": {
+                                                    "parent": "site"
+                                                }
+                                            },
+                                            "align": {
+                                                "value": "right"
+                                            },
+                                            "fill": {
+                                                "value": "black"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cell",
+                            "type": "group",
+                            "from": {
+                                "facet": {
+                                    "name": "facet",
+                                    "data": "source_0",
+                                    "groupby": [
+                                        "site"
+                                    ]
+                                }
+                            },
+                            "encode": {
+                                "update": {
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
                                     },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "variety"
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
                                     },
                                     "stroke": {
-                                        "scale": "color",
-                                        "field": "year"
+                                        "value": "#ccc"
+                                    },
+                                    "strokeWidth": {
+                                        "value": 1
                                     },
                                     "fill": {
                                         "value": "transparent"
                                     }
                                 }
-                            }
+                            },
+                            "data": [
+                                {
+                                    "source": "facet",
+                                    "name": "data_0",
+                                    "transform": [
+                                        {
+                                            "type": "aggregate",
+                                            "groupby": [
+                                                "variety",
+                                                "year"
+                                            ],
+                                            "ops": [
+                                                "median"
+                                            ],
+                                            "fields": [
+                                                "yield"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ],
+                            "marks": [
+                                {
+                                    "name": "child_marks",
+                                    "type": "symbol",
+                                    "role": "point",
+                                    "from": {
+                                        "data": "data_0"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "median_yield"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "variety"
+                                            },
+                                            "stroke": {
+                                                "scale": "color",
+                                                "field": "year"
+                                            },
+                                            "fill": {
+                                                "value": "transparent"
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "domain": false,
+                                    "format": "s",
+                                    "grid": true,
+                                    "labels": false,
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "ticks": false,
+                                    "zindex": 0,
+                                    "gridScale": "y"
+                                }
+                            ]
                         }
-                    ],
-                    "axes": [
+                    ]
+                },
+                {
+                    "name": "row-title",
+                    "role": "row-header",
+                    "type": "group",
+                    "marks": [
                         {
-                            "scale": "x",
-                            "domain": false,
-                            "format": "s",
-                            "grid": true,
-                            "labels": false,
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "ticks": false,
-                            "zindex": 0,
-                            "gridScale": "y"
+                            "type": "text",
+                            "role": "row-labels",
+                            "encode": {
+                                "update": {
+                                    "y": {
+                                        "signal": "0.5 * height"
+                                    },
+                                    "angle": {
+                                        "value": 270
+                                    },
+                                    "text": {
+                                        "value": "site"
+                                    },
+                                    "align": {
+                                        "value": "right"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    }
+                                }
+                            }
                         }
                     ]
                 }
             ],
             "scales": [
-                {
-                    "name": "row",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "site",
-                        "sort": {
-                            "op": "median",
-                            "field": "yield"
-                        }
-                    },
-                    "range": "height",
-                    "round": true,
-                    "reverse": true
-                },
                 {
                     "name": "x",
                     "type": "linear",
@@ -360,32 +409,6 @@
                         "sort": true
                     },
                     "range": "category"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "row",
-                    "domain": false,
-                    "grid": false,
-                    "orient": "right",
-                    "ticks": false,
-                    "title": "site",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 90
-                                },
-                                "align": {
-                                    "value": "center"
-                                },
-                                "baseline": {
-                                    "value": "bottom"
-                                }
-                            }
-                        }
-                    }
                 }
             ],
             "legends": [

--- a/examples/vg-specs/trellis_barley.vg.json
+++ b/examples/vg-specs/trellis_barley.vg.json
@@ -117,16 +117,6 @@
             "from": {
                 "data": "layout"
             },
-            "encode": {
-                "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    }
-                }
-            },
             "layout": {
                 "padding": {
                     "row": 10,

--- a/examples/vg-specs/trellis_barley.vg.json
+++ b/examples/vg-specs/trellis_barley.vg.json
@@ -329,7 +329,7 @@
                     "marks": [
                         {
                             "type": "text",
-                            "role": "row-labels",
+                            "role": "row-title",
                             "encode": {
                                 "update": {
                                     "y": {

--- a/examples/vg-specs/trellis_row_column.vg.json
+++ b/examples/vg-specs/trellis_row_column.vg.json
@@ -109,16 +109,6 @@
             "from": {
                 "data": "layout"
             },
-            "encode": {
-                "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    }
-                }
-            },
             "signals": [
                 {
                     "name": "column",

--- a/examples/vg-specs/trellis_row_column.vg.json
+++ b/examples/vg-specs/trellis_row_column.vg.json
@@ -87,7 +87,7 @@
                 {
                     "type": "formula",
                     "as": "width",
-                    "expr": "(datum[\"child_width\"] + 16) * datum[\"distinct_Origin\"]"
+                    "expr": "(datum[\"child_width\"] + 5) * datum[\"distinct_Origin\"]"
                 },
                 {
                     "type": "formula",
@@ -97,7 +97,7 @@
                 {
                     "type": "formula",
                     "as": "height",
-                    "expr": "(datum[\"child_height\"] + 16) * datum[\"distinct_Cylinders\"]"
+                    "expr": "(datum[\"child_height\"] + 5) * datum[\"distinct_Cylinders\"]"
                 }
             ]
         }
@@ -119,205 +119,329 @@
                     }
                 }
             },
+            "signals": [
+                {
+                    "name": "column",
+                    "update": "data('layout')[0].distinct_Origin"
+                }
+            ],
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10,
+                    "header": 10
+                },
+                "columns": 1,
+                "bounds": "full"
+            },
             "marks": [
                 {
-                    "name": "x-axes",
                     "type": "group",
-                    "from": {
-                        "data": "column"
-                    },
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            },
-                            "x": {
-                                "scale": "column",
-                                "field": "Origin",
-                                "offset": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "x",
-                            "format": "s",
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "title": "Horsepower",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "y-axes",
-                    "type": "group",
-                    "from": {
-                        "data": "row"
-                    },
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "y": {
-                                "scale": "row",
-                                "field": "Cylinders",
-                                "offset": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "y",
-                            "format": "s",
-                            "orient": "left",
-                            "title": "Miles_per_Gallon",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "cell",
-                    "type": "group",
-                    "from": {
-                        "facet": {
-                            "name": "facet",
-                            "data": "source_0",
-                            "groupby": [
-                                "Cylinders",
-                                "Origin"
-                            ]
-                        }
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "column",
-                                "field": "Origin",
-                                "offset": 8
-                            },
-                            "y": {
-                                "scale": "row",
-                                "field": "Cylinders",
-                                "offset": 8
-                            },
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "stroke": {
-                                "value": "#ccc"
-                            },
-                            "strokeWidth": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            }
-                        }
+                    "layout": {
+                        "padding": {
+                            "row": 10,
+                            "column": 10,
+                            "header": 10
+                        },
+                        "columns": {
+                            "signal": "column"
+                        },
+                        "bounds": "full"
                     },
                     "marks": [
                         {
-                            "name": "child_marks",
-                            "type": "symbol",
-                            "role": "point",
+                            "name": "x-axes",
+                            "type": "group",
+                            "role": "column-footer",
                             "from": {
-                                "data": "facet"
+                                "data": "column"
+                            },
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "format": "s",
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "title": "Horsepower",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "y-axes",
+                            "type": "group",
+                            "role": "row-header",
+                            "from": {
+                                "data": "row"
+                            },
+                            "axes": [
+                                {
+                                    "scale": "y",
+                                    "format": "s",
+                                    "orient": "left",
+                                    "title": "Miles_per_Gallon",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "column-labels",
+                            "role": "column-header",
+                            "type": "group",
+                            "from": {
+                                "data": "column"
                             },
                             "encode": {
                                 "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "Horsepower"
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "type": "text",
+                                    "role": "column-labels",
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "field": {
+                                                    "group": "width"
+                                                },
+                                                "mult": 0.5
+                                            },
+                                            "y": {
+                                                "value": -10
+                                            },
+                                            "text": {
+                                                "field": {
+                                                    "parent": "Origin"
+                                                }
+                                            },
+                                            "align": {
+                                                "value": "center"
+                                            },
+                                            "fill": {
+                                                "value": "black"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "row-labels",
+                            "role": "row-header",
+                            "type": "group",
+                            "from": {
+                                "data": "row"
+                            },
+                            "encode": {
+                                "update": {
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "type": "text",
+                                    "role": "row-labels",
+                                    "encode": {
+                                        "update": {
+                                            "y": {
+                                                "field": {
+                                                    "group": "height"
+                                                },
+                                                "mult": 0.5
+                                            },
+                                            "x": {
+                                                "value": -10
+                                            },
+                                            "text": {
+                                                "field": {
+                                                    "parent": "Cylinders"
+                                                }
+                                            },
+                                            "align": {
+                                                "value": "right"
+                                            },
+                                            "fill": {
+                                                "value": "black"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cell",
+                            "type": "group",
+                            "from": {
+                                "facet": {
+                                    "name": "facet",
+                                    "data": "source_0",
+                                    "groupby": [
+                                        "Cylinders",
+                                        "Origin"
+                                    ]
+                                }
+                            },
+                            "encode": {
+                                "update": {
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
                                     },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "Miles_per_Gallon"
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
                                     },
                                     "stroke": {
-                                        "value": "#4c78a8"
+                                        "value": "#ccc"
+                                    },
+                                    "strokeWidth": {
+                                        "value": 1
                                     },
                                     "fill": {
                                         "value": "transparent"
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "name": "child_marks",
+                                    "type": "symbol",
+                                    "role": "point",
+                                    "from": {
+                                        "data": "facet"
                                     },
-                                    "opacity": {
-                                        "value": 0.7
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "Horsepower"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "Miles_per_Gallon"
+                                            },
+                                            "stroke": {
+                                                "value": "#4c78a8"
+                                            },
+                                            "fill": {
+                                                "value": "transparent"
+                                            },
+                                            "opacity": {
+                                                "value": 0.7
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "domain": false,
+                                    "format": "s",
+                                    "grid": true,
+                                    "labels": false,
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "ticks": false,
+                                    "zindex": 0,
+                                    "gridScale": "y"
+                                },
+                                {
+                                    "scale": "y",
+                                    "domain": false,
+                                    "format": "s",
+                                    "grid": true,
+                                    "labels": false,
+                                    "orient": "left",
+                                    "ticks": false,
+                                    "zindex": 0,
+                                    "gridScale": "x"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "column-title",
+                    "role": "column-header",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "column-labels",
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "signal": "0.5 * width"
+                                    },
+                                    "text": {
+                                        "value": "Origin"
+                                    },
+                                    "align": {
+                                        "value": "center"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
                                     }
                                 }
                             }
                         }
-                    ],
-                    "axes": [
+                    ]
+                },
+                {
+                    "name": "row-title",
+                    "role": "row-header",
+                    "type": "group",
+                    "marks": [
                         {
-                            "scale": "x",
-                            "domain": false,
-                            "format": "s",
-                            "grid": true,
-                            "labels": false,
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "ticks": false,
-                            "zindex": 0,
-                            "gridScale": "y"
-                        },
-                        {
-                            "scale": "y",
-                            "domain": false,
-                            "format": "s",
-                            "grid": true,
-                            "labels": false,
-                            "orient": "left",
-                            "ticks": false,
-                            "zindex": 0,
-                            "gridScale": "x"
+                            "type": "text",
+                            "role": "row-labels",
+                            "encode": {
+                                "update": {
+                                    "y": {
+                                        "signal": "0.5 * height"
+                                    },
+                                    "angle": {
+                                        "value": 270
+                                    },
+                                    "text": {
+                                        "value": "Cylinders"
+                                    },
+                                    "align": {
+                                        "value": "right"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    }
+                                }
+                            }
                         }
                     ]
                 }
             ],
             "scales": [
-                {
-                    "name": "row",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Cylinders",
-                        "sort": true
-                    },
-                    "range": "height",
-                    "round": true
-                },
-                {
-                    "name": "column",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Origin",
-                        "sort": true
-                    },
-                    "range": "width",
-                    "round": true
-                },
                 {
                     "name": "x",
                     "type": "linear",
@@ -347,41 +471,6 @@
                     "round": true,
                     "nice": true,
                     "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "row",
-                    "domain": false,
-                    "grid": false,
-                    "orient": "right",
-                    "ticks": false,
-                    "title": "Cylinders",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 90
-                                },
-                                "align": {
-                                    "value": "center"
-                                },
-                                "baseline": {
-                                    "value": "bottom"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "column",
-                    "domain": false,
-                    "grid": false,
-                    "orient": "top",
-                    "ticks": false,
-                    "title": "Origin",
-                    "zindex": 1
                 }
             ]
         }

--- a/examples/vg-specs/trellis_row_column.vg.json
+++ b/examples/vg-specs/trellis_row_column.vg.json
@@ -374,7 +374,7 @@
                     "marks": [
                         {
                             "type": "text",
-                            "role": "column-labels",
+                            "role": "column-title",
                             "encode": {
                                 "update": {
                                     "x": {
@@ -404,7 +404,7 @@
                     "marks": [
                         {
                             "type": "text",
-                            "role": "row-labels",
+                            "role": "row-title",
                             "encode": {
                                 "update": {
                                     "y": {

--- a/examples/vg-specs/trellis_scatter.vg.json
+++ b/examples/vg-specs/trellis_scatter.vg.json
@@ -73,7 +73,7 @@
                 {
                     "type": "formula",
                     "as": "width",
-                    "expr": "(datum[\"child_width\"] + 16) * datum[\"distinct_MPAA_Rating\"]"
+                    "expr": "(datum[\"child_width\"] + 5) * datum[\"distinct_MPAA_Rating\"]"
                 },
                 {
                     "type": "formula",
@@ -83,7 +83,7 @@
                 {
                     "type": "formula",
                     "as": "height",
-                    "expr": "datum[\"child_height\"] + 16"
+                    "expr": "datum[\"child_height\"] + 5"
                 }
             ]
         }
@@ -105,186 +105,244 @@
                     }
                 }
             },
+            "signals": [
+                {
+                    "name": "column",
+                    "update": "data('layout')[0].distinct_MPAA_Rating"
+                }
+            ],
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10,
+                    "header": 10
+                },
+                "columns": 1,
+                "bounds": "full"
+            },
             "marks": [
                 {
-                    "name": "x-axes",
                     "type": "group",
-                    "from": {
-                        "data": "column"
-                    },
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            },
-                            "x": {
-                                "scale": "column",
-                                "field": "MPAA_Rating",
-                                "offset": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "x",
-                            "format": "s",
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "title": "Worldwide_Gross",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "y-axes",
-                    "type": "group",
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "y": {
-                                "value": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "y",
-                            "format": "s",
-                            "orient": "left",
-                            "title": "US_DVD_Sales",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "cell",
-                    "type": "group",
-                    "from": {
-                        "facet": {
-                            "name": "facet",
-                            "data": "source_0",
-                            "groupby": [
-                                "MPAA_Rating"
-                            ]
-                        }
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "column",
-                                "field": "MPAA_Rating",
-                                "offset": 8
-                            },
-                            "y": {
-                                "value": 8
-                            },
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "stroke": {
-                                "value": "#ccc"
-                            },
-                            "strokeWidth": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            }
-                        }
+                    "layout": {
+                        "padding": {
+                            "row": 10,
+                            "column": 10,
+                            "header": 10
+                        },
+                        "columns": {
+                            "signal": "column"
+                        },
+                        "bounds": "full"
                     },
                     "marks": [
                         {
-                            "name": "child_marks",
-                            "type": "symbol",
-                            "role": "point",
+                            "name": "x-axes",
+                            "type": "group",
+                            "role": "column-footer",
                             "from": {
-                                "data": "facet"
+                                "data": "column"
+                            },
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "format": "s",
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "title": "Worldwide_Gross",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "y-axes",
+                            "type": "group",
+                            "role": "row-header",
+                            "axes": [
+                                {
+                                    "scale": "y",
+                                    "format": "s",
+                                    "orient": "left",
+                                    "title": "US_DVD_Sales",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "column-labels",
+                            "role": "column-header",
+                            "type": "group",
+                            "from": {
+                                "data": "column"
                             },
                             "encode": {
                                 "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "Worldwide_Gross"
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "type": "text",
+                                    "role": "column-labels",
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "field": {
+                                                    "group": "width"
+                                                },
+                                                "mult": 0.5
+                                            },
+                                            "y": {
+                                                "value": -10
+                                            },
+                                            "text": {
+                                                "field": {
+                                                    "parent": "MPAA_Rating"
+                                                }
+                                            },
+                                            "align": {
+                                                "value": "center"
+                                            },
+                                            "fill": {
+                                                "value": "black"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cell",
+                            "type": "group",
+                            "from": {
+                                "facet": {
+                                    "name": "facet",
+                                    "data": "source_0",
+                                    "groupby": [
+                                        "MPAA_Rating"
+                                    ]
+                                }
+                            },
+                            "encode": {
+                                "update": {
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
                                     },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "US_DVD_Sales"
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
                                     },
                                     "stroke": {
-                                        "value": "#4c78a8"
+                                        "value": "#ccc"
+                                    },
+                                    "strokeWidth": {
+                                        "value": 1
                                     },
                                     "fill": {
                                         "value": "transparent"
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "name": "child_marks",
+                                    "type": "symbol",
+                                    "role": "point",
+                                    "from": {
+                                        "data": "facet"
                                     },
-                                    "opacity": {
-                                        "value": 0.7
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "Worldwide_Gross"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "US_DVD_Sales"
+                                            },
+                                            "stroke": {
+                                                "value": "#4c78a8"
+                                            },
+                                            "fill": {
+                                                "value": "transparent"
+                                            },
+                                            "opacity": {
+                                                "value": 0.7
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "domain": false,
+                                    "format": "s",
+                                    "grid": true,
+                                    "labels": false,
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "ticks": false,
+                                    "zindex": 0,
+                                    "gridScale": "y"
+                                },
+                                {
+                                    "scale": "y",
+                                    "domain": false,
+                                    "format": "s",
+                                    "grid": true,
+                                    "labels": false,
+                                    "orient": "left",
+                                    "ticks": false,
+                                    "zindex": 0,
+                                    "gridScale": "x"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "column-title",
+                    "role": "column-header",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "column-labels",
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "signal": "0.5 * width"
+                                    },
+                                    "text": {
+                                        "value": "MPAA_Rating"
+                                    },
+                                    "align": {
+                                        "value": "center"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
                                     }
                                 }
                             }
-                        }
-                    ],
-                    "axes": [
-                        {
-                            "scale": "x",
-                            "domain": false,
-                            "format": "s",
-                            "grid": true,
-                            "labels": false,
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "ticks": false,
-                            "zindex": 0,
-                            "gridScale": "y"
-                        },
-                        {
-                            "scale": "y",
-                            "domain": false,
-                            "format": "s",
-                            "grid": true,
-                            "labels": false,
-                            "orient": "left",
-                            "ticks": false,
-                            "zindex": 0,
-                            "gridScale": "x"
                         }
                     ]
                 }
             ],
             "scales": [
-                {
-                    "name": "column",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "MPAA_Rating",
-                        "sort": true
-                    },
-                    "range": "width",
-                    "round": true
-                },
                 {
                     "name": "x",
                     "type": "linear",
@@ -314,17 +372,6 @@
                     "round": true,
                     "nice": true,
                     "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "column",
-                    "domain": false,
-                    "grid": false,
-                    "orient": "top",
-                    "ticks": false,
-                    "title": "MPAA_Rating",
-                    "zindex": 1
                 }
             ]
         }

--- a/examples/vg-specs/trellis_scatter.vg.json
+++ b/examples/vg-specs/trellis_scatter.vg.json
@@ -95,16 +95,6 @@
             "from": {
                 "data": "layout"
             },
-            "encode": {
-                "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    }
-                }
-            },
             "signals": [
                 {
                     "name": "column",

--- a/examples/vg-specs/trellis_scatter.vg.json
+++ b/examples/vg-specs/trellis_scatter.vg.json
@@ -308,7 +308,7 @@
                     "marks": [
                         {
                             "type": "text",
-                            "role": "column-labels",
+                            "role": "column-title",
                             "encode": {
                                 "update": {
                                     "x": {

--- a/examples/vg-specs/trellis_scatter_binned_row.vg.json
+++ b/examples/vg-specs/trellis_scatter_binned_row.vg.json
@@ -101,7 +101,7 @@
                 {
                     "type": "formula",
                     "as": "width",
-                    "expr": "datum[\"child_width\"] + 16"
+                    "expr": "datum[\"child_width\"] + 5"
                 },
                 {
                     "type": "formula",
@@ -111,7 +111,7 @@
                 {
                     "type": "formula",
                     "as": "height",
-                    "expr": "(datum[\"child_height\"] + 16) * datum[\"distinct_bin_maxbins_6_Acceleration_range\"]"
+                    "expr": "(datum[\"child_height\"] + 5) * datum[\"distinct_bin_maxbins_6_Acceleration_range\"]"
                 }
             ]
         }
@@ -134,189 +134,239 @@
                     }
                 }
             },
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10,
+                    "header": 10
+                },
+                "columns": 1,
+                "bounds": "full"
+            },
             "marks": [
                 {
-                    "name": "x-axes",
                     "type": "group",
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            },
-                            "x": {
-                                "value": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "x",
-                            "format": "s",
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "title": "Horsepower",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "y-axes",
-                    "type": "group",
-                    "from": {
-                        "data": "row"
-                    },
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "y": {
-                                "scale": "row",
-                                "field": "bin_maxbins_6_Acceleration_range",
-                                "offset": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "y",
-                            "format": "s",
-                            "orient": "left",
-                            "title": "Miles_per_Gallon",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "cell",
-                    "type": "group",
-                    "from": {
-                        "facet": {
-                            "name": "facet",
-                            "data": "source_0",
-                            "groupby": [
-                                "bin_maxbins_6_Acceleration_range"
-                            ]
-                        }
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "value": 8
-                            },
-                            "y": {
-                                "scale": "row",
-                                "field": "bin_maxbins_6_Acceleration_range",
-                                "offset": 8
-                            },
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "stroke": {
-                                "value": "#ccc"
-                            },
-                            "strokeWidth": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            }
-                        }
+                    "layout": {
+                        "padding": {
+                            "row": 10,
+                            "column": 10,
+                            "header": 10
+                        },
+                        "columns": 1,
+                        "bounds": "full"
                     },
                     "marks": [
                         {
-                            "name": "child_marks",
-                            "type": "symbol",
-                            "role": "point",
+                            "name": "x-axes",
+                            "type": "group",
+                            "role": "column-footer",
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "format": "s",
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "title": "Horsepower",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "y-axes",
+                            "type": "group",
+                            "role": "row-header",
                             "from": {
-                                "data": "facet"
+                                "data": "row"
+                            },
+                            "axes": [
+                                {
+                                    "scale": "y",
+                                    "format": "s",
+                                    "orient": "left",
+                                    "title": "Miles_per_Gallon",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "row-labels",
+                            "role": "row-header",
+                            "type": "group",
+                            "from": {
+                                "data": "row"
                             },
                             "encode": {
                                 "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "Horsepower"
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "type": "text",
+                                    "role": "row-labels",
+                                    "encode": {
+                                        "update": {
+                                            "y": {
+                                                "field": {
+                                                    "group": "height"
+                                                },
+                                                "mult": 0.5
+                                            },
+                                            "x": {
+                                                "value": -10
+                                            },
+                                            "text": {
+                                                "field": {
+                                                    "parent": "bin_maxbins_6_Acceleration_range"
+                                                }
+                                            },
+                                            "align": {
+                                                "value": "right"
+                                            },
+                                            "fill": {
+                                                "value": "black"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cell",
+                            "type": "group",
+                            "from": {
+                                "facet": {
+                                    "name": "facet",
+                                    "data": "source_0",
+                                    "groupby": [
+                                        "bin_maxbins_6_Acceleration_range"
+                                    ]
+                                }
+                            },
+                            "encode": {
+                                "update": {
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
                                     },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "Miles_per_Gallon"
+                                    "height": {
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
                                     },
                                     "stroke": {
-                                        "value": "#4c78a8"
+                                        "value": "#ccc"
+                                    },
+                                    "strokeWidth": {
+                                        "value": 1
                                     },
                                     "fill": {
                                         "value": "transparent"
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "name": "child_marks",
+                                    "type": "symbol",
+                                    "role": "point",
+                                    "from": {
+                                        "data": "facet"
                                     },
-                                    "opacity": {
-                                        "value": 0.7
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "Horsepower"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "Miles_per_Gallon"
+                                            },
+                                            "stroke": {
+                                                "value": "#4c78a8"
+                                            },
+                                            "fill": {
+                                                "value": "transparent"
+                                            },
+                                            "opacity": {
+                                                "value": 0.7
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "domain": false,
+                                    "format": "s",
+                                    "grid": true,
+                                    "labels": false,
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "ticks": false,
+                                    "zindex": 0,
+                                    "gridScale": "y"
+                                },
+                                {
+                                    "scale": "y",
+                                    "domain": false,
+                                    "format": "s",
+                                    "grid": true,
+                                    "labels": false,
+                                    "orient": "left",
+                                    "ticks": false,
+                                    "zindex": 0,
+                                    "gridScale": "x"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "row-title",
+                    "role": "row-header",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "row-labels",
+                            "encode": {
+                                "update": {
+                                    "y": {
+                                        "signal": "0.5 * height"
+                                    },
+                                    "angle": {
+                                        "value": 270
+                                    },
+                                    "text": {
+                                        "value": "BIN(Acceleration)"
+                                    },
+                                    "align": {
+                                        "value": "right"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
                                     }
                                 }
                             }
-                        }
-                    ],
-                    "axes": [
-                        {
-                            "scale": "x",
-                            "domain": false,
-                            "format": "s",
-                            "grid": true,
-                            "labels": false,
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "ticks": false,
-                            "zindex": 0,
-                            "gridScale": "y"
-                        },
-                        {
-                            "scale": "y",
-                            "domain": false,
-                            "format": "s",
-                            "grid": true,
-                            "labels": false,
-                            "orient": "left",
-                            "ticks": false,
-                            "zindex": 0,
-                            "gridScale": "x"
                         }
                     ]
                 }
             ],
             "scales": [
-                {
-                    "name": "row",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "bin_maxbins_6_Acceleration_range",
-                        "sort": {
-                            "field": "bin_maxbins_6_Acceleration_start",
-                            "op": "min"
-                        }
-                    },
-                    "range": "height",
-                    "round": true
-                },
                 {
                     "name": "x",
                     "type": "linear",
@@ -346,33 +396,6 @@
                     "round": true,
                     "nice": true,
                     "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "row",
-                    "domain": false,
-                    "format": "s",
-                    "grid": false,
-                    "orient": "right",
-                    "ticks": false,
-                    "title": "BIN(Acceleration)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 90
-                                },
-                                "align": {
-                                    "value": "center"
-                                },
-                                "baseline": {
-                                    "value": "bottom"
-                                }
-                            }
-                        }
-                    }
                 }
             ]
         }

--- a/examples/vg-specs/trellis_scatter_binned_row.vg.json
+++ b/examples/vg-specs/trellis_scatter_binned_row.vg.json
@@ -329,7 +329,7 @@
                     "marks": [
                         {
                             "type": "text",
-                            "role": "row-labels",
+                            "role": "row-title",
                             "encode": {
                                 "update": {
                                     "y": {

--- a/examples/vg-specs/trellis_scatter_binned_row.vg.json
+++ b/examples/vg-specs/trellis_scatter_binned_row.vg.json
@@ -124,16 +124,6 @@
             "from": {
                 "data": "layout"
             },
-            "encode": {
-                "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    }
-                }
-            },
             "layout": {
                 "padding": {
                     "row": 10,

--- a/examples/vg-specs/trellis_stacked_bar.vg.json
+++ b/examples/vg-specs/trellis_stacked_bar.vg.json
@@ -131,16 +131,6 @@
             "from": {
                 "data": "layout"
             },
-            "encode": {
-                "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    }
-                }
-            },
             "signals": [
                 {
                     "name": "column",

--- a/examples/vg-specs/trellis_stacked_bar.vg.json
+++ b/examples/vg-specs/trellis_stacked_bar.vg.json
@@ -334,7 +334,7 @@
                     "marks": [
                         {
                             "type": "text",
-                            "role": "column-labels",
+                            "role": "column-title",
                             "encode": {
                                 "update": {
                                     "x": {

--- a/examples/vg-specs/trellis_stacked_bar.vg.json
+++ b/examples/vg-specs/trellis_stacked_bar.vg.json
@@ -109,7 +109,7 @@
                 {
                     "type": "formula",
                     "as": "width",
-                    "expr": "(datum[\"child_width\"] + 16) * datum[\"distinct_year\"]"
+                    "expr": "(datum[\"child_width\"] + 5) * datum[\"distinct_year\"]"
                 },
                 {
                     "type": "formula",
@@ -119,7 +119,7 @@
                 {
                     "type": "formula",
                     "as": "height",
-                    "expr": "datum[\"child_height\"] + 16"
+                    "expr": "datum[\"child_height\"] + 5"
                 }
             ]
         }
@@ -141,176 +141,234 @@
                     }
                 }
             },
+            "signals": [
+                {
+                    "name": "column",
+                    "update": "data('layout')[0].distinct_year"
+                }
+            ],
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10,
+                    "header": 10
+                },
+                "columns": 1,
+                "bounds": "full"
+            },
             "marks": [
                 {
-                    "name": "x-axes",
                     "type": "group",
-                    "from": {
-                        "data": "column"
-                    },
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            },
-                            "x": {
-                                "scale": "column",
-                                "field": "year",
-                                "offset": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "x",
-                            "format": "s",
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "title": "SUM(yield)",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "y-axes",
-                    "type": "group",
-                    "encode": {
-                        "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "y": {
-                                "value": 8
-                            }
-                        }
-                    },
-                    "axes": [
-                        {
-                            "scale": "y",
-                            "orient": "left",
-                            "title": "variety",
-                            "zindex": 1
-                        }
-                    ]
-                },
-                {
-                    "name": "cell",
-                    "type": "group",
-                    "from": {
-                        "facet": {
-                            "name": "facet",
-                            "data": "source_0",
-                            "groupby": [
-                                "year"
-                            ]
-                        }
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "column",
-                                "field": "year",
-                                "offset": 8
-                            },
-                            "y": {
-                                "value": 8
-                            },
-                            "width": {
-                                "field": {
-                                    "parent": "child_width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "parent": "child_height"
-                                }
-                            },
-                            "stroke": {
-                                "value": "#ccc"
-                            },
-                            "strokeWidth": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            }
-                        }
+                    "layout": {
+                        "padding": {
+                            "row": 10,
+                            "column": 10,
+                            "header": 10
+                        },
+                        "columns": {
+                            "signal": "column"
+                        },
+                        "bounds": "full"
                     },
                     "marks": [
                         {
-                            "name": "child_marks",
-                            "type": "rect",
-                            "role": "bar",
+                            "name": "x-axes",
+                            "type": "group",
+                            "role": "column-footer",
                             "from": {
-                                "data": "facet"
+                                "data": "column"
+                            },
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "format": "s",
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "title": "SUM(yield)",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "y-axes",
+                            "type": "group",
+                            "role": "row-header",
+                            "axes": [
+                                {
+                                    "scale": "y",
+                                    "orient": "left",
+                                    "title": "variety",
+                                    "zindex": 1
+                                }
+                            ]
+                        },
+                        {
+                            "name": "column-labels",
+                            "role": "column-header",
+                            "type": "group",
+                            "from": {
+                                "data": "column"
                             },
                             "encode": {
                                 "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "sum_yield_end"
-                                    },
-                                    "x2": {
-                                        "scale": "x",
-                                        "field": "sum_yield_start"
-                                    },
-                                    "yc": {
-                                        "scale": "y",
-                                        "field": "variety"
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "type": "text",
+                                    "role": "column-labels",
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "field": {
+                                                    "group": "width"
+                                                },
+                                                "mult": 0.5
+                                            },
+                                            "y": {
+                                                "value": -10
+                                            },
+                                            "text": {
+                                                "field": {
+                                                    "parent": "year"
+                                                }
+                                            },
+                                            "align": {
+                                                "value": "center"
+                                            },
+                                            "fill": {
+                                                "value": "black"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "cell",
+                            "type": "group",
+                            "from": {
+                                "facet": {
+                                    "name": "facet",
+                                    "data": "source_0",
+                                    "groupby": [
+                                        "year"
+                                    ]
+                                }
+                            },
+                            "encode": {
+                                "update": {
+                                    "width": {
+                                        "field": {
+                                            "parent": "child_width",
+                                            "level": 2
+                                        }
                                     },
                                     "height": {
-                                        "value": 20
+                                        "field": {
+                                            "parent": "child_height",
+                                            "level": 2
+                                        }
+                                    },
+                                    "stroke": {
+                                        "value": "#ccc"
+                                    },
+                                    "strokeWidth": {
+                                        "value": 1
                                     },
                                     "fill": {
-                                        "scale": "color",
-                                        "field": "site"
+                                        "value": "transparent"
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "name": "child_marks",
+                                    "type": "rect",
+                                    "role": "bar",
+                                    "from": {
+                                        "data": "facet"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "sum_yield_end"
+                                            },
+                                            "x2": {
+                                                "scale": "x",
+                                                "field": "sum_yield_start"
+                                            },
+                                            "yc": {
+                                                "scale": "y",
+                                                "field": "variety"
+                                            },
+                                            "height": {
+                                                "value": 20
+                                            },
+                                            "fill": {
+                                                "scale": "color",
+                                                "field": "site"
+                                            }
+                                        }
+                                    }
+                                }
+                            ],
+                            "axes": [
+                                {
+                                    "scale": "x",
+                                    "domain": false,
+                                    "format": "s",
+                                    "grid": true,
+                                    "labels": false,
+                                    "orient": "bottom",
+                                    "tickCount": 5,
+                                    "ticks": false,
+                                    "zindex": 0,
+                                    "gridScale": "y"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "name": "column-title",
+                    "role": "column-header",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "column-labels",
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "signal": "0.5 * width"
+                                    },
+                                    "text": {
+                                        "value": "year"
+                                    },
+                                    "align": {
+                                        "value": "center"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
                                     }
                                 }
                             }
-                        }
-                    ],
-                    "axes": [
-                        {
-                            "scale": "x",
-                            "domain": false,
-                            "format": "s",
-                            "grid": true,
-                            "labels": false,
-                            "orient": "bottom",
-                            "tickCount": 5,
-                            "ticks": false,
-                            "zindex": 0,
-                            "gridScale": "y"
                         }
                     ]
                 }
             ],
             "scales": [
-                {
-                    "name": "column",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "year",
-                        "sort": true
-                    },
-                    "range": "width",
-                    "round": true
-                },
                 {
                     "name": "x",
                     "type": "linear",
@@ -352,17 +410,6 @@
                         "sort": true
                     },
                     "range": "category"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "column",
-                    "domain": false,
-                    "grid": false,
-                    "orient": "top",
-                    "ticks": false,
-                    "title": "year",
-                    "zindex": 1
                 }
             ],
             "legends": [

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -219,8 +219,6 @@ For a full list of scale configuration and their default values, please see the 
 Axis configuration determines default properties for `x` and `y` [axes](axis.html).
 For a full list of axis configuration, please see the [Axis Config section in the axis page](axis.html#axis-config).
 
-(For `row` and `column` axes, see [facet axis configuration](#facet-axis-config)).
-
 {:#legend-config}
 ## Legend Configuration  (`config.legend.*`)
 
@@ -237,16 +235,3 @@ For a full list of legend configuration and their default values, please see the
 ### Cell Configuration (`config.facet.cell.*`)
 
 Facet cell configuration overrides [cell config](#cell-config) for faceted (trellis) plots. Please see [cell config](#cell-config) for each property name and default values.
-
-{:#facet-grid-config}
-### Facet Grid Configuration (`config.facet.grid.*`)
-
-{% include table.html props="color,opacity,offset" source="FacetGridConfig" %}
-
-{:#facet-axis-config}
-### Facet Axis Configuration (`config.facet.axis.*`)
-
-Facet axis configuration determines default properties for `row` and `column` [axes](axis.html).
-<span class="note-line">__See Code:__
-For a full list of facet axis configuration and their default values, please see the `AxisConfig` interface and `defaultFacetAxisConfig` in [axis.ts](https://github.com/vega/vega-lite/blob/master/src/axis.ts).
-</span>

--- a/site/docs/scale.md
+++ b/site/docs/scale.md
@@ -207,7 +207,7 @@ We can also create diverging color graph by specify `range` with multiple elemen
 
 <!-- TODO revise -->
 
-{% include table.html props="rangeStep,scheme,padding,spacing" source="Scale" %}
+{% include table.html props="rangeStep,scheme,padding" source="Scale" %}
 
 {:#ex-bandwidth}
 #### Example: Custom Range Step

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -51,6 +51,11 @@ export const OPACITY = Channel.OPACITY;
 
 
 export const CHANNELS = [X, Y, X2, Y2, ROW, COLUMN, SIZE, SHAPE, COLOR, ORDER, OPACITY, TEXT, DETAIL];
+const CHANNEL_INDEX = toSet(CHANNELS);
+
+export function isChannel(str: string): str is Channel {
+  return !!CHANNEL_INDEX[str];
+}
 
 // CHANNELS without COLUMN, ROW
 export const UNIT_CHANNELS = [X, Y, X2, Y2, SIZE, SHAPE, COLOR, ORDER, OPACITY, TEXT, DETAIL];

--- a/src/compile/axis/encode.ts
+++ b/src/compile/axis/encode.ts
@@ -4,9 +4,9 @@ import {contains, extend, keys} from '../../util';
 import {VgAxis} from '../../vega.schema';
 
 import {timeFormatExpression} from '../common';
-import {Model} from '../model';
+import {UnitModel} from '../unit';
 
-export function labels(model: Model, channel: Channel, labelsSpec: any, def: VgAxis) {
+export function labels(model: UnitModel, channel: Channel, labelsSpec: any, def: VgAxis) {
   const fieldDef = model.fieldDef(channel);
   const axis = model.axis(channel);
   const config = model.config;

--- a/src/compile/axis/encode.ts
+++ b/src/compile/axis/encode.ts
@@ -1,4 +1,4 @@
-import {Channel, COLUMN, X} from '../../channel';
+import {Channel, X} from '../../channel';
 import {NOMINAL, ORDINAL, TEMPORAL} from '../../type';
 import {contains, extend, keys} from '../../util';
 import {VgAxis} from '../../vega.schema';
@@ -36,7 +36,7 @@ export function labels(model: UnitModel, channel: Channel, labelsSpec: any, def:
     if (labelsSpec.angle.value === 270) {
       labelsSpec.align = {
         value: def.orient === 'top' ? 'left':
-                (channel === X || channel === COLUMN) ? 'right' :
+                (channel === X) ? 'right' :
                 'center'
       };
     } else if (labelsSpec.angle.value === 90) {
@@ -48,7 +48,7 @@ export function labels(model: UnitModel, channel: Channel, labelsSpec: any, def:
     // Auto set baseline if rotated
     // TODO: consider other value besides 270, 90
     if (labelsSpec.angle.value === 270) {
-      labelsSpec.baseline = {value: (channel === X || channel === COLUMN) ? 'middle' : 'bottom'};
+      labelsSpec.baseline = {value: (channel === X) ? 'middle' : 'bottom'};
     } else if (labelsSpec.angle.value === 90) {
       labelsSpec.baseline = {value: 'bottom'};
     }

--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -6,12 +6,12 @@ import * as encode from './encode';
 import * as rules from './rules';
 
 import {Dict, keys, some} from '../../util';
-import {Model} from '../model';
+import {UnitModel} from '../unit';
 
 type AxisPart = 'domain' | 'grid' | 'labels' | 'ticks' | 'title';
 const AXIS_PARTS: AxisPart[] = ['domain', 'grid', 'labels', 'ticks', 'title'];
 
-export function parseAxisComponent(model: Model, axisChannels: Channel[]): Dict<VgAxis[]> {
+export function parseAxisComponent(model: UnitModel, axisChannels: Channel[]): Dict<VgAxis[]> {
   return axisChannels.reduce(function(axis, channel) {
     const vgAxes: VgAxis[] = [];
     if (model.axis(channel)) {
@@ -58,16 +58,16 @@ function hasAxisPart(axis: VgAxis, part: AxisPart) {
 /**
  * Make an inner axis for showing grid for shared axis.
  */
-export function parseGridAxis(channel: Channel, model: Model): VgAxis {
+export function parseGridAxis(channel: Channel, model: UnitModel): VgAxis {
   // FIXME: support adding ticks for grid axis that are inner axes of faceted plots.
   return parseAxis(channel, model, true);
 }
 
-export function parseMainAxis(channel: Channel, model: Model) {
+export function parseMainAxis(channel: Channel, model: UnitModel) {
   return parseAxis(channel, model, false);
 }
 
-function parseAxis(channel: Channel, model: Model, isGridAxis: boolean): VgAxis {
+function parseAxis(channel: Channel, model: UnitModel, isGridAxis: boolean): VgAxis {
   const axis = model.axis(channel);
 
   const vgAxis: VgAxis = {
@@ -114,7 +114,7 @@ function parseAxis(channel: Channel, model: Model, isGridAxis: boolean): VgAxis 
   return vgAxis;
 }
 
-function getSpecifiedOrDefaultValue(property: keyof VgAxis, specifiedAxis: Axis, channel: Channel, model: Model, isGridAxis: boolean) {
+function getSpecifiedOrDefaultValue(property: keyof VgAxis, specifiedAxis: Axis, channel: Channel, model: UnitModel, isGridAxis: boolean) {
   const fieldDef = model.fieldDef(channel);
 
   switch (property) {

--- a/src/compile/axis/rules.ts
+++ b/src/compile/axis/rules.ts
@@ -9,7 +9,7 @@ import {truncate} from '../../util';
 import {VgAxis} from '../../vega.schema';
 
 import {numberFormat} from '../common';
-import {Model} from '../model';
+import {UnitModel} from '../unit';
 
 export function format(specifiedAxis: Axis, channel: Channel, fieldDef: FieldDef, config: Config) {
   return numberFormat(fieldDef, specifiedAxis.format, config, channel);
@@ -20,16 +20,16 @@ export function format(specifiedAxis: Axis, channel: Channel, fieldDef: FieldDef
  * Default rules for whether to show a grid should be shown for a channel.
  * If `grid` is unspecified, the default value is `true` for ordinal scales that are not binned
  */
-export function gridShow(model: Model, channel: Channel) {
+export function gridShow(model: UnitModel, channel: Channel) {
   const grid = model.axis(channel).grid;
   if (grid !== undefined) {
     return grid;
   }
 
-  return !model.hasDiscreteScale(channel) && !model.fieldDef(channel).bin;
+  return !model.hasDiscreteDomain(channel) && !model.fieldDef(channel).bin;
 }
 
-export function grid(model: Model, channel: Channel, isGridAxis: boolean) {
+export function grid(model: UnitModel, channel: Channel, isGridAxis: boolean) {
   if (channel === ROW || channel === COLUMN) {
     // never apply grid for ROW and COLUMN since we manually create rule-group for them
     return false;
@@ -42,7 +42,7 @@ export function grid(model: Model, channel: Channel, isGridAxis: boolean) {
   return gridShow(model, channel);
 }
 
-export function gridScale(model: Model, channel: Channel, isGridAxis: boolean) {
+export function gridScale(model: UnitModel, channel: Channel, isGridAxis: boolean) {
   if (isGridAxis) {
     const gridChannel: Channel = channel === 'x' ? 'y' : 'x';
     if (model.scale(gridChannel)) {

--- a/src/compile/data/aggregate.ts
+++ b/src/compile/data/aggregate.ts
@@ -4,7 +4,8 @@ import * as log from '../../log';
 import {ORDINAL} from '../../type';
 import {Dict, differ, duplicate, extend, keys, StringSet} from '../../util';
 import {VgAggregateTransform} from '../../vega.schema';
-import {Model} from './../model';
+import {UnitModel} from './../unit';
+
 import {DataFlowNode} from './dataflow';
 
 function addDimension(dims: {[field: string]: boolean}, fieldDef: FieldDef) {
@@ -55,7 +56,7 @@ export class AggregateNode extends DataFlowNode {
     super();
   }
 
-  public static make(model: Model): AggregateNode {
+  public static make(model: UnitModel): AggregateNode {
     let isAggregate = false;
     model.forEachFieldDef(fd => {
       if (fd.aggregate) {

--- a/src/compile/data/formatparse.ts
+++ b/src/compile/data/formatparse.ts
@@ -6,7 +6,7 @@ import {CalculateTransform, FilterTransform, isCalculate, isFilter} from '../../
 import {QUANTITATIVE, TEMPORAL} from '../../type';
 import {Dict, duplicate, extend, isArray, isNumber, isString, keys} from '../../util';
 import {VgFormulaTransform} from '../../vega.schema';
-import {Model} from '../model';
+import {Model, ModelWithField} from '../model';
 import {DataFlowNode} from './dataflow';
 
 
@@ -42,7 +42,7 @@ export class ParseNode extends DataFlowNode {
     this._parse = parse;
   }
 
-  public static make(model: Model) {
+  public static make(model: ModelWithField) {
     const parse = {};
 
     const calcFieldMap = model.transforms.filter(isCalculate).reduce((fieldMap, formula: CalculateTransform) => {

--- a/src/compile/data/nonpositivefilter.ts
+++ b/src/compile/data/nonpositivefilter.ts
@@ -1,7 +1,7 @@
 import {ScaleType} from '../../scale';
 import {Dict, duplicate, extend, keys} from '../../util';
 import {VgFilterTransform, VgTransform} from '../../vega.schema';
-import {Model} from './../model';
+import {UnitModel} from './../unit';
 import {DataFlowNode} from './dataflow';
 
 export class NonPositiveFilterNode extends DataFlowNode {
@@ -17,7 +17,7 @@ export class NonPositiveFilterNode extends DataFlowNode {
     this._filter = filter;
   }
 
-  public static make(model: Model) {
+  public static make(model: UnitModel) {
     const filter = model.channels().reduce(function(nonPositiveComponent, channel) {
       const scale = model.scale(channel);
       if (!scale || !model.field(channel)) {

--- a/src/compile/data/nullfilter.ts
+++ b/src/compile/data/nullfilter.ts
@@ -2,6 +2,7 @@ import {FieldDef} from '../../fielddef';
 import {QUANTITATIVE, TEMPORAL} from '../../type';
 import {contains, Dict, differ, differArray, duplicate, extend, hash, keys} from '../../util';
 import {VgFilterTransform} from '../../vega.schema';
+import {ModelWithField} from '../model';
 import {Model} from './../model';
 import {DataFlowNode} from './dataflow';
 
@@ -26,7 +27,7 @@ export class NullFilterNode extends DataFlowNode {
     this._filteredFields = fields;
   }
 
-  public static make(model: Model) {
+  public static make(model: ModelWithField) {
     const fields = model.reduceFieldDef((aggregator: Dict<FieldDef>, fieldDef: FieldDef) => {
       if (fieldDef.aggregate !== 'count') { // Ignore * for count(*) fields.
         if (model.config.filterInvalid ||

--- a/src/compile/data/stack.ts
+++ b/src/compile/data/stack.ts
@@ -5,11 +5,10 @@ import {StackOffset} from '../../stack';
 import {contains, duplicate} from '../../util';
 import {VgSort, VgTransform} from '../../vega.schema';
 import {sortParams} from '../common';
-import {Model} from '../model';
 import {UnitModel} from './../unit';
 import {DataFlowNode} from './dataflow';
 
-function getStackByFields(model: Model) {
+function getStackByFields(model: UnitModel) {
   return model.stack.stackBy.reduce((fields, by) => {
     const channel = by.channel;
     const fieldDef = by.fieldDef;

--- a/src/compile/data/timeunit.ts
+++ b/src/compile/data/timeunit.ts
@@ -6,7 +6,7 @@ import {TEMPORAL} from '../../type';
 import {Dict, duplicate, extend, StringSet, vals} from '../../util';
 import {VgFormulaTransform, VgTransform} from '../../vega.schema';
 import {format} from '../axis/rules';
-import {Model} from '../model';
+import {ModelWithField} from '../model';
 import {DataFlowNode} from './dataflow';
 
 
@@ -25,7 +25,7 @@ export class TimeUnitNode extends DataFlowNode {
     super();
   }
 
-  public static make(model: Model) {
+  public static make(model: ModelWithField) {
     const formula = model.reduceFieldDef((timeUnitComponent: TimeUnitComponent, fieldDef: FieldDef) => {
       if (fieldDef.type === TEMPORAL && fieldDef.timeUnit) {
         const f = field(fieldDef);

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -386,6 +386,9 @@ export function getLabelGroup(model: FacetModel, channel: 'row' | 'column') {
     name: model.getName(`${channel}-labels`),
     from: {data: model.getName(channel)},
     groupEncode: childSizeEncodeEntryMixins(model, sizeChannel),
+    // TODO: support customizing + remove if Vega will provide padding for this one.
+    offset: -10,
+    // TODO: support customizing row title orientation (horizontal / vertical (using textOrient)
     textRole: `${channel}-labels`,
     textRef: {field: {parent: model.field(channel)}},
     positionRef: {field: {group: sizeChannel}, mult: 0.5}
@@ -398,6 +401,9 @@ export function getTitleGroup(model: FacetModel, channel: 'row' | 'column') {
   return getTextHeader({
     channel,
     name: model.getName(`${channel}-title`),
+
+    // TODO: support customizing row title orientation (horizontal / vertical)
+    textOrient: (channel === 'row' ? 'vertical' : undefined),
     textRole: `${channel}-labels`,
     textRef: {value: fieldDefTitle(fieldDef, model.config)},
     positionRef: {signal: `0.5 * ${sizeChannel}`}

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -26,6 +26,7 @@ import {buildModel} from './common';
 import {assembleData, assembleFacetData, FACET_SCALE_PREFIX} from './data/assemble';
 import {parseData} from './data/parse';
 import {assembleLayoutData, parseFacetLayout} from './layout';
+import {getTextHeader} from './layout/header';
 import {Model, ModelWithField} from './model';
 import initScale from './scale/init';
 import parseScaleComponent from './scale/parse';
@@ -379,61 +380,26 @@ export function getSharedAxisGroup(model: FacetModel, channel: 'x' | 'y'): VgEnc
 }
 
 export function getLabelGroup(model: FacetModel, channel: 'row' | 'column') {
-  const positionChannel = channel === 'row' ? 'y' : 'x';
-  const orthogonalPositionalChannel = channel === 'row' ? 'x' : 'y';
   const sizeChannel = channel === 'row' ? 'height' : 'width';
-
-  const align = channel === 'row' ? 'right' : 'center';
-
-  return {
-    name:  model.getName(`${channel}-labels`),
-    role: `${channel}-header`,
-    type: 'group',
+  return getTextHeader({
+    channel,
+    name: model.getName(`${channel}-labels`),
     from: {data: model.getName(channel)},
-    encode: {
-      update: childSizeEncodeEntryMixins(model, sizeChannel)
-    },
-    marks: [{
-      type: 'text',
-      role: `${channel}-labels`,
-      encode: {
-        update: {
-          // TODO: add label align
-          [positionChannel]: {field: {group: sizeChannel}, mult: 0.5},
-          text: {field: {parent: model.field(channel)}},
-          align: {value: align},
-          fill: {value: 'black'}
-        }
-      }
-    }]
-  };
+    groupEncode: childSizeEncodeEntryMixins(model, sizeChannel),
+    textRole: `${channel}-labels`,
+    textRef: {field: {parent: model.field(channel)}},
+    positionRef: {field: {group: sizeChannel}, mult: 0.5}
+  });
 }
 
 export function getTitleGroup(model: FacetModel, channel: 'row' | 'column') {
-  const positionChannel = channel === 'row' ? 'y' : 'x';
-  const orthogonalPositionalChannel = channel === 'row' ? 'x' : 'y';
   const sizeChannel = channel === 'row' ? 'height' : 'width';
-  const align = channel === 'row' ? 'right' : 'center';
   const fieldDef = model.facet[channel];
-
-  const title = fieldDefTitle(fieldDef, model.config);
-
-  return {
-    name:  model.getName(`${channel}-title`),
-    role: `${channel}-header`,
-    type: 'group',
-    marks: [{
-      type: 'text',
-      role: `${channel}-labels`,
-      encode: {
-        update: {
-          // TODO: add title align
-          [positionChannel]: {signal: `0.5 * ${sizeChannel}`},
-          align: {value: align},
-          text: {value: title},
-          fill: {value: 'black'}
-        }
-      }
-    }]
-  };
+  return getTextHeader({
+    channel,
+    name: model.getName(`${channel}-title`),
+    textRole: `${channel}-labels`,
+    textRef: {value: fieldDefTitle(fieldDef, model.config)},
+    positionRef: {signal: `0.5 * ${sizeChannel}`}
+  });
 }

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -11,6 +11,7 @@ import {Scale} from '../scale';
 import {FacetSpec} from '../spec';
 import {StackProperties} from '../stack';
 import {contains, Dict, extend, flatten, keys, vals} from '../util';
+import {FontWeight} from '../vega.schema';
 import {
   isDataRefDomain,
   isDataRefUnionedDomain,
@@ -390,7 +391,11 @@ export function getLabelGroup(model: FacetModel, channel: 'row' | 'column') {
     offset: -10,
     // TODO: support customizing row title orientation (horizontal / vertical (using textOrient)
     textRole: `${channel}-labels`,
+
+    // TODO: customize axis values
     textRef: {field: {parent: model.field(channel)}},
+
+    // TODO: customize alignment
     positionRef: {field: {group: sizeChannel}, mult: 0.5}
   });
 }
@@ -402,10 +407,19 @@ export function getTitleGroup(model: FacetModel, channel: 'row' | 'column') {
     channel,
     name: model.getName(`${channel}-title`),
 
+    // TODO: support customization
+    textEncodeMixins: {
+      fontWeight: {value: 'bold'}
+    },
+
     // TODO: support customizing row title orientation (horizontal / vertical)
     textOrient: (channel === 'row' ? 'vertical' : undefined),
     textRole: `${channel}-labels`,
+
+    // TODO: customize title
     textRef: {value: fieldDefTitle(fieldDef, model.config)},
+
+    // TODO: customize alignment
     positionRef: {signal: `0.5 * ${sizeChannel}`}
   });
 }

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -223,7 +223,7 @@ export class FacetModel extends ModelWithField {
 
   public assembleLayout(): VgLayout {
     return {
-      padding: {row: 10, column: 10, header: 10}, // TODO: allow customizing padding
+      padding: {row: 10, column: 10, header: 10},
       columns: 1,
       bounds: 'full'
     };
@@ -297,6 +297,7 @@ export function hasSubPlotWithXy(model: FacetModel) {
 function childSizeEncodeEntryMixins(model: FacetModel, size: 'width' | 'height') {
   return {
     [size]: {
+      // TODO: replace this with signal
       field: {
         parent: model.child.sizeName(size),
         // Level 2 because we currently wrap facet's child with two level of groups
@@ -414,7 +415,7 @@ export function getTitleGroup(model: FacetModel, channel: 'row' | 'column') {
 
     // TODO: support customizing row title orientation (horizontal / vertical)
     textOrient: (channel === 'row' ? 'vertical' : undefined),
-    textRole: `${channel}-labels`,
+    textRole: `${channel}-title`,
 
     // TODO: customize title
     textRef: {value: fieldDefTitle(fieldDef, model.config)},

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -4,7 +4,7 @@ import {Config} from '../config';
 import {LAYOUT, MAIN} from '../data';
 import {reduce} from '../encoding';
 import {Facet} from '../facet';
-import {FieldDef, normalize} from '../fielddef';
+import {FieldDef, normalize, title as fieldDefTitle} from '../fielddef';
 import {Legend} from '../legend';
 import * as log from '../log';
 import {Scale} from '../scale';
@@ -220,14 +220,11 @@ export class FacetModel extends ModelWithField {
   }
 
   public assembleLayout(): VgLayout {
-    return null;
-    // const columns = this.channelHasField('column') ? {signal: this.getName('column')} : 1;
-
-    // return {
-    //   padding: {row: 10, header: 5}, // TODO: allow customizing padding
-    //   columns,
-    //   bounds: 'full' // TODO:
-    // };
+    return {
+      padding: {row: 10, column: 10, header: 10}, // TODO: allow customizing padding
+      columns: 1,
+      bounds: 'full'
+    };
   }
 
   public assembleLayoutData(layoutData: VgData[]): VgData[] {
@@ -276,6 +273,8 @@ export class FacetModel extends ModelWithField {
         },
         marks
       }],
+      this.channelHasField('column') ? [getTitleGroup(this, 'column')] : [],
+      this.channelHasField('row') ? [getTitleGroup(this, 'row')] : [],
     );
   }
 
@@ -409,6 +408,29 @@ export function getLabelGroup(model: FacetModel, channel: 'row' | 'column') {
     }]
   };
 }
+
+export function getTitleGroup(model: FacetModel, channel: 'row' | 'column') {
+  const positionChannel = channel === 'row' ? 'y' : 'x';
+  const orthogonalPositionalChannel = channel === 'row' ? 'x' : 'y';
+  const sizeChannel = channel === 'row' ? 'height' : 'width';
+  const align = channel === 'row' ? 'right' : 'center';
+  const fieldDef = model.facet[channel];
+
+  const title = fieldDefTitle(fieldDef, model.config);
+
+  return {
+    name:  model.getName(`${channel}-title`),
+    role: `${channel}-header`,
+    type: 'group',
+    marks: [{
+      type: 'text',
+      role: `${channel}-labels`,
+      encode: {
+        update: {
+          // TODO: add title align
+          [positionChannel]: {signal: `0.5 * ${sizeChannel}`},
+          align: {value: align},
+          text: {value: title},
           fill: {value: 'black'}
         }
       }

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -17,9 +17,9 @@ import {
   isFieldRefUnionDomain,
   VgData,
   VgDataRef,
-  VgEncodeEntry
+  VgEncodeEntry,
+  VgLayout
 } from '../vega.schema';
-import {VgLayout} from '../vega.schema';
 import {parseAxisComponent, parseGridAxis, parseMainAxis} from './axis/parse';
 import {gridShow} from './axis/rules';
 import {buildModel} from './common';
@@ -29,7 +29,6 @@ import {assembleLayoutData, parseFacetLayout} from './layout';
 import {Model} from './model';
 import initScale from './scale/init';
 import parseScaleComponent from './scale/parse';
-
 
 export class FacetModel extends Model {
   public readonly facet: Facet;
@@ -261,8 +260,11 @@ export class FacetModel extends Model {
   }
 
   public assembleLayout(): VgLayout {
-    // TODO: add layout
-    return null;
+    return {
+      padding: {row:5, header: -1}, // TODO: allow customizing padding
+      columns: 1, // FIXME: Need to point to signal that stores column's cardinality
+      bounds: 'full' // TODO:
+    };
   }
 
   public assembleLayoutData(layoutData: VgData[]): VgData[] {
@@ -328,20 +330,6 @@ function getFacetGroupProperties(model: FacetModel) {
   const mergedCellConfig = extend({}, child.config.cell, child.config.facet.cell);
 
   return extend({
-      x: model.channelHasField(COLUMN) ? {
-          scale: model.scaleName(COLUMN),
-          field: model.field(COLUMN),
-          // offset by the spacing / 2
-          offset: model.spacing(COLUMN) / 2
-        } : {value: model.config.scale.facetSpacing / 2},
-
-      y: model.channelHasField(ROW) ? {
-        scale: model.scaleName(ROW),
-        field: model.field(ROW),
-        // offset by the spacing / 2
-        offset: model.spacing(ROW) / 2
-      } : {value: model.config.scale.facetSpacing / 2},
-
       width: {field: {parent: model.child.sizeName('width')}},
       height: {field: {parent: model.child.sizeName('height')}}
     },
@@ -383,10 +371,14 @@ export function getSharedAxisGroup(model: FacetModel, channel: 'x' | 'y'): VgEnc
   const isX = channel === 'x' ;
   const facetChannel = isX ? 'column' : 'row';
   const hasFacet = !!model.facet[facetChannel];
+  const axis = parseMainAxis(channel, model.child);
+
+  const role = facetChannel + '-' + (contains(['left', 'top'], axis.orient) ? 'header': 'footer');
 
   const axesGroup: VgEncodeEntry = {
     name: model.getName(channel + '-axes'),
-    type: 'group'
+    type: 'group',
+    role
   };
 
   if (hasFacet) {
@@ -401,38 +393,19 @@ export function getSharedAxisGroup(model: FacetModel, channel: 'x' | 'y'): VgEnc
     axesGroup.encode = {
       update: {
         width: {field: {parent: model.child.sizeName('width')}},
-        height: {field: {group: 'height'}},
-        x: hasFacet ? {
-          scale: model.scaleName(COLUMN),
-          field: model.field(COLUMN),
-          // offset by the spacing
-          offset: model.spacing(COLUMN) / 2
-        } : {
-          // TODO: support custom spacing here
-          // offset by the spacing
-          value: model.config.scale.facetSpacing / 2
-        }
+        height: {field: {group: 'height'}}
       }
     };
   } else {
     axesGroup.encode = {
       update: {
         width: {field: {group: 'width'}},
-        height: {field: {parent: model.child.sizeName('height')}},
-        y: hasFacet ? {
-          scale: model.scaleName(ROW),
-          field: model.field(ROW),
-          // offset by the spacing
-          offset: model.spacing(ROW) / 2
-        } : {
-          // offset by the spacing
-          value: model.config.scale.facetSpacing / 2
-        }
+        height: {field: {parent: model.child.sizeName('height')}}
       }
     };
   }
 
-  axesGroup.axes = [parseMainAxis(channel, model.child)];
+  axesGroup.axes = [axis];
   return axesGroup;
 }
 

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -323,21 +323,7 @@ export function getSharedAxisGroup(model: FacetModel, channel: 'x' | 'y'): VgEnc
     axesGroup.from = {data: channel === 'x' ? model.getName('column') : model.getName('row')};
   }
 
-  if (isX) {
-    axesGroup.encode = {
-      update: {
-        width: {field: {parent: model.child.sizeName('width')}},
-        height: {field: {group: 'height'}}
-      }
-    };
-  } else {
-    axesGroup.encode = {
-      update: {
-        width: {field: {group: 'width'}},
-        height: {field: {parent: model.child.sizeName('height')}}
-      }
-    };
-  }
+  // TODO: see if we need to setup axesGroup.encode at all
 
   axesGroup.axes = [axis];
   return axesGroup;

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -49,20 +49,6 @@ export class LayerModel extends Model {
     });
   }
 
-  public channelHasField(channel: Channel): boolean {
-    // layer does not have any channels
-    return false;
-  }
-
-  public hasDiscreteScale(channel: Channel) {
-    // since we assume shared scales we can just ask the first child
-    return this.children[0].hasDiscreteScale(channel);
-  }
-
-  public fieldDef(channel: Channel): FieldDef {
-    return null; // layer does not have field defs
-  }
-
   public parseData() {
     this.component.data = parseData(this);
     this.children.forEach((child) => {
@@ -222,17 +208,5 @@ export class LayerModel extends Model {
     return assembleLayeredSelectionMarks(this, flatten(this.children.map((child) => {
       return child.assembleMarks();
     })));
-  }
-
-  public channels(): Channel[] {
-    return [];
-  }
-
-  protected getMapping(): any {
-    return null;
-  }
-
-  public isLayer() {
-    return true;
   }
 }

--- a/src/compile/layout/header.ts
+++ b/src/compile/layout/header.ts
@@ -34,6 +34,8 @@ export function getTextHeader(params: TextHeaderParams): VgMarkGroup {
 
   const positionChannel = channel === 'row' ? 'y' : 'x';
   const offsetChannel = channel === 'row' ? 'x' : 'y';
+
+  // TODO: row could be left too for footer
   const align = channel === 'row' ? 'right' : 'center';
 
   return {

--- a/src/compile/layout/header.ts
+++ b/src/compile/layout/header.ts
@@ -1,0 +1,55 @@
+import {VgEncodeEntry, VgMarkGroup, VgValueRef} from '../../vega.schema';
+import {FacetModel} from '../facet';
+import {Model} from '../model';
+/**
+ * Utility for generating row / column headers
+ */
+
+
+
+export interface TextHeaderParams {
+  channel: 'row' | 'column';
+
+  name: string;
+
+  from?: {data: string};
+
+  groupEncode?: VgEncodeEntry;
+
+  textRole: string;
+
+  textRef: VgValueRef;
+
+  positionRef: VgValueRef;
+}
+
+export function getTextHeader(params: TextHeaderParams): VgMarkGroup {
+  const {channel, name, from, groupEncode, textRole, textRef, positionRef} = params;
+
+  const positionChannel = channel === 'row' ? 'y' : 'x';
+  const orthogonalPositionalChannel = channel === 'row' ? 'x' : 'y';
+  const align = channel === 'row' ? 'right' : 'center';
+
+  return {
+    name,
+    role: `${channel}-header`,
+    type: 'group',
+    ...(from ? {from} : {}),
+    ...(groupEncode ? {update: groupEncode} : {}),
+    marks: [{
+      type: 'text',
+      role: textRole,
+      encode: {
+        update: {
+          // TODO: add label align
+          [positionChannel]: positionRef,
+          text: textRef,
+          align: {value: align},
+          fill: {value: 'black'}
+        }
+      }
+    }]
+  };
+}
+
+

--- a/src/compile/layout/header.ts
+++ b/src/compile/layout/header.ts
@@ -1,4 +1,4 @@
-import {VgEncodeEntry, VgMarkGroup, VgValueRef} from '../../vega.schema';
+import {Orient, VgEncodeEntry, VgMarkGroup, VgValueRef} from '../../vega.schema';
 import {FacetModel} from '../facet';
 import {Model} from '../model';
 /**
@@ -16,6 +16,10 @@ export interface TextHeaderParams {
 
   groupEncode?: VgEncodeEntry;
 
+  offset?: number;
+
+  textOrient?: Orient;
+
   textRole: string;
 
   textRef: VgValueRef;
@@ -24,10 +28,10 @@ export interface TextHeaderParams {
 }
 
 export function getTextHeader(params: TextHeaderParams): VgMarkGroup {
-  const {channel, name, from, groupEncode, textRole, textRef, positionRef} = params;
+  const {channel, name, from, groupEncode, offset, textOrient, textRole, textRef, positionRef} = params;
 
   const positionChannel = channel === 'row' ? 'y' : 'x';
-  const orthogonalPositionalChannel = channel === 'row' ? 'x' : 'y';
+  const offsetChannel = channel === 'row' ? 'x' : 'y';
   const align = channel === 'row' ? 'right' : 'center';
 
   return {
@@ -35,14 +39,15 @@ export function getTextHeader(params: TextHeaderParams): VgMarkGroup {
     role: `${channel}-header`,
     type: 'group',
     ...(from ? {from} : {}),
-    ...(groupEncode ? {update: groupEncode} : {}),
+    ...(groupEncode ? {encode: {update: groupEncode}} : {}),
     marks: [{
       type: 'text',
       role: textRole,
       encode: {
         update: {
-          // TODO: add label align
           [positionChannel]: positionRef,
+          ...(offset ? {[offsetChannel]: {value: offset}} : {}),
+          ...(textOrient === 'vertical' ? {angle: {value: 270}} : {}),
           text: textRef,
           align: {value: align},
           fill: {value: 'black'}

--- a/src/compile/layout/header.ts
+++ b/src/compile/layout/header.ts
@@ -24,11 +24,13 @@ export interface TextHeaderParams {
 
   textRef: VgValueRef;
 
+  textEncodeMixins?: VgEncodeEntry;
+
   positionRef: VgValueRef;
 }
 
 export function getTextHeader(params: TextHeaderParams): VgMarkGroup {
-  const {channel, name, from, groupEncode, offset, textOrient, textRole, textRef, positionRef} = params;
+  const {channel, name, from, groupEncode, offset, textOrient, textRole, textEncodeMixins, textRef, positionRef} = params;
 
   const positionChannel = channel === 'row' ? 'y' : 'x';
   const offsetChannel = channel === 'row' ? 'x' : 'y';
@@ -50,7 +52,8 @@ export function getTextHeader(params: TextHeaderParams): VgMarkGroup {
           ...(textOrient === 'vertical' ? {angle: {value: 270}} : {}),
           text: textRef,
           align: {value: align},
-          fill: {value: 'black'}
+          fill: {value: 'black'},
+          ...textEncodeMixins
         }
       }
     }]

--- a/src/compile/legend/parse.ts
+++ b/src/compile/legend/parse.ts
@@ -4,7 +4,6 @@ import {Dict, keys} from '../../util';
 import {VgLegend} from '../../vega.schema';
 
 import {numberFormat} from '../common';
-import {Model} from '../model';
 import {UnitModel} from '../unit';
 
 import * as encode from './encode';
@@ -63,7 +62,7 @@ export function parseLegend(model: UnitModel, channel: Channel): VgLegend {
   return def;
 }
 
-function getSpecifiedOrDefaultValue(property: keyof VgLegend, specifiedLegend: Legend, channel: Channel, model: Model) {
+function getSpecifiedOrDefaultValue(property: keyof VgLegend, specifiedLegend: Legend, channel: Channel, model: UnitModel) {
   const fieldDef = model.fieldDef(channel);
 
   switch (property) {

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -326,6 +326,7 @@ export abstract class Model {
   }
 }
 
+/** Abstract class for UnitModel and FacetModel.  Both of which can contain fieldDefs as a part of its own specification. */
 export abstract class ModelWithField extends Model {
   public abstract fieldDef(channel: Channel): FieldDef;
 

--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -22,7 +22,7 @@ import {
 
 import {MAIN, RAW} from '../../data';
 import {varName} from '../../util';
-import {Model} from '../model';
+import {UnitModel} from '../unit';
 
 export function initDomain(domain: Domain, fieldDef: FieldDef, scale: ScaleType, scaleConfig: ScaleConfig) {
   if (domain === 'unaggregated') {
@@ -43,7 +43,7 @@ export function initDomain(domain: Domain, fieldDef: FieldDef, scale: ScaleType,
 }
 
 
-export function parseDomain(model: Model, channel: Channel): VgDomain {
+export function parseDomain(model: UnitModel, channel: Channel): VgDomain {
   const scale = model.scale(channel);
 
   // If channel is either X or Y then union them with X2 & Y2 if they exist
@@ -63,7 +63,7 @@ export function parseDomain(model: Model, channel: Channel): VgDomain {
   return parseSingleChannelDomain(scale, model, channel);
 }
 
-function parseSingleChannelDomain(scale: Scale, model: Model, channel:Channel): VgDomain {
+function parseSingleChannelDomain(scale: Scale, model: UnitModel, channel:Channel): VgDomain {
   const fieldDef = model.fieldDef(channel);
 
   if (scale.domain && scale.domain !== 'unaggregated') { // explicit value
@@ -152,7 +152,7 @@ function parseSingleChannelDomain(scale: Scale, model: Model, channel:Channel): 
 }
 
 
-export function domainSort(model: Model, channel: Channel, scaleType: ScaleType): VgSortField {
+export function domainSort(model: UnitModel, channel: Channel, scaleType: ScaleType): VgSortField {
   if (!hasDiscreteDomain(scaleType)) {
     return undefined;
   }

--- a/src/compile/scale/parse.ts
+++ b/src/compile/scale/parse.ts
@@ -2,17 +2,17 @@ import {Channel} from '../../channel';
 import {Scale} from '../../scale';
 import {isSortField} from '../../sort';
 import {Dict} from '../../util';
-
-import {Model} from '../model';
-
 import {VgScale} from '../../vega.schema';
+
+import {UnitModel} from '../unit';
+
 import {parseDomain} from './domain';
 import {parseRange} from './range';
 
 /**
  * Parse scales for all channels of a model.
  */
-export default function parseScaleComponent(model: Model): Dict<VgScale> {
+export default function parseScaleComponent(model: UnitModel): Dict<VgScale> {
   // TODO: should model.channels() inlcude X2/Y2?
   return model.channels().reduce(function(scaleComponentsIndex: Dict<VgScale>, channel: Channel) {
     const scaleComponents = parseScale(model, channel);
@@ -36,7 +36,7 @@ export const NON_TYPE_DOMAIN_RANGE_VEGA_SCALE_PROPERTIES: (keyof Scale)[] = [
 /**
  * Parse scales for a single channel of a model.
  */
-export function parseScale(model: Model, channel: Channel) {
+export function parseScale(model: UnitModel, channel: Channel) {
   if (!model.scale(channel)) {
     return null;
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -101,16 +101,12 @@ export const defaultFacetCellConfig: CellConfig = {
 };
 
 export interface FacetConfig {
-  /** Facet Axis Config */
-  axis?: AxisConfig;
-
   /** Facet Cell Config */
   cell?: CellConfig;
 }
 
 
 export const defaultFacetConfig: FacetConfig = {
-  axis: {},
   cell: defaultFacetCellConfig
 };
 

--- a/src/facet.ts
+++ b/src/facet.ts
@@ -1,4 +1,7 @@
-import {FacetFieldDef} from './fielddef';
+import {FieldDef} from './fielddef';
+
+// TODO: add more facet properties
+export type FacetFieldDef = FieldDef;
 
 export interface Facet {
 

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -131,9 +131,6 @@ export function isValueDef(channelDef: ChannelDef): channelDef is ValueDef<any> 
   return channelDef && 'value' in channelDef && channelDef['value'] !== undefined;
 }
 
-// TODO: consider if we want to distinguish ordinalOnlyScale from scale
-export type FacetFieldDef = PositionFieldDef;
-
 export interface FieldRefOption {
   /** exclude bin, aggregate, timeUnit */
   nofn?: boolean;

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -138,16 +138,6 @@ export interface ScaleConfig {
   pointPadding?: number;
 
   /**
-   * Default spacing between faceted plots.
-   *
-   * __Default value:__ `16`
-   *
-   * @TJS-type integer
-   * @minimum 0
-   */
-  facetSpacing?: number;
-
-  /**
    * Use the source data range before aggregation as scale domain instead of aggregated data for aggregate axis.
    * This property only works with aggregate functions that produce values within the raw data domain (`"mean"`, `"average"`, `"median"`, `"q1"`, `"q3"`, `"min"`, `"max"`). For other aggregations that produce values outside of the raw data domain (e.g. `"count"`, `"sum"`), this property is ignored.
    */
@@ -351,14 +341,6 @@ export interface Scale {
    */
   scheme?: Scheme;
 
-  /**
-   * (For `row` and `column` only) A pixel value for padding between cells in the trellis plots.
-   *
-   * __Default value:__ derived from [scale config](config.html#scale-config)'s `facetSpacing`
-   *
-   * @TJS-type integer
-   */
-  spacing?: number;
 
   /**
    * Applies spacing among ordinal elements in the scale range. The actual effect depends on how the scale is configured. If the __points__ parameter is `true`, the padding value is interpreted as a multiple of the spacing between points. A reasonable value is 1.0, such that the first and last point will be offset from the minimum and maximum value by half the distance between points. Otherwise, padding is typically in the range [0, 1] and corresponds to the fraction of space in the range interval to allocate to padding. A value of 0.5 means that the band size will be equal to the padding width. For more, see the [D3 ordinal scale documentation](https://github.com/mbostock/d3/wiki/Ordinal-Scales).

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -71,6 +71,8 @@ export type VgRange = string | VgDataRef | (number|string|VgDataRef)[] | VgRange
 
 export type VgDomain = any[] | VgDataRef | DataRefUnionDomain | FieldRefUnionDomain | VgSignalRef;
 
+export type VgMarkGroup = any;
+
 export type VgScale = {
   name: string,
   type: ScaleType,

--- a/test/compile/axis/encode.test.ts
+++ b/test/compile/axis/encode.test.ts
@@ -19,17 +19,6 @@ describe('compile/axis', () => {
       assert.equal(labels.angle.value, 270);
     });
 
-    it('should also rotate labels if the channel is column', function() {
-      const model = parseUnitModel({
-        mark: "point",
-        encoding: {
-          column: {field: "a", type: "temporal", timeUnit: "month", axis: {labelAngle: 270}}
-        }
-      });
-      const labels = encode.labels(model, 'column', {}, {});
-      assert.equal(labels.angle.value, 270);
-    });
-
     it('should have correct text.signal for quarter timeUnits', function () {
       const model = parseUnitModel({
         mark: "point",

--- a/test/compile/axis/encode.test.ts
+++ b/test/compile/axis/encode.test.ts
@@ -20,7 +20,7 @@ describe('compile/axis', () => {
     });
 
     it('should also rotate labels if the channel is column', function() {
-      const model = parseModel({
+      const model = parseUnitModel({
         mark: "point",
         encoding: {
           column: {field: "a", type: "temporal", timeUnit: "month", axis: {labelAngle: 270}}

--- a/test/compile/axis/rules.test.ts
+++ b/test/compile/axis/rules.test.ts
@@ -3,12 +3,12 @@
 import {assert} from 'chai';
 import {COLUMN, ROW, X} from '../../../src/channel';
 import * as rules from '../../../src/compile/axis/rules';
-import {parseModel} from '../../util';
+import {parseUnitModel} from '../../util';
 
 describe('compile/axis', ()=> {
   describe('grid()', function () {
     it('should return specified orient', function () {
-      const grid = rules.grid(parseModel({
+      const grid = rules.grid(parseUnitModel({
           mark: "point",
           encoding: {
             x: {field: 'a', type: 'quantitative', axis:{grid: false}}
@@ -18,7 +18,7 @@ describe('compile/axis', ()=> {
     });
 
     it('should return true by default', function () {
-      const grid = rules.grid(parseModel({
+      const grid = rules.grid(parseUnitModel({
           mark: "point",
           encoding: {
             x: {field: 'a', type: 'quantitative'}
@@ -28,7 +28,7 @@ describe('compile/axis', ()=> {
     });
 
     it('should return undefined for COLUMN', function () {
-      const grid = rules.grid(parseModel({
+      const grid = rules.grid(parseUnitModel({
           mark: "point",
           encoding: {
             x: {field: 'a', type: 'quantitative'}
@@ -38,7 +38,7 @@ describe('compile/axis', ()=> {
     });
 
     it('should return undefined for ROW', function () {
-      const grid = rules.grid(parseModel({
+      const grid = rules.grid(parseUnitModel({
           mark: "point",
           encoding: {
             x: {field: 'a', type: 'quantitative'}
@@ -47,7 +47,7 @@ describe('compile/axis', ()=> {
       assert.deepEqual(grid, false);
     });
     it('should return undefined for non-gridAxis', function () {
-      const grid = rules.grid(parseModel({
+      const grid = rules.grid(parseUnitModel({
           mark: "point",
           encoding: {
             x: {field: 'a', type: 'quantitative'}

--- a/test/compile/data/bin.test.ts
+++ b/test/compile/data/bin.test.ts
@@ -3,11 +3,11 @@
 import {assert} from 'chai';
 
 import {BinNode} from '../../../src/compile/data/bin';
-import {Model} from '../../../src/compile/model';
+import {ModelWithField} from '../../../src/compile/model';
 import {VgTransform} from '../../../src/vega.schema';
 import {parseUnitModel} from '../../util';
 
-function assemble(model: Model) {
+function assemble(model: ModelWithField) {
   return BinNode.make(model).assemble();
 }
 

--- a/test/compile/data/formatparse.test.ts
+++ b/test/compile/data/formatparse.test.ts
@@ -2,12 +2,12 @@
 import {assert} from 'chai';
 
 import {ParseNode} from '../../../src/compile/data/formatparse';
-import {Model} from '../../../src/compile/model';
+import {Model, ModelWithField} from '../../../src/compile/model';
 import * as log from '../../../src/log';
 import {parseUnitModel} from '../../util';
 
-function parse(model: Model) {
-  return ParseNode.make(model).parse;
+function parse(model: ModelWithField) {
+  return ParseNode.make(model).assembleFormatParse();
 }
 
 describe('compile/data/formatparse', () => {

--- a/test/compile/data/nullfilter.test.ts
+++ b/test/compile/data/nullfilter.test.ts
@@ -5,12 +5,12 @@ import {assert} from 'chai';
 import {UnitSpec} from '../../../src/spec';
 
 import {NullFilterNode} from '../../../src/compile/data/nullfilter';
-import {Model} from '../../../src/compile/model';
+import {ModelWithField} from '../../../src/compile/model';
 import {FieldDef} from '../../../src/fielddef';
 import {Dict, mergeDeep} from '../../../src/util';
 import {parseUnitModel} from '../../util';
 
-function parse(model: Model) {
+function parse(model: ModelWithField) {
   return NullFilterNode.make(model);
 }
 

--- a/test/compile/data/timeunit.test.ts
+++ b/test/compile/data/timeunit.test.ts
@@ -2,10 +2,10 @@
 
 import {assert} from 'chai';
 import {TimeUnitNode} from '../../../src/compile/data/timeunit';
-import {Model} from '../../../src/compile/model';
+import {ModelWithField} from '../../../src/compile/model';
 import {parseUnitModel} from '../../util';
 
-function assemble(model: Model) {
+function assemble(model: ModelWithField) {
   return TimeUnitNode.make(model).assemble();
 }
 

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -64,41 +64,23 @@ describe('FacetModel', function() {
     });
   });
 
-  describe('spacing', () => {
-    it('should return specified spacing if specified', () => {
-      assert.equal(facet.spacing({spacing: 123}, null, null), 123);
-    });
-
-    it('should return default facetSpacing if there is a subplot and no specified spacing', () => {
+  describe('parseScale', () => {
+    it('should correctly set scale component for a model', () => {
       const model = parseFacetModel({
         facet: {
-          row: {field: 'a', type: 'ordinal'}
+          row: {field: 'a', type: 'quantitative'}
         },
         spec: {
           mark: 'point',
           encoding: {
-            "x": {"aggregate": "sum", "field": "yield", "type": "quantitative"},
-            "y": {"field": "variety", "type": "nominal"},
-            "color": {"field": "site", "type": "nominal"}
+            x: {field: 'b', type: 'quantitative'}
           }
         }
       });
-      assert.equal(facet.spacing({}, model, defaultConfig), defaultConfig.scale.facetSpacing);
-    });
 
-    it('should return 0 if it is a simple table without subplot with x/y and no specified spacing', () => {
-      const model = parseFacetModel({
-        facet: {
-          row: {field: 'a', type: 'ordinal'}
-        },
-        spec: {
-          mark: 'point',
-          encoding: {
-            "color": {"field": "site", "type": "nominal"}
-          }
-        }
-      });
-      assert.equal(facet.spacing({}, model, defaultConfig), 0);
+      model.parseScale();
+
+      assert(model.component.scales['x']);
     });
   });
 });
@@ -203,63 +185,6 @@ describe('compile/facet', () => {
           assert.deepEqual(xSharedAxisGroup.encode.update.x, undefined);
         });
       });
-    });
-  });
-
-  describe('initAxis', () => {
-    it('should include properties from axis and config.facet.axis', () => {
-      const model = parseFacetModel({
-        facet: {
-          row: {field: 'a', type: 'ordinal', axis: {offset: 30}}
-        },
-        spec: {
-          mark: 'point',
-          encoding: {
-            "x": {"aggregate": "sum", "field": "yield", "type": "quantitative"},
-            "y": {"field": "variety", "type": "nominal"},
-          },
-        },
-        config: {"facet": {"axis": {"labelPadding": 123}}}
-      });
-      assert.deepEqual<Axis>(model.axis(ROW), {"orient": "right", "labelAngle": 90, "offset": 30, "labelPadding": 123});
-    });
-
-    it('should set the labelAngle if specified', () => {
-      const model = parseFacetModel({
-        facet: {
-          row: {field: 'c', type: 'ordinal', "axis": {"labelAngle": 0}}
-        },
-        spec: {
-          mark: 'point',
-          encoding: {
-            "x": {"aggregate": "sum", "field": "yield", "type": "quantitative"},
-            "y": {"field": "variety", "type": "nominal"}
-          },
-        }
-      });
-      assert.deepEqual<Axis>(model.axis(ROW), {"orient": "right", "labelAngle": 0});
-    });
-
-    it('should set the labelAngle if labelAngle is not specified', () => {
-      const model = parseFacetModel({
-        facet: {
-          row: {field: 'a', type: 'ordinal'}
-        },
-        spec: {
-          mark: 'point',
-          encoding: {
-            "x": {"aggregate": "sum", "field": "yield", "type": "quantitative"},
-            "y": {"field": "variety", "type": "nominal"},
-            "row": {
-              "field": "c", "type": "nominal",
-              "axis": {
-                  "title": "title"
-              }
-            }
-          },
-        }
-      });
-      assert.deepEqual<Axis>(model.axis(ROW), {"orient": "right", "labelAngle": 90});
     });
   });
 });

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -132,10 +132,10 @@ describe('compile/facet', () => {
           assert.deepEqual(xSharedAxisGroup.from, {data: 'column'});
         });
 
-        it('should have width = child width, height = group height, x = column field', () => {
+        it('should have width = child width, height = group height and have no x', () => {
           assert.deepEqual(xSharedAxisGroup.encode.update.width, {field: {parent: 'child_width'}});
           assert.deepEqual(xSharedAxisGroup.encode.update.height, {field: {group: 'height'}});
-          assert.deepEqual(xSharedAxisGroup.encode.update.x, {scale: 'column', field: 'a', offset: 8});
+          assert.equal(xSharedAxisGroup.encode.update.x, undefined);
         });
       });
 
@@ -147,10 +147,10 @@ describe('compile/facet', () => {
           assert.equal(ySharedAxisGroup.from, undefined);
         });
 
-        it('should have height = child height, width = group width, y = defaultFacetSpacing / 2.', () => {
+        it('should have height = child height, width = group width, and have no y.', () => {
           assert.deepEqual(ySharedAxisGroup.encode.update.height, {field: {parent: 'child_height'}});
           assert.deepEqual(ySharedAxisGroup.encode.update.width, {field: {group: 'width'}});
-          assert.deepEqual(ySharedAxisGroup.encode.update.y, {value: 8});
+          assert.deepEqual(ySharedAxisGroup.encode.update.y, undefined);
         });
       });
     });
@@ -182,10 +182,10 @@ describe('compile/facet', () => {
           assert.deepEqual(ySharedAxisGroup.from, {data: 'row'});
         });
 
-        it('should have height = child height, width = group width, y= row field', () => {
+        it('should have height = child height, width = group width, and have no y.', () => {
           assert.deepEqual(ySharedAxisGroup.encode.update.height, {field: {parent: 'child_height'}});
           assert.deepEqual(ySharedAxisGroup.encode.update.width, {field: {group: 'width'}});
-          assert.deepEqual(ySharedAxisGroup.encode.update.y, {scale: 'row', field: 'a', offset: 8});
+          assert.deepEqual(ySharedAxisGroup.encode.update.y, undefined);
         });
       });
 
@@ -197,10 +197,10 @@ describe('compile/facet', () => {
           assert.equal(xSharedAxisGroup.from, undefined);
         });
 
-        it('should have width = child width, height = group height, x, x = defaultFacetSpacing / 2.', () => {
+        it('should have width = child width, height = group height, x, and have no y.', () => {
           assert.deepEqual(xSharedAxisGroup.encode.update.width, {field: {parent: 'child_width'}});
           assert.deepEqual(xSharedAxisGroup.encode.update.height, {field: {group: 'height'}});
-          assert.deepEqual(xSharedAxisGroup.encode.update.x, {value: 8});
+          assert.deepEqual(xSharedAxisGroup.encode.update.x, undefined);
         });
       });
     });

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -114,11 +114,6 @@ describe('compile/facet', () => {
           assert.deepEqual(xSharedAxisGroup.from, {data: 'column'});
         });
 
-        it('should have width = child width, height = group height and have no x', () => {
-          assert.deepEqual(xSharedAxisGroup.encode.update.width, {field: {parent: 'child_width'}});
-          assert.deepEqual(xSharedAxisGroup.encode.update.height, {field: {group: 'height'}});
-          assert.equal(xSharedAxisGroup.encode.update.x, undefined);
-        });
       });
 
       describe('yAxisGroup', () => {
@@ -127,12 +122,6 @@ describe('compile/facet', () => {
           assert.equal(ySharedAxisGroup.name, 'y-axes');
           assert.equal(ySharedAxisGroup.type, 'group');
           assert.equal(ySharedAxisGroup.from, undefined);
-        });
-
-        it('should have height = child height, width = group width, and have no y.', () => {
-          assert.deepEqual(ySharedAxisGroup.encode.update.height, {field: {parent: 'child_height'}});
-          assert.deepEqual(ySharedAxisGroup.encode.update.width, {field: {group: 'width'}});
-          assert.deepEqual(ySharedAxisGroup.encode.update.y, undefined);
         });
       });
     });
@@ -163,12 +152,6 @@ describe('compile/facet', () => {
           assert.equal(ySharedAxisGroup.type, 'group');
           assert.deepEqual(ySharedAxisGroup.from, {data: 'row'});
         });
-
-        it('should have height = child height, width = group width, and have no y.', () => {
-          assert.deepEqual(ySharedAxisGroup.encode.update.height, {field: {parent: 'child_height'}});
-          assert.deepEqual(ySharedAxisGroup.encode.update.width, {field: {group: 'width'}});
-          assert.deepEqual(ySharedAxisGroup.encode.update.y, undefined);
-        });
       });
 
       describe('xAxisGroup', () => {
@@ -177,12 +160,6 @@ describe('compile/facet', () => {
           assert.equal(xSharedAxisGroup.name, 'x-axes');
           assert.equal(xSharedAxisGroup.type, 'group');
           assert.equal(xSharedAxisGroup.from, undefined);
-        });
-
-        it('should have width = child width, height = group height, x, and have no y.', () => {
-          assert.deepEqual(xSharedAxisGroup.encode.update.width, {field: {parent: 'child_width'}});
-          assert.deepEqual(xSharedAxisGroup.encode.update.height, {field: {group: 'height'}});
-          assert.deepEqual(xSharedAxisGroup.encode.update.x, undefined);
         });
       });
     });

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -4,13 +4,14 @@ import {assert} from 'chai';
 import {Axis} from '../../src/axis';
 import {ROW, SHAPE} from '../../src/channel';
 import * as facet from '../../src/compile/facet';
-import {FacetModel} from '../../src/compile/facet';
+import {FacetModel, getLabelGroup, getTitleGroup} from '../../src/compile/facet';
 import {defaultConfig} from '../../src/config';
 import {Facet} from '../../src/facet';
 import {PositionFieldDef} from '../../src/fielddef';
 import * as log from '../../src/log';
 import {POINT} from '../../src/mark';
 import {ORDINAL} from '../../src/type';
+import {VgLayout} from '../../src/vega.schema';
 import {parseFacetModel} from '../util';
 
 describe('FacetModel', function() {
@@ -81,6 +82,115 @@ describe('FacetModel', function() {
       model.parseScale();
 
       assert(model.component.scales['x']);
+    });
+  });
+
+  describe('assembleLayout', () => {
+    it('returns a layout with only one column', () => {
+      const model = parseFacetModel({
+        facet: {
+          column: {field: 'a', type: 'quantitative'}
+        },
+        spec: {
+          mark: 'point',
+          encoding: {
+            x: {field: 'b', type: 'quantitative'}
+          }
+        }
+      });
+      const layout = model.assembleLayout();
+      assert.deepEqual<VgLayout>(layout, {
+        padding: {row: 10, column: 10, header: 10}, // TODO: allow customizing padding
+        columns: 1,
+        bounds: 'full'
+      });
+    });
+  });
+
+  describe('assembleSignals', () => {
+    it('includes signal for calculating column length when there is a column field', () => {
+      const model = parseFacetModel({
+        facet: {
+          column: {field: 'a', type: 'quantitative'}
+        },
+        spec: {
+          mark: 'point',
+          encoding: {
+            x: {field: 'b', type: 'quantitative'}
+          }
+        }
+      });
+      const signals = model.assembleSignals([]);
+      assert.includeDeepMembers(signals, [
+        {
+          name: 'column',
+          update: `data('layout')[0].distinct_a`
+        }
+      ]);
+    });
+  });
+
+  describe('dataTable', () => {
+    it('should return stacked if there is a stacked data component', () => {
+      const model = parseFacetModel({
+        facet: {
+          row: {field: 'a', type: 'ordinal'}
+        },
+        spec: {
+          mark: 'point',
+          encoding: {
+            "x": {"aggregate": "sum", "field": "yield", "type": "quantitative"},
+            "y": {"field": "variety", "type": "nominal"},
+            "color": {"field": "site", "type": "nominal"}
+          }
+        }
+      });
+
+      // Mock
+      model.component.data = {stack: {}} as any;
+
+      // assert.equal(model.dataTable(), 'stacked');
+    });
+
+    it('should return summary if there is a summary data component and no stacked', () => {
+      const model = parseFacetModel({
+        facet: {
+          row: {field: 'a', type: 'ordinal'}
+        },
+        spec: {
+          mark: 'point',
+          encoding: {
+            "x": {"aggregate": "sum", "field": "yield", "type": "quantitative"},
+            "y": {"field": "variety", "type": "nominal"}
+          }
+        }
+      });
+
+      // Mock
+      model.component.data = {summary: [{
+        measures: {a: 1}
+      }]} as any;
+
+      // assert.equal(model.dataTable(), 'main');
+    });
+
+    it('should return source if there is no stacked nor summary data component', () => {
+      const model = parseFacetModel({
+        facet: {
+          row: {field: 'a', type: 'ordinal'}
+        },
+        spec: {
+          mark: 'point',
+          encoding: {
+            "x": {"field": "yield", "type": "quantitative"},
+            "y": {"field": "variety", "type": "nominal"}
+          }
+        }
+      });
+      // Mock
+      model.component.data = {summary: []} as any;
+
+      // assert.equal(model.dataTable(), 'main');
     });
   });
 });
@@ -160,6 +270,175 @@ describe('compile/facet', () => {
           assert.equal(xSharedAxisGroup.name, 'x-axes');
           assert.equal(xSharedAxisGroup.type, 'group');
           assert.equal(xSharedAxisGroup.from, undefined);
+        });
+      });
+    });
+  });
+
+  describe('getLabelGroup', () => {
+    const model = parseFacetModel({
+      facet: {
+        row: {field: 'a', type: 'ordinal'},
+        column: {field: 'a', type: 'ordinal'}
+      },
+      spec: {
+        mark: 'point',
+        encoding: {
+          x: {field: 'b', type: 'quantitative'},
+          y: {field: 'c', type: 'quantitative'}
+        }
+      }
+    });
+
+    describe('for column', () => {
+      const columnLabelGroup = getLabelGroup(model, 'column');
+      const {marks, ...columnLabelGroupTopLevelProps} = columnLabelGroup;
+      it('returns a header group mark with correct name, role, type, from, and encode.', () => {
+
+        assert.deepEqual(columnLabelGroupTopLevelProps, {
+          name: 'column-labels',
+          type: 'group',
+          role: 'column-header',
+          from: {data: 'column'},
+          encode: {
+            update: {
+              width: {field: {parent: 'child_width', level: 2}}
+            }
+          }
+        });
+      });
+      const textMark = marks[0];
+
+      it('contains a correct text mark with the correct role and encode as the only item in marks', () => {
+        assert.equal(marks.length, 1);
+        assert.deepEqual(textMark, {
+          type: 'text',
+          role: 'column-labels',
+          encode: {
+            update: {
+              x: {field: {group: 'width'}, mult: 0.5},
+              y: {value: -10},
+              text: {field: {parent: 'a'}},
+              align: {value: 'center'},
+              fill: {value: 'black'}
+            }
+          }
+        });
+      });
+    });
+
+    describe('for row', () => {
+      const rowLabelGroup = getLabelGroup(model, 'row');
+      const {marks, ...rowLabelGroupTopLevelProps} = rowLabelGroup;
+      it('returns a header group mark with correct name, role, type, from, and encode.', () => {
+
+        assert.deepEqual(rowLabelGroupTopLevelProps, {
+          name: 'row-labels',
+          type: 'group',
+          role: 'row-header',
+          from: {data: 'row'},
+          encode: {
+            update: {
+              height: {field: {parent: 'child_height', level: 2}}
+            }
+          }
+        });
+      });
+      const textMark = marks[0];
+
+      it('contains a correct text mark with the correct role and encode as the only item in marks', () => {
+        assert.equal(marks.length, 1);
+        assert.deepEqual(textMark, {
+          type: 'text',
+          role: 'row-labels',
+          encode: {
+            update: {
+              y: {field: {group: 'height'}, mult: 0.5},
+              x: {value: -10},
+              text: {field: {parent: 'a'}},
+              align: {value: 'right'},
+              fill: {value: 'black'}
+            }
+          }
+        });
+      });
+    });
+  });
+
+  describe('getTitleGroup', () => {
+    const model = parseFacetModel({
+      facet: {
+        row: {field: 'a', type: 'ordinal'},
+        column: {field: 'a', type: 'ordinal'}
+      },
+      spec: {
+        mark: 'point',
+        encoding: {
+          x: {field: 'b', type: 'quantitative'},
+          y: {field: 'c', type: 'quantitative'}
+        }
+      }
+    });
+
+    describe('for column', () => {
+      const columnLabelGroup = getTitleGroup(model, 'column');
+      const {marks, ...columnTitleGroupTopLevelProps} = columnLabelGroup;
+      it('returns a header group mark with correct name, role, type, and from.', () => {
+
+        assert.deepEqual(columnTitleGroupTopLevelProps, {
+          name: 'column-title',
+          type: 'group',
+          role: 'column-header'
+        });
+      });
+      const textMark = marks[0];
+
+      it('contains a correct text mark with the correct role and encode as the only item in marks', () => {
+        assert.equal(marks.length, 1);
+        assert.deepEqual(textMark, {
+          type: 'text',
+          role: 'column-title',
+          encode: {
+            update: {
+              x: {signal: `0.5 * width`},
+              text: {value: 'a'},
+              fontWeight: {value: 'bold'},
+              align: {value: 'center'},
+              fill: {value: 'black'}
+            }
+          }
+        });
+      });
+    });
+
+    describe('for row', () => {
+      const rowTitleGroup = getTitleGroup(model, 'row');
+      const {marks, ...rowTitleGroupTopLevelProps} = rowTitleGroup;
+      it('returns a header group mark with correct name, role, type, from, and encode.', () => {
+
+        assert.deepEqual(rowTitleGroupTopLevelProps, {
+          name: 'row-title',
+          type: 'group',
+          role: 'row-header'
+        });
+      });
+      const textMark = marks[0];
+
+      it('contains a correct text mark with the correct role and encode as the only item in marks', () => {
+        assert.equal(marks.length, 1);
+        assert.deepEqual(textMark, {
+          type: 'text',
+          role: 'row-title',
+          encode: {
+            update: {
+              y: {signal: `0.5 * height`},
+              text: {value: 'a'},
+              angle: {value: 270},
+              fontWeight: {value: 'bold'},
+              align: {value: 'right'},
+              fill: {value: 'black'}
+            }
+          }
         });
       });
     });


### PR DESCRIPTION
See commit message for details

## To Follow-up
- [ ] ~~Make FacetFieldDef support `sort`~~ #2176
- [x] Rebuild Labels and Title (now that the axis has gone)
  - [x] labels group
  - [x] title 
  - [ ] Re-build using `row-title` and `column-title`
- [ ] Correct write `parseAxis` logic
- [ ] Deal with non-unit child in `parseAxisGroups`
- [x] correctly set `column` of `layout`

- [ ] allow customization
  - [ ] `padding: {header: number, row: number, column: number}`
  - [ ] Axis Title, Axis Labels
