### PR TITLE
No need to test `instanceof`.

### DIFF
--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -14,17 +14,6 @@ import {ORDINAL} from '../../src/type';
 import {parseFacetModel} from '../util';
 
 describe('FacetModel', function() {
-  it('should say it is facet', function() {
-    const model = parseFacetModel({
-      facet: {},
-      spec: {
-        mark: POINT,
-        encoding: {}
-      }
-    });
-    assert(model instanceof FacetModel);
-  });
-
   describe('initFacet', () => {
     it('should drop unsupported channel and throws warning', () => {
       log.runLocalLogger((localLogger) => {

--- a/test/compile/layer.test.ts
+++ b/test/compile/layer.test.ts
@@ -5,11 +5,6 @@ import {LayerSpec} from '../../src/spec';
 import {parseLayerModel} from '../util';
 
 describe('Layer', function() {
-  it('should say it is layer', function() {
-    const model = new LayerModel({layer: []} as LayerSpec, null, null, {});
-    assert(model instanceof LayerModel);
-  });
-
   describe('merge scale domains', () => {
     it('should merge domains', () => {
       const model = parseLayerModel({

--- a/test/compile/unit.test.ts
+++ b/test/compile/unit.test.ts
@@ -8,11 +8,6 @@ import {QUANTITATIVE} from '../../src/type';
 import {parseUnitModel} from '../util';
 
 describe('UnitModel', function() {
-  it('should say it is unit', function() {
-    const model = parseUnitModel({mark: 'point', encoding: {}});
-    assert(model instanceof UnitModel);
-  });
-
   describe('initEncoding', () => {
     it('should drop unsupported channel and throws warning', () => {
       log.runLocalLogger((localLogger) => {


### PR DESCRIPTION
 (These are old tests from testing `isLayer`, `isFacet`, and `isUnit`.)
