### PR TITLE
[WIP] Remove layout data

### DIFF
--- a/examples/vg-specs/area.vg.json
+++ b/examples/vg-specs/area.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -63,158 +43,138 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "300"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "300"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "area",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "area",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "yearmonth_date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "sum_count"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "orient": {
-                                "value": "vertical"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "yearmonth_date"
                     },
-                    "range": [
-                        0,
-                        300
-                    ],
-                    "round": true,
-                    "nice": "month"
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "sum_count"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    },
+                    "orient": {
+                        "value": "vertical"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "data": "source_0",
+                "field": "yearmonth_date"
+            },
+            "range": [
+                0,
+                300
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "YEARMONTH(date)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%Y')"
-                                },
-                                "angle": {
-                                    "value": 0
-                                }
-                            }
+            "round": true,
+            "nice": "month"
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "sum_count"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "YEARMONTH(date)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%Y')"
+                        },
+                        "angle": {
+                            "value": 0
                         }
                     }
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "SUM(count)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "SUM(count)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/area_vertical.vg.json
+++ b/examples/vg-specs/area_vertical.vg.json
@@ -3,26 +3,6 @@
     "description": "Area chart showing weight of cars over time (vertical).",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -64,156 +44,135 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "Area chart showing weight of cars over time (vertical).",
+            "name": "marks",
+            "type": "area",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "area",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "sum_Weight_in_lbs"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "year_Year"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "orient": {
-                                "value": "horizontal"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "sum_Weight_in_lbs"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "time",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "year_Year"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": "year"
+                    "x2": {
+                        "scale": "x",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    },
+                    "orient": {
+                        "value": "horizontal"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "sum_Weight_in_lbs"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "SUM(Weight_in_lbs)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "orient": "left",
-                    "title": "YEAR(Year)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%Y')"
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "time",
+            "domain": {
+                "data": "source_0",
+                "field": "year_Year"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": "year"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "SUM(Weight_in_lbs)",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "orient": "left",
+            "title": "YEAR(Year)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%Y')"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/bar.vg.json
+++ b/examples/vg-specs/bar.vg.json
@@ -3,26 +3,6 @@
     "description": "A simple bar chart with embedded data.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -76,159 +56,131 @@
                     "expr": "datum[\"b\"] !== null && !isNaN(datum[\"b\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "a"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_a\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A simple bar chart with embedded data.",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
+                    "xc": {
+                        "scale": "x",
+                        "field": "a"
+                    },
                     "width": {
-                        "field": "width"
+                        "value": 20
                     },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "a"
-                            },
-                            "width": {
-                                "value": 20
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "b"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "a",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "b"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "a",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "b"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "a",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "a",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "b",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "b",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/bar_1d.vg.json
+++ b/examples/vg-specs/bar_1d.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -52,115 +32,95 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "sum_people"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "value": 0
-                            },
-                            "yc": {
-                                "value": 10.5
-                            },
-                            "height": {
-                                "value": 20
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "sum_people"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "x2": {
+                        "scale": "x",
+                        "value": 0
+                    },
+                    "yc": {
+                        "value": 10.5
+                    },
+                    "height": {
+                        "value": 20
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "sum_people"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "population",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "population",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0
         }
     ]
 }

--- a/examples/vg-specs/bar_1d_rangestep_config.vg.json
+++ b/examples/vg-specs/bar_1d_rangestep_config.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -52,115 +32,95 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "sum_people"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "value": 0
-                            },
-                            "yc": {
-                                "value": 10.5
-                            },
-                            "height": {
-                                "value": 20
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "sum_people"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "x2": {
+                        "scale": "x",
+                        "value": 0
+                    },
+                    "yc": {
+                        "value": 10.5
+                    },
+                    "height": {
+                        "value": 20
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "sum_people"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "population",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "population",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0
         }
     ]
 }

--- a/examples/vg-specs/bar_aggregate.vg.json
+++ b/examples/vg-specs/bar_aggregate.vg.json
@@ -3,26 +3,6 @@
     "description": "A bar chart showing the US population distribution of age groups in 2000.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -55,145 +35,117 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "bandspace(domain('y').length, 1, 0.5) * 17"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "age"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "max(datum[\"distinct_age\"] - 1 + 2*0.5, 0) * 17"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A bar chart showing the US population distribution of age groups in 2000.",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "sum_people"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "value": 0
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "age"
-                            },
-                            "height": {
-                                "value": 16
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "sum_people"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "age",
-                        "sort": true
+                    "x2": {
+                        "scale": "x",
+                        "value": 0
                     },
-                    "range": {
-                        "step": 17
+                    "yc": {
+                        "scale": "y",
+                        "field": "age"
                     },
-                    "round": true,
-                    "padding": 0.5
+                    "height": {
+                        "value": 16
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "sum_people"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "population",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "orient": "left",
-                    "title": "age",
-                    "zindex": 1
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "age",
+                "sort": true
+            },
+            "range": {
+                "step": 17
+            },
+            "round": true,
+            "padding": 0.5
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "population",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "orient": "left",
+            "title": "age",
+            "zindex": 1
         }
     ]
 }

--- a/examples/vg-specs/bar_aggregate_count.vg.json
+++ b/examples/vg-specs/bar_aggregate_count.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -69,152 +49,132 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x2": {
+                        "scale": "x",
+                        "field": "bin_maxbins_10_precipitation_start",
+                        "offset": 1
                     },
-                    "height": {
-                        "field": "height"
+                    "x": {
+                        "scale": "x",
+                        "field": "bin_maxbins_10_precipitation_end"
                     },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x2": {
-                                "scale": "x",
-                                "field": "bin_maxbins_10_precipitation_start",
-                                "offset": 1
-                            },
-                            "x": {
-                                "scale": "x",
-                                "field": "bin_maxbins_10_precipitation_end"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "count_*"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(bin_maxbins_10_precipitation_bins.start, bin_maxbins_10_precipitation_bins.stop + bin_maxbins_10_precipitation_bins.step, bin_maxbins_10_precipitation_bins.step)"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "count_*"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "bin-linear",
+            "domain": {
+                "signal": "sequence(bin_maxbins_10_precipitation_bins.start, bin_maxbins_10_precipitation_bins.stop + bin_maxbins_10_precipitation_bins.step, bin_maxbins_10_precipitation_bins.step)"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "title": "BIN(precipitation)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "count_*"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "title": "BIN(precipitation)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Number of Records",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/bar_aggregate_size.vg.json
+++ b/examples/vg-specs/bar_aggregate_size.vg.json
@@ -3,26 +3,6 @@
     "description": "A bar chart showing the US population distribution of age groups in 2000.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -55,159 +35,131 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 17"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "age"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_age\"] - 1 + 2*0.5, 0) * 17"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A bar chart showing the US population distribution of age groups in 2000.",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
+                    "xc": {
+                        "scale": "x",
+                        "field": "age"
+                    },
                     "width": {
-                        "field": "width"
+                        "value": 10
                     },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "width": {
-                                "value": 10
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "sum_people"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "age",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 17
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "sum_people"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "age",
+                "sort": true
+            },
+            "range": {
+                "step": 17
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "sum_people"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "age",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "age",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "population",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "population",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/bar_aggregate_vertical.vg.json
+++ b/examples/vg-specs/bar_aggregate_vertical.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -50,158 +30,131 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "Cylinders"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_Cylinders\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
+                    "xc": {
+                        "scale": "x",
+                        "field": "Cylinders"
+                    },
                     "width": {
-                        "field": "width"
+                        "value": 20
                     },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "Cylinders"
-                            },
-                            "width": {
-                                "value": 20
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "mean_Acceleration"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Cylinders",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "mean_Acceleration"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "Cylinders",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "mean_Acceleration"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Cylinders",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Cylinders",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "MEAN(Acceleration)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "MEAN(Acceleration)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/bar_array_aggregate.vg.json
+++ b/examples/vg-specs/bar_array_aggregate.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -87,158 +67,131 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "a"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_a\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
+                    "xc": {
+                        "scale": "x",
+                        "field": "a"
+                    },
                     "width": {
-                        "field": "width"
+                        "value": 20
                     },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "a"
-                            },
-                            "width": {
-                                "value": 20
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "average_b"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "a",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "average_b"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "a",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "average_b"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "a",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "a",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "AVERAGE(b)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "AVERAGE(b)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/bar_filter_calc.vg.json
+++ b/examples/vg-specs/bar_filter_calc.vg.json
@@ -3,26 +3,6 @@
     "description": "A simple bar chart with embedded data that uses a filter and calculate.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -83,159 +63,131 @@
                     "expr": "datum[\"b2\"] !== null && !isNaN(datum[\"b2\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "a"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_a\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A simple bar chart with embedded data that uses a filter and calculate.",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
+                    "xc": {
+                        "scale": "x",
+                        "field": "a"
+                    },
                     "width": {
-                        "field": "width"
+                        "value": 20
                     },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "a"
-                            },
-                            "width": {
-                                "value": 20
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "b2"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "a",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "b2"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "a",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "b2"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "a",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "a",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "b2",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "b2",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/bar_grouped.vg.json
+++ b/examples/vg-specs/bar_grouped.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -95,343 +75,317 @@
             ]
         },
         {
-            "name": "layout",
-            "source": "source_0",
+            "name": "column-layout",
+            "source": "column",
             "transform": [
                 {
                     "type": "aggregate",
-                    "fields": [
-                        "age",
-                        "gender"
-                    ],
                     "ops": [
-                        "distinct",
                         "distinct"
+                    ],
+                    "fields": [
+                        "age"
                     ]
-                },
-                {
-                    "type": "formula",
-                    "as": "child_width",
-                    "expr": "max(datum[\"distinct_gender\"] - 1 + 2*0.5, 0) * 12"
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "(datum[\"child_width\"] + 5) * datum[\"distinct_age\"]"
-                },
-                {
-                    "type": "formula",
-                    "as": "child_height",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "datum[\"child_height\"] + 5"
                 }
             ]
         }
     ],
+    "signals": [
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        },
+        {
+            "name": "child_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 12"
+        },
+        {
+            "name": "child_height",
+            "update": "200"
+        }
+    ],
+    "layout": {
+        "padding": {
+            "row": 10,
+            "column": 10,
+            "header": 10
+        },
+        "columns": 1,
+        "bounds": "full"
+    },
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "from": {
-                "data": "layout"
-            },
-            "signals": [
-                {
-                    "name": "column",
-                    "update": "data('layout')[0].distinct_age"
-                }
-            ],
             "layout": {
                 "padding": {
                     "row": 10,
                     "column": 10,
                     "header": 10
                 },
-                "columns": 1,
+                "columns": {
+                    "signal": "data('column-layout')[0].distinct_age"
+                },
                 "bounds": "full"
             },
             "marks": [
                 {
+                    "name": "x-axes",
                     "type": "group",
-                    "layout": {
-                        "padding": {
-                            "row": 10,
-                            "column": 10,
-                            "header": 10
-                        },
-                        "columns": {
-                            "signal": "column"
-                        },
-                        "bounds": "full"
+                    "role": "column-footer",
+                    "from": {
+                        "data": "column"
                     },
-                    "marks": [
+                    "axes": [
                         {
-                            "name": "x-axes",
-                            "type": "group",
-                            "role": "column-footer",
-                            "from": {
-                                "data": "column"
-                            },
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "title": "",
-                                    "zindex": 1,
-                                    "encode": {
-                                        "labels": {
-                                            "update": {
-                                                "angle": {
-                                                    "value": 270
-                                                },
-                                                "align": {
-                                                    "value": "right"
-                                                },
-                                                "baseline": {
-                                                    "value": "middle"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "y-axes",
-                            "type": "group",
-                            "role": "row-header",
-                            "axes": [
-                                {
-                                    "scale": "y",
-                                    "format": "s",
-                                    "orient": "left",
-                                    "title": "population",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "column-labels",
-                            "role": "column-header",
-                            "type": "group",
-                            "from": {
-                                "data": "column"
-                            },
+                            "scale": "x",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "",
+                            "zindex": 1,
                             "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
+                                "labels": {
+                                    "update": {
+                                        "angle": {
+                                            "value": 270
+                                        },
+                                        "align": {
+                                            "value": "right"
+                                        },
+                                        "baseline": {
+                                            "value": "middle"
                                         }
                                     }
                                 }
-                            },
-                            "marks": [
-                                {
-                                    "type": "text",
-                                    "role": "column-labels",
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "field": {
-                                                    "group": "width"
-                                                },
-                                                "mult": 0.5
-                                            },
-                                            "y": {
-                                                "value": -10
-                                            },
-                                            "text": {
-                                                "field": {
-                                                    "parent": "age"
-                                                }
-                                            },
-                                            "align": {
-                                                "value": "center"
-                                            },
-                                            "fill": {
-                                                "value": "black"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "cell",
-                            "type": "group",
-                            "from": {
-                                "facet": {
-                                    "name": "facet",
-                                    "data": "source_0",
-                                    "groupby": [
-                                        "age"
-                                    ]
-                                }
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    },
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
-                                        }
-                                    },
-                                    "stroke": {
-                                        "value": "#ccc"
-                                    },
-                                    "strokeWidth": {
-                                        "value": 0
-                                    },
-                                    "fill": {
-                                        "value": "transparent"
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "name": "child_marks",
-                                    "type": "rect",
-                                    "role": "bar",
-                                    "from": {
-                                        "data": "facet"
-                                    },
-                                    "encode": {
-                                        "update": {
-                                            "xc": {
-                                                "scale": "x",
-                                                "field": "gender"
-                                            },
-                                            "width": {
-                                                "value": 11
-                                            },
-                                            "y": {
-                                                "scale": "y",
-                                                "field": "sum_people_end"
-                                            },
-                                            "y2": {
-                                                "scale": "y",
-                                                "field": "sum_people_start"
-                                            },
-                                            "fill": {
-                                                "scale": "color",
-                                                "field": "gender"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
+                            }
                         }
                     ]
                 },
                 {
-                    "name": "column-title",
+                    "name": "y-axes",
+                    "type": "group",
+                    "role": "row-header",
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "population",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "column-labels",
                     "role": "column-header",
                     "type": "group",
+                    "from": {
+                        "data": "column"
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
                     "marks": [
                         {
                             "type": "text",
-                            "role": "column-title",
+                            "role": "column-labels",
                             "encode": {
                                 "update": {
                                     "x": {
-                                        "signal": "0.5 * width"
+                                        "field": {
+                                            "group": "width"
+                                        },
+                                        "mult": 0.5
+                                    },
+                                    "y": {
+                                        "value": -10
                                     },
                                     "text": {
-                                        "value": "age"
+                                        "field": {
+                                            "parent": "age"
+                                        }
                                     },
                                     "align": {
                                         "value": "center"
                                     },
                                     "fill": {
                                         "value": "black"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "age"
+                            ]
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "gender"
                                     },
-                                    "fontWeight": {
-                                        "value": "bold"
+                                    "width": {
+                                        "value": 11
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "sum_people_end"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "sum_people_start"
+                                    },
+                                    "fill": {
+                                        "scale": "color",
+                                        "field": "gender"
                                     }
                                 }
                             }
                         }
                     ]
                 }
-            ],
-            "scales": [
+            ]
+        },
+        {
+            "name": "column-title",
+            "role": "column-header",
+            "type": "group",
+            "marks": [
                 {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "gender",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 12
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "sum_people_start",
-                            "sum_people_end"
-                        ]
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "gender",
-                        "sort": true
-                    },
-                    "range": [
-                        "#EA98D2",
-                        "#659CCA"
-                    ]
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "gender",
+                    "type": "text",
+                    "role": "column-title",
                     "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "square"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                }
+                        "update": {
+                            "x": {
+                                "signal": "0.5 * width"
+                            },
+                            "text": {
+                                "value": "age"
+                            },
+                            "align": {
+                                "value": "center"
+                            },
+                            "fill": {
+                                "value": "black"
+                            },
+                            "fontWeight": {
+                                "value": "bold"
                             }
                         }
                     }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "gender",
+                "sort": true
+            },
+            "range": {
+                "step": 12
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "sum_people_start",
+                    "sum_people_end"
+                ]
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "gender",
+                "sort": true
+            },
+            "range": [
+                "#EA98D2",
+                "#659CCA"
+            ]
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "gender",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "square"
+                        },
+                        "strokeWidth": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/bar_grouped_horizontal.vg.json
+++ b/examples/vg-specs/bar_grouped_horizontal.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -93,52 +73,40 @@
                     ]
                 }
             ]
-        },
-        {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
-                {
-                    "type": "aggregate",
-                    "fields": [
-                        "age",
-                        "gender"
-                    ],
-                    "ops": [
-                        "distinct",
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "child_width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "datum[\"child_width\"] + 5"
-                },
-                {
-                    "type": "formula",
-                    "as": "child_height",
-                    "expr": "max(datum[\"distinct_gender\"] - 1 + 2*0.5, 0) * 6"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "(datum[\"child_height\"] + 5) * datum[\"distinct_age\"]"
-                }
-            ]
         }
     ],
+    "signals": [
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        },
+        {
+            "name": "child_width",
+            "update": "200"
+        },
+        {
+            "name": "child_height",
+            "update": "bandspace(domain('y').length, 1, 0.5) * 6"
+        }
+    ],
+    "layout": {
+        "padding": {
+            "row": 10,
+            "column": 10,
+            "header": 10
+        },
+        "columns": 1,
+        "bounds": "full"
+    },
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "from": {
-                "data": "layout"
-            },
             "layout": {
                 "padding": {
                     "row": 10,
@@ -150,252 +118,229 @@
             },
             "marks": [
                 {
+                    "name": "x-axes",
                     "type": "group",
-                    "layout": {
-                        "padding": {
-                            "row": 10,
-                            "column": 10,
-                            "header": 10
-                        },
-                        "columns": 1,
-                        "bounds": "full"
-                    },
-                    "marks": [
+                    "role": "column-footer",
+                    "axes": [
                         {
-                            "name": "x-axes",
-                            "type": "group",
-                            "role": "column-footer",
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "format": "s",
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "title": "population",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "row-labels",
-                            "role": "row-header",
-                            "type": "group",
-                            "from": {
-                                "data": "row"
-                            },
-                            "encode": {
-                                "update": {
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
-                                        }
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "type": "text",
-                                    "role": "row-labels",
-                                    "encode": {
-                                        "update": {
-                                            "y": {
-                                                "field": {
-                                                    "group": "height"
-                                                },
-                                                "mult": 0.5
-                                            },
-                                            "x": {
-                                                "value": -10
-                                            },
-                                            "text": {
-                                                "field": {
-                                                    "parent": "age"
-                                                }
-                                            },
-                                            "align": {
-                                                "value": "right"
-                                            },
-                                            "fill": {
-                                                "value": "black"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "cell",
-                            "type": "group",
-                            "from": {
-                                "facet": {
-                                    "name": "facet",
-                                    "data": "source_0",
-                                    "groupby": [
-                                        "age"
-                                    ]
-                                }
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    },
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
-                                        }
-                                    },
-                                    "stroke": {
-                                        "value": "#ccc"
-                                    },
-                                    "strokeWidth": {
-                                        "value": 0
-                                    },
-                                    "fill": {
-                                        "value": "transparent"
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "name": "child_marks",
-                                    "type": "rect",
-                                    "role": "bar",
-                                    "from": {
-                                        "data": "facet"
-                                    },
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "scale": "x",
-                                                "field": "sum_people_end"
-                                            },
-                                            "x2": {
-                                                "scale": "x",
-                                                "field": "sum_people_start"
-                                            },
-                                            "yc": {
-                                                "scale": "y",
-                                                "field": "gender"
-                                            },
-                                            "height": {
-                                                "value": 5
-                                            },
-                                            "fill": {
-                                                "scale": "color",
-                                                "field": "gender"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "population",
+                            "zindex": 1
                         }
                     ]
                 },
                 {
-                    "name": "row-title",
+                    "name": "row-labels",
                     "role": "row-header",
                     "type": "group",
+                    "from": {
+                        "data": "row"
+                    },
+                    "encode": {
+                        "update": {
+                            "height": {
+                                "signal": "child_height"
+                            }
+                        }
+                    },
                     "marks": [
                         {
                             "type": "text",
-                            "role": "row-title",
+                            "role": "row-labels",
                             "encode": {
                                 "update": {
                                     "y": {
-                                        "signal": "0.5 * height"
+                                        "field": {
+                                            "group": "height"
+                                        },
+                                        "mult": 0.5
                                     },
-                                    "angle": {
-                                        "value": 270
+                                    "x": {
+                                        "value": -10
                                     },
                                     "text": {
-                                        "value": "age"
+                                        "field": {
+                                            "parent": "age"
+                                        }
                                     },
                                     "align": {
                                         "value": "right"
                                     },
                                     "fill": {
                                         "value": "black"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "age"
+                            ]
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "sum_people_end"
                                     },
-                                    "fontWeight": {
-                                        "value": "bold"
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "sum_people_start"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "gender"
+                                    },
+                                    "height": {
+                                        "value": 5
+                                    },
+                                    "fill": {
+                                        "scale": "color",
+                                        "field": "gender"
                                     }
                                 }
                             }
                         }
                     ]
                 }
-            ],
-            "scales": [
+            ]
+        },
+        {
+            "name": "row-title",
+            "role": "row-header",
+            "type": "group",
+            "marks": [
                 {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "sum_people_start",
-                            "sum_people_end"
-                        ]
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "gender",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 6
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "gender",
-                        "sort": true
-                    },
-                    "range": [
-                        "#EA98D2",
-                        "#659CCA"
-                    ]
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "gender",
+                    "type": "text",
+                    "role": "row-title",
                     "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "square"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                }
+                        "update": {
+                            "y": {
+                                "signal": "0.5 * height"
+                            },
+                            "angle": {
+                                "value": 270
+                            },
+                            "text": {
+                                "value": "age"
+                            },
+                            "align": {
+                                "value": "right"
+                            },
+                            "fill": {
+                                "value": "black"
+                            },
+                            "fontWeight": {
+                                "value": "bold"
                             }
                         }
                     }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "sum_people_start",
+                    "sum_people_end"
+                ]
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "gender",
+                "sort": true
+            },
+            "range": {
+                "step": 6
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "gender",
+                "sort": true
+            },
+            "range": [
+                "#EA98D2",
+                "#659CCA"
+            ]
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "gender",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "square"
+                        },
+                        "strokeWidth": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/bar_layered_transparent.vg.json
+++ b/examples/vg-specs/bar_layered_transparent.vg.json
@@ -3,26 +3,6 @@
     "description": "A bar chart showing the US population distribution of age groups and gender in 2000.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -61,194 +41,166 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 17"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "age"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_age\"] - 1 + 2*0.5, 0) * 17"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A bar chart showing the US population distribution of age groups and gender in 2000.",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
+                    "xc": {
+                        "scale": "x",
+                        "field": "age"
+                    },
                     "width": {
-                        "field": "width"
+                        "value": 16
                     },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "width": {
-                                "value": 16
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "sum_people"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "gender"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "age",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 17
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "sum_people"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "gender",
-                        "sort": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
                     },
-                    "range": [
-                        "#e377c2",
-                        "#1f77b4"
-                    ]
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "age",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "population",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "gender",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "square"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                }
-                            }
-                        }
+                    "fill": {
+                        "scale": "color",
+                        "field": "gender"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "age",
+                "sort": true
+            },
+            "range": {
+                "step": 17
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "sum_people"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "gender",
+                "sort": true
+            },
+            "range": [
+                "#e377c2",
+                "#1f77b4"
             ]
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "age",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "population",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "gender",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "square"
+                        },
+                        "strokeWidth": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/bar_month.vg.json
+++ b/examples/vg-specs/bar_month.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -56,161 +36,134 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "month_date"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_month_date\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
+                    "xc": {
+                        "scale": "x",
+                        "field": "month_date"
+                    },
                     "width": {
-                        "field": "width"
+                        "value": 20
                     },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "month_date"
-                            },
-                            "width": {
-                                "value": 20
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "mean_temp"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "month_date",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "mean_temp"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "month_date",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "mean_temp"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "MONTH(date)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "MONTH(date)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "MEAN(temp)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "MEAN(temp)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/bar_size_default.vg.json
+++ b/examples/vg-specs/bar_size_default.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -44,158 +24,131 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 25"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "Origin"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_Origin\"] - 1 + 2*0.5, 0) * 25"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
+                    "xc": {
+                        "scale": "x",
+                        "field": "Origin"
+                    },
                     "width": {
-                        "field": "width"
+                        "value": 24
                     },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "Origin"
-                            },
-                            "width": {
-                                "value": 24
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "count_*"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Origin",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 25
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "count_*"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": {
+                "step": 25
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "count_*"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Origin",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Origin",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Number of Records",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/bar_size_explicit.vg.json
+++ b/examples/vg-specs/bar_size_explicit.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -44,161 +24,134 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "120"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "120"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "Origin"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "120"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "120"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
+                    "x": {
+                        "scale": "x",
+                        "field": "Origin"
+                    },
                     "width": {
-                        "field": "width"
+                        "scale": "x",
+                        "band": true
                     },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Origin"
-                            },
-                            "width": {
-                                "scale": "x",
-                                "band": true
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "count_*"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Origin",
-                        "sort": true
-                    },
-                    "range": [
-                        0,
-                        120
-                    ],
-                    "round": true,
-                    "paddingInner": 0.1,
-                    "paddingOuter": 0.05
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "count_*"
                     },
-                    "range": [
-                        120,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "band",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": [
+                0,
+                120
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Origin",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "paddingInner": 0.1,
+            "paddingOuter": 0.05
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "count_*"
+            },
+            "range": [
+                120,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Origin",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Number of Records",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/bar_size_explicit_bad.vg.json
+++ b/examples/vg-specs/bar_size_explicit_bad.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -44,161 +24,134 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "120"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "120"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "Name"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "120"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "120"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
+                    "x": {
+                        "scale": "x",
+                        "field": "Name"
+                    },
                     "width": {
-                        "field": "width"
+                        "scale": "x",
+                        "band": true
                     },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Name"
-                            },
-                            "width": {
-                                "scale": "x",
-                                "band": true
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "count_*"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Name",
-                        "sort": true
-                    },
-                    "range": [
-                        0,
-                        120
-                    ],
-                    "round": false,
-                    "paddingInner": 0.1,
-                    "paddingOuter": 0.05
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "count_*"
                     },
-                    "range": [
-                        120,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "band",
+            "domain": {
+                "data": "source_0",
+                "field": "Name",
+                "sort": true
+            },
+            "range": [
+                0,
+                120
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Name",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": false,
+            "paddingInner": 0.1,
+            "paddingOuter": 0.05
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "count_*"
+            },
+            "range": [
+                120,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Name",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Number of Records",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/bar_size_fit.vg.json
+++ b/examples/vg-specs/bar_size_fit.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -44,161 +24,134 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "Origin"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
+                    "x": {
+                        "scale": "x",
+                        "field": "Origin"
+                    },
                     "width": {
-                        "field": "width"
+                        "scale": "x",
+                        "band": true
                     },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Origin"
-                            },
-                            "width": {
-                                "scale": "x",
-                                "band": true
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "count_*"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Origin",
-                        "sort": true
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "paddingInner": 0.1,
-                    "paddingOuter": 0.05
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "count_*"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "band",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Origin",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "paddingInner": 0.1,
+            "paddingOuter": 0.05
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "count_*"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Origin",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Number of Records",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/bar_size_rangestep_small.vg.json
+++ b/examples/vg-specs/bar_size_rangestep_small.vg.json
@@ -3,26 +3,6 @@
     "description": "A simple bar chart with embedded data.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -76,159 +56,131 @@
                     "expr": "datum[\"b\"] !== null && !isNaN(datum[\"b\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 11"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "a"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_a\"] - 1 + 2*0.5, 0) * 11"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A simple bar chart with embedded data.",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
+                    "xc": {
+                        "scale": "x",
+                        "field": "a"
+                    },
                     "width": {
-                        "field": "width"
+                        "value": 10
                     },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "a"
-                            },
-                            "width": {
-                                "value": 10
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "b"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "a",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 11
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "b"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "a",
+                "sort": true
+            },
+            "range": {
+                "step": 11
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "b"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "a",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "a",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "b",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "b",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/bar_swap_axes.vg.json
+++ b/examples/vg-specs/bar_swap_axes.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -87,144 +67,117 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "bandspace(domain('y').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "a"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "max(datum[\"distinct_a\"] - 1 + 2*0.5, 0) * 21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "average_b"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "value": 0
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "a"
-                            },
-                            "height": {
-                                "value": 20
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "average_b"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "a",
-                        "sort": true
+                    "x2": {
+                        "scale": "x",
+                        "value": 0
                     },
-                    "range": {
-                        "step": 21
+                    "yc": {
+                        "scale": "y",
+                        "field": "a"
                     },
-                    "round": true,
-                    "padding": 0.5
+                    "height": {
+                        "value": 20
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "average_b"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "AVERAGE(b)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "orient": "left",
-                    "title": "a",
-                    "zindex": 1
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "a",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "AVERAGE(b)",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "orient": "left",
+            "title": "a",
+            "zindex": 1
         }
     ]
 }

--- a/examples/vg-specs/bar_swap_custom.vg.json
+++ b/examples/vg-specs/bar_swap_custom.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -87,144 +67,117 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "bandspace(domain('y').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "a"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "max(datum[\"distinct_a\"] - 1 + 2*0.5, 0) * 21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "average_b"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "value": 0
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "a"
-                            },
-                            "height": {
-                                "value": 20
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "average_b"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "a",
-                        "sort": true
+                    "x2": {
+                        "scale": "x",
+                        "value": 0
                     },
-                    "range": {
-                        "step": 21
+                    "yc": {
+                        "scale": "y",
+                        "field": "a"
                     },
-                    "round": true,
-                    "padding": 0.5
+                    "height": {
+                        "value": 20
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "average_b"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Average of b",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "orient": "left",
-                    "title": "a",
-                    "zindex": 1
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "a",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Average of b",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "orient": "left",
+            "title": "a",
+            "zindex": 1
         }
     ]
 }

--- a/examples/vg-specs/bar_yearmonth.vg.json
+++ b/examples/vg-specs/bar_yearmonth.vg.json
@@ -3,26 +3,6 @@
     "description": "Temperature in Seattle as a bar chart with yearmonth time unit.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -57,166 +37,145 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "Temperature in Seattle as a bar chart with yearmonth time unit.",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "yearmonth_date"
-                            },
-                            "width": {
-                                "value": 2
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "mean_temp"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "data": "source_0",
+                    "xc": {
+                        "scale": "x",
                         "field": "yearmonth_date"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": "month"
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "width": {
+                        "value": 2
+                    },
+                    "y": {
+                        "scale": "y",
                         "field": "mean_temp"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "data": "source_0",
+                "field": "yearmonth_date"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "YEARMONTH(date)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%B of %Y')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": "month"
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "mean_temp"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "YEARMONTH(date)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%B of %Y')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "MEAN(temp)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "MEAN(temp)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/box_plot.vg.json
+++ b/examples/vg-specs/box_plot.vg.json
@@ -3,26 +3,6 @@
     "description": "A box plot showing mean, min, and max in the US population distribution of age groups in 2000.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -169,346 +149,354 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "max(layer_0_width, layer_1_width, layer_2_width, layer_3_width, layer_4_width)"
         },
         {
-            "name": "layout",
-            "source": "data_0",
-            "transform": [
+            "name": "height",
+            "update": "max(layer_0_height, layer_1_height, layer_2_height, layer_3_height, layer_4_height)"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "age"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_age\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
+        },
+        {
+            "name": "layer_4_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_4_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_3_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_3_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_2_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_2_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_1_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_0_height",
+            "update": "200"
         }
     ],
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "description": "A box plot showing mean, min, and max in the US population distribution of age groups in 2000.",
-            "from": {
-                "data": "layout"
-            },
             "encode": {
-                "update": {
+                "enter": {
                     "width": {
-                        "field": "width"
+                        "signal": "width"
                     },
                     "height": {
-                        "field": "height"
+                        "signal": "height"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "clip": {
+                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "type": "group",
-                    "encode": {
-                        "enter": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "clip": {
-                                "value": true
-                            }
-                        }
+                    "name": "layer_0_marks",
+                    "type": "rule",
+                    "from": {
+                        "data": "data_0"
                     },
-                    "marks": [
-                        {
-                            "name": "layer_0_marks",
-                            "type": "rule",
-                            "from": {
-                                "data": "data_0"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "age"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "min_people"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "field": "max_people"
-                                    },
-                                    "stroke": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_1_marks",
-                            "type": "rect",
-                            "role": "tick",
-                            "from": {
-                                "data": "data_1"
-                            },
-                            "encode": {
-                                "update": {
-                                    "xc": {
-                                        "scale": "x",
-                                        "field": "age"
-                                    },
-                                    "yc": {
-                                        "scale": "y",
-                                        "field": "min_people"
-                                    },
-                                    "width": {
-                                        "value": 5
-                                    },
-                                    "height": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_2_marks",
-                            "type": "rect",
-                            "role": "tick",
-                            "from": {
-                                "data": "data_2"
-                            },
-                            "encode": {
-                                "update": {
-                                    "xc": {
-                                        "scale": "x",
-                                        "field": "age"
-                                    },
-                                    "yc": {
-                                        "scale": "y",
-                                        "field": "max_people"
-                                    },
-                                    "width": {
-                                        "value": 5
-                                    },
-                                    "height": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_3_marks",
-                            "type": "rect",
-                            "role": "bar",
-                            "from": {
-                                "data": "data_3"
-                            },
-                            "encode": {
-                                "update": {
-                                    "xc": {
-                                        "scale": "x",
-                                        "field": "age"
-                                    },
-                                    "width": {
-                                        "value": 5
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "q1_people"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "field": "q3_people"
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_4_marks",
-                            "type": "rect",
-                            "role": "tick",
-                            "from": {
-                                "data": "data_4"
-                            },
-                            "encode": {
-                                "update": {
-                                    "xc": {
-                                        "scale": "x",
-                                        "field": "age"
-                                    },
-                                    "yc": {
-                                        "scale": "y",
-                                        "field": "median_people"
-                                    },
-                                    "width": {
-                                        "value": 5
-                                    },
-                                    "height": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "white"
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "fields": [
-                            {
-                                "field": "age",
-                                "data": "data_0"
-                            },
-                            {
-                                "field": "age",
-                                "data": "data_1"
-                            },
-                            {
-                                "field": "age",
-                                "data": "data_2"
-                            },
-                            {
-                                "field": "age",
-                                "data": "data_3"
-                            },
-                            {
-                                "data": "data_4",
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
                                 "field": "age"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "fields": [
-                            {
-                                "field": "min_people",
-                                "data": "data_0"
                             },
-                            {
-                                "field": "max_people",
-                                "data": "data_0"
+                            "y": {
+                                "scale": "y",
+                                "field": "min_people"
                             },
-                            {
-                                "field": "min_people",
-                                "data": "data_1"
+                            "y2": {
+                                "scale": "y",
+                                "field": "max_people"
                             },
-                            {
-                                "field": "max_people",
-                                "data": "data_2"
-                            },
-                            {
-                                "field": "q1_people",
-                                "data": "data_3"
-                            },
-                            {
-                                "field": "q3_people",
-                                "data": "data_3"
-                            },
-                            {
-                                "data": "data_4",
-                                "field": "median_people"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "age",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
+                            "stroke": {
+                                "value": "#4c78a8"
                             }
                         }
                     }
                 },
                 {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "population",
-                    "zindex": 1
+                    "name": "layer_1_marks",
+                    "type": "rect",
+                    "role": "tick",
+                    "from": {
+                        "data": "data_1"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "age"
+                            },
+                            "yc": {
+                                "scale": "y",
+                                "field": "min_people"
+                            },
+                            "width": {
+                                "value": 5
+                            },
+                            "height": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
                 },
                 {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
+                    "name": "layer_2_marks",
+                    "type": "rect",
+                    "role": "tick",
+                    "from": {
+                        "data": "data_2"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "age"
+                            },
+                            "yc": {
+                                "scale": "y",
+                                "field": "max_people"
+                            },
+                            "width": {
+                                "value": 5
+                            },
+                            "height": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "layer_3_marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "data_3"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "age"
+                            },
+                            "width": {
+                                "value": 5
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "q1_people"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "field": "q3_people"
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "layer_4_marks",
+                    "type": "rect",
+                    "role": "tick",
+                    "from": {
+                        "data": "data_4"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "age"
+                            },
+                            "yc": {
+                                "scale": "y",
+                                "field": "median_people"
+                            },
+                            "width": {
+                                "value": 5
+                            },
+                            "height": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "white"
+                            }
+                        }
+                    }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "fields": [
+                    {
+                        "field": "age",
+                        "data": "data_0"
+                    },
+                    {
+                        "field": "age",
+                        "data": "data_1"
+                    },
+                    {
+                        "field": "age",
+                        "data": "data_2"
+                    },
+                    {
+                        "field": "age",
+                        "data": "data_3"
+                    },
+                    {
+                        "data": "data_4",
+                        "field": "age"
+                    }
+                ],
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {
+                        "field": "min_people",
+                        "data": "data_0"
+                    },
+                    {
+                        "field": "max_people",
+                        "data": "data_0"
+                    },
+                    {
+                        "field": "min_people",
+                        "data": "data_1"
+                    },
+                    {
+                        "field": "max_people",
+                        "data": "data_2"
+                    },
+                    {
+                        "field": "q1_people",
+                        "data": "data_3"
+                    },
+                    {
+                        "field": "q3_people",
+                        "data": "data_3"
+                    },
+                    {
+                        "data": "data_4",
+                        "field": "median_people"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "age",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "population",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -358,7 +358,7 @@
                     },
                     "stroke": [
                         {
-                            "test": "!vlInterval(\"brush_store\", parent._id, datum, \"union\", \"all\")",
+                            "test": "!vlInterval(\"brush_store\", datum._id, datum, \"union\", \"all\")",
                             "value": "grey"
                         },
                         {

--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -3,26 +3,6 @@
     "description": "Drag out a rectangular brush to highlight points.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -42,522 +22,499 @@
             ]
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "brush_store"
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
+        },
+        {
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         },
         {
-            "name": "brush_store"
-        }
-    ],
-    "marks": [
-        {
-            "name": "main-group",
-            "type": "group",
-            "description": "Drag out a rectangular brush to highlight points.",
-            "from": {
-                "data": "layout"
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "field": "width"
+            "name": "brush_x",
+            "value": [],
+            "on": [
+                {
+                    "events": {
+                        "source": "scope",
+                        "type": "mousedown",
+                        "filter": [
+                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                        ]
                     },
-                    "height": {
-                        "field": "height"
+                    "update": "invert(\"x\", [x(unit), x(unit)])"
+                },
+                {
+                    "events": {
+                        "source": "window",
+                        "type": "mousemove",
+                        "consume": true,
+                        "between": [
+                            {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                ]
+                            },
+                            {
+                                "source": "window",
+                                "type": "mouseup"
+                            }
+                        ]
                     },
-                    "fill": {
-                        "value": "transparent"
-                    }
+                    "update": "[brush_x[0], invert(\"x\", clamp(x(unit), 0, width))]"
+                },
+                {
+                    "events": {
+                        "signal": "brush_translate_delta"
+                    },
+                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+                },
+                {
+                    "events": {
+                        "signal": "brush_zoom_delta"
+                    },
+                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
                 }
-            },
-            "signals": [
+            ]
+        },
+        {
+            "name": "brush_y",
+            "value": [],
+            "on": [
                 {
-                    "name": "brush_x",
-                    "value": [],
-                    "on": [
-                        {
-                            "events": {
+                    "events": {
+                        "source": "scope",
+                        "type": "mousedown",
+                        "filter": [
+                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                        ]
+                    },
+                    "update": "invert(\"y\", [y(unit), y(unit)])"
+                },
+                {
+                    "events": {
+                        "source": "window",
+                        "type": "mousemove",
+                        "consume": true,
+                        "between": [
+                            {
                                 "source": "scope",
                                 "type": "mousedown",
                                 "filter": [
                                     "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
                                 ]
                             },
-                            "update": "invert(\"x\", [x(unit), x(unit)])"
-                        },
-                        {
-                            "events": {
+                            {
                                 "source": "window",
-                                "type": "mousemove",
-                                "consume": true,
-                                "between": [
-                                    {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
-                                    },
-                                    {
-                                        "source": "window",
-                                        "type": "mouseup"
-                                    }
-                                ]
-                            },
-                            "update": "[brush_x[0], invert(\"x\", clamp(x(unit), 0, width))]"
-                        },
-                        {
-                            "events": {
-                                "signal": "brush_translate_delta"
-                            },
-                            "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
-                        },
-                        {
-                            "events": {
-                                "signal": "brush_zoom_delta"
-                            },
-                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
-                        }
-                    ]
+                                "type": "mouseup"
+                            }
+                        ]
+                    },
+                    "update": "[brush_y[0], invert(\"y\", clamp(y(unit), 0, height))]"
                 },
                 {
-                    "name": "brush_y",
-                    "value": [],
-                    "on": [
-                        {
-                            "events": {
+                    "events": {
+                        "signal": "brush_translate_delta"
+                    },
+                    "update": "clampRange([brush_translate_anchor.extent_y[0] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height, brush_translate_anchor.extent_y[1] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
+                },
+                {
+                    "events": {
+                        "signal": "brush_zoom_delta"
+                    },
+                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
+                }
+            ]
+        },
+        {
+            "name": "brush_size",
+            "value": [],
+            "on": [
+                {
+                    "events": {
+                        "source": "scope",
+                        "type": "mousedown",
+                        "filter": [
+                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                        ]
+                    },
+                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
+                },
+                {
+                    "events": {
+                        "source": "window",
+                        "type": "mousemove",
+                        "consume": true,
+                        "between": [
+                            {
                                 "source": "scope",
                                 "type": "mousedown",
                                 "filter": [
                                     "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
                                 ]
                             },
-                            "update": "invert(\"y\", [y(unit), y(unit)])"
-                        },
-                        {
-                            "events": {
+                            {
                                 "source": "window",
-                                "type": "mousemove",
-                                "consume": true,
-                                "between": [
-                                    {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
-                                    },
-                                    {
-                                        "source": "window",
-                                        "type": "mouseup"
-                                    }
-                                ]
-                            },
-                            "update": "[brush_y[0], invert(\"y\", clamp(y(unit), 0, height))]"
-                        },
+                                "type": "mouseup"
+                            }
+                        ]
+                    },
+                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
+                },
+                {
+                    "events": {
+                        "signal": "brush_zoom_delta"
+                    },
+                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                }
+            ]
+        },
+        {
+            "name": "brush",
+            "update": "[{field: \"Horsepower\", extent: brush_x}, {field: \"Miles_per_Gallon\", extent: brush_y}]"
+        },
+        {
+            "name": "brush_translate_anchor",
+            "value": {},
+            "on": [
+                {
+                    "events": [
                         {
-                            "events": {
-                                "signal": "brush_translate_delta"
-                            },
-                            "update": "clampRange([brush_translate_anchor.extent_y[0] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height, brush_translate_anchor.extent_y[1] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
-                        },
-                        {
-                            "events": {
-                                "signal": "brush_zoom_delta"
-                            },
-                            "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
+                            "source": "scope",
+                            "type": "mousedown",
+                            "markname": "brush_brush"
                         }
-                    ]
-                },
+                    ],
+                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_x), extent_y: slice(brush_y), }"
+                }
+            ]
+        },
+        {
+            "name": "brush_translate_delta",
+            "value": {},
+            "on": [
                 {
-                    "name": "brush_size",
-                    "value": [],
-                    "on": [
+                    "events": [
                         {
-                            "events": {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                ]
-                            },
-                            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                        },
-                        {
-                            "events": {
-                                "source": "window",
-                                "type": "mousemove",
-                                "consume": true,
-                                "between": [
-                                    {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
-                                    },
-                                    {
-                                        "source": "window",
-                                        "type": "mouseup"
-                                    }
-                                ]
-                            },
-                            "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                        },
-                        {
-                            "events": {
-                                "signal": "brush_zoom_delta"
-                            },
-                            "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
-                        }
-                    ]
-                },
-                {
-                    "name": "brush",
-                    "update": "[{field: \"Horsepower\", extent: brush_x}, {field: \"Miles_per_Gallon\", extent: brush_y}]"
-                },
-                {
-                    "name": "brush_translate_anchor",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
+                            "source": "window",
+                            "type": "mousemove",
+                            "consume": true,
+                            "between": [
                                 {
                                     "source": "scope",
                                     "type": "mousedown",
                                     "markname": "brush_brush"
-                                }
-                            ],
-                            "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_x), extent_y: slice(brush_y), }"
-                        }
-                    ]
-                },
-                {
-                    "name": "brush_translate_delta",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
+                                },
                                 {
                                     "source": "window",
-                                    "type": "mousemove",
-                                    "consume": true,
-                                    "between": [
-                                        {
-                                            "source": "scope",
-                                            "type": "mousedown",
-                                            "markname": "brush_brush"
-                                        },
-                                        {
-                                            "source": "window",
-                                            "type": "mouseup"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "update": "{x: x(unit) - brush_translate_anchor.x, y: y(unit) - brush_translate_anchor.y}"
-                        }
-                    ]
-                },
-                {
-                    "name": "brush_zoom_anchor",
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "source": "scope",
-                                    "type": "wheel",
-                                    "markname": "brush_brush"
-                                }
-                            ],
-                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
-                        }
-                    ]
-                },
-                {
-                    "name": "brush_zoom_delta",
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "source": "scope",
-                                    "type": "wheel",
-                                    "markname": "brush_brush"
-                                }
-                            ],
-                            "force": true,
-                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-                        }
-                    ]
-                },
-                {
-                    "name": "brush_tuple",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "brush"
-                            },
-                            "update": "{unit: unit.datum && unit.datum._id, intervals: brush}"
-                        }
-                    ]
-                },
-                {
-                    "name": "brush_modify",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "brush"
-                            },
-                            "update": "modify(\"brush_store\", brush_tuple, true)"
-                        }
-                    ]
-                }
-            ],
-            "marks": [
-                {
-                    "type": "rect",
-                    "encode": {
-                        "enter": {
-                            "fill": {
-                                "value": "#eee"
-                            }
-                        },
-                        "update": {
-                            "x": [
-                                {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[0]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "x2": [
-                                {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[1]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "y": [
-                                {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[0]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "y2": [
-                                {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[1]"
-                                },
-                                {
-                                    "value": 0
+                                    "type": "mouseup"
                                 }
                             ]
                         }
-                    }
-                },
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": [
-                                {
-                                    "test": "!vlInterval(\"brush_store\", parent._id, datum, \"union\", \"all\")",
-                                    "value": "grey"
-                                },
-                                {
-                                    "scale": "color",
-                                    "field": "Cylinders"
-                                }
-                            ],
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "brush_brush",
-                    "type": "rect",
-                    "encode": {
-                        "enter": {
-                            "fill": {
-                                "value": "transparent"
-                            }
-                        },
-                        "update": {
-                            "x": [
-                                {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[0]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "x2": [
-                                {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[1]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "y": [
-                                {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[0]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "y2": [
-                                {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[1]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ]
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Cylinders",
-                        "sort": true
-                    },
-                    "range": "ordinal"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "title": "Cylinders"
+                    "update": "{x: x(unit) - brush_translate_anchor.x, y: y(unit) - brush_translate_anchor.y}"
                 }
             ]
+        },
+        {
+            "name": "brush_zoom_anchor",
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "wheel",
+                            "markname": "brush_brush"
+                        }
+                    ],
+                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                }
+            ]
+        },
+        {
+            "name": "brush_zoom_delta",
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "wheel",
+                            "markname": "brush_brush"
+                        }
+                    ],
+                    "force": true,
+                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                }
+            ]
+        },
+        {
+            "name": "brush_tuple",
+            "on": [
+                {
+                    "events": {
+                        "signal": "brush"
+                    },
+                    "update": "{unit: unit.datum && unit.datum._id, intervals: brush}"
+                }
+            ]
+        },
+        {
+            "name": "brush_modify",
+            "on": [
+                {
+                    "events": {
+                        "signal": "brush"
+                    },
+                    "update": "modify(\"brush_store\", brush_tuple, true)"
+                }
+            ]
+        }
+    ],
+    "marks": [
+        {
+            "type": "rect",
+            "encode": {
+                "enter": {
+                    "fill": {
+                        "value": "#eee"
+                    }
+                },
+                "update": {
+                    "x": [
+                        {
+                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                            "scale": "x",
+                            "signal": "brush[0].extent[0]"
+                        },
+                        {
+                            "value": 0
+                        }
+                    ],
+                    "x2": [
+                        {
+                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                            "scale": "x",
+                            "signal": "brush[0].extent[1]"
+                        },
+                        {
+                            "value": 0
+                        }
+                    ],
+                    "y": [
+                        {
+                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                            "scale": "y",
+                            "signal": "brush[1].extent[0]"
+                        },
+                        {
+                            "value": 0
+                        }
+                    ],
+                    "y2": [
+                        {
+                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                            "scale": "y",
+                            "signal": "brush[1].extent[1]"
+                        },
+                        {
+                            "value": 0
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
+            "from": {
+                "data": "source_0"
+            },
+            "encode": {
+                "update": {
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
+                    },
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "stroke": [
+                        {
+                            "test": "!vlInterval(\"brush_store\", parent._id, datum, \"union\", \"all\")",
+                            "value": "grey"
+                        },
+                        {
+                            "scale": "color",
+                            "field": "Cylinders"
+                        }
+                    ],
+                    "fill": {
+                        "value": "transparent"
+                    },
+                    "opacity": {
+                        "value": 0.7
+                    }
+                }
+            }
+        },
+        {
+            "name": "brush_brush",
+            "type": "rect",
+            "encode": {
+                "enter": {
+                    "fill": {
+                        "value": "transparent"
+                    }
+                },
+                "update": {
+                    "x": [
+                        {
+                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                            "scale": "x",
+                            "signal": "brush[0].extent[0]"
+                        },
+                        {
+                            "value": 0
+                        }
+                    ],
+                    "x2": [
+                        {
+                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                            "scale": "x",
+                            "signal": "brush[0].extent[1]"
+                        },
+                        {
+                            "value": 0
+                        }
+                    ],
+                    "y": [
+                        {
+                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                            "scale": "y",
+                            "signal": "brush[1].extent[0]"
+                        },
+                        {
+                            "value": 0
+                        }
+                    ],
+                    "y2": [
+                        {
+                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                            "scale": "y",
+                            "signal": "brush[1].extent[1]"
+                        },
+                        {
+                            "value": 0
+                        }
+                    ]
+                }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Cylinders",
+                "sort": true
+            },
+            "range": "ordinal"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "title": "Cylinders"
         }
     ]
 }

--- a/examples/vg-specs/bubble_health_income.vg.json
+++ b/examples/vg-specs/bubble_health_income.vg.json
@@ -3,26 +3,6 @@
     "description": "A bubble plot showing the correlation between health and income for 187 countries in the world (modified from an example in Lisa Charlotte Rost's blog post 'One Chart, Twelve Charting Libraries' --http://lisacharlotterost.github.io/2016/05/17/one-chart-code/).",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -45,189 +25,168 @@
                     "expr": "datum[\"income\"] > 0"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "500"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "300"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "500"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "300"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A bubble plot showing the correlation between health and income for 187 countries in the world (modified from an example in Lisa Charlotte Rost's blog post 'One Chart, Twelve Charting Libraries' --http://lisacharlotterost.github.io/2016/05/17/one-chart-code/).",
+            "name": "marks",
+            "type": "symbol",
+            "role": "circle",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "circle",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "income"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "health"
-                            },
-                            "fill": {
-                                "value": "#000"
-                            },
-                            "size": {
-                                "scale": "size",
-                                "field": "population"
-                            },
-                            "shape": {
-                                "value": "circle"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "log",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "income"
                     },
-                    "range": [
-                        0,
-                        500
-                    ],
-                    "round": true,
-                    "nice": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "health"
                     },
-                    "range": [
-                        300,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                },
-                {
-                    "name": "size",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "fill": {
+                        "value": "#000"
+                    },
+                    "size": {
+                        "scale": "size",
                         "field": "population"
                     },
-                    "range": [
-                        0,
-                        361
-                    ],
-                    "nice": false,
-                    "zero": true
+                    "shape": {
+                        "value": "circle"
+                    },
+                    "opacity": {
+                        "value": 0.7
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "log",
+            "domain": {
+                "data": "source_0",
+                "field": "income"
+            },
+            "range": [
+                0,
+                500
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "income",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "health",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
+            "round": true,
+            "nice": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "health"
+            },
+            "range": [
+                300,
+                0
             ],
-            "legends": [
-                {
-                    "size": "size",
-                    "format": "s",
-                    "title": "population",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "circle"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                },
-                                "fill": {
-                                    "value": "#000"
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": false
+        },
+        {
+            "name": "size",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "population"
+            },
+            "range": [
+                0,
+                361
+            ],
+            "nice": false,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "income",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "health",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "size": "size",
+            "format": "s",
+            "title": "population",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "circle"
+                        },
+                        "strokeWidth": {
+                            "value": 0
+                        },
+                        "fill": {
+                            "value": "#000"
                         }
                     }
                 }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/circle.vg.json
+++ b/examples/vg-specs/circle.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -39,149 +19,129 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "circle",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "circle",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "shape": {
-                                "value": "circle"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "Horsepower"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "Miles_per_Gallon"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "fill": {
+                        "value": "#4c78a8"
+                    },
+                    "shape": {
+                        "value": "circle"
+                    },
+                    "opacity": {
+                        "value": 0.7
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/diverging_color_points.vg.json
+++ b/examples/vg-specs/diverging_color_points.vg.json
@@ -3,26 +3,6 @@
     "description": "A bubbleplot showing horsepower on x, miles per gallons on y, and weight with a diverging color scale.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -41,175 +21,154 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"]) && datum[\"Weight_in_lbs\"] !== null && !isNaN(datum[\"Weight_in_lbs\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A bubbleplot showing horsepower on x, miles per gallons on y, and weight with a diverging color scale.",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "stroke": {
+                        "scale": "color",
+                        "field": "Weight_in_lbs"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "Weight_in_lbs"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
+            "range": [
+                0,
+                200
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "sequential",
-                    "domain": [
-                        1000,
-                        2750,
-                        4500
-                    ],
-                    "range": [
-                        "#ff7f0e",
-                        "#e7ba52",
-                        "#17becf"
-                    ],
-                    "nice": false,
-                    "zero": false
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "sequential",
+            "domain": [
+                1000,
+                2750,
+                4500
             ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "format": "s",
-                    "title": "Weight_in_lbs",
-                    "type": "gradient"
-                }
-            ]
+            "range": [
+                "#ff7f0e",
+                "#e7ba52",
+                "#17becf"
+            ],
+            "nice": false,
+            "zero": false
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "format": "s",
+            "title": "Weight_in_lbs",
+            "type": "gradient"
         }
     ]
 }

--- a/examples/vg-specs/errorbar_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_aggregate.vg.json
@@ -3,26 +3,6 @@
     "description": "A error bar plot showing mean, min, and max in the US population distribution of age groups in 2000.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -146,304 +126,304 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "max(layer_0_width, layer_1_width, layer_2_width, layer_3_width)"
         },
         {
-            "name": "layout",
-            "source": "data_0",
-            "transform": [
+            "name": "height",
+            "update": "max(layer_0_height, layer_1_height, layer_2_height, layer_3_height)"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "age"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_age\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
+        },
+        {
+            "name": "layer_3_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_3_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_2_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_2_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_1_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_0_height",
+            "update": "200"
         }
     ],
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "description": "A error bar plot showing mean, min, and max in the US population distribution of age groups in 2000.",
-            "from": {
-                "data": "layout"
-            },
             "encode": {
-                "update": {
+                "enter": {
                     "width": {
-                        "field": "width"
+                        "signal": "width"
                     },
                     "height": {
-                        "field": "height"
+                        "signal": "height"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "clip": {
+                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "type": "group",
-                    "encode": {
-                        "enter": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "clip": {
-                                "value": true
-                            }
-                        }
+                    "name": "layer_0_marks",
+                    "type": "rule",
+                    "from": {
+                        "data": "data_0"
                     },
-                    "marks": [
-                        {
-                            "name": "layer_0_marks",
-                            "type": "rule",
-                            "from": {
-                                "data": "data_0"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "age"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "min_people"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "field": "max_people"
-                                    },
-                                    "stroke": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_1_marks",
-                            "type": "rect",
-                            "role": "tick",
-                            "from": {
-                                "data": "data_1"
-                            },
-                            "encode": {
-                                "update": {
-                                    "xc": {
-                                        "scale": "x",
-                                        "field": "age"
-                                    },
-                                    "yc": {
-                                        "scale": "y",
-                                        "field": "min_people"
-                                    },
-                                    "width": {
-                                        "value": 5
-                                    },
-                                    "height": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_2_marks",
-                            "type": "rect",
-                            "role": "tick",
-                            "from": {
-                                "data": "data_2"
-                            },
-                            "encode": {
-                                "update": {
-                                    "xc": {
-                                        "scale": "x",
-                                        "field": "age"
-                                    },
-                                    "yc": {
-                                        "scale": "y",
-                                        "field": "max_people"
-                                    },
-                                    "width": {
-                                        "value": 5
-                                    },
-                                    "height": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_3_marks",
-                            "type": "symbol",
-                            "role": "point",
-                            "from": {
-                                "data": "data_3"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "age"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "mean_people"
-                                    },
-                                    "stroke": {
-                                        "value": "#4c78a8"
-                                    },
-                                    "fill": {
-                                        "value": "transparent"
-                                    },
-                                    "size": {
-                                        "value": 2
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "fields": [
-                            {
-                                "field": "age",
-                                "data": "data_0"
-                            },
-                            {
-                                "field": "age",
-                                "data": "data_1"
-                            },
-                            {
-                                "field": "age",
-                                "data": "data_2"
-                            },
-                            {
-                                "data": "data_3",
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
                                 "field": "age"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "fields": [
-                            {
-                                "field": "min_people",
-                                "data": "data_0"
                             },
-                            {
-                                "field": "max_people",
-                                "data": "data_0"
+                            "y": {
+                                "scale": "y",
+                                "field": "min_people"
                             },
-                            {
-                                "field": "min_people",
-                                "data": "data_1"
+                            "y2": {
+                                "scale": "y",
+                                "field": "max_people"
                             },
-                            {
-                                "field": "max_people",
-                                "data": "data_2"
-                            },
-                            {
-                                "data": "data_3",
-                                "field": "mean_people"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "age",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
+                            "stroke": {
+                                "value": "#4c78a8"
                             }
                         }
                     }
                 },
                 {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "population",
-                    "zindex": 1
+                    "name": "layer_1_marks",
+                    "type": "rect",
+                    "role": "tick",
+                    "from": {
+                        "data": "data_1"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "age"
+                            },
+                            "yc": {
+                                "scale": "y",
+                                "field": "min_people"
+                            },
+                            "width": {
+                                "value": 5
+                            },
+                            "height": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
                 },
                 {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
+                    "name": "layer_2_marks",
+                    "type": "rect",
+                    "role": "tick",
+                    "from": {
+                        "data": "data_2"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "age"
+                            },
+                            "yc": {
+                                "scale": "y",
+                                "field": "max_people"
+                            },
+                            "width": {
+                                "value": 5
+                            },
+                            "height": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "layer_3_marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "data_3"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "age"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "mean_people"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "size": {
+                                "value": 2
+                            }
+                        }
+                    }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "fields": [
+                    {
+                        "field": "age",
+                        "data": "data_0"
+                    },
+                    {
+                        "field": "age",
+                        "data": "data_1"
+                    },
+                    {
+                        "field": "age",
+                        "data": "data_2"
+                    },
+                    {
+                        "data": "data_3",
+                        "field": "age"
+                    }
+                ],
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {
+                        "field": "min_people",
+                        "data": "data_0"
+                    },
+                    {
+                        "field": "max_people",
+                        "data": "data_0"
+                    },
+                    {
+                        "field": "min_people",
+                        "data": "data_1"
+                    },
+                    {
+                        "field": "max_people",
+                        "data": "data_2"
+                    },
+                    {
+                        "data": "data_3",
+                        "field": "mean_people"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "age",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "population",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
@@ -3,26 +3,6 @@
     "description": "A bar chart showing the US population distribution of age groups in 2000.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -146,290 +126,290 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "max(layer_0_width, layer_1_width, layer_2_width, layer_3_width)"
         },
         {
-            "name": "layout",
-            "source": "data_0",
-            "transform": [
+            "name": "height",
+            "update": "max(layer_0_height, layer_1_height, layer_2_height, layer_3_height)"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "age"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "max(datum[\"distinct_age\"] - 1 + 2*0.5, 0) * 21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
+        },
+        {
+            "name": "layer_3_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_3_height",
+            "update": "bandspace(domain('y').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_2_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_2_height",
+            "update": "bandspace(domain('y').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_1_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_height",
+            "update": "bandspace(domain('y').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_0_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_height",
+            "update": "bandspace(domain('y').length, 1, 0.5) * 21"
         }
     ],
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "description": "A bar chart showing the US population distribution of age groups in 2000.",
-            "from": {
-                "data": "layout"
-            },
             "encode": {
-                "update": {
+                "enter": {
                     "width": {
-                        "field": "width"
+                        "signal": "width"
                     },
                     "height": {
-                        "field": "height"
+                        "signal": "height"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "clip": {
+                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "type": "group",
+                    "name": "layer_0_marks",
+                    "type": "rule",
+                    "from": {
+                        "data": "data_0"
+                    },
                     "encode": {
-                        "enter": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "min_people"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "age"
+                            },
+                            "x2": {
+                                "scale": "x",
+                                "field": "max_people"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "layer_1_marks",
+                    "type": "rect",
+                    "role": "tick",
+                    "from": {
+                        "data": "data_1"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "min_people"
+                            },
+                            "yc": {
+                                "scale": "y",
+                                "field": "age"
                             },
                             "height": {
-                                "field": {
-                                    "group": "height"
-                                }
+                                "value": 5
+                            },
+                            "width": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "layer_2_marks",
+                    "type": "rect",
+                    "role": "tick",
+                    "from": {
+                        "data": "data_2"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "max_people"
+                            },
+                            "yc": {
+                                "scale": "y",
+                                "field": "age"
+                            },
+                            "height": {
+                                "value": 5
+                            },
+                            "width": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "layer_3_marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "data_3"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "mean_people"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "age"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
                             },
                             "fill": {
                                 "value": "transparent"
                             },
-                            "clip": {
-                                "value": true
+                            "size": {
+                                "value": 2
                             }
                         }
-                    },
-                    "marks": [
-                        {
-                            "name": "layer_0_marks",
-                            "type": "rule",
-                            "from": {
-                                "data": "data_0"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "min_people"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "age"
-                                    },
-                                    "x2": {
-                                        "scale": "x",
-                                        "field": "max_people"
-                                    },
-                                    "stroke": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_1_marks",
-                            "type": "rect",
-                            "role": "tick",
-                            "from": {
-                                "data": "data_1"
-                            },
-                            "encode": {
-                                "update": {
-                                    "xc": {
-                                        "scale": "x",
-                                        "field": "min_people"
-                                    },
-                                    "yc": {
-                                        "scale": "y",
-                                        "field": "age"
-                                    },
-                                    "height": {
-                                        "value": 5
-                                    },
-                                    "width": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_2_marks",
-                            "type": "rect",
-                            "role": "tick",
-                            "from": {
-                                "data": "data_2"
-                            },
-                            "encode": {
-                                "update": {
-                                    "xc": {
-                                        "scale": "x",
-                                        "field": "max_people"
-                                    },
-                                    "yc": {
-                                        "scale": "y",
-                                        "field": "age"
-                                    },
-                                    "height": {
-                                        "value": 5
-                                    },
-                                    "width": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_3_marks",
-                            "type": "symbol",
-                            "role": "point",
-                            "from": {
-                                "data": "data_3"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "mean_people"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "age"
-                                    },
-                                    "stroke": {
-                                        "value": "#4c78a8"
-                                    },
-                                    "fill": {
-                                        "value": "transparent"
-                                    },
-                                    "size": {
-                                        "value": 2
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "fields": [
-                            {
-                                "field": "min_people",
-                                "data": "data_0"
-                            },
-                            {
-                                "field": "max_people",
-                                "data": "data_0"
-                            },
-                            {
-                                "field": "min_people",
-                                "data": "data_1"
-                            },
-                            {
-                                "field": "max_people",
-                                "data": "data_2"
-                            },
-                            {
-                                "data": "data_3",
-                                "field": "mean_people"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "point",
-                    "domain": {
-                        "fields": [
-                            {
-                                "field": "age",
-                                "data": "data_0"
-                            },
-                            {
-                                "field": "age",
-                                "data": "data_1"
-                            },
-                            {
-                                "field": "age",
-                                "data": "data_2"
-                            },
-                            {
-                                "data": "data_3",
-                                "field": "age"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "population",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "orient": "left",
-                    "title": "age",
-                    "zindex": 1
+                    }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {
+                        "field": "min_people",
+                        "data": "data_0"
+                    },
+                    {
+                        "field": "max_people",
+                        "data": "data_0"
+                    },
+                    {
+                        "field": "min_people",
+                        "data": "data_1"
+                    },
+                    {
+                        "field": "max_people",
+                        "data": "data_2"
+                    },
+                    {
+                        "data": "data_3",
+                        "field": "mean_people"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "point",
+            "domain": {
+                "fields": [
+                    {
+                        "field": "age",
+                        "data": "data_0"
+                    },
+                    {
+                        "field": "age",
+                        "data": "data_1"
+                    },
+                    {
+                        "field": "age",
+                        "data": "data_2"
+                    },
+                    {
+                        "data": "data_3",
+                        "field": "age"
+                    }
+                ],
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "population",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "orient": "left",
+            "title": "age",
+            "zindex": 1
         }
     ]
 }

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -3,15 +3,62 @@
     "description": "Anscombe's Quartet",
     "autosize": "pad",
     "padding": 5,
+    "data": [
+        {
+            "name": "source_0",
+            "url": "data/anscombe.json",
+            "format": {
+                "type": "json",
+                "parse": {
+                    "X": "number",
+                    "Y": "number"
+                }
+            },
+            "transform": [
+                {
+                    "type": "filter",
+                    "expr": "datum[\"X\"] !== null && !isNaN(datum[\"X\"]) && datum[\"Y\"] !== null && !isNaN(datum[\"Y\"])"
+                }
+            ]
+        },
+        {
+            "name": "column",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "aggregate",
+                    "groupby": [
+                        "Series"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "column-layout",
+            "source": "column",
+            "transform": [
+                {
+                    "type": "aggregate",
+                    "ops": [
+                        "distinct"
+                    ],
+                    "fields": [
+                        "Series"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "child_brush_store"
+        },
+        {
+            "name": "child_grid_store"
+        },
+        {
+            "name": "child_xenc_store"
+        }
+    ],
     "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
         {
             "name": "child_xenc_X",
             "value": "",
@@ -49,855 +96,759 @@
         {
             "name": "child_xenc",
             "update": "data(\"child_xenc_store\")[0]"
+        },
+        {
+            "name": "child_width",
+            "update": "200"
+        },
+        {
+            "name": "child_height",
+            "update": "200"
         }
     ],
-    "data": [
-        {
-            "name": "source_0",
-            "url": "data/anscombe.json",
-            "format": {
-                "type": "json",
-                "parse": {
-                    "X": "number",
-                    "Y": "number"
-                }
-            },
-            "transform": [
-                {
-                    "type": "filter",
-                    "expr": "datum[\"X\"] !== null && !isNaN(datum[\"X\"]) && datum[\"Y\"] !== null && !isNaN(datum[\"Y\"])"
-                }
-            ]
+    "layout": {
+        "padding": {
+            "row": 10,
+            "column": 10,
+            "header": 10
         },
-        {
-            "name": "column",
-            "source": "source_0",
-            "transform": [
-                {
-                    "type": "aggregate",
-                    "groupby": [
-                        "Series"
-                    ]
-                }
-            ]
-        },
-        {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
-                {
-                    "type": "aggregate",
-                    "fields": [
-                        "Series"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "child_width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "(datum[\"child_width\"] + 5) * datum[\"distinct_Series\"]"
-                },
-                {
-                    "type": "formula",
-                    "as": "child_height",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "datum[\"child_height\"] + 5"
-                }
-            ]
-        },
-        {
-            "name": "child_brush_store"
-        },
-        {
-            "name": "child_grid_store"
-        },
-        {
-            "name": "child_xenc_store"
-        }
-    ],
+        "columns": 1,
+        "bounds": "full"
+    },
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "description": "Anscombe's Quartet",
-            "from": {
-                "data": "layout"
-            },
-            "signals": [
-                {
-                    "name": "column",
-                    "update": "data('layout')[0].distinct_Series"
-                }
-            ],
             "layout": {
                 "padding": {
                     "row": 10,
                     "column": 10,
                     "header": 10
                 },
-                "columns": 1,
+                "columns": {
+                    "signal": "data('column-layout')[0].distinct_Series"
+                },
                 "bounds": "full"
             },
             "marks": [
                 {
+                    "name": "x-axes",
                     "type": "group",
-                    "layout": {
-                        "padding": {
-                            "row": 10,
-                            "column": 10,
-                            "header": 10
-                        },
-                        "columns": {
-                            "signal": "column"
-                        },
-                        "bounds": "full"
+                    "role": "column-footer",
+                    "from": {
+                        "data": "column"
                     },
-                    "marks": [
+                    "axes": [
                         {
-                            "name": "x-axes",
-                            "type": "group",
-                            "role": "column-footer",
-                            "from": {
-                                "data": "column"
-                            },
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "format": "s",
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "title": "X",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "y-axes",
-                            "type": "group",
-                            "role": "row-header",
-                            "axes": [
-                                {
-                                    "scale": "y",
-                                    "format": "s",
-                                    "orient": "left",
-                                    "title": "Y",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "column-labels",
-                            "role": "column-header",
-                            "type": "group",
-                            "from": {
-                                "data": "column"
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "type": "text",
-                                    "role": "column-labels",
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "field": {
-                                                    "group": "width"
-                                                },
-                                                "mult": 0.5
-                                            },
-                                            "y": {
-                                                "value": -10
-                                            },
-                                            "text": {
-                                                "field": {
-                                                    "parent": "Series"
-                                                }
-                                            },
-                                            "align": {
-                                                "value": "center"
-                                            },
-                                            "fill": {
-                                                "value": "black"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "cell",
-                            "type": "group",
-                            "from": {
-                                "facet": {
-                                    "name": "facet",
-                                    "data": "source_0",
-                                    "groupby": [
-                                        "Series"
-                                    ]
-                                }
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    },
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
-                                        }
-                                    },
-                                    "stroke": {
-                                        "value": "#ccc"
-                                    },
-                                    "strokeWidth": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "transparent"
-                                    }
-                                }
-                            },
-                            "signals": [
-                                {
-                                    "name": "child_brush_x",
-                                    "value": [],
-                                    "on": [
-                                        {
-                                            "events": {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
-                                                ]
-                                            },
-                                            "update": "invert(\"x\", [x(unit), x(unit)])"
-                                        },
-                                        {
-                                            "events": {
-                                                "source": "window",
-                                                "type": "mousemove",
-                                                "consume": true,
-                                                "between": [
-                                                    {
-                                                        "source": "scope",
-                                                        "type": "mousedown",
-                                                        "filter": [
-                                                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
-                                                        ]
-                                                    },
-                                                    {
-                                                        "source": "window",
-                                                        "type": "mouseup"
-                                                    }
-                                                ]
-                                            },
-                                            "update": "[child_brush_x[0], invert(\"x\", clamp(x(unit), 0, width))]"
-                                        },
-                                        {
-                                            "events": {
-                                                "signal": "child_brush_translate_delta"
-                                            },
-                                            "update": "clampRange([child_brush_translate_anchor.extent_x[0] + abs(span(child_brush_translate_anchor.extent_x)) * child_brush_translate_delta.x / child_brush_translate_anchor.width, child_brush_translate_anchor.extent_x[1] + abs(span(child_brush_translate_anchor.extent_x)) * child_brush_translate_delta.x / child_brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
-                                        },
-                                        {
-                                            "events": {
-                                                "signal": "child_brush_zoom_delta"
-                                            },
-                                            "update": "clampRange([child_brush_zoom_anchor.x + (child_brush_x[0] - child_brush_zoom_anchor.x) * child_brush_zoom_delta, child_brush_zoom_anchor.x + (child_brush_x[1] - child_brush_zoom_anchor.x) * child_brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "child_brush_size",
-                                    "value": [],
-                                    "on": [
-                                        {
-                                            "events": {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
-                                                ]
-                                            },
-                                            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                                        },
-                                        {
-                                            "events": {
-                                                "source": "window",
-                                                "type": "mousemove",
-                                                "consume": true,
-                                                "between": [
-                                                    {
-                                                        "source": "scope",
-                                                        "type": "mousedown",
-                                                        "filter": [
-                                                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
-                                                        ]
-                                                    },
-                                                    {
-                                                        "source": "window",
-                                                        "type": "mouseup"
-                                                    }
-                                                ]
-                                            },
-                                            "update": "{x: child_brush_size.x, y: child_brush_size.y, width: abs(x(unit) - child_brush_size.x), height: abs(y(unit) - child_brush_size.y)}"
-                                        },
-                                        {
-                                            "events": {
-                                                "signal": "child_brush_zoom_delta"
-                                            },
-                                            "update": "{x: child_brush_size.x, y: child_brush_size.y, width: child_brush_size.width * child_brush_zoom_delta , height: child_brush_size.height * child_brush_zoom_delta}"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "child_brush",
-                                    "update": "[{field: \"X\", extent: child_brush_x}]"
-                                },
-                                {
-                                    "name": "child_brush_translate_anchor",
-                                    "value": {},
-                                    "on": [
-                                        {
-                                            "events": [
-                                                {
-                                                    "source": "scope",
-                                                    "type": "mousedown",
-                                                    "markname": "child_brush_brush"
-                                                }
-                                            ],
-                                            "update": "{x: x(unit), y: y(unit), width: child_brush_size.width, height: child_brush_size.height, extent_x: slice(child_brush_x), }"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "child_brush_translate_delta",
-                                    "value": {},
-                                    "on": [
-                                        {
-                                            "events": [
-                                                {
-                                                    "source": "window",
-                                                    "type": "mousemove",
-                                                    "consume": true,
-                                                    "between": [
-                                                        {
-                                                            "source": "scope",
-                                                            "type": "mousedown",
-                                                            "markname": "child_brush_brush"
-                                                        },
-                                                        {
-                                                            "source": "window",
-                                                            "type": "mouseup"
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "update": "{x: x(unit) - child_brush_translate_anchor.x, y: y(unit) - child_brush_translate_anchor.y}"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "child_brush_zoom_anchor",
-                                    "on": [
-                                        {
-                                            "events": [
-                                                {
-                                                    "source": "scope",
-                                                    "type": "wheel",
-                                                    "markname": "child_brush_brush"
-                                                }
-                                            ],
-                                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "child_brush_zoom_delta",
-                                    "on": [
-                                        {
-                                            "events": [
-                                                {
-                                                    "source": "scope",
-                                                    "type": "wheel",
-                                                    "markname": "child_brush_brush"
-                                                }
-                                            ],
-                                            "force": true,
-                                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "child_brush_tuple",
-                                    "on": [
-                                        {
-                                            "events": {
-                                                "signal": "child_brush"
-                                            },
-                                            "update": "{unit: unit.datum && unit.datum._id, intervals: child_brush}"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "child_brush_modify",
-                                    "on": [
-                                        {
-                                            "events": {
-                                                "signal": "child_brush"
-                                            },
-                                            "update": "modify(\"child_brush_store\", child_brush_tuple, {unit: child_brush_tuple.unit})"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "child_grid_x",
-                                    "on": [
-                                        {
-                                            "events": {
-                                                "signal": "child_grid_translate_delta"
-                                            },
-                                            "update": "[child_grid_translate_anchor.extent_x[0] - abs(span(child_grid_translate_anchor.extent_x)) * child_grid_translate_delta.x / child_grid_translate_anchor.width, child_grid_translate_anchor.extent_x[1] - abs(span(child_grid_translate_anchor.extent_x)) * child_grid_translate_delta.x / child_grid_translate_anchor.width]"
-                                        },
-                                        {
-                                            "events": {
-                                                "signal": "child_grid_zoom_delta"
-                                            },
-                                            "update": "[child_grid_zoom_anchor.x + (domain(\"x\")[0] - child_grid_zoom_anchor.x) * child_grid_zoom_delta, child_grid_zoom_anchor.x + (domain(\"x\")[1] - child_grid_zoom_anchor.x) * child_grid_zoom_delta]"
-                                        }
-                                    ],
-                                    "push": "outer"
-                                },
-                                {
-                                    "name": "child_grid_y",
-                                    "on": [
-                                        {
-                                            "events": {
-                                                "signal": "child_grid_translate_delta"
-                                            },
-                                            "update": "[child_grid_translate_anchor.extent_y[0] + abs(span(child_grid_translate_anchor.extent_y)) * child_grid_translate_delta.y / child_grid_translate_anchor.height, child_grid_translate_anchor.extent_y[1] + abs(span(child_grid_translate_anchor.extent_y)) * child_grid_translate_delta.y / child_grid_translate_anchor.height]"
-                                        },
-                                        {
-                                            "events": {
-                                                "signal": "child_grid_zoom_delta"
-                                            },
-                                            "update": "[child_grid_zoom_anchor.y + (domain(\"y\")[0] - child_grid_zoom_anchor.y) * child_grid_zoom_delta, child_grid_zoom_anchor.y + (domain(\"y\")[1] - child_grid_zoom_anchor.y) * child_grid_zoom_delta]"
-                                        }
-                                    ],
-                                    "push": "outer"
-                                },
-                                {
-                                    "name": "child_grid",
-                                    "update": "[{field: \"X\", extent: child_grid_x}, {field: \"Y\", extent: child_grid_y}]"
-                                },
-                                {
-                                    "name": "child_grid_translate_anchor",
-                                    "value": {},
-                                    "on": [
-                                        {
-                                            "events": [
-                                                {
-                                                    "source": "scope",
-                                                    "type": "mousedown",
-                                                    "filter": [
-                                                        "event.shiftKey"
-                                                    ]
-                                                }
-                                            ],
-                                            "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "child_grid_translate_delta",
-                                    "value": {},
-                                    "on": [
-                                        {
-                                            "events": [
-                                                {
-                                                    "source": "scope",
-                                                    "type": "mousemove",
-                                                    "between": [
-                                                        {
-                                                            "source": "scope",
-                                                            "type": "mousedown",
-                                                            "filter": [
-                                                                "event.shiftKey"
-                                                            ]
-                                                        },
-                                                        {
-                                                            "source": "scope",
-                                                            "type": "mouseup"
-                                                        }
-                                                    ]
-                                                }
-                                            ],
-                                            "update": "{x: x(unit) - child_grid_translate_anchor.x, y: y(unit) - child_grid_translate_anchor.y}"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "child_grid_zoom_anchor",
-                                    "on": [
-                                        {
-                                            "events": [
-                                                {
-                                                    "source": "scope",
-                                                    "type": "wheel"
-                                                }
-                                            ],
-                                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "child_grid_zoom_delta",
-                                    "on": [
-                                        {
-                                            "events": [
-                                                {
-                                                    "source": "scope",
-                                                    "type": "wheel"
-                                                }
-                                            ],
-                                            "force": true,
-                                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "child_grid_tuple",
-                                    "on": [
-                                        {
-                                            "events": {
-                                                "signal": "child_grid"
-                                            },
-                                            "update": "{unit: unit.datum && unit.datum._id, intervals: child_grid}"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "child_grid_modify",
-                                    "on": [
-                                        {
-                                            "events": {
-                                                "signal": "child_grid"
-                                            },
-                                            "update": "modify(\"child_grid_store\", child_grid_tuple, true)"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "child_xenc",
-                                    "update": "{fields: [\"X\"], values: [child_xenc_X]}"
-                                },
-                                {
-                                    "name": "child_xenc_tuple",
-                                    "on": [
-                                        {
-                                            "events": {
-                                                "signal": "child_xenc"
-                                            },
-                                            "update": "{unit: unit.datum && unit.datum._id, fields: child_xenc.fields, values: child_xenc.values, X: child_xenc.values[0]}"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "name": "child_xenc_modify",
-                                    "on": [
-                                        {
-                                            "events": {
-                                                "signal": "child_xenc"
-                                            },
-                                            "update": "modify(\"child_xenc_store\", child_xenc_tuple, true)"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "marks": [
-                                {
-                                    "type": "group",
-                                    "encode": {
-                                        "enter": {
-                                            "width": {
-                                                "field": {
-                                                    "group": "width"
-                                                }
-                                            },
-                                            "height": {
-                                                "field": {
-                                                    "group": "height"
-                                                }
-                                            },
-                                            "fill": {
-                                                "value": "transparent"
-                                            },
-                                            "clip": {
-                                                "value": true
-                                            }
-                                        }
-                                    },
-                                    "marks": [
-                                        {
-                                            "type": "rect",
-                                            "encode": {
-                                                "enter": {
-                                                    "fill": {
-                                                        "value": "#eee"
-                                                    }
-                                                },
-                                                "update": {
-                                                    "x": {
-                                                        "scale": "x",
-                                                        "signal": "child_brush[0].extent[0]"
-                                                    },
-                                                    "x2": {
-                                                        "scale": "x",
-                                                        "signal": "child_brush[0].extent[1]"
-                                                    },
-                                                    "y": {
-                                                        "value": 0
-                                                    },
-                                                    "y2": {
-                                                        "field": {
-                                                            "group": "height"
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "name": "child_marks",
-                                            "type": "symbol",
-                                            "role": "circle",
-                                            "from": {
-                                                "data": "facet"
-                                            },
-                                            "encode": {
-                                                "update": {
-                                                    "x": {
-                                                        "scale": "x",
-                                                        "field": "X"
-                                                    },
-                                                    "y": {
-                                                        "scale": "y",
-                                                        "field": "Y"
-                                                    },
-                                                    "fill": [
-                                                        {
-                                                            "test": "vlPoint(\"child_xenc_store\", parent._id, datum, \"union\", \"all\")",
-                                                            "value": "red"
-                                                        },
-                                                        {
-                                                            "value": "steelblue"
-                                                        }
-                                                    ],
-                                                    "size": [
-                                                        {
-                                                            "test": "vlInterval(\"child_brush_store\", parent._id, datum, \"intersect\", \"all\")",
-                                                            "value": 250
-                                                        },
-                                                        {
-                                                            "value": 100
-                                                        }
-                                                    ],
-                                                    "shape": {
-                                                        "value": "circle"
-                                                    }
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "name": "child_voronoi",
-                                            "type": "path",
-                                            "from": {
-                                                "data": "child_marks"
-                                            },
-                                            "encode": {
-                                                "enter": {
-                                                    "fill": {
-                                                        "value": "transparent"
-                                                    },
-                                                    "strokeWidth": {
-                                                        "value": 0.35
-                                                    },
-                                                    "stroke": {
-                                                        "value": "transparent"
-                                                    },
-                                                    "isVoronoi": {
-                                                        "value": true
-                                                    }
-                                                }
-                                            },
-                                            "transform": [
-                                                {
-                                                    "type": "voronoi",
-                                                    "x": "datum.x",
-                                                    "y": "datum.y",
-                                                    "size": [
-                                                        {
-                                                            "signal": "width"
-                                                        },
-                                                        {
-                                                            "signal": "height"
-                                                        }
-                                                    ]
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "name": "child_brush_brush",
-                                            "type": "rect",
-                                            "encode": {
-                                                "enter": {
-                                                    "fill": {
-                                                        "value": "transparent"
-                                                    }
-                                                },
-                                                "update": {
-                                                    "x": {
-                                                        "scale": "x",
-                                                        "signal": "child_brush[0].extent[0]"
-                                                    },
-                                                    "x2": {
-                                                        "scale": "x",
-                                                        "signal": "child_brush[0].extent[1]"
-                                                    },
-                                                    "y": {
-                                                        "value": 0
-                                                    },
-                                                    "y2": {
-                                                        "field": {
-                                                            "group": "height"
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    ]
-                                }
-                            ],
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "domain": false,
-                                    "format": "s",
-                                    "grid": true,
-                                    "labels": false,
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "ticks": false,
-                                    "zindex": 0,
-                                    "gridScale": "y"
-                                },
-                                {
-                                    "scale": "y",
-                                    "domain": false,
-                                    "format": "s",
-                                    "grid": true,
-                                    "labels": false,
-                                    "orient": "left",
-                                    "ticks": false,
-                                    "zindex": 0,
-                                    "gridScale": "x"
-                                }
-                            ]
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "X",
+                            "zindex": 1
                         }
                     ]
                 },
                 {
-                    "name": "column-title",
+                    "name": "y-axes",
+                    "type": "group",
+                    "role": "row-header",
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Y",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "column-labels",
                     "role": "column-header",
                     "type": "group",
+                    "from": {
+                        "data": "column"
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
                     "marks": [
                         {
                             "type": "text",
-                            "role": "column-title",
+                            "role": "column-labels",
                             "encode": {
                                 "update": {
                                     "x": {
-                                        "signal": "0.5 * width"
+                                        "field": {
+                                            "group": "width"
+                                        },
+                                        "mult": 0.5
+                                    },
+                                    "y": {
+                                        "value": -10
                                     },
                                     "text": {
-                                        "value": "Series"
+                                        "field": {
+                                            "parent": "Series"
+                                        }
                                     },
                                     "align": {
                                         "value": "center"
                                     },
                                     "fill": {
                                         "value": "black"
-                                    },
-                                    "fontWeight": {
-                                        "value": "bold"
                                     }
                                 }
                             }
                         }
                     ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "X"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false,
-                    "domainRaw": {
-                        "signal": "child_grid_x"
-                    }
                 },
                 {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Y"
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "Series"
+                            ]
+                        }
                     },
-                    "range": [
-                        200,
-                        0
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "signals": [
+                        {
+                            "name": "child_brush_x",
+                            "value": [],
+                            "on": [
+                                {
+                                    "events": {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
+                                        ]
+                                    },
+                                    "update": "invert(\"x\", [x(unit), x(unit)])"
+                                },
+                                {
+                                    "events": {
+                                        "source": "window",
+                                        "type": "mousemove",
+                                        "consume": true,
+                                        "between": [
+                                            {
+                                                "source": "scope",
+                                                "type": "mousedown",
+                                                "filter": [
+                                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
+                                                ]
+                                            },
+                                            {
+                                                "source": "window",
+                                                "type": "mouseup"
+                                            }
+                                        ]
+                                    },
+                                    "update": "[child_brush_x[0], invert(\"x\", clamp(x(unit), 0, width))]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "child_brush_translate_delta"
+                                    },
+                                    "update": "clampRange([child_brush_translate_anchor.extent_x[0] + abs(span(child_brush_translate_anchor.extent_x)) * child_brush_translate_delta.x / child_brush_translate_anchor.width, child_brush_translate_anchor.extent_x[1] + abs(span(child_brush_translate_anchor.extent_x)) * child_brush_translate_delta.x / child_brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "child_brush_zoom_delta"
+                                    },
+                                    "update": "clampRange([child_brush_zoom_anchor.x + (child_brush_x[0] - child_brush_zoom_anchor.x) * child_brush_zoom_delta, child_brush_zoom_anchor.x + (child_brush_x[1] - child_brush_zoom_anchor.x) * child_brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_size",
+                            "value": [],
+                            "on": [
+                                {
+                                    "events": {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
+                                        ]
+                                    },
+                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
+                                },
+                                {
+                                    "events": {
+                                        "source": "window",
+                                        "type": "mousemove",
+                                        "consume": true,
+                                        "between": [
+                                            {
+                                                "source": "scope",
+                                                "type": "mousedown",
+                                                "filter": [
+                                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
+                                                ]
+                                            },
+                                            {
+                                                "source": "window",
+                                                "type": "mouseup"
+                                            }
+                                        ]
+                                    },
+                                    "update": "{x: child_brush_size.x, y: child_brush_size.y, width: abs(x(unit) - child_brush_size.x), height: abs(y(unit) - child_brush_size.y)}"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "child_brush_zoom_delta"
+                                    },
+                                    "update": "{x: child_brush_size.x, y: child_brush_size.y, width: child_brush_size.width * child_brush_zoom_delta , height: child_brush_size.height * child_brush_zoom_delta}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush",
+                            "update": "[{field: \"X\", extent: child_brush_x}]"
+                        },
+                        {
+                            "name": "child_brush_translate_anchor",
+                            "value": {},
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "markname": "child_brush_brush"
+                                        }
+                                    ],
+                                    "update": "{x: x(unit), y: y(unit), width: child_brush_size.width, height: child_brush_size.height, extent_x: slice(child_brush_x), }"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_translate_delta",
+                            "value": {},
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "window",
+                                            "type": "mousemove",
+                                            "consume": true,
+                                            "between": [
+                                                {
+                                                    "source": "scope",
+                                                    "type": "mousedown",
+                                                    "markname": "child_brush_brush"
+                                                },
+                                                {
+                                                    "source": "window",
+                                                    "type": "mouseup"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "update": "{x: x(unit) - child_brush_translate_anchor.x, y: y(unit) - child_brush_translate_anchor.y}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_zoom_anchor",
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "wheel",
+                                            "markname": "child_brush_brush"
+                                        }
+                                    ],
+                                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_zoom_delta",
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "wheel",
+                                            "markname": "child_brush_brush"
+                                        }
+                                    ],
+                                    "force": true,
+                                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_tuple",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_brush"
+                                    },
+                                    "update": "{unit: unit.datum && unit.datum._id, intervals: child_brush}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_modify",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_brush"
+                                    },
+                                    "update": "modify(\"child_brush_store\", child_brush_tuple, {unit: child_brush_tuple.unit})"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_x",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_grid_translate_delta"
+                                    },
+                                    "update": "[child_grid_translate_anchor.extent_x[0] - abs(span(child_grid_translate_anchor.extent_x)) * child_grid_translate_delta.x / child_grid_translate_anchor.width, child_grid_translate_anchor.extent_x[1] - abs(span(child_grid_translate_anchor.extent_x)) * child_grid_translate_delta.x / child_grid_translate_anchor.width]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "child_grid_zoom_delta"
+                                    },
+                                    "update": "[child_grid_zoom_anchor.x + (domain(\"x\")[0] - child_grid_zoom_anchor.x) * child_grid_zoom_delta, child_grid_zoom_anchor.x + (domain(\"x\")[1] - child_grid_zoom_anchor.x) * child_grid_zoom_delta]"
+                                }
+                            ],
+                            "push": "outer"
+                        },
+                        {
+                            "name": "child_grid_y",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_grid_translate_delta"
+                                    },
+                                    "update": "[child_grid_translate_anchor.extent_y[0] + abs(span(child_grid_translate_anchor.extent_y)) * child_grid_translate_delta.y / child_grid_translate_anchor.height, child_grid_translate_anchor.extent_y[1] + abs(span(child_grid_translate_anchor.extent_y)) * child_grid_translate_delta.y / child_grid_translate_anchor.height]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "child_grid_zoom_delta"
+                                    },
+                                    "update": "[child_grid_zoom_anchor.y + (domain(\"y\")[0] - child_grid_zoom_anchor.y) * child_grid_zoom_delta, child_grid_zoom_anchor.y + (domain(\"y\")[1] - child_grid_zoom_anchor.y) * child_grid_zoom_delta]"
+                                }
+                            ],
+                            "push": "outer"
+                        },
+                        {
+                            "name": "child_grid",
+                            "update": "[{field: \"X\", extent: child_grid_x}, {field: \"Y\", extent: child_grid_y}]"
+                        },
+                        {
+                            "name": "child_grid_translate_anchor",
+                            "value": {},
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ]
+                                        }
+                                    ],
+                                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_translate_delta",
+                            "value": {},
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousemove",
+                                            "between": [
+                                                {
+                                                    "source": "scope",
+                                                    "type": "mousedown",
+                                                    "filter": [
+                                                        "event.shiftKey"
+                                                    ]
+                                                },
+                                                {
+                                                    "source": "scope",
+                                                    "type": "mouseup"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "update": "{x: x(unit) - child_grid_translate_anchor.x, y: y(unit) - child_grid_translate_anchor.y}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_zoom_anchor",
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "wheel"
+                                        }
+                                    ],
+                                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_zoom_delta",
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "wheel"
+                                        }
+                                    ],
+                                    "force": true,
+                                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_tuple",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_grid"
+                                    },
+                                    "update": "{unit: unit.datum && unit.datum._id, intervals: child_grid}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_modify",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_grid"
+                                    },
+                                    "update": "modify(\"child_grid_store\", child_grid_tuple, true)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_xenc",
+                            "update": "{fields: [\"X\"], values: [child_xenc_X]}"
+                        },
+                        {
+                            "name": "child_xenc_tuple",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_xenc"
+                                    },
+                                    "update": "{unit: unit.datum && unit.datum._id, fields: child_xenc.fields, values: child_xenc.values, X: child_xenc.values[0]}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_xenc_modify",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_xenc"
+                                    },
+                                    "update": "modify(\"child_xenc_store\", child_xenc_tuple, true)"
+                                }
+                            ]
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false,
-                    "domainRaw": {
-                        "signal": "child_grid_y"
+                    "marks": [
+                        {
+                            "type": "group",
+                            "encode": {
+                                "enter": {
+                                    "width": {
+                                        "signal": "child_width"
+                                    },
+                                    "height": {
+                                        "signal": "child_height"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "clip": {
+                                        "value": true
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "type": "rect",
+                                    "encode": {
+                                        "enter": {
+                                            "fill": {
+                                                "value": "#eee"
+                                            }
+                                        },
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "signal": "child_brush[0].extent[0]"
+                                            },
+                                            "x2": {
+                                                "scale": "x",
+                                                "signal": "child_brush[0].extent[1]"
+                                            },
+                                            "y": {
+                                                "value": 0
+                                            },
+                                            "y2": {
+                                                "field": {
+                                                    "group": "height"
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "name": "child_marks",
+                                    "type": "symbol",
+                                    "role": "circle",
+                                    "from": {
+                                        "data": "facet"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "X"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "Y"
+                                            },
+                                            "fill": [
+                                                {
+                                                    "test": "vlPoint(\"child_xenc_store\", parent._id, datum, \"union\", \"all\")",
+                                                    "value": "red"
+                                                },
+                                                {
+                                                    "value": "steelblue"
+                                                }
+                                            ],
+                                            "size": [
+                                                {
+                                                    "test": "vlInterval(\"child_brush_store\", parent._id, datum, \"intersect\", \"all\")",
+                                                    "value": 250
+                                                },
+                                                {
+                                                    "value": 100
+                                                }
+                                            ],
+                                            "shape": {
+                                                "value": "circle"
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "name": "child_voronoi",
+                                    "type": "path",
+                                    "from": {
+                                        "data": "child_marks"
+                                    },
+                                    "encode": {
+                                        "enter": {
+                                            "fill": {
+                                                "value": "transparent"
+                                            },
+                                            "strokeWidth": {
+                                                "value": 0.35
+                                            },
+                                            "stroke": {
+                                                "value": "transparent"
+                                            },
+                                            "isVoronoi": {
+                                                "value": true
+                                            }
+                                        }
+                                    },
+                                    "transform": [
+                                        {
+                                            "type": "voronoi",
+                                            "x": "datum.x",
+                                            "y": "datum.y",
+                                            "size": [
+                                                {
+                                                    "signal": "width"
+                                                },
+                                                {
+                                                    "signal": "height"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "child_brush_brush",
+                                    "type": "rect",
+                                    "encode": {
+                                        "enter": {
+                                            "fill": {
+                                                "value": "transparent"
+                                            }
+                                        },
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "signal": "child_brush[0].extent[0]"
+                                            },
+                                            "x2": {
+                                                "scale": "x",
+                                                "signal": "child_brush[0].extent[1]"
+                                            },
+                                            "y": {
+                                                "value": 0
+                                            },
+                                            "y2": {
+                                                "field": {
+                                                    "group": "height"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "y"
+                        },
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "column-title",
+            "role": "column-header",
+            "type": "group",
+            "marks": [
+                {
+                    "type": "text",
+                    "role": "column-title",
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "signal": "0.5 * width"
+                            },
+                            "text": {
+                                "value": "Series"
+                            },
+                            "align": {
+                                "value": "center"
+                            },
+                            "fill": {
+                                "value": "black"
+                            },
+                            "fontWeight": {
+                                "value": "bold"
+                            }
+                        }
                     }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "X"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": false,
+            "domainRaw": {
+                "signal": "child_grid_x"
+            }
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Y"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": false,
+            "domainRaw": {
+                "signal": "child_grid_y"
+            }
         }
     ]
 }

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -662,7 +662,7 @@
                                             },
                                             "fill": [
                                                 {
-                                                    "test": "vlPoint(\"child_xenc_store\", parent._id, datum, \"union\", \"all\")",
+                                                    "test": "vlPoint(\"child_xenc_store\", datum._id, datum, \"union\", \"all\")",
                                                     "value": "red"
                                                 },
                                                 {
@@ -671,7 +671,7 @@
                                             ],
                                             "size": [
                                                 {
-                                                    "test": "vlInterval(\"child_brush_store\", parent._id, datum, \"intersect\", \"all\")",
+                                                    "test": "vlInterval(\"child_brush_store\", datum._id, datum, \"intersect\", \"all\")",
                                                     "value": 250
                                                 },
                                                 {

--- a/examples/vg-specs/field_spaces.vg.json
+++ b/examples/vg-specs/field_spaces.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -80,149 +60,129 @@
                     "expr": "datum[\"a b\"] !== null && !isNaN(datum[\"a b\"]) && datum[\"c d\"] !== null && !isNaN(datum[\"c d\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "a b"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "c d"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "a b"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "a b"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "c d"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
+            "range": [
+                0,
+                200
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "a b"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "c d"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "c d"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "a b",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "c d",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "a b",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "c d",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/github_punchcard.vg.json
+++ b/examples/vg-specs/github_punchcard.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -62,195 +42,166 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "bandspace(domain('y').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "hours_time",
-                        "day_time"
-                    ],
-                    "ops": [
-                        "distinct",
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_hours_time\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "max(datum[\"distinct_day_time\"] - 1 + 2*0.5, 0) * 21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "circle",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "hours_time"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "day_time"
                     },
                     "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "circle",
-                    "from": {
-                        "data": "source_0"
+                        "value": "#4c78a8"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "hours_time"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "day_time"
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "size": {
-                                "scale": "size",
-                                "field": "sum_count"
-                            },
-                            "shape": {
-                                "value": "circle"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "hours_time",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "day_time",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "size",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "size": {
+                        "scale": "size",
                         "field": "sum_count"
                     },
-                    "range": [
-                        0,
-                        361
-                    ],
-                    "nice": false,
-                    "zero": true
+                    "shape": {
+                        "value": "circle"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "hours_time",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "day_time",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "size",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "sum_count"
+            },
+            "range": [
+                0,
+                361
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "HOURS(time)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%H')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "y",
-                    "orient": "left",
-                    "title": "DAY(time)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%A')"
-                                }
-                            }
+            "nice": false,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "HOURS(time)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%H')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
                 }
-            ],
-            "legends": [
-                {
-                    "size": "size",
-                    "format": "s",
-                    "title": "SUM(count)",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "circle"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                },
-                                "fill": {
-                                    "value": "#4c78a8"
-                                }
-                            }
+            }
+        },
+        {
+            "scale": "y",
+            "orient": "left",
+            "title": "DAY(time)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%A')"
                         }
                     }
                 }
-            ]
+            }
+        }
+    ],
+    "legends": [
+        {
+            "size": "size",
+            "format": "s",
+            "title": "SUM(count)",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "circle"
+                        },
+                        "strokeWidth": {
+                            "value": 0
+                        },
+                        "fill": {
+                            "value": "#4c78a8"
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/histogram.vg.json
+++ b/examples/vg-specs/histogram.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -69,152 +49,132 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x2": {
+                        "scale": "x",
+                        "field": "bin_maxbins_10_IMDB_Rating_start",
+                        "offset": 1
                     },
-                    "height": {
-                        "field": "height"
+                    "x": {
+                        "scale": "x",
+                        "field": "bin_maxbins_10_IMDB_Rating_end"
                     },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x2": {
-                                "scale": "x",
-                                "field": "bin_maxbins_10_IMDB_Rating_start",
-                                "offset": 1
-                            },
-                            "x": {
-                                "scale": "x",
-                                "field": "bin_maxbins_10_IMDB_Rating_end"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "count_*"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(bin_maxbins_10_IMDB_Rating_bins.start, bin_maxbins_10_IMDB_Rating_bins.stop + bin_maxbins_10_IMDB_Rating_bins.step, bin_maxbins_10_IMDB_Rating_bins.step)"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "count_*"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "bin-linear",
+            "domain": {
+                "signal": "sequence(bin_maxbins_10_IMDB_Rating_bins.start, bin_maxbins_10_IMDB_Rating_bins.stop + bin_maxbins_10_IMDB_Rating_bins.step, bin_maxbins_10_IMDB_Rating_bins.step)"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "title": "BIN(IMDB_Rating)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "count_*"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "title": "BIN(IMDB_Rating)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Number of Records",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/histogram_bin_change.vg.json
+++ b/examples/vg-specs/histogram_bin_change.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -69,152 +49,132 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x2": {
+                        "scale": "x",
+                        "field": "bin_maxbins_30_IMDB_Rating_start",
+                        "offset": 1
                     },
-                    "height": {
-                        "field": "height"
+                    "x": {
+                        "scale": "x",
+                        "field": "bin_maxbins_30_IMDB_Rating_end"
                     },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x2": {
-                                "scale": "x",
-                                "field": "bin_maxbins_30_IMDB_Rating_start",
-                                "offset": 1
-                            },
-                            "x": {
-                                "scale": "x",
-                                "field": "bin_maxbins_30_IMDB_Rating_end"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "count_*"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(bin_maxbins_30_IMDB_Rating_bins.start, bin_maxbins_30_IMDB_Rating_bins.stop + bin_maxbins_30_IMDB_Rating_bins.step, bin_maxbins_30_IMDB_Rating_bins.step)"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "count_*"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "bin-linear",
+            "domain": {
+                "signal": "sequence(bin_maxbins_30_IMDB_Rating_bins.start, bin_maxbins_30_IMDB_Rating_bins.stop + bin_maxbins_30_IMDB_Rating_bins.step, bin_maxbins_30_IMDB_Rating_bins.step)"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "title": "BIN(IMDB_Rating)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "count_*"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "title": "BIN(IMDB_Rating)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Number of Records",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/histogram_no_spacing.vg.json
+++ b/examples/vg-specs/histogram_no_spacing.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -69,151 +49,131 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x2": {
+                        "scale": "x",
+                        "field": "bin_maxbins_10_IMDB_Rating_start"
                     },
-                    "height": {
-                        "field": "height"
+                    "x": {
+                        "scale": "x",
+                        "field": "bin_maxbins_10_IMDB_Rating_end"
                     },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x2": {
-                                "scale": "x",
-                                "field": "bin_maxbins_10_IMDB_Rating_start"
-                            },
-                            "x": {
-                                "scale": "x",
-                                "field": "bin_maxbins_10_IMDB_Rating_end"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "count_*"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(bin_maxbins_10_IMDB_Rating_bins.start, bin_maxbins_10_IMDB_Rating_bins.stop + bin_maxbins_10_IMDB_Rating_bins.step, bin_maxbins_10_IMDB_Rating_bins.step)"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "count_*"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "y2": {
+                        "scale": "y",
+                        "value": 0
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "bin-linear",
+            "domain": {
+                "signal": "sequence(bin_maxbins_10_IMDB_Rating_bins.start, bin_maxbins_10_IMDB_Rating_bins.stop + bin_maxbins_10_IMDB_Rating_bins.step, bin_maxbins_10_IMDB_Rating_bins.step)"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "title": "BIN(IMDB_Rating)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "count_*"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "title": "BIN(IMDB_Rating)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Number of Records",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/histogram_sort_mean.vg.json
+++ b/examples/vg-specs/histogram_sort_mean.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -56,147 +36,120 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "source": "data_0",
-            "transform": [
+            "name": "height",
+            "update": "bandspace(domain('y').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "Origin"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "max(datum[\"distinct_Origin\"] - 1 + 2*0.5, 0) * 21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "data_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "data_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "mean_Horsepower"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "value": 0
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "Origin"
-                            },
-                            "height": {
-                                "value": 20
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_0",
+                    "x": {
+                        "scale": "x",
                         "field": "mean_Horsepower"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Origin",
-                        "sort": {
-                            "op": "mean",
-                            "field": "Horsepower"
-                        }
+                    "x2": {
+                        "scale": "x",
+                        "value": 0
                     },
-                    "range": {
-                        "step": 21
+                    "yc": {
+                        "scale": "y",
+                        "field": "Origin"
                     },
-                    "round": true,
-                    "padding": 0.5
+                    "height": {
+                        "value": 20
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "data_0",
+                "field": "mean_Horsepower"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "MEAN(Horsepower)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "orient": "left",
-                    "title": "Origin",
-                    "zindex": 1
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": {
+                    "op": "mean",
+                    "field": "Horsepower"
                 }
-            ]
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "MEAN(Horsepower)",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "orient": "left",
+            "title": "Origin",
+            "zindex": 1
         }
     ]
 }

--- a/examples/vg-specs/layer_bar_line.vg.json
+++ b/examples/vg-specs/layer_bar_line.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -103,222 +83,207 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "max(layer_0_width, layer_1_width)"
         },
         {
-            "name": "layout",
-            "source": "data_0",
-            "transform": [
+            "name": "height",
+            "update": "max(layer_0_height, layer_1_height)"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "a"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_a\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
+        },
+        {
+            "name": "layer_1_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_1_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_0_height",
+            "update": "200"
         }
     ],
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "from": {
-                "data": "layout"
-            },
             "encode": {
-                "update": {
+                "enter": {
                     "width": {
-                        "field": "width"
+                        "signal": "width"
                     },
                     "height": {
-                        "field": "height"
+                        "signal": "height"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "clip": {
+                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "type": "group",
+                    "name": "layer_0_marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "data_0"
+                    },
                     "encode": {
-                        "enter": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "a"
                             },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
+                            "width": {
+                                "value": 20
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "b"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
                             },
                             "fill": {
-                                "value": "transparent"
-                            },
-                            "clip": {
-                                "value": true
-                            }
-                        }
-                    },
-                    "marks": [
-                        {
-                            "name": "layer_0_marks",
-                            "type": "rect",
-                            "role": "bar",
-                            "from": {
-                                "data": "data_0"
-                            },
-                            "encode": {
-                                "update": {
-                                    "xc": {
-                                        "scale": "x",
-                                        "field": "a"
-                                    },
-                                    "width": {
-                                        "value": 20
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "b"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "value": 0
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_1_marks",
-                            "type": "line",
-                            "from": {
-                                "data": "data_1"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "a"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "b"
-                                    },
-                                    "stroke": {
-                                        "value": "red"
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "fields": [
-                            {
-                                "data": "data_0",
-                                "field": "a"
-                            },
-                            {
-                                "data": "data_1",
-                                "field": "a"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "fields": [
-                            {
-                                "data": "data_0",
-                                "field": "b"
-                            },
-                            {
-                                "data": "data_1",
-                                "field": "b"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "a",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
+                                "value": "#4c78a8"
                             }
                         }
                     }
                 },
                 {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "b",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
+                    "name": "layer_1_marks",
+                    "type": "line",
+                    "from": {
+                        "data": "data_1"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "a"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "b"
+                            },
+                            "stroke": {
+                                "value": "red"
+                            }
+                        }
+                    }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "a"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "a"
+                    }
+                ],
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "b"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "b"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "a",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "b",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/layer_bar_line_union.vg.json
+++ b/examples/vg-specs/layer_bar_line_union.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -112,222 +92,207 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "max(layer_0_width, layer_1_width)"
         },
         {
-            "name": "layout",
-            "source": "data_0",
-            "transform": [
+            "name": "height",
+            "update": "max(layer_0_height, layer_1_height)"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "a"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_a\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
+        },
+        {
+            "name": "layer_1_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_1_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_0_height",
+            "update": "200"
         }
     ],
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "from": {
-                "data": "layout"
-            },
             "encode": {
-                "update": {
+                "enter": {
                     "width": {
-                        "field": "width"
+                        "signal": "width"
                     },
                     "height": {
-                        "field": "height"
+                        "signal": "height"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "clip": {
+                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "type": "group",
-                    "encode": {
-                        "enter": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "clip": {
-                                "value": true
-                            }
-                        }
+                    "name": "layer_0_marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "data_0"
                     },
-                    "marks": [
-                        {
-                            "name": "layer_0_marks",
-                            "type": "rect",
-                            "role": "bar",
-                            "from": {
-                                "data": "data_0"
-                            },
-                            "encode": {
-                                "update": {
-                                    "xc": {
-                                        "scale": "x",
-                                        "field": "a"
-                                    },
-                                    "width": {
-                                        "value": 20
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "c"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "value": 0
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_1_marks",
-                            "type": "line",
-                            "from": {
-                                "data": "data_1"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "b"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "c"
-                                    },
-                                    "stroke": {
-                                        "value": "red"
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "fields": [
-                            {
-                                "data": "data_0",
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
                                 "field": "a"
                             },
-                            {
-                                "data": "data_1",
-                                "field": "b"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "fields": [
-                            {
-                                "data": "data_0",
+                            "width": {
+                                "value": 20
+                            },
+                            "y": {
+                                "scale": "y",
                                 "field": "c"
                             },
-                            {
-                                "data": "data_1",
-                                "field": "c"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "a",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
                             }
                         }
                     }
                 },
                 {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "c",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
+                    "name": "layer_1_marks",
+                    "type": "line",
+                    "from": {
+                        "data": "data_1"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "b"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "c"
+                            },
+                            "stroke": {
+                                "value": "red"
+                            }
+                        }
+                    }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "a"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "b"
+                    }
+                ],
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "c"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "c"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "a",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "c",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/layer_histogram.vg.json
+++ b/examples/vg-specs/layer_histogram.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -125,231 +105,223 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "max(layer_0_width, layer_1_width)"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "max(layer_0_height, layer_1_height)"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
+        },
+        {
+            "name": "layer_1_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_height",
+            "update": "200"
         }
     ],
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "from": {
-                "data": "layout"
-            },
             "encode": {
-                "update": {
+                "enter": {
                     "width": {
-                        "field": "width"
+                        "signal": "width"
                     },
                     "height": {
-                        "field": "height"
+                        "signal": "height"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "clip": {
+                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "type": "group",
+                    "name": "layer_0_marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "data_0"
+                    },
                     "encode": {
-                        "enter": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                        "update": {
+                            "x2": {
+                                "scale": "layer_0_x",
+                                "field": "bin_maxbins_10_distance_start",
+                                "offset": 1
                             },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
+                            "x": {
+                                "scale": "layer_0_x",
+                                "field": "bin_maxbins_10_distance_end"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "count_*"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
                             },
                             "fill": {
-                                "value": "transparent"
-                            },
-                            "clip": {
-                                "value": true
-                            }
-                        }
-                    },
-                    "marks": [
-                        {
-                            "name": "layer_0_marks",
-                            "type": "rect",
-                            "role": "bar",
-                            "from": {
-                                "data": "data_0"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x2": {
-                                        "scale": "layer_0_x",
-                                        "field": "bin_maxbins_10_distance_start",
-                                        "offset": 1
-                                    },
-                                    "x": {
-                                        "scale": "layer_0_x",
-                                        "field": "bin_maxbins_10_distance_end"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "count_*"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "value": 0
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_1_marks",
-                            "type": "rect",
-                            "role": "bar",
-                            "from": {
-                                "data": "data_1"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x2": {
-                                        "scale": "layer_1_x",
-                                        "field": "bin_maxbins_10_distance_start",
-                                        "offset": 1
-                                    },
-                                    "x": {
-                                        "scale": "layer_1_x",
-                                        "field": "bin_maxbins_10_distance_end"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "count_*"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "value": 0
-                                    },
-                                    "fill": {
-                                        "value": "goldenrod"
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "fields": [
-                            {
-                                "data": "data_0",
-                                "field": "count_*"
-                            },
-                            {
-                                "data": "data_1",
-                                "field": "count_*"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "layer_0_x",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(layer_0_bin_maxbins_10_distance_bins.start, layer_0_bin_maxbins_10_distance_bins.stop + layer_0_bin_maxbins_10_distance_bins.step, layer_0_bin_maxbins_10_distance_bins.step)"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true
-                },
-                {
-                    "name": "layer_1_x",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(layer_1_bin_maxbins_10_distance_bins.start, layer_1_bin_maxbins_10_distance_bins.stop + layer_1_bin_maxbins_10_distance_bins.step, layer_1_bin_maxbins_10_distance_bins.step)"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "layer_0_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "title": "BIN(distance)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
+                                "value": "#4c78a8"
                             }
                         }
                     }
                 },
                 {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "layer_0_x"
+                    "name": "layer_1_marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "data_1"
+                    },
+                    "encode": {
+                        "update": {
+                            "x2": {
+                                "scale": "layer_1_x",
+                                "field": "bin_maxbins_10_distance_start",
+                                "offset": 1
+                            },
+                            "x": {
+                                "scale": "layer_1_x",
+                                "field": "bin_maxbins_10_distance_end"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "count_*"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "goldenrod"
+                            }
+                        }
+                    }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "count_*"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "count_*"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "layer_0_x",
+            "type": "bin-linear",
+            "domain": {
+                "signal": "sequence(layer_0_bin_maxbins_10_distance_bins.start, layer_0_bin_maxbins_10_distance_bins.stop + layer_0_bin_maxbins_10_distance_bins.step, layer_0_bin_maxbins_10_distance_bins.step)"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true
+        },
+        {
+            "name": "layer_1_x",
+            "type": "bin-linear",
+            "domain": {
+                "signal": "sequence(layer_1_bin_maxbins_10_distance_bins.start, layer_1_bin_maxbins_10_distance_bins.stop + layer_1_bin_maxbins_10_distance_bins.step, layer_1_bin_maxbins_10_distance_bins.step)"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "layer_0_x",
+            "format": "s",
+            "orient": "bottom",
+            "title": "BIN(distance)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Number of Records",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "layer_0_x"
         }
     ]
 }

--- a/examples/vg-specs/layer_line_color_rule.vg.json
+++ b/examples/vg-specs/layer_line_color_rule.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -83,51 +63,78 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "max(layer_0_width, layer_1_width)"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "max(layer_0_height, layer_1_height)"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
+        },
+        {
+            "name": "layer_1_width",
+            "update": "21"
+        },
+        {
+            "name": "layer_1_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_height",
+            "update": "200"
         }
     ],
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "from": {
-                "data": "layout"
-            },
             "encode": {
-                "update": {
+                "enter": {
                     "width": {
-                        "field": "width"
+                        "signal": "width"
                     },
                     "height": {
-                        "field": "height"
+                        "signal": "height"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "clip": {
+                        "value": true
                     }
                 }
             },
             "marks": [
                 {
+                    "name": "layer_0_pathgroup",
                     "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "faceted-path-layer_0_main",
+                            "data": "data_0",
+                            "groupby": [
+                                "symbol"
+                            ]
+                        }
+                    },
                     "encode": {
-                        "enter": {
+                        "update": {
                             "width": {
                                 "field": {
                                     "group": "width"
@@ -137,223 +144,188 @@
                                 "field": {
                                     "group": "height"
                                 }
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "clip": {
-                                "value": true
                             }
                         }
                     },
                     "marks": [
                         {
-                            "name": "layer_0_pathgroup",
-                            "type": "group",
+                            "name": "layer_0_marks",
+                            "type": "line",
                             "from": {
-                                "facet": {
-                                    "name": "faceted-path-layer_0_main",
-                                    "data": "data_0",
-                                    "groupby": [
-                                        "symbol"
-                                    ]
-                                }
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "group": "width"
-                                        }
-                                    },
-                                    "height": {
-                                        "field": {
-                                            "group": "height"
-                                        }
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "name": "layer_0_marks",
-                                    "type": "line",
-                                    "from": {
-                                        "data": "faceted-path-layer_0_main"
-                                    },
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "scale": "x",
-                                                "field": "date"
-                                            },
-                                            "y": {
-                                                "scale": "y",
-                                                "field": "price"
-                                            },
-                                            "stroke": {
-                                                "scale": "color",
-                                                "field": "symbol"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "layer_1_marks",
-                            "type": "rule",
-                            "from": {
-                                "data": "data_1"
+                                "data": "faceted-path-layer_0_main"
                             },
                             "encode": {
                                 "update": {
                                     "x": {
-                                        "value": 0
+                                        "scale": "x",
+                                        "field": "date"
                                     },
                                     "y": {
                                         "scale": "y",
-                                        "field": "mean_price"
-                                    },
-                                    "x2": {
-                                        "field": {
-                                            "group": "width"
-                                        }
+                                        "field": "price"
                                     },
                                     "stroke": {
                                         "scale": "color",
                                         "field": "symbol"
-                                    },
-                                    "opacity": {
-                                        "value": 0.5
-                                    },
-                                    "strokeWidth": {
-                                        "value": 2
                                     }
                                 }
                             }
                         }
                     ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "data": "data_0",
-                        "field": "date"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true
                 },
                 {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "fields": [
-                            {
-                                "data": "data_0",
-                                "field": "price"
-                            },
-                            {
-                                "data": "data_1",
-                                "field": "mean_price"
-                            }
-                        ],
-                        "sort": true
+                    "name": "layer_1_marks",
+                    "type": "rule",
+                    "from": {
+                        "data": "data_1"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "fields": [
-                            {
-                                "data": "data_0",
-                                "field": "symbol"
-                            },
-                            {
-                                "data": "data_1",
-                                "field": "symbol"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": "category"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "date",
-                    "zindex": 1,
                     "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b %d, %Y')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
+                        "update": {
+                            "x": {
+                                "value": 0
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "mean_price"
+                            },
+                            "x2": {
+                                "field": {
+                                    "group": "width"
                                 }
+                            },
+                            "stroke": {
+                                "scale": "color",
+                                "field": "symbol"
+                            },
+                            "opacity": {
+                                "value": 0.5
+                            },
+                            "strokeWidth": {
+                                "value": 2
                             }
                         }
                     }
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "price",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "title": "symbol"
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "data": "data_0",
+                "field": "date"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "price"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "mean_price"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "symbol"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "symbol"
+                    }
+                ],
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "date",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b %d, %Y')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "price",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "title": "symbol"
         }
     ]
 }

--- a/examples/vg-specs/layer_overlay.vg.json
+++ b/examples/vg-specs/layer_overlay.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -163,50 +143,92 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "max(layer_0_width, layer_1_width)"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "max(layer_0_height, layer_1_height)"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "Cylinders"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_Cylinders\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
+        },
+        {
+            "name": "layer_1_width",
+            "update": "max(layer_1_layer_0_width, layer_1_layer_1_width)"
+        },
+        {
+            "name": "layer_1_height",
+            "update": "max(layer_1_layer_0_height, layer_1_layer_1_height)"
+        },
+        {
+            "name": "layer_1_layer_1_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_1_layer_1_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_layer_0_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_1_layer_0_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_width",
+            "update": "max(layer_0_layer_0_width, layer_0_layer_1_width)"
+        },
+        {
+            "name": "layer_0_height",
+            "update": "max(layer_0_layer_0_height, layer_0_layer_1_height)"
+        },
+        {
+            "name": "layer_0_layer_1_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_0_layer_1_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_layer_0_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_0_layer_0_height",
+            "update": "200"
         }
     ],
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "from": {
-                "data": "layout"
-            },
             "encode": {
-                "update": {
+                "enter": {
                     "width": {
-                        "field": "width"
+                        "signal": "width"
                     },
                     "height": {
-                        "field": "height"
+                        "signal": "height"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "clip": {
+                        "value": true
                     }
                 }
             },
@@ -216,14 +238,10 @@
                     "encode": {
                         "enter": {
                             "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                                "signal": "layer_0_width"
                             },
                             "height": {
-                                "field": {
-                                    "group": "height"
-                                }
+                                "signal": "layer_0_height"
                             },
                             "fill": {
                                 "value": "transparent"
@@ -235,254 +253,225 @@
                     },
                     "marks": [
                         {
-                            "type": "group",
-                            "encode": {
-                                "enter": {
-                                    "width": {
-                                        "field": {
-                                            "group": "width"
-                                        }
-                                    },
-                                    "height": {
-                                        "field": {
-                                            "group": "height"
-                                        }
-                                    },
-                                    "fill": {
-                                        "value": "transparent"
-                                    },
-                                    "clip": {
-                                        "value": true
-                                    }
-                                }
+                            "name": "layer_0_layer_0_marks",
+                            "type": "line",
+                            "from": {
+                                "data": "data_4"
                             },
-                            "marks": [
-                                {
-                                    "name": "layer_0_layer_0_marks",
-                                    "type": "line",
-                                    "from": {
-                                        "data": "data_4"
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "Cylinders"
                                     },
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "scale": "x",
-                                                "field": "Cylinders"
-                                            },
-                                            "y": {
-                                                "scale": "y",
-                                                "field": "max_Horsepower"
-                                            },
-                                            "stroke": {
-                                                "value": "darkred"
-                                            }
-                                        }
-                                    }
-                                },
-                                {
-                                    "name": "layer_0_layer_1_marks",
-                                    "type": "symbol",
-                                    "role": "pointOverlay",
-                                    "from": {
-                                        "data": "data_5"
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "max_Horsepower"
                                     },
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "scale": "x",
-                                                "field": "Cylinders"
-                                            },
-                                            "y": {
-                                                "scale": "y",
-                                                "field": "max_Horsepower"
-                                            },
-                                            "fill": {
-                                                "value": "darkred"
-                                            }
-                                        }
+                                    "stroke": {
+                                        "value": "darkred"
                                     }
                                 }
-                            ]
+                            }
                         },
                         {
-                            "type": "group",
+                            "name": "layer_0_layer_1_marks",
+                            "type": "symbol",
+                            "role": "pointOverlay",
+                            "from": {
+                                "data": "data_5"
+                            },
                             "encode": {
-                                "enter": {
-                                    "width": {
-                                        "field": {
-                                            "group": "width"
-                                        }
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "Cylinders"
                                     },
-                                    "height": {
-                                        "field": {
-                                            "group": "height"
-                                        }
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "max_Horsepower"
                                     },
                                     "fill": {
-                                        "value": "transparent"
-                                    },
-                                    "clip": {
-                                        "value": true
+                                        "value": "darkred"
                                     }
                                 }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "type": "group",
+                    "encode": {
+                        "enter": {
+                            "width": {
+                                "signal": "layer_1_width"
                             },
-                            "marks": [
-                                {
-                                    "name": "layer_1_layer_0_marks",
-                                    "type": "line",
-                                    "from": {
-                                        "data": "data_1"
+                            "height": {
+                                "signal": "layer_1_height"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_1_layer_0_marks",
+                            "type": "line",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "Cylinders"
                                     },
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "scale": "x",
-                                                "field": "Cylinders"
-                                            },
-                                            "y": {
-                                                "scale": "y",
-                                                "field": "min_Horsepower"
-                                            },
-                                            "stroke": {
-                                                "value": "#4c78a8"
-                                            }
-                                        }
-                                    }
-                                },
-                                {
-                                    "name": "layer_1_layer_1_marks",
-                                    "type": "symbol",
-                                    "role": "pointOverlay",
-                                    "from": {
-                                        "data": "data_3"
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "min_Horsepower"
                                     },
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "scale": "x",
-                                                "field": "Cylinders"
-                                            },
-                                            "y": {
-                                                "scale": "y",
-                                                "field": "min_Horsepower"
-                                            },
-                                            "fill": {
-                                                "value": "#4c78a8"
-                                            }
-                                        }
+                                    "stroke": {
+                                        "value": "#4c78a8"
                                     }
                                 }
-                            ]
+                            }
+                        },
+                        {
+                            "name": "layer_1_layer_1_marks",
+                            "type": "symbol",
+                            "role": "pointOverlay",
+                            "from": {
+                                "data": "data_3"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "Cylinders"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "min_Horsepower"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
                         }
                     ]
                 }
+            ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "fields": [
+                    {
+                        "field": "Cylinders",
+                        "data": "data_4"
+                    },
+                    {
+                        "field": "Cylinders",
+                        "data": "data_5"
+                    },
+                    {
+                        "field": "Cylinders",
+                        "data": "data_1"
+                    },
+                    {
+                        "field": "Cylinders",
+                        "data": "data_3"
+                    }
+                ],
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {
+                        "field": "max_Horsepower",
+                        "data": "data_4"
+                    },
+                    {
+                        "field": "max_Horsepower",
+                        "data": "data_5"
+                    },
+                    {
+                        "field": "min_Horsepower",
+                        "data": "data_1"
+                    },
+                    {
+                        "field": "min_Horsepower",
+                        "data": "data_3"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                200,
+                0
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "fields": [
-                            {
-                                "field": "Cylinders",
-                                "data": "data_4"
-                            },
-                            {
-                                "field": "Cylinders",
-                                "data": "data_5"
-                            },
-                            {
-                                "field": "Cylinders",
-                                "data": "data_1"
-                            },
-                            {
-                                "field": "Cylinders",
-                                "data": "data_3"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "fields": [
-                            {
-                                "field": "max_Horsepower",
-                                "data": "data_4"
-                            },
-                            {
-                                "field": "max_Horsepower",
-                                "data": "data_5"
-                            },
-                            {
-                                "field": "min_Horsepower",
-                                "data": "data_1"
-                            },
-                            {
-                                "field": "min_Horsepower",
-                                "data": "data_3"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Cylinders",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Cylinders",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "MAX(Horsepower)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "MAX(Horsepower)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -631,7 +631,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"layer_1_brush_store\", parent._id, datum, \"union\", \"all\")",
+                                    "test": "vlInterval(\"layer_1_brush_store\", datum._id, datum, \"union\", \"all\")",
                                     "value": "grey"
                                 },
                                 {
@@ -670,7 +670,7 @@
                             },
                             "fill": [
                                 {
-                                    "test": "!vlInterval(\"layer_1_brush_store\", parent._id, datum, \"union\", \"all\")",
+                                    "test": "!vlInterval(\"layer_1_brush_store\", datum._id, datum, \"union\", \"all\")",
                                     "value": "grey"
                                 },
                                 {
@@ -680,7 +680,7 @@
                             ],
                             "size": [
                                 {
-                                    "test": "vlPoint(\"layer_0_cyl_store\", parent._id, datum, \"union\", \"all\")",
+                                    "test": "vlPoint(\"layer_0_cyl_store\", datum._id, datum, \"union\", \"all\")",
                                     "value": 150
                                 },
                                 {

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -3,57 +3,6 @@
     "description": "Drag out a rectangular brush to highlight points.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "layer_0_cyl_Cylinders",
-            "value": "",
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "click"
-                        }
-                    ],
-                    "update": "(item().isVoronoi ? datum.datum : datum)[\"Cylinders\"]"
-                }
-            ],
-            "bind": {
-                "input": "range",
-                "min": 3,
-                "max": 8,
-                "step": 1
-            }
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        },
-        {
-            "name": "layer_0_grid_x"
-        },
-        {
-            "name": "layer_0_grid_y"
-        },
-        {
-            "name": "layer_0_cyl",
-            "update": "data(\"layer_0_cyl_store\")[0]"
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -103,24 +52,6 @@
             ]
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
-                }
-            ]
-        },
-        {
             "name": "layer_0_grid_store"
         },
         {
@@ -130,345 +61,241 @@
             "name": "layer_1_brush_store"
         }
     ],
-    "marks": [
+    "signals": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "Drag out a rectangular brush to highlight points.",
-            "from": {
-                "data": "layout"
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
+            "name": "width",
+            "update": "max(layer_0_width, layer_1_width)"
+        },
+        {
+            "name": "height",
+            "update": "max(layer_0_height, layer_1_height)"
+        },
+        {
+            "name": "layer_0_cyl_Cylinders",
+            "value": "",
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "click"
+                        }
+                    ],
+                    "update": "(item().isVoronoi ? datum.datum : datum)[\"Cylinders\"]"
                 }
-            },
-            "signals": [
+            ],
+            "bind": {
+                "input": "range",
+                "min": 3,
+                "max": 8,
+                "step": 1
+            }
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "name": "layer_0_grid_x",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "layer_0_grid_translate_delta"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        },
+        {
+            "name": "layer_0_grid_x"
+        },
+        {
+            "name": "layer_0_grid_y"
+        },
+        {
+            "name": "layer_0_cyl",
+            "update": "data(\"layer_0_cyl_store\")[0]"
+        },
+        {
+            "name": "layer_1_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_brush_x",
+            "value": [],
+            "on": [
+                {
+                    "events": {
+                        "source": "scope",
+                        "type": "mousedown",
+                        "filter": [
+                            "event.shiftKey",
+                            "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                        ]
+                    },
+                    "update": "invert(\"x\", [x(unit), x(unit)])"
+                },
+                {
+                    "events": {
+                        "source": "scope",
+                        "type": "mousemove",
+                        "between": [
+                            {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "event.shiftKey",
+                                    "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                                ]
                             },
-                            "update": "[layer_0_grid_translate_anchor.extent_x[0] - abs(span(layer_0_grid_translate_anchor.extent_x)) * layer_0_grid_translate_delta.x / layer_0_grid_translate_anchor.width, layer_0_grid_translate_anchor.extent_x[1] - abs(span(layer_0_grid_translate_anchor.extent_x)) * layer_0_grid_translate_delta.x / layer_0_grid_translate_anchor.width]"
-                        },
-                        {
-                            "events": {
-                                "signal": "layer_0_grid_zoom_delta"
+                            {
+                                "source": "scope",
+                                "type": "mouseup"
+                            }
+                        ]
+                    },
+                    "update": "[layer_1_brush_x[0], invert(\"x\", clamp(x(unit), 0, width))]"
+                },
+                {
+                    "events": {
+                        "signal": "layer_1_brush_translate_delta"
+                    },
+                    "update": "clampRange([layer_1_brush_translate_anchor.extent_x[0] + abs(span(layer_1_brush_translate_anchor.extent_x)) * layer_1_brush_translate_delta.x / layer_1_brush_translate_anchor.width, layer_1_brush_translate_anchor.extent_x[1] + abs(span(layer_1_brush_translate_anchor.extent_x)) * layer_1_brush_translate_delta.x / layer_1_brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+                },
+                {
+                    "events": {
+                        "signal": "layer_1_brush_zoom_delta"
+                    },
+                    "update": "clampRange([layer_1_brush_zoom_anchor.x + (layer_1_brush_x[0] - layer_1_brush_zoom_anchor.x) * layer_1_brush_zoom_delta, layer_1_brush_zoom_anchor.x + (layer_1_brush_x[1] - layer_1_brush_zoom_anchor.x) * layer_1_brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+                }
+            ]
+        },
+        {
+            "name": "layer_1_brush_y",
+            "value": [],
+            "on": [
+                {
+                    "events": {
+                        "source": "scope",
+                        "type": "mousedown",
+                        "filter": [
+                            "event.shiftKey",
+                            "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                        ]
+                    },
+                    "update": "invert(\"y\", [y(unit), y(unit)])"
+                },
+                {
+                    "events": {
+                        "source": "scope",
+                        "type": "mousemove",
+                        "between": [
+                            {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "event.shiftKey",
+                                    "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                                ]
                             },
-                            "update": "[layer_0_grid_zoom_anchor.x + (domain(\"x\")[0] - layer_0_grid_zoom_anchor.x) * layer_0_grid_zoom_delta, layer_0_grid_zoom_anchor.x + (domain(\"x\")[1] - layer_0_grid_zoom_anchor.x) * layer_0_grid_zoom_delta]"
+                            {
+                                "source": "scope",
+                                "type": "mouseup"
+                            }
+                        ]
+                    },
+                    "update": "[layer_1_brush_y[0], invert(\"y\", clamp(y(unit), 0, height))]"
+                },
+                {
+                    "events": {
+                        "signal": "layer_1_brush_translate_delta"
+                    },
+                    "update": "clampRange([layer_1_brush_translate_anchor.extent_y[0] - abs(span(layer_1_brush_translate_anchor.extent_y)) * layer_1_brush_translate_delta.y / layer_1_brush_translate_anchor.height, layer_1_brush_translate_anchor.extent_y[1] - abs(span(layer_1_brush_translate_anchor.extent_y)) * layer_1_brush_translate_delta.y / layer_1_brush_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
+                },
+                {
+                    "events": {
+                        "signal": "layer_1_brush_zoom_delta"
+                    },
+                    "update": "clampRange([layer_1_brush_zoom_anchor.y + (layer_1_brush_y[0] - layer_1_brush_zoom_anchor.y) * layer_1_brush_zoom_delta, layer_1_brush_zoom_anchor.y + (layer_1_brush_y[1] - layer_1_brush_zoom_anchor.y) * layer_1_brush_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
+                }
+            ]
+        },
+        {
+            "name": "layer_1_brush_size",
+            "value": [],
+            "on": [
+                {
+                    "events": {
+                        "source": "scope",
+                        "type": "mousedown",
+                        "filter": [
+                            "event.shiftKey",
+                            "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                        ]
+                    },
+                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
+                },
+                {
+                    "events": {
+                        "source": "scope",
+                        "type": "mousemove",
+                        "between": [
+                            {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "event.shiftKey",
+                                    "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                                ]
+                            },
+                            {
+                                "source": "scope",
+                                "type": "mouseup"
+                            }
+                        ]
+                    },
+                    "update": "{x: layer_1_brush_size.x, y: layer_1_brush_size.y, width: abs(x(unit) - layer_1_brush_size.x), height: abs(y(unit) - layer_1_brush_size.y)}"
+                },
+                {
+                    "events": {
+                        "signal": "layer_1_brush_zoom_delta"
+                    },
+                    "update": "{x: layer_1_brush_size.x, y: layer_1_brush_size.y, width: layer_1_brush_size.width * layer_1_brush_zoom_delta , height: layer_1_brush_size.height * layer_1_brush_zoom_delta}"
+                }
+            ]
+        },
+        {
+            "name": "layer_1_brush",
+            "update": "[{field: \"Horsepower\", extent: layer_1_brush_x}, {field: \"Miles_per_Gallon\", extent: layer_1_brush_y}]"
+        },
+        {
+            "name": "layer_1_brush_translate_anchor",
+            "value": {},
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "mousedown",
+                            "filter": [
+                                "event.shiftKey"
+                            ],
+                            "markname": "layer_1_brush_brush"
                         }
                     ],
-                    "push": "outer"
-                },
+                    "update": "{x: x(unit), y: y(unit), width: layer_1_brush_size.width, height: layer_1_brush_size.height, extent_x: slice(layer_1_brush_x), extent_y: slice(layer_1_brush_y), }"
+                }
+            ]
+        },
+        {
+            "name": "layer_1_brush_translate_delta",
+            "value": {},
+            "on": [
                 {
-                    "name": "layer_0_grid_y",
-                    "on": [
+                    "events": [
                         {
-                            "events": {
-                                "signal": "layer_0_grid_translate_delta"
-                            },
-                            "update": "[layer_0_grid_translate_anchor.extent_y[0] + abs(span(layer_0_grid_translate_anchor.extent_y)) * layer_0_grid_translate_delta.y / layer_0_grid_translate_anchor.height, layer_0_grid_translate_anchor.extent_y[1] + abs(span(layer_0_grid_translate_anchor.extent_y)) * layer_0_grid_translate_delta.y / layer_0_grid_translate_anchor.height]"
-                        },
-                        {
-                            "events": {
-                                "signal": "layer_0_grid_zoom_delta"
-                            },
-                            "update": "[layer_0_grid_zoom_anchor.y + (domain(\"y\")[0] - layer_0_grid_zoom_anchor.y) * layer_0_grid_zoom_delta, layer_0_grid_zoom_anchor.y + (domain(\"y\")[1] - layer_0_grid_zoom_anchor.y) * layer_0_grid_zoom_delta]"
-                        }
-                    ],
-                    "push": "outer"
-                },
-                {
-                    "name": "layer_0_grid",
-                    "update": "[{field: \"Horsepower\", extent: layer_0_grid_x}, {field: \"Miles_per_Gallon\", extent: layer_0_grid_y}]"
-                },
-                {
-                    "name": "layer_0_grid_translate_anchor",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "source": "scope",
-                                    "type": "mousedown",
-                                    "filter": [
-                                        "!event.shiftKey"
-                                    ]
-                                }
-                            ],
-                            "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
-                        }
-                    ]
-                },
-                {
-                    "name": "layer_0_grid_translate_delta",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "source": "scope",
-                                    "type": "mousemove",
-                                    "between": [
-                                        {
-                                            "source": "scope",
-                                            "type": "mousedown",
-                                            "filter": [
-                                                "!event.shiftKey"
-                                            ]
-                                        },
-                                        {
-                                            "source": "scope",
-                                            "type": "mouseup"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "update": "{x: x(unit) - layer_0_grid_translate_anchor.x, y: y(unit) - layer_0_grid_translate_anchor.y}"
-                        }
-                    ]
-                },
-                {
-                    "name": "layer_0_grid_zoom_anchor",
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "source": "scope",
-                                    "type": "wheel"
-                                }
-                            ],
-                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
-                        }
-                    ]
-                },
-                {
-                    "name": "layer_0_grid_zoom_delta",
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "source": "scope",
-                                    "type": "wheel"
-                                }
-                            ],
-                            "force": true,
-                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-                        }
-                    ]
-                },
-                {
-                    "name": "layer_0_grid_tuple",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "layer_0_grid"
-                            },
-                            "update": "{unit: unit.datum && unit.datum._id, intervals: layer_0_grid}"
-                        }
-                    ]
-                },
-                {
-                    "name": "layer_0_grid_modify",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "layer_0_grid"
-                            },
-                            "update": "modify(\"layer_0_grid_store\", layer_0_grid_tuple, true)"
-                        }
-                    ]
-                },
-                {
-                    "name": "layer_0_cyl",
-                    "update": "{fields: [\"Cylinders\"], values: [layer_0_cyl_Cylinders]}"
-                },
-                {
-                    "name": "layer_0_cyl_tuple",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "layer_0_cyl"
-                            },
-                            "update": "{unit: unit.datum && unit.datum._id, fields: layer_0_cyl.fields, values: layer_0_cyl.values, Cylinders: layer_0_cyl.values[0]}"
-                        }
-                    ]
-                },
-                {
-                    "name": "layer_0_cyl_modify",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "layer_0_cyl"
-                            },
-                            "update": "modify(\"layer_0_cyl_store\", layer_0_cyl_tuple, true)"
-                        }
-                    ]
-                },
-                {
-                    "name": "layer_1_brush_x",
-                    "value": [],
-                    "on": [
-                        {
-                            "events": {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "event.shiftKey",
-                                    "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
-                                ]
-                            },
-                            "update": "invert(\"x\", [x(unit), x(unit)])"
-                        },
-                        {
-                            "events": {
-                                "source": "scope",
-                                "type": "mousemove",
-                                "between": [
-                                    {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
-                                        ]
-                                    },
-                                    {
-                                        "source": "scope",
-                                        "type": "mouseup"
-                                    }
-                                ]
-                            },
-                            "update": "[layer_1_brush_x[0], invert(\"x\", clamp(x(unit), 0, width))]"
-                        },
-                        {
-                            "events": {
-                                "signal": "layer_1_brush_translate_delta"
-                            },
-                            "update": "clampRange([layer_1_brush_translate_anchor.extent_x[0] + abs(span(layer_1_brush_translate_anchor.extent_x)) * layer_1_brush_translate_delta.x / layer_1_brush_translate_anchor.width, layer_1_brush_translate_anchor.extent_x[1] + abs(span(layer_1_brush_translate_anchor.extent_x)) * layer_1_brush_translate_delta.x / layer_1_brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
-                        },
-                        {
-                            "events": {
-                                "signal": "layer_1_brush_zoom_delta"
-                            },
-                            "update": "clampRange([layer_1_brush_zoom_anchor.x + (layer_1_brush_x[0] - layer_1_brush_zoom_anchor.x) * layer_1_brush_zoom_delta, layer_1_brush_zoom_anchor.x + (layer_1_brush_x[1] - layer_1_brush_zoom_anchor.x) * layer_1_brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
-                        }
-                    ]
-                },
-                {
-                    "name": "layer_1_brush_y",
-                    "value": [],
-                    "on": [
-                        {
-                            "events": {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "event.shiftKey",
-                                    "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
-                                ]
-                            },
-                            "update": "invert(\"y\", [y(unit), y(unit)])"
-                        },
-                        {
-                            "events": {
-                                "source": "scope",
-                                "type": "mousemove",
-                                "between": [
-                                    {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
-                                        ]
-                                    },
-                                    {
-                                        "source": "scope",
-                                        "type": "mouseup"
-                                    }
-                                ]
-                            },
-                            "update": "[layer_1_brush_y[0], invert(\"y\", clamp(y(unit), 0, height))]"
-                        },
-                        {
-                            "events": {
-                                "signal": "layer_1_brush_translate_delta"
-                            },
-                            "update": "clampRange([layer_1_brush_translate_anchor.extent_y[0] - abs(span(layer_1_brush_translate_anchor.extent_y)) * layer_1_brush_translate_delta.y / layer_1_brush_translate_anchor.height, layer_1_brush_translate_anchor.extent_y[1] - abs(span(layer_1_brush_translate_anchor.extent_y)) * layer_1_brush_translate_delta.y / layer_1_brush_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
-                        },
-                        {
-                            "events": {
-                                "signal": "layer_1_brush_zoom_delta"
-                            },
-                            "update": "clampRange([layer_1_brush_zoom_anchor.y + (layer_1_brush_y[0] - layer_1_brush_zoom_anchor.y) * layer_1_brush_zoom_delta, layer_1_brush_zoom_anchor.y + (layer_1_brush_y[1] - layer_1_brush_zoom_anchor.y) * layer_1_brush_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
-                        }
-                    ]
-                },
-                {
-                    "name": "layer_1_brush_size",
-                    "value": [],
-                    "on": [
-                        {
-                            "events": {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "event.shiftKey",
-                                    "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
-                                ]
-                            },
-                            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                        },
-                        {
-                            "events": {
-                                "source": "scope",
-                                "type": "mousemove",
-                                "between": [
-                                    {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
-                                        ]
-                                    },
-                                    {
-                                        "source": "scope",
-                                        "type": "mouseup"
-                                    }
-                                ]
-                            },
-                            "update": "{x: layer_1_brush_size.x, y: layer_1_brush_size.y, width: abs(x(unit) - layer_1_brush_size.x), height: abs(y(unit) - layer_1_brush_size.y)}"
-                        },
-                        {
-                            "events": {
-                                "signal": "layer_1_brush_zoom_delta"
-                            },
-                            "update": "{x: layer_1_brush_size.x, y: layer_1_brush_size.y, width: layer_1_brush_size.width * layer_1_brush_zoom_delta , height: layer_1_brush_size.height * layer_1_brush_zoom_delta}"
-                        }
-                    ]
-                },
-                {
-                    "name": "layer_1_brush",
-                    "update": "[{field: \"Horsepower\", extent: layer_1_brush_x}, {field: \"Miles_per_Gallon\", extent: layer_1_brush_y}]"
-                },
-                {
-                    "name": "layer_1_brush_translate_anchor",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
+                            "source": "scope",
+                            "type": "mousemove",
+                            "between": [
                                 {
                                     "source": "scope",
                                     "type": "mousedown",
@@ -476,431 +303,573 @@
                                         "event.shiftKey"
                                     ],
                                     "markname": "layer_1_brush_brush"
-                                }
-                            ],
-                            "update": "{x: x(unit), y: y(unit), width: layer_1_brush_size.width, height: layer_1_brush_size.height, extent_x: slice(layer_1_brush_x), extent_y: slice(layer_1_brush_y), }"
-                        }
-                    ]
-                },
-                {
-                    "name": "layer_1_brush_translate_delta",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
+                                },
                                 {
                                     "source": "scope",
-                                    "type": "mousemove",
-                                    "between": [
-                                        {
-                                            "source": "scope",
-                                            "type": "mousedown",
-                                            "filter": [
-                                                "event.shiftKey"
-                                            ],
-                                            "markname": "layer_1_brush_brush"
-                                        },
-                                        {
-                                            "source": "scope",
-                                            "type": "mouseup"
-                                        }
-                                    ]
+                                    "type": "mouseup"
                                 }
-                            ],
-                            "update": "{x: x(unit) - layer_1_brush_translate_anchor.x, y: y(unit) - layer_1_brush_translate_anchor.y}"
+                            ]
                         }
-                    ]
+                    ],
+                    "update": "{x: x(unit) - layer_1_brush_translate_anchor.x, y: y(unit) - layer_1_brush_translate_anchor.y}"
+                }
+            ]
+        },
+        {
+            "name": "layer_1_brush_zoom_anchor",
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "wheel",
+                            "markname": "layer_1_brush_brush"
+                        }
+                    ],
+                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                }
+            ]
+        },
+        {
+            "name": "layer_1_brush_zoom_delta",
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "wheel",
+                            "markname": "layer_1_brush_brush"
+                        }
+                    ],
+                    "force": true,
+                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                }
+            ]
+        },
+        {
+            "name": "layer_1_brush_tuple",
+            "on": [
+                {
+                    "events": {
+                        "signal": "layer_1_brush"
+                    },
+                    "update": "{unit: unit.datum && unit.datum._id, intervals: layer_1_brush}"
+                }
+            ]
+        },
+        {
+            "name": "layer_1_brush_modify",
+            "on": [
+                {
+                    "events": {
+                        "signal": "layer_1_brush"
+                    },
+                    "update": "modify(\"layer_1_brush_store\", layer_1_brush_tuple, true)"
+                }
+            ]
+        },
+        {
+            "name": "layer_0_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_grid_x",
+            "on": [
+                {
+                    "events": {
+                        "signal": "layer_0_grid_translate_delta"
+                    },
+                    "update": "[layer_0_grid_translate_anchor.extent_x[0] - abs(span(layer_0_grid_translate_anchor.extent_x)) * layer_0_grid_translate_delta.x / layer_0_grid_translate_anchor.width, layer_0_grid_translate_anchor.extent_x[1] - abs(span(layer_0_grid_translate_anchor.extent_x)) * layer_0_grid_translate_delta.x / layer_0_grid_translate_anchor.width]"
                 },
                 {
-                    "name": "layer_1_brush_zoom_anchor",
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "source": "scope",
-                                    "type": "wheel",
-                                    "markname": "layer_1_brush_brush"
-                                }
-                            ],
-                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
-                        }
-                    ]
-                },
-                {
-                    "name": "layer_1_brush_zoom_delta",
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "source": "scope",
-                                    "type": "wheel",
-                                    "markname": "layer_1_brush_brush"
-                                }
-                            ],
-                            "force": true,
-                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-                        }
-                    ]
-                },
-                {
-                    "name": "layer_1_brush_tuple",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "layer_1_brush"
-                            },
-                            "update": "{unit: unit.datum && unit.datum._id, intervals: layer_1_brush}"
-                        }
-                    ]
-                },
-                {
-                    "name": "layer_1_brush_modify",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "layer_1_brush"
-                            },
-                            "update": "modify(\"layer_1_brush_store\", layer_1_brush_tuple, true)"
-                        }
-                    ]
+                    "events": {
+                        "signal": "layer_0_grid_zoom_delta"
+                    },
+                    "update": "[layer_0_grid_zoom_anchor.x + (domain(\"x\")[0] - layer_0_grid_zoom_anchor.x) * layer_0_grid_zoom_delta, layer_0_grid_zoom_anchor.x + (domain(\"x\")[1] - layer_0_grid_zoom_anchor.x) * layer_0_grid_zoom_delta]"
                 }
             ],
+            "push": "outer"
+        },
+        {
+            "name": "layer_0_grid_y",
+            "on": [
+                {
+                    "events": {
+                        "signal": "layer_0_grid_translate_delta"
+                    },
+                    "update": "[layer_0_grid_translate_anchor.extent_y[0] + abs(span(layer_0_grid_translate_anchor.extent_y)) * layer_0_grid_translate_delta.y / layer_0_grid_translate_anchor.height, layer_0_grid_translate_anchor.extent_y[1] + abs(span(layer_0_grid_translate_anchor.extent_y)) * layer_0_grid_translate_delta.y / layer_0_grid_translate_anchor.height]"
+                },
+                {
+                    "events": {
+                        "signal": "layer_0_grid_zoom_delta"
+                    },
+                    "update": "[layer_0_grid_zoom_anchor.y + (domain(\"y\")[0] - layer_0_grid_zoom_anchor.y) * layer_0_grid_zoom_delta, layer_0_grid_zoom_anchor.y + (domain(\"y\")[1] - layer_0_grid_zoom_anchor.y) * layer_0_grid_zoom_delta]"
+                }
+            ],
+            "push": "outer"
+        },
+        {
+            "name": "layer_0_grid",
+            "update": "[{field: \"Horsepower\", extent: layer_0_grid_x}, {field: \"Miles_per_Gallon\", extent: layer_0_grid_y}]"
+        },
+        {
+            "name": "layer_0_grid_translate_anchor",
+            "value": {},
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "mousedown",
+                            "filter": [
+                                "!event.shiftKey"
+                            ]
+                        }
+                    ],
+                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
+                }
+            ]
+        },
+        {
+            "name": "layer_0_grid_translate_delta",
+            "value": {},
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "mousemove",
+                            "between": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousedown",
+                                    "filter": [
+                                        "!event.shiftKey"
+                                    ]
+                                },
+                                {
+                                    "source": "scope",
+                                    "type": "mouseup"
+                                }
+                            ]
+                        }
+                    ],
+                    "update": "{x: x(unit) - layer_0_grid_translate_anchor.x, y: y(unit) - layer_0_grid_translate_anchor.y}"
+                }
+            ]
+        },
+        {
+            "name": "layer_0_grid_zoom_anchor",
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "wheel"
+                        }
+                    ],
+                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                }
+            ]
+        },
+        {
+            "name": "layer_0_grid_zoom_delta",
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "wheel"
+                        }
+                    ],
+                    "force": true,
+                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                }
+            ]
+        },
+        {
+            "name": "layer_0_grid_tuple",
+            "on": [
+                {
+                    "events": {
+                        "signal": "layer_0_grid"
+                    },
+                    "update": "{unit: unit.datum && unit.datum._id, intervals: layer_0_grid}"
+                }
+            ]
+        },
+        {
+            "name": "layer_0_grid_modify",
+            "on": [
+                {
+                    "events": {
+                        "signal": "layer_0_grid"
+                    },
+                    "update": "modify(\"layer_0_grid_store\", layer_0_grid_tuple, true)"
+                }
+            ]
+        },
+        {
+            "name": "layer_0_cyl",
+            "update": "{fields: [\"Cylinders\"], values: [layer_0_cyl_Cylinders]}"
+        },
+        {
+            "name": "layer_0_cyl_tuple",
+            "on": [
+                {
+                    "events": {
+                        "signal": "layer_0_cyl"
+                    },
+                    "update": "{unit: unit.datum && unit.datum._id, fields: layer_0_cyl.fields, values: layer_0_cyl.values, Cylinders: layer_0_cyl.values[0]}"
+                }
+            ]
+        },
+        {
+            "name": "layer_0_cyl_modify",
+            "on": [
+                {
+                    "events": {
+                        "signal": "layer_0_cyl"
+                    },
+                    "update": "modify(\"layer_0_cyl_store\", layer_0_cyl_tuple, true)"
+                }
+            ]
+        }
+    ],
+    "marks": [
+        {
+            "type": "group",
+            "encode": {
+                "enter": {
+                    "width": {
+                        "signal": "width"
+                    },
+                    "height": {
+                        "signal": "height"
+                    },
+                    "fill": {
+                        "value": "transparent"
+                    },
+                    "clip": {
+                        "value": true
+                    }
+                }
+            },
             "marks": [
                 {
-                    "type": "group",
+                    "type": "rect",
                     "encode": {
                         "enter": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
+                            "fill": {
+                                "value": "#eee"
+                            }
+                        },
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                    "scale": "x",
+                                    "signal": "layer_1_brush[0].extent[0]"
+                                },
+                                {
+                                    "value": 0
                                 }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                    "scale": "x",
+                                    "signal": "layer_1_brush[0].extent[1]"
+                                },
+                                {
+                                    "value": 0
                                 }
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                    "scale": "y",
+                                    "signal": "layer_1_brush[1].extent[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                    "scale": "y",
+                                    "signal": "layer_1_brush[1].extent[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "layer_0_marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "data_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
                             },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": [
+                                {
+                                    "test": "vlInterval(\"layer_1_brush_store\", parent._id, datum, \"union\", \"all\")",
+                                    "value": "grey"
+                                },
+                                {
+                                    "scale": "color",
+                                    "field": "Cylinders"
+                                }
+                            ],
                             "fill": {
                                 "value": "transparent"
                             },
-                            "clip": {
-                                "value": true
+                            "size": {
+                                "value": 100
+                            },
+                            "opacity": {
+                                "value": 0.7
                             }
                         }
-                    },
-                    "marks": [
-                        {
-                            "type": "rect",
-                            "encode": {
-                                "enter": {
-                                    "fill": {
-                                        "value": "#eee"
-                                    }
-                                },
-                                "update": {
-                                    "x": [
-                                        {
-                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
-                                            "scale": "x",
-                                            "signal": "layer_1_brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
-                                            "scale": "x",
-                                            "signal": "layer_1_brush[0].extent[1]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "y": [
-                                        {
-                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
-                                            "scale": "y",
-                                            "signal": "layer_1_brush[1].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "y2": [
-                                        {
-                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
-                                            "scale": "y",
-                                            "signal": "layer_1_brush[1].extent[1]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ]
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_0_marks",
-                            "type": "symbol",
-                            "role": "point",
-                            "from": {
-                                "data": "data_0"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "Horsepower"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "Miles_per_Gallon"
-                                    },
-                                    "stroke": [
-                                        {
-                                            "test": "vlInterval(\"layer_1_brush_store\", parent._id, datum, \"union\", \"all\")",
-                                            "value": "grey"
-                                        },
-                                        {
-                                            "scale": "color",
-                                            "field": "Cylinders"
-                                        }
-                                    ],
-                                    "fill": {
-                                        "value": "transparent"
-                                    },
-                                    "size": {
-                                        "value": 100
-                                    },
-                                    "opacity": {
-                                        "value": 0.7
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_1_marks",
-                            "type": "symbol",
-                            "role": "square",
-                            "from": {
-                                "data": "data_1"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "Horsepower"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "Miles_per_Gallon"
-                                    },
-                                    "fill": [
-                                        {
-                                            "test": "!vlInterval(\"layer_1_brush_store\", parent._id, datum, \"union\", \"all\")",
-                                            "value": "grey"
-                                        },
-                                        {
-                                            "scale": "color",
-                                            "field": "Cylinders"
-                                        }
-                                    ],
-                                    "size": [
-                                        {
-                                            "test": "vlPoint(\"layer_0_cyl_store\", parent._id, datum, \"union\", \"all\")",
-                                            "value": 150
-                                        },
-                                        {
-                                            "value": 50
-                                        }
-                                    ],
-                                    "shape": {
-                                        "value": "square"
-                                    },
-                                    "opacity": {
-                                        "value": 0.7
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_1_brush_brush",
-                            "type": "rect",
-                            "encode": {
-                                "enter": {
-                                    "fill": {
-                                        "value": "transparent"
-                                    }
-                                },
-                                "update": {
-                                    "x": [
-                                        {
-                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
-                                            "scale": "x",
-                                            "signal": "layer_1_brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
-                                            "scale": "x",
-                                            "signal": "layer_1_brush[0].extent[1]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "y": [
-                                        {
-                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
-                                            "scale": "y",
-                                            "signal": "layer_1_brush[1].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "y2": [
-                                        {
-                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
-                                            "scale": "y",
-                                            "signal": "layer_1_brush[1].extent[1]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ]
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "fields": [
-                            {
-                                "data": "data_0",
-                                "field": "Horsepower"
-                            },
-                            {
-                                "data": "data_1",
-                                "field": "Horsepower"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true,
-                    "domainRaw": {
-                        "signal": "layer_0_grid_x"
                     }
                 },
                 {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "fields": [
-                            {
-                                "data": "data_0",
+                    "name": "layer_1_marks",
+                    "type": "symbol",
+                    "role": "square",
+                    "from": {
+                        "data": "data_1"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
                                 "field": "Miles_per_Gallon"
                             },
-                            {
-                                "data": "data_1",
-                                "field": "Miles_per_Gallon"
+                            "fill": [
+                                {
+                                    "test": "!vlInterval(\"layer_1_brush_store\", parent._id, datum, \"union\", \"all\")",
+                                    "value": "grey"
+                                },
+                                {
+                                    "scale": "color",
+                                    "field": "Cylinders"
+                                }
+                            ],
+                            "size": [
+                                {
+                                    "test": "vlPoint(\"layer_0_cyl_store\", parent._id, datum, \"union\", \"all\")",
+                                    "value": 150
+                                },
+                                {
+                                    "value": 50
+                                }
+                            ],
+                            "shape": {
+                                "value": "square"
+                            },
+                            "opacity": {
+                                "value": 0.7
                             }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true,
-                    "domainRaw": {
-                        "signal": "layer_0_grid_y"
+                        }
                     }
                 },
                 {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "fields": [
-                            {
-                                "data": "data_0",
-                                "field": "Cylinders"
-                            },
-                            {
-                                "data": "data_1",
-                                "field": "Cylinders"
+                    "name": "layer_1_brush_brush",
+                    "type": "rect",
+                    "encode": {
+                        "enter": {
+                            "fill": {
+                                "value": "transparent"
                             }
-                        ],
-                        "sort": true
-                    },
-                    "range": "ordinal"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "title": "Cylinders"
+                        },
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                    "scale": "x",
+                                    "signal": "layer_1_brush[0].extent[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                    "scale": "x",
+                                    "signal": "layer_1_brush[0].extent[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                    "scale": "y",
+                                    "signal": "layer_1_brush[1].extent[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                    "scale": "y",
+                                    "signal": "layer_1_brush[1].extent[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ]
+                        }
+                    }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "Horsepower"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "Horsepower"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true,
+            "domainRaw": {
+                "signal": "layer_0_grid_x"
+            }
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "Miles_per_Gallon"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "Miles_per_Gallon"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true,
+            "domainRaw": {
+                "signal": "layer_0_grid_y"
+            }
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "Cylinders"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "Cylinders"
+                    }
+                ],
+                "sort": true
+            },
+            "range": "ordinal"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "title": "Cylinders"
         }
     ]
 }

--- a/examples/vg-specs/line.vg.json
+++ b/examples/vg-specs/line.vg.json
@@ -3,26 +3,6 @@
     "description": "Google's stock price over time.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -51,157 +31,136 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "Google's stock price over time.",
+            "name": "marks",
+            "type": "line",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "line",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "date"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "price"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "stroke": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "data": "source_0",
+                "field": "date"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "date",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b %d, %Y')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "price"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "date",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b %d, %Y')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "price",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "price",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/line_calculate.vg.json
+++ b/examples/vg-specs/line_calculate.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -67,153 +47,126 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "month_date"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_month_date\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "line",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "month_date"
                     },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "line",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "month_date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "mean_temp_range"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "month_date",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "mean_temp_range"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "stroke": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "month_date",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "mean_temp_range"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "MONTH(date)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "MONTH(date)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "MEAN(temp_range)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "MEAN(temp_range)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/line_color.vg.json
+++ b/examples/vg-specs/line_color.vg.json
@@ -3,26 +3,6 @@
     "description": "Stock prices of 5 Tech Companies Over Time.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -47,203 +27,182 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
+            "name": "pathgroup",
             "type": "group",
-            "description": "Stock prices of 5 Tech Companies Over Time.",
             "from": {
-                "data": "layout"
+                "facet": {
+                    "name": "faceted-path-main",
+                    "data": "source_0",
+                    "groupby": [
+                        "symbol"
+                    ]
+                }
             },
             "encode": {
                 "update": {
                     "width": {
-                        "field": "width"
+                        "field": {
+                            "group": "width"
+                        }
                     },
                     "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
+                        "field": {
+                            "group": "height"
+                        }
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "pathgroup",
-                    "type": "group",
+                    "name": "marks",
+                    "type": "line",
                     "from": {
-                        "facet": {
-                            "name": "faceted-path-main",
-                            "data": "source_0",
-                            "groupby": [
-                                "symbol"
-                            ]
-                        }
+                        "data": "faceted-path-main"
                     },
                     "encode": {
                         "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                            "x": {
+                                "scale": "x",
+                                "field": "date"
                             },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            }
-                        }
-                    },
-                    "marks": [
-                        {
-                            "name": "marks",
-                            "type": "line",
-                            "from": {
-                                "data": "faceted-path-main"
+                            "y": {
+                                "scale": "y",
+                                "field": "price"
                             },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "date"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "price"
-                                    },
-                                    "stroke": {
-                                        "scale": "color",
-                                        "field": "symbol"
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "date"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "price"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "symbol",
-                        "sort": true
-                    },
-                    "range": "category"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "date",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%Y')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
+                            "stroke": {
+                                "scale": "color",
+                                "field": "symbol"
                             }
                         }
                     }
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "price",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "title": "symbol"
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "data": "source_0",
+                "field": "date"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "price"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "symbol",
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "date",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%Y')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "price",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "title": "symbol"
         }
     ]
 }

--- a/examples/vg-specs/line_detail.vg.json
+++ b/examples/vg-specs/line_detail.vg.json
@@ -3,26 +3,6 @@
     "description": "Stock prices of 5 Tech Companies Over Time.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -47,186 +27,165 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
+            "name": "pathgroup",
             "type": "group",
-            "description": "Stock prices of 5 Tech Companies Over Time.",
             "from": {
-                "data": "layout"
+                "facet": {
+                    "name": "faceted-path-main",
+                    "data": "source_0",
+                    "groupby": [
+                        "symbol"
+                    ]
+                }
             },
             "encode": {
                 "update": {
                     "width": {
-                        "field": "width"
+                        "field": {
+                            "group": "width"
+                        }
                     },
                     "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
+                        "field": {
+                            "group": "height"
+                        }
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "pathgroup",
-                    "type": "group",
+                    "name": "marks",
+                    "type": "line",
                     "from": {
-                        "facet": {
-                            "name": "faceted-path-main",
-                            "data": "source_0",
-                            "groupby": [
-                                "symbol"
-                            ]
-                        }
+                        "data": "faceted-path-main"
                     },
                     "encode": {
                         "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                            "x": {
+                                "scale": "x",
+                                "field": "date"
                             },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            }
-                        }
-                    },
-                    "marks": [
-                        {
-                            "name": "marks",
-                            "type": "line",
-                            "from": {
-                                "data": "faceted-path-main"
+                            "y": {
+                                "scale": "y",
+                                "field": "price"
                             },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "date"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "price"
-                                    },
-                                    "stroke": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "date"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "price"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "date",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b %d, %Y')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
+                            "stroke": {
+                                "value": "#4c78a8"
                             }
                         }
                     }
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "price",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "data": "source_0",
+                "field": "date"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "price"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "date",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b %d, %Y')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "price",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/line_max_year.vg.json
+++ b/examples/vg-specs/line_max_year.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -63,157 +43,137 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "line",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "line",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "yearmonth_date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "max_temp_max"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "yearmonth_date"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": "month"
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "max_temp_max"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "stroke": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "data": "source_0",
+                "field": "yearmonth_date"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "YEARMONTH(date)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b %Y')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": "month"
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "max_temp_max"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "YEARMONTH(date)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b %Y')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "MAX(temp_max)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "MAX(temp_max)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/line_mean_month.vg.json
+++ b/examples/vg-specs/line_mean_month.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -63,153 +43,126 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "month_date"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_month_date\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "line",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "month_date"
                     },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "line",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "month_date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "mean_precipitation"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "month_date",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "mean_precipitation"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "stroke": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "month_date",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "mean_precipitation"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "MONTH(date)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "MONTH(date)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "MEAN(precipitation)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "MEAN(precipitation)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/line_mean_year.vg.json
+++ b/examples/vg-specs/line_mean_year.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -63,157 +43,137 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "line",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "line",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "year_date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "mean_temp_max"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "year_date"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": "year"
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "mean_temp_max"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "stroke": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "data": "source_0",
+                "field": "year_date"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "YEAR(date)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%Y')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": "year"
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "mean_temp_max"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "YEAR(date)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%Y')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "MEAN(temp_max)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "MEAN(temp_max)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/line_monotone.vg.json
+++ b/examples/vg-specs/line_monotone.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -50,156 +30,136 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "line",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "line",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "date"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "price"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "stroke": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "data": "source_0",
+                "field": "date"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "date",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b %d, %Y')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "price"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "date",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b %d, %Y')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "price",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "price",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/line_month.vg.json
+++ b/examples/vg-specs/line_month.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -63,153 +43,126 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "month_date"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_month_date\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "line",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "month_date"
                     },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "line",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "month_date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "mean_temp"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "month_date",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "mean_temp"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "stroke": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "month_date",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "mean_temp"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "MONTH(date)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "MONTH(date)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "MEAN(temp)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "MEAN(temp)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/line_quarter.vg.json
+++ b/examples/vg-specs/line_quarter.vg.json
@@ -3,26 +3,6 @@
     "description": "Stock price mean per quarter broken down by years.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -82,338 +62,311 @@
             ]
         },
         {
-            "name": "layout",
-            "source": "source_0",
+            "name": "column-layout",
+            "source": "column",
             "transform": [
                 {
                     "type": "aggregate",
-                    "fields": [
-                        "year_date",
-                        "quarter_date"
-                    ],
                     "ops": [
-                        "distinct",
                         "distinct"
+                    ],
+                    "fields": [
+                        "year_date"
                     ]
-                },
-                {
-                    "type": "formula",
-                    "as": "child_width",
-                    "expr": "max(datum[\"distinct_quarter_date\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "(datum[\"child_width\"] + 5) * datum[\"distinct_year_date\"]"
-                },
-                {
-                    "type": "formula",
-                    "as": "child_height",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "datum[\"child_height\"] + 5"
                 }
             ]
         }
     ],
+    "signals": [
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        },
+        {
+            "name": "child_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "child_height",
+            "update": "200"
+        }
+    ],
+    "layout": {
+        "padding": {
+            "row": 10,
+            "column": 10,
+            "header": 10
+        },
+        "columns": 1,
+        "bounds": "full"
+    },
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "description": "Stock price mean per quarter broken down by years.",
-            "from": {
-                "data": "layout"
-            },
-            "signals": [
-                {
-                    "name": "column",
-                    "update": "data('layout')[0].distinct_year_date"
-                }
-            ],
             "layout": {
                 "padding": {
                     "row": 10,
                     "column": 10,
                     "header": 10
                 },
-                "columns": 1,
+                "columns": {
+                    "signal": "data('column-layout')[0].distinct_year_date"
+                },
                 "bounds": "full"
             },
             "marks": [
                 {
+                    "name": "x-axes",
                     "type": "group",
-                    "layout": {
-                        "padding": {
-                            "row": 10,
-                            "column": 10,
-                            "header": 10
-                        },
-                        "columns": {
-                            "signal": "column"
-                        },
-                        "bounds": "full"
+                    "role": "column-footer",
+                    "from": {
+                        "data": "column"
                     },
-                    "marks": [
+                    "axes": [
                         {
-                            "name": "x-axes",
-                            "type": "group",
-                            "role": "column-footer",
-                            "from": {
-                                "data": "column"
-                            },
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "title": "QUARTER(date)",
-                                    "zindex": 1,
-                                    "encode": {
-                                        "labels": {
-                                            "update": {
-                                                "text": {
-                                                    "signal": "'Q' + quarter(datum.value)"
-                                                },
-                                                "angle": {
-                                                    "value": 270
-                                                },
-                                                "align": {
-                                                    "value": "right"
-                                                },
-                                                "baseline": {
-                                                    "value": "middle"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "y-axes",
-                            "type": "group",
-                            "role": "row-header",
-                            "axes": [
-                                {
-                                    "scale": "y",
-                                    "format": "s",
-                                    "orient": "left",
-                                    "title": "MEAN(price)",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "column-labels",
-                            "role": "column-header",
-                            "type": "group",
-                            "from": {
-                                "data": "column"
-                            },
+                            "scale": "x",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "QUARTER(date)",
+                            "zindex": 1,
                             "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
+                                "labels": {
+                                    "update": {
+                                        "text": {
+                                            "signal": "'Q' + quarter(datum.value)"
+                                        },
+                                        "angle": {
+                                            "value": 270
+                                        },
+                                        "align": {
+                                            "value": "right"
+                                        },
+                                        "baseline": {
+                                            "value": "middle"
                                         }
                                     }
                                 }
-                            },
-                            "marks": [
-                                {
-                                    "type": "text",
-                                    "role": "column-labels",
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "field": {
-                                                    "group": "width"
-                                                },
-                                                "mult": 0.5
-                                            },
-                                            "y": {
-                                                "value": -10
-                                            },
-                                            "text": {
-                                                "field": {
-                                                    "parent": "year_date"
-                                                }
-                                            },
-                                            "align": {
-                                                "value": "center"
-                                            },
-                                            "fill": {
-                                                "value": "black"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "cell",
-                            "type": "group",
-                            "from": {
-                                "facet": {
-                                    "name": "facet",
-                                    "data": "source_0",
-                                    "groupby": [
-                                        "year_date"
-                                    ]
-                                }
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    },
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
-                                        }
-                                    },
-                                    "stroke": {
-                                        "value": "#ccc"
-                                    },
-                                    "strokeWidth": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "transparent"
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "name": "child_marks",
-                                    "type": "symbol",
-                                    "role": "point",
-                                    "from": {
-                                        "data": "facet"
-                                    },
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "scale": "x",
-                                                "field": "quarter_date"
-                                            },
-                                            "y": {
-                                                "scale": "y",
-                                                "field": "mean_price"
-                                            },
-                                            "stroke": {
-                                                "scale": "color",
-                                                "field": "symbol"
-                                            },
-                                            "fill": {
-                                                "value": "transparent"
-                                            }
-                                        }
-                                    }
-                                }
-                            ],
-                            "axes": [
-                                {
-                                    "scale": "y",
-                                    "domain": false,
-                                    "format": "s",
-                                    "grid": true,
-                                    "labels": false,
-                                    "orient": "left",
-                                    "ticks": false,
-                                    "zindex": 0,
-                                    "gridScale": "x"
-                                }
-                            ]
+                            }
                         }
                     ]
                 },
                 {
-                    "name": "column-title",
+                    "name": "y-axes",
+                    "type": "group",
+                    "role": "row-header",
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "MEAN(price)",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "column-labels",
                     "role": "column-header",
                     "type": "group",
+                    "from": {
+                        "data": "column"
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
                     "marks": [
                         {
                             "type": "text",
-                            "role": "column-title",
+                            "role": "column-labels",
                             "encode": {
                                 "update": {
                                     "x": {
-                                        "signal": "0.5 * width"
+                                        "field": {
+                                            "group": "width"
+                                        },
+                                        "mult": 0.5
+                                    },
+                                    "y": {
+                                        "value": -10
                                     },
                                     "text": {
-                                        "value": "YEAR(date)"
+                                        "field": {
+                                            "parent": "year_date"
+                                        }
                                     },
                                     "align": {
                                         "value": "center"
                                     },
                                     "fill": {
                                         "value": "black"
-                                    },
-                                    "fontWeight": {
-                                        "value": "bold"
                                     }
                                 }
                             }
                         }
                     ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "quarter_date",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
                 },
                 {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "mean_price"
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "year_date"
+                            ]
+                        }
                     },
-                    "range": [
-                        200,
-                        0
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "quarter_date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "mean_price"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "symbol"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    }
+                                }
+                            }
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "symbol",
-                        "sort": true
-                    },
-                    "range": "category"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "title": "symbol"
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
+                        }
+                    ]
                 }
             ]
+        },
+        {
+            "name": "column-title",
+            "role": "column-header",
+            "type": "group",
+            "marks": [
+                {
+                    "type": "text",
+                    "role": "column-title",
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "signal": "0.5 * width"
+                            },
+                            "text": {
+                                "value": "YEAR(date)"
+                            },
+                            "align": {
+                                "value": "center"
+                            },
+                            "fill": {
+                                "value": "black"
+                            },
+                            "fontWeight": {
+                                "value": "bold"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "quarter_date",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "mean_price"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "symbol",
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "title": "symbol"
         }
     ]
 }

--- a/examples/vg-specs/line_quarter_legend.vg.json
+++ b/examples/vg-specs/line_quarter_legend.vg.json
@@ -3,26 +3,6 @@
     "description": "Stock price average broken down by quarter.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -70,214 +50,193 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
+            "name": "pathgroup",
             "type": "group",
-            "description": "Stock price average broken down by quarter.",
             "from": {
-                "data": "layout"
+                "facet": {
+                    "name": "faceted-path-main",
+                    "data": "source_0",
+                    "groupby": [
+                        "quarter_date"
+                    ]
+                }
             },
             "encode": {
                 "update": {
                     "width": {
-                        "field": "width"
+                        "field": {
+                            "group": "width"
+                        }
                     },
                     "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
+                        "field": {
+                            "group": "height"
+                        }
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "pathgroup",
-                    "type": "group",
+                    "name": "marks",
+                    "type": "line",
                     "from": {
-                        "facet": {
-                            "name": "faceted-path-main",
-                            "data": "source_0",
-                            "groupby": [
-                                "quarter_date"
-                            ]
-                        }
+                        "data": "faceted-path-main"
                     },
                     "encode": {
                         "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                            "x": {
+                                "scale": "x",
+                                "field": "year_date"
                             },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            }
-                        }
-                    },
-                    "marks": [
-                        {
-                            "name": "marks",
-                            "type": "line",
-                            "from": {
-                                "data": "faceted-path-main"
+                            "y": {
+                                "scale": "y",
+                                "field": "mean_price"
                             },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "year_date"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "mean_price"
-                                    },
-                                    "stroke": {
-                                        "scale": "color",
-                                        "field": "quarter_date"
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "year_date"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": "year"
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "mean_price"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "sequential",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "quarter_date"
-                    },
-                    "range": "ramp",
-                    "nice": false,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "YEAR(date)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%Y')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "MEAN(price)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "title": "QUARTER(date)",
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "'Q' + quarter(datum.value)"
-                                }
+                            "stroke": {
+                                "scale": "color",
+                                "field": "quarter_date"
                             }
                         }
                     }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "data": "source_0",
+                "field": "year_date"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": "year"
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "mean_price"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "sequential",
+            "domain": {
+                "data": "source_0",
+                "field": "quarter_date"
+            },
+            "range": "ramp",
+            "nice": false,
+            "zero": false
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "YEAR(date)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%Y')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "MEAN(price)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "title": "QUARTER(date)",
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "'Q' + quarter(datum.value)"
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/line_slope.vg.json
+++ b/examples/vg-specs/line_slope.vg.json
@@ -3,26 +3,6 @@
     "description": "Slope graph showing the change in yield for different barley sites. It shows the error in the year labels for the Morris site.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -59,197 +39,169 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 50"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "year"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_year\"] - 1 + 2*0.5, 0) * 50"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
+            "name": "pathgroup",
             "type": "group",
-            "description": "Slope graph showing the change in yield for different barley sites. It shows the error in the year labels for the Morris site.",
             "from": {
-                "data": "layout"
+                "facet": {
+                    "name": "faceted-path-main",
+                    "data": "source_0",
+                    "groupby": [
+                        "site"
+                    ]
+                }
             },
             "encode": {
                 "update": {
                     "width": {
-                        "field": "width"
+                        "field": {
+                            "group": "width"
+                        }
                     },
                     "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
+                        "field": {
+                            "group": "height"
+                        }
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "pathgroup",
-                    "type": "group",
+                    "name": "marks",
+                    "type": "line",
                     "from": {
-                        "facet": {
-                            "name": "faceted-path-main",
-                            "data": "source_0",
-                            "groupby": [
-                                "site"
-                            ]
-                        }
+                        "data": "faceted-path-main"
                     },
                     "encode": {
                         "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                            "x": {
+                                "scale": "x",
+                                "field": "year"
                             },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            }
-                        }
-                    },
-                    "marks": [
-                        {
-                            "name": "marks",
-                            "type": "line",
-                            "from": {
-                                "data": "faceted-path-main"
+                            "y": {
+                                "scale": "y",
+                                "field": "median_yield"
                             },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "year"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "median_yield"
-                                    },
-                                    "stroke": {
-                                        "scale": "color",
-                                        "field": "site"
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "year",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 50
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "median_yield"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "site",
-                        "sort": true
-                    },
-                    "range": "category"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "year",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
+                            "stroke": {
+                                "scale": "color",
+                                "field": "site"
                             }
                         }
                     }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "MEDIAN(yield)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "title": "site"
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "year",
+                "sort": true
+            },
+            "range": {
+                "step": 50
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "median_yield"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "site",
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "year",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "MEDIAN(yield)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "title": "site"
         }
     ]
 }

--- a/examples/vg-specs/line_step.vg.json
+++ b/examples/vg-specs/line_step.vg.json
@@ -3,26 +3,6 @@
     "description": "Google's stock price over time.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -51,157 +31,136 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "Google's stock price over time.",
+            "name": "marks",
+            "type": "line",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "line",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "date"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "price"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "stroke": {
+                        "value": "#4c78a8"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "data": "source_0",
+                "field": "date"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "date",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b %d, %Y')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
+            "round": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "price"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "date",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b %d, %Y')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "price",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
-            ]
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "price",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/minimal.vg.json
+++ b/examples/vg-specs/minimal.vg.json
@@ -2,14 +2,26 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
+    "data": [
+        {
+            "name": "source_0",
+            "values": [
+                {}
+            ],
+            "format": {
+                "type": "json",
+                "parse": {}
+            }
+        }
+    ],
     "signals": [
         {
             "name": "width",
-            "update": "data('layout')[0].width"
+            "update": "21"
         },
         {
             "name": "height",
-            "update": "data('layout')[0].height"
+            "update": "21"
         },
         {
             "name": "unit",
@@ -22,85 +34,33 @@
             ]
         }
     ],
-    "data": [
-        {
-            "name": "source_0",
-            "values": [
-                {}
-            ],
-            "format": {
-                "type": "json",
-                "parse": {}
-            }
-        },
-        {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "21"
-                }
-            ]
-        }
-    ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "value": 10.5
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "value": 10.5
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "fill": {
                         "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "value": 10.5
-                            },
-                            "y": {
-                                "value": 10.5
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/overlay_area_full.vg.json
+++ b/examples/vg-specs/overlay_area_full.vg.json
@@ -3,26 +3,6 @@
     "description": "Google's stock price over time.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -110,263 +90,262 @@
                     "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"price\"] !== null && !isNaN(datum[\"price\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "max(layer_0_width, layer_1_width, layer_2_width)"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "max(layer_0_height, layer_1_height, layer_2_height)"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
+        },
+        {
+            "name": "layer_2_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_2_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_height",
+            "update": "200"
         }
     ],
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "description": "Google's stock price over time.",
-            "from": {
-                "data": "layout"
-            },
             "encode": {
-                "update": {
+                "enter": {
                     "width": {
-                        "field": "width"
+                        "signal": "width"
                     },
                     "height": {
-                        "field": "height"
+                        "signal": "height"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "clip": {
+                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "type": "group",
+                    "name": "layer_0_marks",
+                    "type": "area",
+                    "from": {
+                        "data": "data_0"
+                    },
                     "encode": {
-                        "enter": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "date"
                             },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
+                            "y": {
+                                "scale": "y",
+                                "field": "price"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
                             },
                             "fill": {
-                                "value": "transparent"
+                                "value": "#4c78a8"
                             },
-                            "clip": {
-                                "value": true
-                            }
-                        }
-                    },
-                    "marks": [
-                        {
-                            "name": "layer_0_marks",
-                            "type": "area",
-                            "from": {
-                                "data": "data_0"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "date"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "price"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "value": 0
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    },
-                                    "orient": {
-                                        "value": "vertical"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_1_marks",
-                            "type": "line",
-                            "from": {
-                                "data": "data_1"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "date"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "price"
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_2_marks",
-                            "type": "symbol",
-                            "role": "point",
-                            "from": {
-                                "data": "data_2"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "date"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "price"
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    },
-                                    "opacity": {
-                                        "value": 0.7
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "fields": [
-                            {
-                                "field": "date",
-                                "data": "data_0"
-                            },
-                            {
-                                "field": "date",
-                                "data": "data_1"
-                            },
-                            {
-                                "data": "data_2",
-                                "field": "date"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "fields": [
-                            {
-                                "field": "price",
-                                "data": "data_0"
-                            },
-                            {
-                                "field": "price",
-                                "data": "data_1"
-                            },
-                            {
-                                "data": "data_2",
-                                "field": "price"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "date",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b %d, %Y')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
+                            "orient": {
+                                "value": "vertical"
                             }
                         }
                     }
                 },
                 {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
+                    "name": "layer_1_marks",
+                    "type": "line",
+                    "from": {
+                        "data": "data_1"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "date"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "price"
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
                 },
                 {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "price",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
+                    "name": "layer_2_marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "data_2"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "date"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "price"
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "fields": [
+                    {
+                        "field": "date",
+                        "data": "data_0"
+                    },
+                    {
+                        "field": "date",
+                        "data": "data_1"
+                    },
+                    {
+                        "data": "data_2",
+                        "field": "date"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {
+                        "field": "price",
+                        "data": "data_0"
+                    },
+                    {
+                        "field": "price",
+                        "data": "data_1"
+                    },
+                    {
+                        "data": "data_2",
+                        "field": "price"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "date",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b %d, %Y')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "price",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/overlay_area_short.vg.json
+++ b/examples/vg-specs/overlay_area_short.vg.json
@@ -3,26 +3,6 @@
     "description": "Google's stock price over time.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -110,263 +90,262 @@
                     "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"price\"] !== null && !isNaN(datum[\"price\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "max(layer_0_width, layer_1_width, layer_2_width)"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "max(layer_0_height, layer_1_height, layer_2_height)"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
+        },
+        {
+            "name": "layer_2_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_2_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_height",
+            "update": "200"
         }
     ],
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "description": "Google's stock price over time.",
-            "from": {
-                "data": "layout"
-            },
             "encode": {
-                "update": {
+                "enter": {
                     "width": {
-                        "field": "width"
+                        "signal": "width"
                     },
                     "height": {
-                        "field": "height"
+                        "signal": "height"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "clip": {
+                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "type": "group",
+                    "name": "layer_0_marks",
+                    "type": "area",
+                    "from": {
+                        "data": "data_0"
+                    },
                     "encode": {
-                        "enter": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "date"
                             },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
+                            "y": {
+                                "scale": "y",
+                                "field": "price"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
                             },
                             "fill": {
-                                "value": "transparent"
+                                "value": "#4c78a8"
                             },
-                            "clip": {
-                                "value": true
-                            }
-                        }
-                    },
-                    "marks": [
-                        {
-                            "name": "layer_0_marks",
-                            "type": "area",
-                            "from": {
-                                "data": "data_0"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "date"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "price"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "value": 0
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    },
-                                    "orient": {
-                                        "value": "vertical"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_1_marks",
-                            "type": "line",
-                            "from": {
-                                "data": "data_1"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "date"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "price"
-                                    },
-                                    "stroke": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_2_marks",
-                            "type": "symbol",
-                            "role": "pointOverlay",
-                            "from": {
-                                "data": "data_2"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "date"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "price"
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    },
-                                    "opacity": {
-                                        "value": 0.7
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "fields": [
-                            {
-                                "field": "date",
-                                "data": "data_0"
-                            },
-                            {
-                                "field": "date",
-                                "data": "data_1"
-                            },
-                            {
-                                "data": "data_2",
-                                "field": "date"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "fields": [
-                            {
-                                "field": "price",
-                                "data": "data_0"
-                            },
-                            {
-                                "field": "price",
-                                "data": "data_1"
-                            },
-                            {
-                                "data": "data_2",
-                                "field": "price"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "date",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b %d, %Y')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
+                            "orient": {
+                                "value": "vertical"
                             }
                         }
                     }
                 },
                 {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
+                    "name": "layer_1_marks",
+                    "type": "line",
+                    "from": {
+                        "data": "data_1"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "date"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "price"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
                 },
                 {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "price",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
+                    "name": "layer_2_marks",
+                    "type": "symbol",
+                    "role": "pointOverlay",
+                    "from": {
+                        "data": "data_2"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "date"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "price"
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "fields": [
+                    {
+                        "field": "date",
+                        "data": "data_0"
+                    },
+                    {
+                        "field": "date",
+                        "data": "data_1"
+                    },
+                    {
+                        "data": "data_2",
+                        "field": "date"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {
+                        "field": "price",
+                        "data": "data_0"
+                    },
+                    {
+                        "field": "price",
+                        "data": "data_1"
+                    },
+                    {
+                        "data": "data_2",
+                        "field": "price"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "date",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b %d, %Y')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "price",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/overlay_line_full.vg.json
+++ b/examples/vg-specs/overlay_line_full.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -82,225 +62,217 @@
                     "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"price\"] !== null && !isNaN(datum[\"price\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "max(layer_0_width, layer_1_width)"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "max(layer_0_height, layer_1_height)"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
+        },
+        {
+            "name": "layer_1_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_height",
+            "update": "200"
         }
     ],
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "from": {
-                "data": "layout"
-            },
             "encode": {
-                "update": {
+                "enter": {
                     "width": {
-                        "field": "width"
+                        "signal": "width"
                     },
                     "height": {
-                        "field": "height"
+                        "signal": "height"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "clip": {
+                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "type": "group",
-                    "encode": {
-                        "enter": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "clip": {
-                                "value": true
-                            }
-                        }
+                    "name": "layer_0_marks",
+                    "type": "line",
+                    "from": {
+                        "data": "data_0"
                     },
-                    "marks": [
-                        {
-                            "name": "layer_0_marks",
-                            "type": "line",
-                            "from": {
-                                "data": "data_0"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "date"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "price"
-                                    },
-                                    "stroke": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_1_marks",
-                            "type": "symbol",
-                            "role": "point",
-                            "from": {
-                                "data": "data_1"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "date"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "price"
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    },
-                                    "opacity": {
-                                        "value": 0.7
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "fields": [
-                            {
-                                "data": "data_0",
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
                                 "field": "date"
                             },
-                            {
-                                "data": "data_1",
-                                "field": "date"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "fields": [
-                            {
-                                "data": "data_0",
+                            "y": {
+                                "scale": "y",
                                 "field": "price"
                             },
-                            {
-                                "data": "data_1",
-                                "field": "price"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "date",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b %d, %Y')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
+                            "stroke": {
+                                "value": "#4c78a8"
                             }
                         }
                     }
                 },
                 {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "price",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
+                    "name": "layer_1_marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "data_1"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "date"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "price"
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "date"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "date"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "price"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "price"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "date",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b %d, %Y')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "price",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/overlay_line_short.vg.json
+++ b/examples/vg-specs/overlay_line_short.vg.json
@@ -3,26 +3,6 @@
     "description": "Google's stock price over time.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -83,226 +63,217 @@
                     "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"price\"] !== null && !isNaN(datum[\"price\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "max(layer_0_width, layer_1_width)"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "max(layer_0_height, layer_1_height)"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
+        },
+        {
+            "name": "layer_1_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_height",
+            "update": "200"
         }
     ],
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "description": "Google's stock price over time.",
-            "from": {
-                "data": "layout"
-            },
             "encode": {
-                "update": {
+                "enter": {
                     "width": {
-                        "field": "width"
+                        "signal": "width"
                     },
                     "height": {
-                        "field": "height"
+                        "signal": "height"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "clip": {
+                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "type": "group",
-                    "encode": {
-                        "enter": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "clip": {
-                                "value": true
-                            }
-                        }
+                    "name": "layer_0_marks",
+                    "type": "line",
+                    "from": {
+                        "data": "data_0"
                     },
-                    "marks": [
-                        {
-                            "name": "layer_0_marks",
-                            "type": "line",
-                            "from": {
-                                "data": "data_0"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "date"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "price"
-                                    },
-                                    "stroke": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_1_marks",
-                            "type": "symbol",
-                            "role": "pointOverlay",
-                            "from": {
-                                "data": "data_1"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "date"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "price"
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    },
-                                    "opacity": {
-                                        "value": 0.7
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "fields": [
-                            {
-                                "data": "data_0",
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
                                 "field": "date"
                             },
-                            {
-                                "data": "data_1",
-                                "field": "date"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "fields": [
-                            {
-                                "data": "data_0",
+                            "y": {
+                                "scale": "y",
                                 "field": "price"
                             },
-                            {
-                                "data": "data_1",
-                                "field": "price"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "date",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b %d, %Y')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
+                            "stroke": {
+                                "value": "#4c78a8"
                             }
                         }
                     }
                 },
                 {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "price",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
+                    "name": "layer_1_marks",
+                    "type": "symbol",
+                    "role": "pointOverlay",
+                    "from": {
+                        "data": "data_1"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "date"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "price"
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "date"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "date"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "price"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "price"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "date",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b %d, %Y')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "price",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/paintbrush.vg.json
+++ b/examples/vg-specs/paintbrush.vg.json
@@ -3,26 +3,6 @@
     "description": "Select multiple points with the shift key.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -42,252 +22,229 @@
             ]
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "paintbrush_store"
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
+        },
+        {
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         },
         {
-            "name": "paintbrush_store"
+            "name": "paintbrush",
+            "value": {},
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "mouseover"
+                        }
+                    ],
+                    "update": "{fields: [\"_id\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_id\"]]}"
+                }
+            ]
+        },
+        {
+            "name": "paintbrush_toggle",
+            "value": false,
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "mouseover"
+                        }
+                    ],
+                    "update": "event.shiftKey"
+                }
+            ]
+        },
+        {
+            "name": "paintbrush_tuple",
+            "on": [
+                {
+                    "events": {
+                        "signal": "paintbrush"
+                    },
+                    "update": "{unit: unit.datum && unit.datum._id, fields: paintbrush.fields, values: paintbrush.values}"
+                }
+            ]
+        },
+        {
+            "name": "paintbrush_modify",
+            "on": [
+                {
+                    "events": {
+                        "signal": "paintbrush"
+                    },
+                    "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+                }
+            ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "Select multiple points with the shift key.",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "size": [
+                        {
+                            "test": "vlPoint(\"paintbrush_store\", parent._id, datum, \"union\", \"all\")",
+                            "value": 300
+                        },
+                        {
+                            "value": 50
+                        }
+                    ],
+                    "opacity": {
+                        "value": 0.7
+                    }
+                }
+            }
+        },
+        {
+            "name": "voronoi",
+            "type": "path",
+            "from": {
+                "data": "marks"
+            },
+            "encode": {
+                "enter": {
+                    "fill": {
+                        "value": "transparent"
+                    },
+                    "strokeWidth": {
+                        "value": 0.35
+                    },
+                    "stroke": {
+                        "value": "transparent"
+                    },
+                    "isVoronoi": {
+                        "value": true
                     }
                 }
             },
-            "signals": [
+            "transform": [
                 {
-                    "name": "paintbrush",
-                    "value": {},
-                    "on": [
+                    "type": "voronoi",
+                    "x": "datum.x",
+                    "y": "datum.y",
+                    "size": [
                         {
-                            "events": [
-                                {
-                                    "source": "scope",
-                                    "type": "mouseover"
-                                }
-                            ],
-                            "update": "{fields: [\"_id\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_id\"]]}"
+                            "signal": "width"
+                        },
+                        {
+                            "signal": "height"
                         }
                     ]
-                },
-                {
-                    "name": "paintbrush_toggle",
-                    "value": false,
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "source": "scope",
-                                    "type": "mouseover"
-                                }
-                            ],
-                            "update": "event.shiftKey"
-                        }
-                    ]
-                },
-                {
-                    "name": "paintbrush_tuple",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "paintbrush"
-                            },
-                            "update": "{unit: unit.datum && unit.datum._id, fields: paintbrush.fields, values: paintbrush.values}"
-                        }
-                    ]
-                },
-                {
-                    "name": "paintbrush_modify",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "paintbrush"
-                            },
-                            "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
-                        }
-                    ]
-                }
-            ],
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "size": [
-                                {
-                                    "test": "vlPoint(\"paintbrush_store\", parent._id, datum, \"union\", \"all\")",
-                                    "value": 300
-                                },
-                                {
-                                    "value": 50
-                                }
-                            ],
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "voronoi",
-                    "type": "path",
-                    "from": {
-                        "data": "marks"
-                    },
-                    "encode": {
-                        "enter": {
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "strokeWidth": {
-                                "value": 0.35
-                            },
-                            "stroke": {
-                                "value": "transparent"
-                            },
-                            "isVoronoi": {
-                                "value": true
-                            }
-                        }
-                    },
-                    "transform": [
-                        {
-                            "type": "voronoi",
-                            "x": "datum.x",
-                            "y": "datum.y",
-                            "size": [
-                                {
-                                    "signal": "width"
-                                },
-                                {
-                                    "signal": "height"
-                                }
-                            ]
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/paintbrush.vg.json
+++ b/examples/vg-specs/paintbrush.vg.json
@@ -123,7 +123,7 @@
                     },
                     "size": [
                         {
-                            "test": "vlPoint(\"paintbrush_store\", parent._id, datum, \"union\", \"all\")",
+                            "test": "vlPoint(\"paintbrush_store\", datum._id, datum, \"union\", \"all\")",
                             "value": 300
                         },
                         {

--- a/examples/vg-specs/panzoom_scatter.vg.json
+++ b/examples/vg-specs/panzoom_scatter.vg.json
@@ -2,32 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        },
-        {
-            "name": "grid_x"
-        },
-        {
-            "name": "grid_y"
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -48,355 +22,335 @@
             ]
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "grid_store"
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
+        },
+        {
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         },
         {
-            "name": "grid_store"
+            "name": "grid_x"
+        },
+        {
+            "name": "grid_y"
+        },
+        {
+            "name": "grid_x",
+            "on": [
+                {
+                    "events": {
+                        "signal": "grid_translate_delta"
+                    },
+                    "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
+                },
+                {
+                    "events": {
+                        "signal": "grid_zoom_delta"
+                    },
+                    "update": "[grid_zoom_anchor.x + (domain(\"x\")[0] - grid_zoom_anchor.x) * grid_zoom_delta, grid_zoom_anchor.x + (domain(\"x\")[1] - grid_zoom_anchor.x) * grid_zoom_delta]"
+                }
+            ],
+            "push": "outer"
+        },
+        {
+            "name": "grid_y",
+            "on": [
+                {
+                    "events": {
+                        "signal": "grid_translate_delta"
+                    },
+                    "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                },
+                {
+                    "events": {
+                        "signal": "grid_zoom_delta"
+                    },
+                    "update": "[grid_zoom_anchor.y + (domain(\"y\")[0] - grid_zoom_anchor.y) * grid_zoom_delta, grid_zoom_anchor.y + (domain(\"y\")[1] - grid_zoom_anchor.y) * grid_zoom_delta]"
+                }
+            ],
+            "push": "outer"
+        },
+        {
+            "name": "grid",
+            "update": "[{field: \"Horsepower\", extent: grid_x}, {field: \"Miles_per_Gallon\", extent: grid_y}]"
+        },
+        {
+            "name": "grid_translate_anchor",
+            "value": {},
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "mousedown"
+                        }
+                    ],
+                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
+                }
+            ]
+        },
+        {
+            "name": "grid_translate_delta",
+            "value": {},
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "window",
+                            "type": "mousemove",
+                            "consume": true,
+                            "between": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousedown"
+                                },
+                                {
+                                    "source": "window",
+                                    "type": "mouseup"
+                                }
+                            ]
+                        }
+                    ],
+                    "update": "{x: x(unit) - grid_translate_anchor.x, y: y(unit) - grid_translate_anchor.y}"
+                }
+            ]
+        },
+        {
+            "name": "grid_zoom_anchor",
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "wheel"
+                        }
+                    ],
+                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                }
+            ]
+        },
+        {
+            "name": "grid_zoom_delta",
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "wheel"
+                        }
+                    ],
+                    "force": true,
+                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                }
+            ]
+        },
+        {
+            "name": "grid_tuple",
+            "on": [
+                {
+                    "events": {
+                        "signal": "grid"
+                    },
+                    "update": "{unit: unit.datum && unit.datum._id, intervals: grid}"
+                }
+            ]
+        },
+        {
+            "name": "grid_modify",
+            "on": [
+                {
+                    "events": {
+                        "signal": "grid"
+                    },
+                    "update": "modify(\"grid_store\", grid_tuple, true)"
+                }
+            ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "from": {
-                "data": "layout"
-            },
             "encode": {
-                "update": {
+                "enter": {
                     "width": {
-                        "field": "width"
+                        "signal": "width"
                     },
                     "height": {
-                        "field": "height"
+                        "signal": "height"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "clip": {
+                        "value": true
                     }
                 }
             },
-            "signals": [
-                {
-                    "name": "grid_x",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "grid_translate_delta"
-                            },
-                            "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
-                        },
-                        {
-                            "events": {
-                                "signal": "grid_zoom_delta"
-                            },
-                            "update": "[grid_zoom_anchor.x + (domain(\"x\")[0] - grid_zoom_anchor.x) * grid_zoom_delta, grid_zoom_anchor.x + (domain(\"x\")[1] - grid_zoom_anchor.x) * grid_zoom_delta]"
-                        }
-                    ],
-                    "push": "outer"
-                },
-                {
-                    "name": "grid_y",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "grid_translate_delta"
-                            },
-                            "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
-                        },
-                        {
-                            "events": {
-                                "signal": "grid_zoom_delta"
-                            },
-                            "update": "[grid_zoom_anchor.y + (domain(\"y\")[0] - grid_zoom_anchor.y) * grid_zoom_delta, grid_zoom_anchor.y + (domain(\"y\")[1] - grid_zoom_anchor.y) * grid_zoom_delta]"
-                        }
-                    ],
-                    "push": "outer"
-                },
-                {
-                    "name": "grid",
-                    "update": "[{field: \"Horsepower\", extent: grid_x}, {field: \"Miles_per_Gallon\", extent: grid_y}]"
-                },
-                {
-                    "name": "grid_translate_anchor",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "source": "scope",
-                                    "type": "mousedown"
-                                }
-                            ],
-                            "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
-                        }
-                    ]
-                },
-                {
-                    "name": "grid_translate_delta",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "source": "window",
-                                    "type": "mousemove",
-                                    "consume": true,
-                                    "between": [
-                                        {
-                                            "source": "scope",
-                                            "type": "mousedown"
-                                        },
-                                        {
-                                            "source": "window",
-                                            "type": "mouseup"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "update": "{x: x(unit) - grid_translate_anchor.x, y: y(unit) - grid_translate_anchor.y}"
-                        }
-                    ]
-                },
-                {
-                    "name": "grid_zoom_anchor",
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "source": "scope",
-                                    "type": "wheel"
-                                }
-                            ],
-                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
-                        }
-                    ]
-                },
-                {
-                    "name": "grid_zoom_delta",
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "source": "scope",
-                                    "type": "wheel"
-                                }
-                            ],
-                            "force": true,
-                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-                        }
-                    ]
-                },
-                {
-                    "name": "grid_tuple",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "grid"
-                            },
-                            "update": "{unit: unit.datum && unit.datum._id, intervals: grid}"
-                        }
-                    ]
-                },
-                {
-                    "name": "grid_modify",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "grid"
-                            },
-                            "update": "modify(\"grid_store\", grid_tuple, true)"
-                        }
-                    ]
-                }
-            ],
             "marks": [
                 {
-                    "type": "group",
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "circle",
+                    "from": {
+                        "data": "source_0"
+                    },
                     "encode": {
-                        "enter": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
                             },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
                             },
                             "fill": {
-                                "value": "transparent"
+                                "value": "#4c78a8"
                             },
-                            "clip": {
-                                "value": true
-                            }
-                        }
-                    },
-                    "marks": [
-                        {
-                            "name": "marks",
-                            "type": "symbol",
-                            "role": "circle",
-                            "from": {
-                                "data": "source_0"
+                            "size": {
+                                "scale": "size",
+                                "field": "Cylinders"
                             },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "Horsepower"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "Miles_per_Gallon"
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    },
-                                    "size": {
-                                        "scale": "size",
-                                        "field": "Cylinders"
-                                    },
-                                    "shape": {
-                                        "value": "circle"
-                                    },
-                                    "opacity": {
-                                        "value": 0.7
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": [
-                        75,
-                        150
-                    ],
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false,
-                    "domainRaw": {
-                        "signal": "grid_x"
-                    }
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": [
-                        20,
-                        40
-                    ],
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false,
-                    "domainRaw": {
-                        "signal": "grid_y"
-                    }
-                },
-                {
-                    "name": "size",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Cylinders"
-                    },
-                    "range": [
-                        0,
-                        361
-                    ],
-                    "nice": false,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "size": "size",
-                    "format": "s",
-                    "title": "Cylinders",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "circle"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                },
-                                "fill": {
-                                    "value": "#4c78a8"
-                                }
+                            "shape": {
+                                "value": "circle"
+                            },
+                            "opacity": {
+                                "value": 0.7
                             }
                         }
                     }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": [
+                75,
+                150
+            ],
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": false,
+            "domainRaw": {
+                "signal": "grid_x"
+            }
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": [
+                20,
+                40
+            ],
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": false,
+            "domainRaw": {
+                "signal": "grid_y"
+            }
+        },
+        {
+            "name": "size",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Cylinders"
+            },
+            "range": [
+                0,
+                361
+            ],
+            "nice": false,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "size": "size",
+            "format": "s",
+            "title": "Cylinders",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "circle"
+                        },
+                        "strokeWidth": {
+                            "value": 0
+                        },
+                        "fill": {
+                            "value": "#4c78a8"
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/point_1d.vg.json
+++ b/examples/vg-specs/point_1d.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -38,114 +18,94 @@
                     "expr": "datum[\"IMDB_Rating\"] !== null && !isNaN(datum[\"IMDB_Rating\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "IMDB_Rating"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "value": 10.5
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "IMDB_Rating"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "IMDB_Rating"
-                            },
-                            "y": {
-                                "value": 10.5
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
+            "range": [
+                0,
+                200
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "IMDB_Rating"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "IMDB_Rating",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "IMDB_Rating",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0
         }
     ]
 }

--- a/examples/vg-specs/point_1d_array.vg.json
+++ b/examples/vg-specs/point_1d_array.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -67,123 +47,96 @@
                 "type": "json",
                 "parse": {}
             }
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "a"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_a\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "a"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "value": 10.5
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "a",
+                "sort": true
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "a"
-                            },
-                            "y": {
-                                "value": 10.5
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "a",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
                 }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "a",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "a",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/point_1d_bin.vg.json
+++ b/examples/vg-specs/point_1d_bin.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -56,114 +36,94 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "signal": "(scale(\"x\", datum[\"bin_maxbins_10_IMDB_Rating_start\"]) + scale(\"x\", datum[\"bin_maxbins_10_IMDB_Rating_end\"]))/2"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "value": 10.5
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "bin-linear",
+            "domain": {
+                "signal": "sequence(bin_maxbins_10_IMDB_Rating_bins.start, bin_maxbins_10_IMDB_Rating_bins.stop + bin_maxbins_10_IMDB_Rating_bins.step, bin_maxbins_10_IMDB_Rating_bins.step)"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "signal": "(scale(\"x\", datum[\"bin_maxbins_10_IMDB_Rating_start\"]) + scale(\"x\", datum[\"bin_maxbins_10_IMDB_Rating_end\"]))/2"
-                            },
-                            "y": {
-                                "value": 10.5
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "title": "BIN(IMDB_Rating)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
                 }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(bin_maxbins_10_IMDB_Rating_bins.start, bin_maxbins_10_IMDB_Rating_bins.stop + bin_maxbins_10_IMDB_Rating_bins.step, bin_maxbins_10_IMDB_Rating_bins.step)"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "title": "BIN(IMDB_Rating)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/point_2d_aggregate.vg.json
+++ b/examples/vg-specs/point_2d_aggregate.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -87,154 +67,127 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "a"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_a\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "a"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "average_b"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "fill": {
                         "value": "transparent"
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "a",
+                "sort": true
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "a"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "average_b"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            }
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "average_b"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "a",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
                 }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "a",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "average_b"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "a",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "AVERAGE(b)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "AVERAGE(b)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/point_2d_array.vg.json
+++ b/examples/vg-specs/point_2d_array.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -75,157 +55,130 @@
                     "expr": "datum[\"b\"] !== null && !isNaN(datum[\"b\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "a"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_a\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "a"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "b"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "a",
+                "sort": true
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "a"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "b"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "b"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "a",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
                 }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "a",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "b"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "a",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "b",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ]
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "b",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/point_color.vg.json
+++ b/examples/vg-specs/point_color.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -34,75 +14,55 @@
                 "type": "json",
                 "parse": {}
             }
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "21"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "value": 10.5
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "value": 10.5
+                    },
+                    "stroke": {
+                        "value": "purple"
                     },
                     "fill": {
                         "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "value": 10.5
-                            },
-                            "y": {
-                                "value": 10.5
-                            },
-                            "stroke": {
-                                "value": "purple"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/point_dot_timeunit_color.vg.json
+++ b/examples/vg-specs/point_dot_timeunit_color.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -56,138 +36,118 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "mean_temp"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "value": 10.5
+                    },
+                    "stroke": {
+                        "scale": "color",
+                        "field": "yearmonth_date"
                     },
                     "fill": {
                         "value": "transparent"
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "mean_temp"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "mean_temp"
-                            },
-                            "y": {
-                                "value": 10.5
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "yearmonth_date"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            }
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "sequential",
+            "domain": {
+                "data": "source_0",
+                "field": "yearmonth_date"
+            },
+            "range": "ramp",
+            "nice": false,
+            "zero": false
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "MEAN(temp)",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "title": "YEARMONTH(date)",
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b %Y')"
                         }
                     }
                 }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "mean_temp"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "sequential",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "yearmonth_date"
-                    },
-                    "range": "ramp",
-                    "nice": false,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "MEAN(temp)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "title": "YEARMONTH(date)",
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b %Y')"
-                                }
-                            }
-                        }
-                    }
-                }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/point_filled.vg.json
+++ b/examples/vg-specs/point_filled.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -39,146 +19,126 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "Horsepower"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "Miles_per_Gallon"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "fill": {
+                        "value": "#4c78a8"
+                    },
+                    "opacity": {
+                        "value": 0.7
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/point_ordinal_color.vg.json
+++ b/examples/vg-specs/point_ordinal_color.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -70,166 +50,146 @@
                     "expr": "datum[\"x\"] !== null && !isNaN(datum[\"x\"]) && datum[\"y\"] !== null && !isNaN(datum[\"y\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "x"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "y"
+                    },
+                    "stroke": {
+                        "scale": "color",
+                        "field": "a"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "x"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "x"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "y"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "a"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
+            "range": [
+                0,
+                200
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "x"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "y"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "a",
-                        "sort": true
-                    },
-                    "range": "ordinal"
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "y"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "x",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "y",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "title": "a"
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "a",
+                "sort": true
+            },
+            "range": "ordinal"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "x",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "y",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "title": "a"
         }
     ]
 }

--- a/examples/vg-specs/point_overlap.vg.json
+++ b/examples/vg-specs/point_overlap.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -67,75 +47,55 @@
                 "type": "json",
                 "parse": {}
             }
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "21"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "value": 10.5
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "value": 10.5
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "fill": {
                         "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "value": 10.5
-                            },
-                            "y": {
-                                "value": 10.5
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/query_widgets.vg.json
+++ b/examples/vg-specs/query_widgets.vg.json
@@ -142,7 +142,7 @@
                     },
                     "fill": [
                         {
-                            "test": "!vlPoint(\"CylYr_store\", parent._id, datum, \"union\", \"all\")",
+                            "test": "!vlPoint(\"CylYr_store\", datum._id, datum, \"union\", \"all\")",
                             "value": "grey"
                         },
                         {

--- a/examples/vg-specs/query_widgets.vg.json
+++ b/examples/vg-specs/query_widgets.vg.json
@@ -3,14 +3,41 @@
     "description": "Drag the sliders to highlight points.",
     "autosize": "pad",
     "padding": 5,
+    "data": [
+        {
+            "name": "source_0",
+            "url": "data/cars.json",
+            "format": {
+                "type": "json",
+                "parse": {
+                    "Horsepower": "number",
+                    "Miles_per_Gallon": "number"
+                }
+            },
+            "transform": [
+                {
+                    "type": "formula",
+                    "expr": "year(datum.Year)",
+                    "as": "Year"
+                },
+                {
+                    "type": "filter",
+                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
+                }
+            ]
+        },
+        {
+            "name": "CylYr_store"
+        }
+    ],
     "signals": [
         {
             "name": "width",
-            "update": "data('layout')[0].width"
+            "update": "200"
         },
         {
             "name": "height",
-            "update": "data('layout')[0].height"
+            "update": "200"
         },
         {
             "name": "CylYr_Year",
@@ -67,240 +94,170 @@
         {
             "name": "CylYr",
             "update": "data(\"CylYr_store\")[0]"
-        }
-    ],
-    "data": [
+        },
         {
-            "name": "source_0",
-            "url": "data/cars.json",
-            "format": {
-                "type": "json",
-                "parse": {
-                    "Horsepower": "number",
-                    "Miles_per_Gallon": "number"
-                }
-            },
-            "transform": [
+            "name": "CylYr",
+            "update": "{fields: [\"Cylinders\", \"Year\"], values: [CylYr_Cylinders, CylYr_Year]}"
+        },
+        {
+            "name": "CylYr_tuple",
+            "on": [
                 {
-                    "type": "formula",
-                    "expr": "year(datum.Year)",
-                    "as": "Year"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
+                    "events": {
+                        "signal": "CylYr"
+                    },
+                    "update": "{unit: unit.datum && unit.datum._id, fields: CylYr.fields, values: CylYr.values, Cylinders: CylYr.values[0], Year: CylYr.values[1]}"
                 }
             ]
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "CylYr_modify",
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": {
+                        "signal": "CylYr"
+                    },
+                    "update": "modify(\"CylYr_store\", CylYr_tuple, true)"
                 }
             ]
-        },
-        {
-            "name": "CylYr_store"
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "Drag the sliders to highlight points.",
+            "name": "marks",
+            "type": "symbol",
+            "role": "circle",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "signals": [
-                {
-                    "name": "CylYr",
-                    "update": "{fields: [\"Cylinders\", \"Year\"], values: [CylYr_Cylinders, CylYr_Year]}"
-                },
-                {
-                    "name": "CylYr_tuple",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "CylYr"
-                            },
-                            "update": "{unit: unit.datum && unit.datum._id, fields: CylYr.fields, values: CylYr.values, Cylinders: CylYr.values[0], Year: CylYr.values[1]}"
-                        }
-                    ]
-                },
-                {
-                    "name": "CylYr_modify",
-                    "on": [
-                        {
-                            "events": {
-                                "signal": "CylYr"
-                            },
-                            "update": "modify(\"CylYr_store\", CylYr_tuple, true)"
-                        }
-                    ]
-                }
-            ],
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "circle",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "fill": [
-                                {
-                                    "test": "!vlPoint(\"CylYr_store\", parent._id, datum, \"union\", \"all\")",
-                                    "value": "grey"
-                                },
-                                {
-                                    "scale": "color",
-                                    "field": "Origin"
-                                }
-                            ],
-                            "shape": {
-                                "value": "circle"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "Horsepower"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "Miles_per_Gallon"
                     },
-                    "range": [
-                        200,
-                        0
+                    "fill": [
+                        {
+                            "test": "!vlPoint(\"CylYr_store\", parent._id, datum, \"union\", \"all\")",
+                            "value": "grey"
+                        },
+                        {
+                            "scale": "color",
+                            "field": "Origin"
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Origin",
-                        "sort": true
+                    "shape": {
+                        "value": "circle"
                     },
-                    "range": "category"
+                    "opacity": {
+                        "value": 0.7
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
             ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "Origin",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "circle"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "Origin",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "circle"
+                        },
+                        "strokeWidth": {
+                            "value": 0
                         }
                     }
                 }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/rect_heatmap.vg.json
+++ b/examples/vg-specs/rect_heatmap.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -51,178 +31,149 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 0.1, 0.05) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "bandspace(domain('y').length, 0.1, 0.05) * 21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "Cylinders",
-                        "Origin"
-                    ],
-                    "ops": [
-                        "distinct",
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_Cylinders\"] - 0.1 + 2*0.05, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "max(datum[\"distinct_Origin\"] - 0.1 + 2*0.05, 0) * 21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
+                    "x": {
+                        "scale": "x",
+                        "field": "Cylinders"
+                    },
                     "width": {
-                        "field": "width"
+                        "scale": "x",
+                        "band": true
+                    },
+                    "y": {
+                        "scale": "y",
+                        "field": "Origin"
                     },
                     "height": {
-                        "field": "height"
+                        "scale": "y",
+                        "band": true
                     },
                     "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Cylinders"
-                            },
-                            "width": {
-                                "scale": "x",
-                                "band": true
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Origin"
-                            },
-                            "height": {
-                                "scale": "y",
-                                "band": true
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "mean_Horsepower"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Cylinders",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "paddingInner": 0.1,
-                    "paddingOuter": 0.05
-                },
-                {
-                    "name": "y",
-                    "type": "band",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Origin",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "paddingInner": 0.1,
-                    "paddingOuter": 0.05
-                },
-                {
-                    "name": "color",
-                    "type": "sequential",
-                    "domain": {
-                        "data": "source_0",
+                        "scale": "color",
                         "field": "mean_Horsepower"
-                    },
-                    "range": "heatmap",
-                    "nice": false,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Cylinders",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "y",
-                    "orient": "left",
-                    "title": "Origin",
-                    "zindex": 1
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "format": "s",
-                    "title": "MEAN(Horsepower)",
-                    "type": "gradient",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "strokeWidth": {
-                                    "value": 0
-                                }
-                            }
-                        }
                     }
                 }
-            ]
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "band",
+            "domain": {
+                "data": "source_0",
+                "field": "Cylinders",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "paddingInner": 0.1,
+            "paddingOuter": 0.05
+        },
+        {
+            "name": "y",
+            "type": "band",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "paddingInner": 0.1,
+            "paddingOuter": 0.05
+        },
+        {
+            "name": "color",
+            "type": "sequential",
+            "domain": {
+                "data": "source_0",
+                "field": "mean_Horsepower"
+            },
+            "range": "heatmap",
+            "nice": false,
+            "zero": false
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Cylinders",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "y",
+            "orient": "left",
+            "title": "Origin",
+            "zindex": 1
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "format": "s",
+            "title": "MEAN(Horsepower)",
+            "type": "gradient",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "strokeWidth": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/scatter.vg.json
+++ b/examples/vg-specs/scatter.vg.json
@@ -3,26 +3,6 @@
     "description": "A scatterplot showing horsepower and miles per gallons for various cars.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -40,150 +20,129 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A scatterplot showing horsepower and miles per gallons for various cars.",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
+            "range": [
+                0,
+                200
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/scatter_aggregate_detail.vg.json
+++ b/examples/vg-specs/scatter_aggregate_detail.vg.json
@@ -3,26 +3,6 @@
     "description": "A scatterplot showing average horsepower and displacement for cars from different origins.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -54,147 +34,126 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A scatterplot showing average horsepower and displacement for cars from different origins.",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "mean_Horsepower"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "mean_Displacement"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "fill": {
                         "value": "transparent"
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "mean_Horsepower"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "mean_Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "mean_Displacement"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            }
-                        }
-                    }
-                }
+            "range": [
+                0,
+                200
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "mean_Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "mean_Displacement"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "mean_Displacement"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "MEAN(Horsepower)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "MEAN(Displacement)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "MEAN(Horsepower)",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "MEAN(Displacement)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/scatter_binned.vg.json
+++ b/examples/vg-specs/scatter_binned.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -90,171 +70,151 @@
                     ]
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "circle",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "signal": "(scale(\"x\", datum[\"bin_maxbins_10_IMDB_Rating_start\"]) + scale(\"x\", datum[\"bin_maxbins_10_IMDB_Rating_end\"]))/2"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "signal": "(scale(\"y\", datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_start\"]) + scale(\"y\", datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_end\"]))/2"
                     },
                     "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "circle",
-                    "from": {
-                        "data": "source_0"
+                        "value": "#4c78a8"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "signal": "(scale(\"x\", datum[\"bin_maxbins_10_IMDB_Rating_start\"]) + scale(\"x\", datum[\"bin_maxbins_10_IMDB_Rating_end\"]))/2"
-                            },
-                            "y": {
-                                "signal": "(scale(\"y\", datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_start\"]) + scale(\"y\", datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_end\"]))/2"
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "size": {
-                                "scale": "size",
-                                "field": "count_*"
-                            },
-                            "shape": {
-                                "value": "circle"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(bin_maxbins_10_IMDB_Rating_bins.start, bin_maxbins_10_IMDB_Rating_bins.stop + bin_maxbins_10_IMDB_Rating_bins.step, bin_maxbins_10_IMDB_Rating_bins.step)"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true
-                },
-                {
-                    "name": "y",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(bin_maxbins_10_Rotten_Tomatoes_Rating_bins.start, bin_maxbins_10_Rotten_Tomatoes_Rating_bins.stop + bin_maxbins_10_Rotten_Tomatoes_Rating_bins.step, bin_maxbins_10_Rotten_Tomatoes_Rating_bins.step)"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true
-                },
-                {
-                    "name": "size",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "size": {
+                        "scale": "size",
                         "field": "count_*"
                     },
-                    "range": [
-                        0,
-                        361
-                    ],
-                    "nice": false,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "title": "BIN(IMDB_Rating)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "BIN(Rotten_Tomatoes_Rating)",
-                    "zindex": 1
-                }
-            ],
-            "legends": [
-                {
-                    "size": "size",
-                    "format": "s",
-                    "title": "Number of Records",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "circle"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                },
-                                "fill": {
-                                    "value": "#4c78a8"
-                                }
-                            }
-                        }
+                    "shape": {
+                        "value": "circle"
                     }
                 }
-            ]
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "bin-linear",
+            "domain": {
+                "signal": "sequence(bin_maxbins_10_IMDB_Rating_bins.start, bin_maxbins_10_IMDB_Rating_bins.stop + bin_maxbins_10_IMDB_Rating_bins.step, bin_maxbins_10_IMDB_Rating_bins.step)"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true
+        },
+        {
+            "name": "y",
+            "type": "bin-linear",
+            "domain": {
+                "signal": "sequence(bin_maxbins_10_Rotten_Tomatoes_Rating_bins.start, bin_maxbins_10_Rotten_Tomatoes_Rating_bins.stop + bin_maxbins_10_Rotten_Tomatoes_Rating_bins.step, bin_maxbins_10_Rotten_Tomatoes_Rating_bins.step)"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true
+        },
+        {
+            "name": "size",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "count_*"
+            },
+            "range": [
+                0,
+                361
+            ],
+            "nice": false,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "title": "BIN(IMDB_Rating)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "BIN(Rotten_Tomatoes_Rating)",
+            "zindex": 1
+        }
+    ],
+    "legends": [
+        {
+            "size": "size",
+            "format": "s",
+            "title": "Number of Records",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "circle"
+                        },
+                        "strokeWidth": {
+                            "value": 0
+                        },
+                        "fill": {
+                            "value": "#4c78a8"
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/scatter_binned_color.vg.json
+++ b/examples/vg-specs/scatter_binned_color.vg.json
@@ -3,26 +3,6 @@
     "description": "A scatterplot showing horsepower and miles per gallons with binned acceleration on color.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -64,167 +44,146 @@
                     "as": "bin_maxbins_5_Acceleration_range"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A scatterplot showing horsepower and miles per gallons with binned acceleration on color.",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "stroke": {
+                        "scale": "color",
+                        "field": "bin_maxbins_5_Acceleration_start"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "bin_maxbins_5_Acceleration_start"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
+            "range": [
+                0,
+                200
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "bin-ordinal",
-                    "domain": {
-                        "signal": "sequence(bin_maxbins_5_Acceleration_bins.start, bin_maxbins_5_Acceleration_bins.stop + bin_maxbins_5_Acceleration_bins.step, bin_maxbins_5_Acceleration_bins.step)"
-                    },
-                    "range": "ramp",
-                    "zero": false
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "format": "s",
-                    "title": "BIN(Acceleration)"
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "bin-ordinal",
+            "domain": {
+                "signal": "sequence(bin_maxbins_5_Acceleration_bins.start, bin_maxbins_5_Acceleration_bins.stop + bin_maxbins_5_Acceleration_bins.step, bin_maxbins_5_Acceleration_bins.step)"
+            },
+            "range": "ramp",
+            "zero": false
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "format": "s",
+            "title": "BIN(Acceleration)"
         }
     ]
 }

--- a/examples/vg-specs/scatter_binned_opacity.vg.json
+++ b/examples/vg-specs/scatter_binned_opacity.vg.json
@@ -3,26 +3,6 @@
     "description": "A scatterplot showing horsepower and miles per gallons with binned acceleration on opacity.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -59,179 +39,158 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A scatterplot showing horsepower and miles per gallons with binned acceleration on opacity.",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "opacity": {
+                        "scale": "opacity",
+                        "field": "bin_maxbins_10_Acceleration_start"
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "scale": "opacity",
-                                "field": "bin_maxbins_10_Acceleration_start"
-                            }
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "opacity",
+            "type": "bin-linear",
+            "domain": {
+                "signal": "sequence(bin_maxbins_10_Acceleration_bins.start, bin_maxbins_10_Acceleration_bins.stop + bin_maxbins_10_Acceleration_bins.step, bin_maxbins_10_Acceleration_bins.step)"
+            },
+            "range": [
+                0.3,
+                0.8
+            ],
+            "nice": false
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "opacity": "opacity",
+            "format": "s",
+            "title": "BIN(Acceleration)",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "stroke": {
+                            "value": "#4c78a8"
                         }
                     }
                 }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "opacity",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(bin_maxbins_10_Acceleration_bins.start, bin_maxbins_10_Acceleration_bins.stop + bin_maxbins_10_Acceleration_bins.step, bin_maxbins_10_Acceleration_bins.step)"
-                    },
-                    "range": [
-                        0.3,
-                        0.8
-                    ],
-                    "nice": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "opacity": "opacity",
-                    "format": "s",
-                    "title": "BIN(Acceleration)",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "stroke": {
-                                    "value": "#4c78a8"
-                                }
-                            }
-                        }
-                    }
-                }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/scatter_binned_size.vg.json
+++ b/examples/vg-specs/scatter_binned_size.vg.json
@@ -3,26 +3,6 @@
     "description": "A scatterplot showing horsepower and miles per gallons with binned acceleration on size.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -59,182 +39,161 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A scatterplot showing horsepower and miles per gallons with binned acceleration on size.",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "size": {
+                        "scale": "size",
+                        "field": "bin_maxbins_6_Acceleration_start"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "size": {
-                                "scale": "size",
-                                "field": "bin_maxbins_6_Acceleration_start"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "size",
+            "type": "bin-linear",
+            "domain": {
+                "signal": "sequence(bin_maxbins_6_Acceleration_bins.start, bin_maxbins_6_Acceleration_bins.stop + bin_maxbins_6_Acceleration_bins.step, bin_maxbins_6_Acceleration_bins.step)"
+            },
+            "range": [
+                9,
+                361
+            ],
+            "nice": false
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "size": "size",
+            "format": "s",
+            "title": "BIN(Acceleration)",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "stroke": {
+                            "value": "#4c78a8"
                         }
                     }
                 }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "size",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(bin_maxbins_6_Acceleration_bins.start, bin_maxbins_6_Acceleration_bins.stop + bin_maxbins_6_Acceleration_bins.step, bin_maxbins_6_Acceleration_bins.step)"
-                    },
-                    "range": [
-                        9,
-                        361
-                    ],
-                    "nice": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "size": "size",
-                    "format": "s",
-                    "title": "BIN(Acceleration)",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "stroke": {
-                                    "value": "#4c78a8"
-                                }
-                            }
-                        }
-                    }
-                }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/scatter_bubble.vg.json
+++ b/examples/vg-specs/scatter_bubble.vg.json
@@ -3,26 +3,6 @@
     "description": "A bubbleplot showing horsepower on x, miles per gallons on y, and binned acceleration on size.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -41,184 +21,163 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"]) && datum[\"Acceleration\"] !== null && !isNaN(datum[\"Acceleration\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A bubbleplot showing horsepower on x, miles per gallons on y, and binned acceleration on size.",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "fill": {
                         "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "size": {
-                                "scale": "size",
-                                "field": "Acceleration"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "size",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "size": {
+                        "scale": "size",
                         "field": "Acceleration"
                     },
-                    "range": [
-                        0,
-                        361
-                    ],
-                    "nice": false,
-                    "zero": true
+                    "opacity": {
+                        "value": 0.7
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
             ],
-            "legends": [
-                {
-                    "size": "size",
-                    "format": "s",
-                    "title": "Acceleration",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "stroke": {
-                                    "value": "#4c78a8"
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "size",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Acceleration"
+            },
+            "range": [
+                0,
+                361
+            ],
+            "nice": false,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "size": "size",
+            "format": "s",
+            "title": "Acceleration",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "stroke": {
+                            "value": "#4c78a8"
                         }
                     }
                 }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/scatter_color.vg.json
+++ b/examples/vg-specs/scatter_color.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -39,166 +19,146 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "stroke": {
+                        "scale": "color",
+                        "field": "Origin"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
+            "range": [
+                0,
+                200
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Origin",
-                        "sort": true
-                    },
-                    "range": "category"
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "title": "Origin"
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "title": "Origin"
         }
     ]
 }

--- a/examples/vg-specs/scatter_color_custom.vg.json
+++ b/examples/vg-specs/scatter_color_custom.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -39,170 +19,150 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "stroke": {
+                        "scale": "color",
+                        "field": "Origin"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
+            "range": [
+                0,
+                200
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Origin",
-                        "sort": true
-                    },
-                    "range": [
-                        "purple",
-                        "#ff0000",
-                        "teal"
-                    ]
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "title": "Origin"
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": [
+                "purple",
+                "#ff0000",
+                "teal"
             ]
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "title": "Origin"
         }
     ]
 }

--- a/examples/vg-specs/scatter_color_ordinal.vg.json
+++ b/examples/vg-specs/scatter_color_ordinal.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -39,166 +19,146 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "stroke": {
+                        "scale": "color",
+                        "field": "Cylinders"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "Cylinders"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
+            "range": [
+                0,
+                200
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Cylinders",
-                        "sort": true
-                    },
-                    "range": "ordinal"
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "title": "Cylinders"
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Cylinders",
+                "sort": true
+            },
+            "range": "ordinal"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "title": "Cylinders"
         }
     ]
 }

--- a/examples/vg-specs/scatter_color_ordinal_custom.vg.json
+++ b/examples/vg-specs/scatter_color_ordinal_custom.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -39,169 +19,149 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "stroke": {
+                        "scale": "color",
+                        "field": "Cylinders"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "Cylinders"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
+            "range": [
+                0,
+                200
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Cylinders",
-                        "sort": true
-                    },
-                    "range": [
-                        "pink",
-                        "red"
-                    ]
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "title": "Cylinders"
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Cylinders",
+                "sort": true
+            },
+            "range": [
+                "pink",
+                "red"
             ]
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "title": "Cylinders"
         }
     ]
 }

--- a/examples/vg-specs/scatter_color_quantitative.vg.json
+++ b/examples/vg-specs/scatter_color_quantitative.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -40,169 +20,149 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"]) && datum[\"Displacement\"] !== null && !isNaN(datum[\"Displacement\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "stroke": {
+                        "scale": "color",
+                        "field": "Displacement"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "Displacement"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
+            "range": [
+                0,
+                200
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "sequential",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Displacement"
-                    },
-                    "range": "ramp",
-                    "nice": false,
-                    "zero": false
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "format": "s",
-                    "title": "Displacement",
-                    "type": "gradient"
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "sequential",
+            "domain": {
+                "data": "source_0",
+                "field": "Displacement"
+            },
+            "range": "ramp",
+            "nice": false,
+            "zero": false
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "format": "s",
+            "title": "Displacement",
+            "type": "gradient"
         }
     ]
 }

--- a/examples/vg-specs/scatter_color_shape_constant.vg.json
+++ b/examples/vg-specs/scatter_color_shape_constant.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -39,152 +19,132 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "stroke": {
+                        "value": "#ff9900"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "shape": {
+                        "value": "square"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": {
-                                "value": "#ff9900"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "shape": {
-                                "value": "square"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
+            "range": [
+                0,
+                200
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/scatter_colored_with_shape.vg.json
+++ b/examples/vg-specs/scatter_colored_with_shape.vg.json
@@ -3,26 +3,6 @@
     "description": "A scatterplot showing horsepower and miles per gallons.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -40,194 +20,173 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A scatterplot showing horsepower and miles per gallons.",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "stroke": {
+                        "scale": "color",
+                        "field": "Origin"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "shape": {
+                        "scale": "shape",
+                        "field": "Origin"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "shape": {
-                                "scale": "shape",
-                                "field": "Origin"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "shape",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": "symbol"
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "title": "Origin"
+        },
+        {
+            "shape": "shape",
+            "title": "Origin",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "stroke": {
+                            "value": "#4c78a8"
                         }
                     }
                 }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "shape",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Origin",
-                        "sort": true
-                    },
-                    "range": "symbol"
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Origin",
-                        "sort": true
-                    },
-                    "range": "category"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "title": "Origin"
-                },
-                {
-                    "shape": "shape",
-                    "title": "Origin",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "stroke": {
-                                    "value": "#4c78a8"
-                                }
-                            }
-                        }
-                    }
-                }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/scatter_connected.vg.json
+++ b/examples/vg-specs/scatter_connected.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -90,211 +70,203 @@
                     "expr": "datum[\"miles\"] !== null && !isNaN(datum[\"miles\"]) && datum[\"gas\"] !== null && !isNaN(datum[\"gas\"]) && datum[\"year\"] !== null && !isNaN(datum[\"year\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "max(layer_0_width, layer_1_width)"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "max(layer_0_height, layer_1_height)"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
+        },
+        {
+            "name": "layer_1_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_height",
+            "update": "200"
         }
     ],
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "from": {
-                "data": "layout"
-            },
             "encode": {
-                "update": {
+                "enter": {
                     "width": {
-                        "field": "width"
+                        "signal": "width"
                     },
                     "height": {
-                        "field": "height"
+                        "signal": "height"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "clip": {
+                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "type": "group",
+                    "name": "layer_0_marks",
+                    "type": "line",
+                    "from": {
+                        "data": "data_0"
+                    },
                     "encode": {
-                        "enter": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "miles"
                             },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
+                            "y": {
+                                "scale": "y",
+                                "field": "gas"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "layer_1_marks",
+                    "type": "symbol",
+                    "role": "pointOverlay",
+                    "from": {
+                        "data": "data_1"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "miles"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "gas"
                             },
                             "fill": {
-                                "value": "transparent"
+                                "value": "#4c78a8"
                             },
-                            "clip": {
-                                "value": true
+                            "opacity": {
+                                "value": 0.7
                             }
                         }
-                    },
-                    "marks": [
-                        {
-                            "name": "layer_0_marks",
-                            "type": "line",
-                            "from": {
-                                "data": "data_0"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "miles"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "gas"
-                                    },
-                                    "stroke": {
-                                        "value": "#4c78a8"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_1_marks",
-                            "type": "symbol",
-                            "role": "pointOverlay",
-                            "from": {
-                                "data": "data_1"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "miles"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "gas"
-                                    },
-                                    "fill": {
-                                        "value": "#4c78a8"
-                                    },
-                                    "opacity": {
-                                        "value": 0.7
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "fields": [
-                            {
-                                "data": "data_0",
-                                "field": "miles"
-                            },
-                            {
-                                "data": "data_1",
-                                "field": "miles"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "fields": [
-                            {
-                                "data": "data_0",
-                                "field": "gas"
-                            },
-                            {
-                                "data": "data_1",
-                                "field": "gas"
-                            }
-                        ],
-                        "sort": true
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "miles",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "gas",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
+                    }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "miles"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "miles"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": false
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "gas"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "gas"
+                    }
+                ],
+                "sort": true
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": false
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "miles",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "gas",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/scatter_log.vg.json
+++ b/examples/vg-specs/scatter_log.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -76,148 +56,128 @@
                     "expr": "datum[\"y\"] > 0"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "x"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "y"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "x"
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "x"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "y"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
+            "range": [
+                0,
+                200
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "x"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "log",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "y"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "log",
+            "domain": {
+                "data": "source_0",
+                "field": "y"
+            },
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "x",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "y",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ]
+            "round": true,
+            "nice": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "x",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "y",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/scatter_opacity.vg.json
+++ b/examples/vg-specs/scatter_opacity.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -39,186 +19,166 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "circle",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "circle",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "shape": {
-                                "value": "circle"
-                            },
-                            "opacity": {
-                                "scale": "opacity",
-                                "field": "Miles_per_Gallon"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "Horsepower"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "Miles_per_Gallon"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "opacity",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
+                    "fill": {
+                        "value": "#4c78a8"
                     },
-                    "range": [
-                        0.3,
-                        0.8
-                    ],
-                    "nice": false,
-                    "zero": false
+                    "shape": {
+                        "value": "circle"
+                    },
+                    "opacity": {
+                        "scale": "opacity",
+                        "field": "Miles_per_Gallon"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
             ],
-            "legends": [
-                {
-                    "opacity": "opacity",
-                    "format": "s",
-                    "title": "Miles_per_Gallon",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "circle"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                },
-                                "fill": {
-                                    "value": "#4c78a8"
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "opacity",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                0.3,
+                0.8
+            ],
+            "nice": false,
+            "zero": false
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "opacity": "opacity",
+            "format": "s",
+            "title": "Miles_per_Gallon",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "circle"
+                        },
+                        "strokeWidth": {
+                            "value": 0
+                        },
+                        "fill": {
+                            "value": "#4c78a8"
                         }
                     }
                 }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/scatter_shape_custom.vg.json
+++ b/examples/vg-specs/scatter_shape_custom.vg.json
@@ -3,26 +3,6 @@
     "description": "A scatterplot with custom star shapes.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -41,214 +21,193 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"]) && datum[\"Weight_in_lbs\"] !== null && !isNaN(datum[\"Weight_in_lbs\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A scatterplot with custom star shapes.",
+            "name": "marks",
+            "type": "symbol",
+            "role": "point",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
                     },
-                    "height": {
-                        "field": "height"
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "stroke": {
+                        "scale": "color",
+                        "field": "Cylinders"
                     },
                     "fill": {
                         "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "source_0"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "Cylinders"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "size": {
-                                "scale": "size",
-                                "field": "Weight_in_lbs"
-                            },
-                            "shape": {
-                                "value": "M0,0.2L0.2351,0.3236 0.1902,0.0618 0.3804,-0.1236 0.1175,-0.1618 0,-0.4 -0.1175,-0.1618 -0.3804,-0.1236 -0.1902,0.0618 -0.2351,0.3236 0,0.2Z"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "size",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "size": {
+                        "scale": "size",
                         "field": "Weight_in_lbs"
                     },
-                    "range": [
-                        0,
-                        361
-                    ],
-                    "nice": false,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Cylinders",
-                        "sort": true
+                    "shape": {
+                        "value": "M0,0.2L0.2351,0.3236 0.1902,0.0618 0.3804,-0.1236 0.1175,-0.1618 0,-0.4 -0.1175,-0.1618 -0.3804,-0.1236 -0.1902,0.0618 -0.2351,0.3236 0,0.2Z"
                     },
-                    "range": "category"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "title": "Cylinders",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "M0,0.2L0.2351,0.3236 0.1902,0.0618 0.3804,-0.1236 0.1175,-0.1618 0,-0.4 -0.1175,-0.1618 -0.3804,-0.1236 -0.1902,0.0618 -0.2351,0.3236 0,0.2Z"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "size": "size",
-                    "format": "s",
-                    "title": "Weight_in_lbs",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "stroke": {
-                                    "value": "#4c78a8"
-                                },
-                                "shape": {
-                                    "value": "M0,0.2L0.2351,0.3236 0.1902,0.0618 0.3804,-0.1236 0.1175,-0.1618 0,-0.4 -0.1175,-0.1618 -0.3804,-0.1236 -0.1902,0.0618 -0.2351,0.3236 0,0.2Z"
-                                }
-                            }
-                        }
+                    "opacity": {
+                        "value": 0.7
                     }
                 }
-            ]
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "size",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Weight_in_lbs"
+            },
+            "range": [
+                0,
+                361
+            ],
+            "nice": false,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Cylinders",
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "title": "Cylinders",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "M0,0.2L0.2351,0.3236 0.1902,0.0618 0.3804,-0.1236 0.1175,-0.1618 0,-0.4 -0.1175,-0.1618 -0.3804,-0.1236 -0.1902,0.0618 -0.2351,0.3236 0,0.2Z"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "size": "size",
+            "format": "s",
+            "title": "Weight_in_lbs",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "stroke": {
+                            "value": "#4c78a8"
+                        },
+                        "shape": {
+                            "value": "M0,0.2L0.2351,0.3236 0.1902,0.0618 0.3804,-0.1236 0.1175,-0.1618 0,-0.4 -0.1175,-0.1618 -0.3804,-0.1236 -0.1902,0.0618 -0.2351,0.3236 0,0.2Z"
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/square.vg.json
+++ b/examples/vg-specs/square.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -39,149 +19,129 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "symbol",
+            "role": "square",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "square",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "shape": {
-                                "value": "square"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "Horsepower"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "Miles_per_Gallon"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "fill": {
+                        "value": "#4c78a8"
+                    },
+                    "shape": {
+                        "value": "square"
+                    },
+                    "opacity": {
+                        "value": 0.7
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/stacked_area.vg.json
+++ b/examples/vg-specs/stacked_area.vg.json
@@ -3,26 +3,6 @@
     "description": "Area chart showing weight of cars over time.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -97,219 +77,198 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "300"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "300"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
+            "name": "pathgroup",
             "type": "group",
-            "description": "Area chart showing weight of cars over time.",
             "from": {
-                "data": "layout"
+                "facet": {
+                    "name": "faceted-path-main",
+                    "data": "source_0",
+                    "groupby": [
+                        "series"
+                    ]
+                }
             },
             "encode": {
                 "update": {
                     "width": {
-                        "field": "width"
+                        "field": {
+                            "group": "width"
+                        }
                     },
                     "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
+                        "field": {
+                            "group": "height"
+                        }
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "pathgroup",
-                    "type": "group",
+                    "name": "marks",
+                    "type": "area",
                     "from": {
-                        "facet": {
-                            "name": "faceted-path-main",
-                            "data": "source_0",
-                            "groupby": [
-                                "series"
-                            ]
-                        }
+                        "data": "faceted-path-main"
                     },
                     "encode": {
                         "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                            "x": {
+                                "scale": "x",
+                                "field": "yearmonth_date"
                             },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            }
-                        }
-                    },
-                    "marks": [
-                        {
-                            "name": "marks",
-                            "type": "area",
-                            "from": {
-                                "data": "faceted-path-main"
+                            "y": {
+                                "scale": "y",
+                                "field": "sum_count_end"
                             },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "yearmonth_date"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "sum_count_end"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "field": "sum_count_start"
-                                    },
-                                    "fill": {
-                                        "scale": "color",
-                                        "field": "series"
-                                    },
-                                    "orient": {
-                                        "value": "vertical"
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "yearmonth_date"
-                    },
-                    "range": [
-                        0,
-                        300
-                    ],
-                    "round": true,
-                    "nice": "month"
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "sum_count_start",
-                            "sum_count_end"
-                        ]
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "series",
-                        "sort": true
-                    },
-                    "range": {
-                        "scheme": "category20b"
-                    }
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "YEARMONTH(date)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%Y')"
-                                },
-                                "angle": {
-                                    "value": 0
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "SUM(count)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "series",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "strokeWidth": {
-                                    "value": 0
-                                }
+                            "y2": {
+                                "scale": "y",
+                                "field": "sum_count_start"
+                            },
+                            "fill": {
+                                "scale": "color",
+                                "field": "series"
+                            },
+                            "orient": {
+                                "value": "vertical"
                             }
                         }
                     }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "data": "source_0",
+                "field": "yearmonth_date"
+            },
+            "range": [
+                0,
+                300
+            ],
+            "round": true,
+            "nice": "month"
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "sum_count_start",
+                    "sum_count_end"
+                ]
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "series",
+                "sort": true
+            },
+            "range": {
+                "scheme": "category20b"
+            }
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "YEARMONTH(date)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%Y')"
+                        },
+                        "angle": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "SUM(count)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "series",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "strokeWidth": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/stacked_area_binned.vg.json
+++ b/examples/vg-specs/stacked_area_binned.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -112,206 +92,186 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
+            "name": "pathgroup",
             "type": "group",
             "from": {
-                "data": "layout"
+                "facet": {
+                    "name": "faceted-path-main",
+                    "data": "source_0",
+                    "groupby": [
+                        "Cylinders"
+                    ]
+                }
             },
             "encode": {
                 "update": {
                     "width": {
-                        "field": "width"
+                        "field": {
+                            "group": "width"
+                        }
                     },
                     "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
+                        "field": {
+                            "group": "height"
+                        }
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "pathgroup",
-                    "type": "group",
+                    "name": "marks",
+                    "type": "area",
                     "from": {
-                        "facet": {
-                            "name": "faceted-path-main",
-                            "data": "source_0",
-                            "groupby": [
-                                "Cylinders"
-                            ]
-                        }
+                        "data": "faceted-path-main"
                     },
                     "encode": {
                         "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                            "x": {
+                                "signal": "(scale(\"x\", datum[\"bin_maxbins_10_Acceleration_start\"]) + scale(\"x\", datum[\"bin_maxbins_10_Acceleration_end\"]))/2"
                             },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            }
-                        }
-                    },
-                    "marks": [
-                        {
-                            "name": "marks",
-                            "type": "area",
-                            "from": {
-                                "data": "faceted-path-main"
+                            "y": {
+                                "scale": "y",
+                                "field": "sum_Horsepower_end"
                             },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "signal": "(scale(\"x\", datum[\"bin_maxbins_10_Acceleration_start\"]) + scale(\"x\", datum[\"bin_maxbins_10_Acceleration_end\"]))/2"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "sum_Horsepower_end"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "field": "sum_Horsepower_start"
-                                    },
-                                    "fill": {
-                                        "scale": "color",
-                                        "field": "Cylinders"
-                                    },
-                                    "orient": {
-                                        "value": "vertical"
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(bin_maxbins_10_Acceleration_bins.start, bin_maxbins_10_Acceleration_bins.stop + bin_maxbins_10_Acceleration_bins.step, bin_maxbins_10_Acceleration_bins.step)"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "sum_Horsepower_start",
-                            "sum_Horsepower_end"
-                        ]
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Cylinders",
-                        "sort": true
-                    },
-                    "range": "category"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "title": "BIN(Acceleration)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "SUM(Horsepower)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "Cylinders",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "strokeWidth": {
-                                    "value": 0
-                                }
+                            "y2": {
+                                "scale": "y",
+                                "field": "sum_Horsepower_start"
+                            },
+                            "fill": {
+                                "scale": "color",
+                                "field": "Cylinders"
+                            },
+                            "orient": {
+                                "value": "vertical"
                             }
                         }
                     }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "bin-linear",
+            "domain": {
+                "signal": "sequence(bin_maxbins_10_Acceleration_bins.start, bin_maxbins_10_Acceleration_bins.stop + bin_maxbins_10_Acceleration_bins.step, bin_maxbins_10_Acceleration_bins.step)"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "sum_Horsepower_start",
+                    "sum_Horsepower_end"
+                ]
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Cylinders",
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "title": "BIN(Acceleration)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "SUM(Horsepower)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "Cylinders",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "strokeWidth": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/stacked_area_normalize.vg.json
+++ b/examples/vg-specs/stacked_area_normalize.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -96,198 +76,178 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "300"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "300"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
+            "name": "pathgroup",
             "type": "group",
             "from": {
-                "data": "layout"
+                "facet": {
+                    "name": "faceted-path-main",
+                    "data": "source_0",
+                    "groupby": [
+                        "series"
+                    ]
+                }
             },
             "encode": {
                 "update": {
                     "width": {
-                        "field": "width"
+                        "field": {
+                            "group": "width"
+                        }
                     },
                     "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
+                        "field": {
+                            "group": "height"
+                        }
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "pathgroup",
-                    "type": "group",
+                    "name": "marks",
+                    "type": "area",
                     "from": {
-                        "facet": {
-                            "name": "faceted-path-main",
-                            "data": "source_0",
-                            "groupby": [
-                                "series"
-                            ]
-                        }
+                        "data": "faceted-path-main"
                     },
                     "encode": {
                         "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                            "x": {
+                                "scale": "x",
+                                "field": "yearmonth_date"
                             },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            }
-                        }
-                    },
-                    "marks": [
-                        {
-                            "name": "marks",
-                            "type": "area",
-                            "from": {
-                                "data": "faceted-path-main"
+                            "y": {
+                                "scale": "y",
+                                "field": "sum_count_end"
                             },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "yearmonth_date"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "sum_count_end"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "field": "sum_count_start"
-                                    },
-                                    "fill": {
-                                        "scale": "color",
-                                        "field": "series"
-                                    },
-                                    "orient": {
-                                        "value": "vertical"
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "yearmonth_date"
-                    },
-                    "range": [
-                        0,
-                        300
-                    ],
-                    "round": true,
-                    "nice": "month"
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": [
-                        0,
-                        1
-                    ],
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "series",
-                        "sort": true
-                    },
-                    "range": {
-                        "scheme": "category20b"
-                    }
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "YEARMONTH(date)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%Y')"
-                                },
-                                "angle": {
-                                    "value": 0
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "series",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "strokeWidth": {
-                                    "value": 0
-                                }
+                            "y2": {
+                                "scale": "y",
+                                "field": "sum_count_start"
+                            },
+                            "fill": {
+                                "scale": "color",
+                                "field": "series"
+                            },
+                            "orient": {
+                                "value": "vertical"
                             }
                         }
                     }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "data": "source_0",
+                "field": "yearmonth_date"
+            },
+            "range": [
+                0,
+                300
+            ],
+            "round": true,
+            "nice": "month"
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": [
+                0,
+                1
+            ],
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "series",
+                "sort": true
+            },
+            "range": {
+                "scheme": "category20b"
+            }
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "domain": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "YEARMONTH(date)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%Y')"
+                        },
+                        "angle": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "series",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "strokeWidth": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/stacked_area_ordinal.vg.json
+++ b/examples/vg-specs/stacked_area_ordinal.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -96,222 +76,202 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
+            "name": "pathgroup",
             "type": "group",
             "from": {
-                "data": "layout"
+                "facet": {
+                    "name": "faceted-path-main",
+                    "data": "source_0",
+                    "groupby": [
+                        "Cylinders"
+                    ]
+                }
             },
             "encode": {
                 "update": {
                     "width": {
-                        "field": "width"
+                        "field": {
+                            "group": "width"
+                        }
                     },
                     "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
+                        "field": {
+                            "group": "height"
+                        }
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "pathgroup",
-                    "type": "group",
+                    "name": "marks",
+                    "type": "area",
                     "from": {
-                        "facet": {
-                            "name": "faceted-path-main",
-                            "data": "source_0",
-                            "groupby": [
-                                "Cylinders"
-                            ]
-                        }
+                        "data": "faceted-path-main"
                     },
                     "encode": {
                         "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                            "x": {
+                                "scale": "x",
+                                "field": "year_Year"
                             },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            }
-                        }
-                    },
-                    "marks": [
-                        {
-                            "name": "marks",
-                            "type": "area",
-                            "from": {
-                                "data": "faceted-path-main"
+                            "y": {
+                                "scale": "y",
+                                "field": "sum_Weight_in_lbs_end"
                             },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "year_Year"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "sum_Weight_in_lbs_end"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "field": "sum_Weight_in_lbs_start"
-                                    },
-                                    "fill": {
-                                        "scale": "color",
-                                        "field": "Cylinders"
-                                    },
-                                    "orient": {
-                                        "value": "vertical"
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "year_Year"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": "year"
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "sum_Weight_in_lbs_start",
-                            "sum_Weight_in_lbs_end"
-                        ]
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Cylinders",
-                        "sort": true
-                    },
-                    "range": "ordinal"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "YEAR(Year)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%Y')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "SUM(Weight_in_lbs)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "Cylinders",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "strokeWidth": {
-                                    "value": 0
-                                }
+                            "y2": {
+                                "scale": "y",
+                                "field": "sum_Weight_in_lbs_start"
+                            },
+                            "fill": {
+                                "scale": "color",
+                                "field": "Cylinders"
+                            },
+                            "orient": {
+                                "value": "vertical"
                             }
                         }
                     }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "data": "source_0",
+                "field": "year_Year"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": "year"
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "sum_Weight_in_lbs_start",
+                    "sum_Weight_in_lbs_end"
+                ]
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Cylinders",
+                "sort": true
+            },
+            "range": "ordinal"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "YEAR(Year)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%Y')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "SUM(Weight_in_lbs)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "Cylinders",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "strokeWidth": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/stacked_area_stream.vg.json
+++ b/examples/vg-specs/stacked_area_stream.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -96,203 +76,183 @@
                     }
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "300"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "300"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
+            "name": "pathgroup",
             "type": "group",
             "from": {
-                "data": "layout"
+                "facet": {
+                    "name": "faceted-path-main",
+                    "data": "source_0",
+                    "groupby": [
+                        "series"
+                    ]
+                }
             },
             "encode": {
                 "update": {
                     "width": {
-                        "field": "width"
+                        "field": {
+                            "group": "width"
+                        }
                     },
                     "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
+                        "field": {
+                            "group": "height"
+                        }
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "pathgroup",
-                    "type": "group",
+                    "name": "marks",
+                    "type": "area",
                     "from": {
-                        "facet": {
-                            "name": "faceted-path-main",
-                            "data": "source_0",
-                            "groupby": [
-                                "series"
-                            ]
-                        }
+                        "data": "faceted-path-main"
                     },
                     "encode": {
                         "update": {
-                            "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                            "x": {
+                                "scale": "x",
+                                "field": "yearmonth_date"
                             },
-                            "height": {
-                                "field": {
-                                    "group": "height"
-                                }
-                            }
-                        }
-                    },
-                    "marks": [
-                        {
-                            "name": "marks",
-                            "type": "area",
-                            "from": {
-                                "data": "faceted-path-main"
+                            "y": {
+                                "scale": "y",
+                                "field": "sum_count_end"
                             },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "yearmonth_date"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "sum_count_end"
-                                    },
-                                    "y2": {
-                                        "scale": "y",
-                                        "field": "sum_count_start"
-                                    },
-                                    "fill": {
-                                        "scale": "color",
-                                        "field": "series"
-                                    },
-                                    "orient": {
-                                        "value": "vertical"
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "time",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "yearmonth_date"
-                    },
-                    "range": [
-                        0,
-                        300
-                    ],
-                    "round": true,
-                    "nice": "month"
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "sum_count_start",
-                            "sum_count_end"
-                        ]
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "series",
-                        "sort": true
-                    },
-                    "range": {
-                        "scheme": "category20b"
-                    }
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "tickSize": 0,
-                    "title": "YEARMONTH(date)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%Y')"
-                                },
-                                "angle": {
-                                    "value": 0
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "tickSize": 0,
-                    "zindex": 0,
-                    "gridScale": "y"
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "series",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "strokeWidth": {
-                                    "value": 0
-                                }
+                            "y2": {
+                                "scale": "y",
+                                "field": "sum_count_start"
+                            },
+                            "fill": {
+                                "scale": "color",
+                                "field": "series"
+                            },
+                            "orient": {
+                                "value": "vertical"
                             }
                         }
                     }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "time",
+            "domain": {
+                "data": "source_0",
+                "field": "yearmonth_date"
+            },
+            "range": [
+                0,
+                300
+            ],
+            "round": true,
+            "nice": "month"
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "sum_count_start",
+                    "sum_count_end"
+                ]
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "series",
+                "sort": true
+            },
+            "range": {
+                "scheme": "category20b"
+            }
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "domain": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "tickSize": 0,
+            "title": "YEARMONTH(date)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%Y')"
+                        },
+                        "angle": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "tickSize": 0,
+            "zindex": 0,
+            "gridScale": "y"
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "series",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "strokeWidth": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/stacked_bar_1d.vg.json
+++ b/examples/vg-specs/stacked_bar_1d.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -68,147 +48,127 @@
                     "offset": "zero"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "sum_Acceleration_end"
+                    },
+                    "x2": {
+                        "scale": "x",
+                        "field": "sum_Acceleration_start"
+                    },
+                    "yc": {
+                        "value": 10.5
                     },
                     "height": {
-                        "field": "height"
+                        "value": 20
                     },
                     "fill": {
-                        "value": "transparent"
+                        "scale": "color",
+                        "field": "Origin"
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "sum_Acceleration_start",
+                    "sum_Acceleration_end"
+                ]
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "sum_Acceleration_end"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "field": "sum_Acceleration_start"
-                            },
-                            "yc": {
-                                "value": 10.5
-                            },
-                            "height": {
-                                "value": 20
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "Origin"
-                            }
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "SUM(Acceleration)",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "Origin",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "square"
+                        },
+                        "strokeWidth": {
+                            "value": 0
                         }
                     }
                 }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "sum_Acceleration_start",
-                            "sum_Acceleration_end"
-                        ]
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Origin",
-                        "sort": true
-                    },
-                    "range": "category"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "SUM(Acceleration)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "Origin",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "square"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                }
-                            }
-                        }
-                    }
-                }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/stacked_bar_count.vg.json
+++ b/examples/vg-specs/stacked_bar_count.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -76,193 +56,166 @@
                     "offset": "zero"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "month_date"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_month_date\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "xc": {
+                        "scale": "x",
+                        "field": "month_date"
                     },
-                    "height": {
-                        "field": "height"
+                    "width": {
+                        "value": 20
+                    },
+                    "y": {
+                        "scale": "y",
+                        "field": "count_*_end"
+                    },
+                    "y2": {
+                        "scale": "y",
+                        "field": "count_*_start"
                     },
                     "fill": {
-                        "value": "transparent"
+                        "scale": "color",
+                        "field": "weather"
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "month_date",
+                "sort": true
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "month_date"
-                            },
-                            "width": {
-                                "value": 20
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "count_*_end"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "count_*_start"
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "weather"
-                            }
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "count_*_start",
+                    "count_*_end"
+                ]
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "weather",
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "MONTH(date)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
                 }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "month_date",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "count_*_start",
-                            "count_*_end"
-                        ]
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "weather",
-                        "sort": true
-                    },
-                    "range": "category"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "MONTH(date)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "weather",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "square"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                }
-                            }
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Number of Records",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "weather",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "square"
+                        },
+                        "strokeWidth": {
+                            "value": 0
                         }
                     }
                 }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/stacked_bar_h.vg.json
+++ b/examples/vg-specs/stacked_bar_h.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -71,176 +51,149 @@
                     "offset": "zero"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "bandspace(domain('y').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "variety"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "max(datum[\"distinct_variety\"] - 1 + 2*0.5, 0) * 21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "sum_yield_end"
+                    },
+                    "x2": {
+                        "scale": "x",
+                        "field": "sum_yield_start"
+                    },
+                    "yc": {
+                        "scale": "y",
+                        "field": "variety"
                     },
                     "height": {
-                        "field": "height"
+                        "value": 20
                     },
                     "fill": {
-                        "value": "transparent"
+                        "scale": "color",
+                        "field": "site"
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "sum_yield_start",
+                    "sum_yield_end"
+                ]
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "sum_yield_end"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "field": "sum_yield_start"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "variety"
-                            },
-                            "height": {
-                                "value": 20
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "site"
-                            }
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "variety",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "site",
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "SUM(yield)",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "orient": "left",
+            "title": "variety",
+            "zindex": 1
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "site",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "square"
+                        },
+                        "strokeWidth": {
+                            "value": 0
                         }
                     }
                 }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "sum_yield_start",
-                            "sum_yield_end"
-                        ]
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "variety",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "site",
-                        "sort": true
-                    },
-                    "range": "category"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "SUM(yield)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "orient": "left",
-                    "title": "variety",
-                    "zindex": 1
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "site",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "square"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                }
-                            }
-                        }
-                    }
-                }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/stacked_bar_h_order.vg.json
+++ b/examples/vg-specs/stacked_bar_h_order.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -71,176 +51,149 @@
                     "offset": "zero"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "bandspace(domain('y').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "variety"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "max(datum[\"distinct_variety\"] - 1 + 2*0.5, 0) * 21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "x": {
+                        "scale": "x",
+                        "field": "sum_yield_end"
+                    },
+                    "x2": {
+                        "scale": "x",
+                        "field": "sum_yield_start"
+                    },
+                    "yc": {
+                        "scale": "y",
+                        "field": "variety"
                     },
                     "height": {
-                        "field": "height"
+                        "value": 20
                     },
                     "fill": {
-                        "value": "transparent"
+                        "scale": "color",
+                        "field": "site"
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "sum_yield_start",
+                    "sum_yield_end"
+                ]
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "sum_yield_end"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "field": "sum_yield_start"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "variety"
-                            },
-                            "height": {
-                                "value": 20
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "site"
-                            }
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "variety",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "site",
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "SUM(yield)",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "orient": "left",
+            "title": "variety",
+            "zindex": 1
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "site",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "square"
+                        },
+                        "strokeWidth": {
+                            "value": 0
                         }
                     }
                 }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "sum_yield_start",
-                            "sum_yield_end"
-                        ]
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "variety",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "site",
-                        "sort": true
-                    },
-                    "range": "category"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "SUM(yield)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "orient": "left",
-                    "title": "variety",
-                    "zindex": 1
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "site",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "square"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                }
-                            }
-                        }
-                    }
-                }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/stacked_bar_normalize.vg.json
+++ b/examples/vg-specs/stacked_bar_normalize.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -80,190 +60,163 @@
                     "offset": "normalize"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 17"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "age"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_age\"] - 1 + 2*0.5, 0) * 17"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "xc": {
+                        "scale": "x",
+                        "field": "age"
                     },
-                    "height": {
-                        "field": "height"
+                    "width": {
+                        "value": 16
+                    },
+                    "y": {
+                        "scale": "y",
+                        "field": "sum_people_end"
+                    },
+                    "y2": {
+                        "scale": "y",
+                        "field": "sum_people_start"
                     },
                     "fill": {
-                        "value": "transparent"
+                        "scale": "color",
+                        "field": "gender"
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "age",
+                "sort": true
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "width": {
-                                "value": 16
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "sum_people_end"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "sum_people_start"
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "gender"
-                            }
-                        }
-                    }
-                }
+            "range": {
+                "step": 17
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": [
+                0,
+                1
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "age",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 17
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": [
-                        0,
-                        1
-                    ],
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "gender",
-                        "sort": true
-                    },
-                    "range": [
-                        "#EA98D2",
-                        "#659CCA"
-                    ]
-                }
+            "range": [
+                200,
+                0
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "age",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "population",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "gender",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "square"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                }
-                            }
-                        }
-                    }
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "gender",
+                "sort": true
+            },
+            "range": [
+                "#EA98D2",
+                "#659CCA"
             ]
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "age",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "population",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "gender",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "square"
+                        },
+                        "strokeWidth": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/stacked_bar_population.vg.json
+++ b/examples/vg-specs/stacked_bar_population.vg.json
@@ -3,26 +3,6 @@
     "description": "A bar chart showing the US population distribution of age groups and gender in 2000.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -81,194 +61,166 @@
                     "offset": "zero"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 17"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "age"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_age\"] - 1 + 2*0.5, 0) * 17"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A bar chart showing the US population distribution of age groups and gender in 2000.",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "xc": {
+                        "scale": "x",
+                        "field": "age"
                     },
-                    "height": {
-                        "field": "height"
+                    "width": {
+                        "value": 16
+                    },
+                    "y": {
+                        "scale": "y",
+                        "field": "sum_people_end"
+                    },
+                    "y2": {
+                        "scale": "y",
+                        "field": "sum_people_start"
                     },
                     "fill": {
-                        "value": "transparent"
+                        "scale": "color",
+                        "field": "gender"
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "age",
+                "sort": true
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "width": {
-                                "value": 16
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "sum_people_end"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "sum_people_start"
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "gender"
-                            }
-                        }
-                    }
-                }
+            "range": {
+                "step": 17
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "sum_people_start",
+                    "sum_people_end"
+                ]
+            },
+            "range": [
+                200,
+                0
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "age",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 17
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "sum_people_start",
-                            "sum_people_end"
-                        ]
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "gender",
-                        "sort": true
-                    },
-                    "range": [
-                        "#EA98D2",
-                        "#659CCA"
-                    ]
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "age",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "population",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "gender",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "square"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                }
-                            }
-                        }
-                    }
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "gender",
+                "sort": true
+            },
+            "range": [
+                "#EA98D2",
+                "#659CCA"
             ]
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "age",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "population",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "gender",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "square"
+                        },
+                        "strokeWidth": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/stacked_bar_size.vg.json
+++ b/examples/vg-specs/stacked_bar_size.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -76,199 +56,172 @@
                     "offset": "zero"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "month_date"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_month_date\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "xc": {
+                        "scale": "x",
+                        "field": "month_date"
                     },
-                    "height": {
-                        "field": "height"
+                    "width": {
+                        "scale": "size",
+                        "field": "weather"
+                    },
+                    "y": {
+                        "scale": "y",
+                        "field": "count_*_end"
+                    },
+                    "y2": {
+                        "scale": "y",
+                        "field": "count_*_start"
                     },
                     "fill": {
-                        "value": "transparent"
+                        "value": "#4c78a8"
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "month_date",
+                "sort": true
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "month_date"
-                            },
-                            "width": {
-                                "scale": "size",
-                                "field": "weather"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "count_*_end"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "count_*_start"
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                }
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "count_*_start",
+                    "count_*_end"
+                ]
+            },
+            "range": [
+                200,
+                0
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "month_date",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "count_*_start",
-                            "count_*_end"
-                        ]
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "size",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "weather",
-                        "sort": true
-                    },
-                    "range": [
-                        2,
-                        20
-                    ]
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "MONTH(date)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "size": "size",
-                    "title": "weather",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "square"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                },
-                                "fill": {
-                                    "value": "#4c78a8"
-                                }
-                            }
-                        }
-                    }
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "size",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "weather",
+                "sort": true
+            },
+            "range": [
+                2,
+                20
             ]
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "MONTH(date)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Number of Records",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "size": "size",
+            "title": "weather",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "square"
+                        },
+                        "strokeWidth": {
+                            "value": 0
+                        },
+                        "fill": {
+                            "value": "#4c78a8"
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/stacked_bar_sum_opacity.vg.json
+++ b/examples/vg-specs/stacked_bar_sum_opacity.vg.json
@@ -3,26 +3,6 @@
     "description": "A bar chart showing the US population distribution of age groups and gender in 2000.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -81,202 +61,174 @@
                     "offset": "zero"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 17"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "age"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_age\"] - 1 + 2*0.5, 0) * 17"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "A bar chart showing the US population distribution of age groups and gender in 2000.",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "xc": {
+                        "scale": "x",
+                        "field": "age"
                     },
-                    "height": {
-                        "field": "height"
+                    "width": {
+                        "value": 16
+                    },
+                    "y": {
+                        "scale": "y",
+                        "field": "sum_people_end"
+                    },
+                    "y2": {
+                        "scale": "y",
+                        "field": "sum_people_start"
                     },
                     "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
+                        "value": "#4c78a8"
                     },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "width": {
-                                "value": 16
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "sum_people_end"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "sum_people_start"
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "opacity": {
-                                "scale": "opacity",
-                                "field": "people"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "age",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 17
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "sum_people_start",
-                            "sum_people_end"
-                        ]
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "opacity",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "opacity": {
+                        "scale": "opacity",
                         "field": "people"
-                    },
-                    "range": [
-                        0.3,
-                        0.8
-                    ],
-                    "nice": false,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "age",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "population",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "opacity": "opacity",
-                    "format": "s",
-                    "title": "people",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "square"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                },
-                                "fill": {
-                                    "value": "#4c78a8"
-                                }
-                            }
-                        }
                     }
                 }
-            ]
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "age",
+                "sort": true
+            },
+            "range": {
+                "step": 17
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "sum_people_start",
+                    "sum_people_end"
+                ]
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "opacity",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "people"
+            },
+            "range": [
+                0.3,
+                0.8
+            ],
+            "nice": false,
+            "zero": false
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "age",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "population",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "opacity": "opacity",
+            "format": "s",
+            "title": "people",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "square"
+                        },
+                        "strokeWidth": {
+                            "value": 0
+                        },
+                        "fill": {
+                            "value": "#4c78a8"
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/stacked_bar_v.vg.json
+++ b/examples/vg-specs/stacked_bar_v.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -71,190 +51,163 @@
                     "offset": "zero"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "variety"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_variety\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "xc": {
+                        "scale": "x",
+                        "field": "variety"
                     },
-                    "height": {
-                        "field": "height"
+                    "width": {
+                        "value": 20
+                    },
+                    "y": {
+                        "scale": "y",
+                        "field": "sum_yield_end"
+                    },
+                    "y2": {
+                        "scale": "y",
+                        "field": "sum_yield_start"
                     },
                     "fill": {
-                        "value": "transparent"
+                        "scale": "color",
+                        "field": "site"
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "variety",
+                "sort": true
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "variety"
-                            },
-                            "width": {
-                                "value": 20
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "sum_yield_end"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "sum_yield_start"
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "site"
-                            }
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "sum_yield_start",
+                    "sum_yield_end"
+                ]
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "site",
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "variety",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
                         }
                     }
                 }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "variety",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "sum_yield_start",
-                            "sum_yield_end"
-                        ]
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "site",
-                        "sort": true
-                    },
-                    "range": "category"
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "variety",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "SUM(yield)",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "site",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "square"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                }
-                            }
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "SUM(yield)",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "site",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "square"
+                        },
+                        "strokeWidth": {
+                            "value": 0
                         }
                     }
                 }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/stacked_bar_weather.vg.json
+++ b/examples/vg-specs/stacked_bar_weather.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -76,201 +56,174 @@
                     "offset": "zero"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "month_date"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "max(datum[\"distinct_month_date\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "bar",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
+                    "xc": {
+                        "scale": "x",
+                        "field": "month_date"
                     },
-                    "height": {
-                        "field": "height"
+                    "width": {
+                        "value": 20
+                    },
+                    "y": {
+                        "scale": "y",
+                        "field": "count_*_end"
+                    },
+                    "y2": {
+                        "scale": "y",
+                        "field": "count_*_start"
                     },
                     "fill": {
-                        "value": "transparent"
+                        "scale": "color",
+                        "field": "weather"
                     }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "month_date",
+                "sort": true
             },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "month_date"
-                            },
-                            "width": {
-                                "value": 20
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "count_*_end"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "count_*_start"
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "weather"
-                            }
-                        }
-                    }
-                }
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "count_*_start",
+                    "count_*_end"
+                ]
+            },
+            "range": [
+                200,
+                0
             ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "month_date",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "count_*_start",
-                            "count_*_end"
-                        ]
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": [
-                        "sun",
-                        "fog",
-                        "drizzle",
-                        "rain",
-                        "snow"
-                    ],
-                    "range": [
-                        "#e7ba52",
-                        "#c7c7c7",
-                        "#aec7e8",
-                        "#1f77b4",
-                        "#9467bd"
-                    ]
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": [
+                "sun",
+                "fog",
+                "drizzle",
+                "rain",
+                "snow"
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Month of the year",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b')"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
-                                }
-                            }
-                        }
-                    }
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "Weather type",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "square"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                }
-                            }
-                        }
-                    }
-                }
+            "range": [
+                "#e7ba52",
+                "#c7c7c7",
+                "#aec7e8",
+                "#1f77b4",
+                "#9467bd"
             ]
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Month of the year",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Number of Records",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "Weather type",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "square"
+                        },
+                        "strokeWidth": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/text_scatter_colored.vg.json
+++ b/examples/vg-specs/text_scatter_colored.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -44,177 +24,157 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "200"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "text",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "text",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "text": {
-                                "field": "OriginInitial"
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "Origin"
-                            },
-                            "align": {
-                                "value": "center"
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "x": {
+                        "scale": "x",
                         "field": "Horsepower"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "y": {
+                        "scale": "y",
                         "field": "Miles_per_Gallon"
                     },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Origin",
-                        "sort": true
+                    "text": {
+                        "field": "OriginInitial"
                     },
-                    "range": "category"
+                    "fill": {
+                        "scale": "color",
+                        "field": "Origin"
+                    },
+                    "align": {
+                        "value": "center"
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
-                }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
             ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "Origin",
-                    "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "square"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                }
-                            }
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "format": "s",
+            "orient": "left",
+            "title": "Miles_per_Gallon",
+            "zindex": 1
+        },
+        {
+            "scale": "y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "Origin",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "square"
+                        },
+                        "strokeWidth": {
+                            "value": 0
                         }
                     }
                 }
-            ]
+            }
         }
     ]
 }

--- a/examples/vg-specs/tick_dot.vg.json
+++ b/examples/vg-specs/tick_dot.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -38,117 +18,97 @@
                     "expr": "datum[\"precipitation\"] !== null && !isNaN(datum[\"precipitation\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "tick",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "tick",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "precipitation"
-                            },
-                            "yc": {
-                                "value": 10.5
-                            },
-                            "height": {
-                                "value": 14
-                            },
-                            "width": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "xc": {
+                        "scale": "x",
                         "field": "precipitation"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "yc": {
+                        "value": 10.5
+                    },
+                    "height": {
+                        "value": 14
+                    },
+                    "width": {
+                        "value": 1
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    },
+                    "opacity": {
+                        "value": 0.7
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "precipitation"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "precipitation",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "precipitation",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0
         }
     ]
 }

--- a/examples/vg-specs/tick_dot_thickness.vg.json
+++ b/examples/vg-specs/tick_dot_thickness.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -38,117 +18,97 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "tick",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "tick",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "yc": {
-                                "value": 10.5
-                            },
-                            "height": {
-                                "value": 10
-                            },
-                            "width": {
-                                "value": 2
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "xc": {
+                        "scale": "x",
                         "field": "Horsepower"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "yc": {
+                        "value": 10.5
+                    },
+                    "height": {
+                        "value": 10
+                    },
+                    "width": {
+                        "value": 2
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    },
+                    "opacity": {
+                        "value": 0.7
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0
         }
     ]
 }

--- a/examples/vg-specs/tick_sort.vg.json
+++ b/examples/vg-specs/tick_sort.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -38,118 +18,98 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "values": [
-                {}
-            ],
-            "transform": [
+            "name": "height",
+            "update": "21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
+            "name": "marks",
+            "type": "rect",
+            "role": "tick",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "tick",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "yc": {
-                                "value": 10.5
-                            },
-                            "height": {
-                                "value": 14
-                            },
-                            "width": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "xc": {
+                        "scale": "x",
                         "field": "Horsepower"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true,
-                    "reverse": true
+                    "yc": {
+                        "value": 10.5
+                    },
+                    "height": {
+                        "value": 14
+                    },
+                    "width": {
+                        "value": 1
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    },
+                    "opacity": {
+                        "value": 0.7
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true,
+            "reverse": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0
         }
     ]
 }

--- a/examples/vg-specs/tick_strip.vg.json
+++ b/examples/vg-specs/tick_strip.vg.json
@@ -3,26 +3,6 @@
     "description": "Shows the relationship between horsepower and the numbver of cylinders using tick marks.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -39,147 +19,119 @@
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
                 }
             ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "200"
         },
         {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
+            "name": "height",
+            "update": "bandspace(domain('y').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
                 {
-                    "type": "aggregate",
-                    "fields": [
-                        "Cylinders"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "max(datum[\"distinct_Cylinders\"] - 1 + 2*0.5, 0) * 21"
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
                 }
             ]
         }
     ],
     "marks": [
         {
-            "name": "main-group",
-            "type": "group",
-            "description": "Shows the relationship between horsepower and the numbver of cylinders using tick marks.",
+            "name": "marks",
+            "type": "rect",
+            "role": "tick",
             "from": {
-                "data": "layout"
+                "data": "source_0"
             },
             "encode": {
                 "update": {
-                    "width": {
-                        "field": "width"
-                    },
-                    "height": {
-                        "field": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "marks",
-                    "type": "rect",
-                    "role": "tick",
-                    "from": {
-                        "data": "source_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "Cylinders"
-                            },
-                            "height": {
-                                "value": 14
-                            },
-                            "width": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
+                    "xc": {
+                        "scale": "x",
                         "field": "Horsepower"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "y",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Cylinders",
-                        "sort": true
+                    "yc": {
+                        "scale": "y",
+                        "field": "Cylinders"
                     },
-                    "range": {
-                        "step": 21
+                    "height": {
+                        "value": 14
                     },
-                    "round": true,
-                    "padding": 0.5
+                    "width": {
+                        "value": 1
+                    },
+                    "fill": {
+                        "value": "#4c78a8"
+                    },
+                    "opacity": {
+                        "value": 0.7
+                    }
                 }
+            }
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
+            },
+            "range": [
+                0,
+                200
             ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "orient": "left",
-                    "title": "Cylinders",
-                    "zindex": 1
-                }
-            ]
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "Cylinders",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "format": "s",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "Horsepower",
+            "zindex": 1
+        },
+        {
+            "scale": "x",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "bottom",
+            "tickCount": 5,
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "y"
+        },
+        {
+            "scale": "y",
+            "orient": "left",
+            "title": "Cylinders",
+            "zindex": 1
         }
     ]
 }

--- a/examples/vg-specs/trellis_anscombe.vg.json
+++ b/examples/vg-specs/trellis_anscombe.vg.json
@@ -3,26 +3,6 @@
     "description": "Anscombe's Quartet",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -54,315 +34,290 @@
             ]
         },
         {
-            "name": "layout",
-            "source": "source_0",
+            "name": "column-layout",
+            "source": "column",
             "transform": [
                 {
                     "type": "aggregate",
-                    "fields": [
-                        "Series"
-                    ],
                     "ops": [
                         "distinct"
+                    ],
+                    "fields": [
+                        "Series"
                     ]
-                },
-                {
-                    "type": "formula",
-                    "as": "child_width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "(datum[\"child_width\"] + 5) * datum[\"distinct_Series\"]"
-                },
-                {
-                    "type": "formula",
-                    "as": "child_height",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "datum[\"child_height\"] + 5"
                 }
             ]
         }
     ],
+    "signals": [
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        },
+        {
+            "name": "child_width",
+            "update": "200"
+        },
+        {
+            "name": "child_height",
+            "update": "200"
+        }
+    ],
+    "layout": {
+        "padding": {
+            "row": 10,
+            "column": 10,
+            "header": 10
+        },
+        "columns": 1,
+        "bounds": "full"
+    },
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "description": "Anscombe's Quartet",
-            "from": {
-                "data": "layout"
-            },
-            "signals": [
-                {
-                    "name": "column",
-                    "update": "data('layout')[0].distinct_Series"
-                }
-            ],
             "layout": {
                 "padding": {
                     "row": 10,
                     "column": 10,
                     "header": 10
                 },
-                "columns": 1,
+                "columns": {
+                    "signal": "data('column-layout')[0].distinct_Series"
+                },
                 "bounds": "full"
             },
             "marks": [
                 {
+                    "name": "x-axes",
                     "type": "group",
-                    "layout": {
-                        "padding": {
-                            "row": 10,
-                            "column": 10,
-                            "header": 10
-                        },
-                        "columns": {
-                            "signal": "column"
-                        },
-                        "bounds": "full"
+                    "role": "column-footer",
+                    "from": {
+                        "data": "column"
                     },
-                    "marks": [
+                    "axes": [
                         {
-                            "name": "x-axes",
-                            "type": "group",
-                            "role": "column-footer",
-                            "from": {
-                                "data": "column"
-                            },
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "format": "s",
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "title": "X",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "y-axes",
-                            "type": "group",
-                            "role": "row-header",
-                            "axes": [
-                                {
-                                    "scale": "y",
-                                    "format": "s",
-                                    "orient": "left",
-                                    "title": "Y",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "column-labels",
-                            "role": "column-header",
-                            "type": "group",
-                            "from": {
-                                "data": "column"
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "type": "text",
-                                    "role": "column-labels",
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "field": {
-                                                    "group": "width"
-                                                },
-                                                "mult": 0.5
-                                            },
-                                            "y": {
-                                                "value": -10
-                                            },
-                                            "text": {
-                                                "field": {
-                                                    "parent": "Series"
-                                                }
-                                            },
-                                            "align": {
-                                                "value": "center"
-                                            },
-                                            "fill": {
-                                                "value": "black"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "cell",
-                            "type": "group",
-                            "from": {
-                                "facet": {
-                                    "name": "facet",
-                                    "data": "source_0",
-                                    "groupby": [
-                                        "Series"
-                                    ]
-                                }
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    },
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
-                                        }
-                                    },
-                                    "stroke": {
-                                        "value": "#ccc"
-                                    },
-                                    "strokeWidth": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "transparent"
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "name": "child_marks",
-                                    "type": "symbol",
-                                    "role": "circle",
-                                    "from": {
-                                        "data": "facet"
-                                    },
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "scale": "x",
-                                                "field": "X"
-                                            },
-                                            "y": {
-                                                "scale": "y",
-                                                "field": "Y"
-                                            },
-                                            "fill": {
-                                                "value": "#4c78a8"
-                                            },
-                                            "shape": {
-                                                "value": "circle"
-                                            }
-                                        }
-                                    }
-                                }
-                            ],
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "domain": false,
-                                    "format": "s",
-                                    "grid": true,
-                                    "labels": false,
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "ticks": false,
-                                    "zindex": 0,
-                                    "gridScale": "y"
-                                },
-                                {
-                                    "scale": "y",
-                                    "domain": false,
-                                    "format": "s",
-                                    "grid": true,
-                                    "labels": false,
-                                    "orient": "left",
-                                    "ticks": false,
-                                    "zindex": 0,
-                                    "gridScale": "x"
-                                }
-                            ]
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "X",
+                            "zindex": 1
                         }
                     ]
                 },
                 {
-                    "name": "column-title",
+                    "name": "y-axes",
+                    "type": "group",
+                    "role": "row-header",
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Y",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "column-labels",
                     "role": "column-header",
                     "type": "group",
+                    "from": {
+                        "data": "column"
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
                     "marks": [
                         {
                             "type": "text",
-                            "role": "column-title",
+                            "role": "column-labels",
                             "encode": {
                                 "update": {
                                     "x": {
-                                        "signal": "0.5 * width"
+                                        "field": {
+                                            "group": "width"
+                                        },
+                                        "mult": 0.5
+                                    },
+                                    "y": {
+                                        "value": -10
                                     },
                                     "text": {
-                                        "value": "Series"
+                                        "field": {
+                                            "parent": "Series"
+                                        }
                                     },
                                     "align": {
                                         "value": "center"
                                     },
                                     "fill": {
                                         "value": "black"
-                                    },
-                                    "fontWeight": {
-                                        "value": "bold"
                                     }
                                 }
                             }
                         }
                     ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "X"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
                 },
                 {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Y"
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "Series"
+                            ]
+                        }
                     },
-                    "range": [
-                        200,
-                        0
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "symbol",
+                            "role": "circle",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "X"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "Y"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "shape": {
+                                        "value": "circle"
+                                    }
+                                }
+                            }
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "y"
+                        },
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
+                        }
+                    ]
                 }
             ]
+        },
+        {
+            "name": "column-title",
+            "role": "column-header",
+            "type": "group",
+            "marks": [
+                {
+                    "type": "text",
+                    "role": "column-title",
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "signal": "0.5 * width"
+                            },
+                            "text": {
+                                "value": "Series"
+                            },
+                            "align": {
+                                "value": "center"
+                            },
+                            "fill": {
+                                "value": "black"
+                            },
+                            "fontWeight": {
+                                "value": "bold"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "X"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": false
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Y"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": false
         }
     ]
 }

--- a/examples/vg-specs/trellis_bar.vg.json
+++ b/examples/vg-specs/trellis_bar.vg.json
@@ -3,26 +3,6 @@
     "description": "A trellis bar chart showing the US population distribution of age groups and gender in 2000.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -94,53 +74,40 @@
                     ]
                 }
             ]
-        },
-        {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
-                {
-                    "type": "aggregate",
-                    "fields": [
-                        "age",
-                        "gender"
-                    ],
-                    "ops": [
-                        "distinct",
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "child_width",
-                    "expr": "max(datum[\"distinct_age\"] - 1 + 2*0.5, 0) * 17"
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "datum[\"child_width\"] + 5"
-                },
-                {
-                    "type": "formula",
-                    "as": "child_height",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "(datum[\"child_height\"] + 5) * datum[\"distinct_gender\"]"
-                }
-            ]
         }
     ],
+    "signals": [
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        },
+        {
+            "name": "child_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 17"
+        },
+        {
+            "name": "child_height",
+            "update": "200"
+        }
+    ],
+    "layout": {
+        "padding": {
+            "row": 10,
+            "column": 10,
+            "header": 10
+        },
+        "columns": 1,
+        "bounds": "full"
+    },
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "description": "A trellis bar chart showing the US population distribution of age groups and gender in 2000.",
-            "from": {
-                "data": "layout"
-            },
             "layout": {
                 "padding": {
                     "row": 10,
@@ -152,296 +119,273 @@
             },
             "marks": [
                 {
+                    "name": "x-axes",
                     "type": "group",
-                    "layout": {
-                        "padding": {
-                            "row": 10,
-                            "column": 10,
-                            "header": 10
-                        },
-                        "columns": 1,
-                        "bounds": "full"
-                    },
-                    "marks": [
+                    "role": "column-footer",
+                    "axes": [
                         {
-                            "name": "x-axes",
-                            "type": "group",
-                            "role": "column-footer",
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "title": "age",
-                                    "zindex": 1,
-                                    "encode": {
-                                        "labels": {
-                                            "update": {
-                                                "angle": {
-                                                    "value": 270
-                                                },
-                                                "align": {
-                                                    "value": "right"
-                                                },
-                                                "baseline": {
-                                                    "value": "middle"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "y-axes",
-                            "type": "group",
-                            "role": "row-header",
-                            "from": {
-                                "data": "row"
-                            },
-                            "axes": [
-                                {
-                                    "scale": "y",
-                                    "format": "s",
-                                    "orient": "left",
-                                    "title": "population",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "row-labels",
-                            "role": "row-header",
-                            "type": "group",
-                            "from": {
-                                "data": "row"
-                            },
+                            "scale": "x",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "age",
+                            "zindex": 1,
                             "encode": {
-                                "update": {
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
+                                "labels": {
+                                    "update": {
+                                        "angle": {
+                                            "value": 270
+                                        },
+                                        "align": {
+                                            "value": "right"
+                                        },
+                                        "baseline": {
+                                            "value": "middle"
                                         }
                                     }
                                 }
-                            },
-                            "marks": [
-                                {
-                                    "type": "text",
-                                    "role": "row-labels",
-                                    "encode": {
-                                        "update": {
-                                            "y": {
-                                                "field": {
-                                                    "group": "height"
-                                                },
-                                                "mult": 0.5
-                                            },
-                                            "x": {
-                                                "value": -10
-                                            },
-                                            "text": {
-                                                "field": {
-                                                    "parent": "gender"
-                                                }
-                                            },
-                                            "align": {
-                                                "value": "right"
-                                            },
-                                            "fill": {
-                                                "value": "black"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "cell",
-                            "type": "group",
-                            "from": {
-                                "facet": {
-                                    "name": "facet",
-                                    "data": "source_0",
-                                    "groupby": [
-                                        "gender"
-                                    ]
-                                }
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    },
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
-                                        }
-                                    },
-                                    "stroke": {
-                                        "value": "#ccc"
-                                    },
-                                    "strokeWidth": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "transparent"
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "name": "child_marks",
-                                    "type": "rect",
-                                    "role": "bar",
-                                    "from": {
-                                        "data": "facet"
-                                    },
-                                    "encode": {
-                                        "update": {
-                                            "xc": {
-                                                "scale": "x",
-                                                "field": "age"
-                                            },
-                                            "width": {
-                                                "value": 16
-                                            },
-                                            "y": {
-                                                "scale": "y",
-                                                "field": "sum_people_end"
-                                            },
-                                            "y2": {
-                                                "scale": "y",
-                                                "field": "sum_people_start"
-                                            },
-                                            "fill": {
-                                                "scale": "color",
-                                                "field": "gender"
-                                            }
-                                        }
-                                    }
-                                }
-                            ],
-                            "axes": [
-                                {
-                                    "scale": "y",
-                                    "domain": false,
-                                    "format": "s",
-                                    "grid": true,
-                                    "labels": false,
-                                    "orient": "left",
-                                    "ticks": false,
-                                    "zindex": 0,
-                                    "gridScale": "x"
-                                }
-                            ]
+                            }
                         }
                     ]
                 },
                 {
-                    "name": "row-title",
+                    "name": "y-axes",
+                    "type": "group",
+                    "role": "row-header",
+                    "from": {
+                        "data": "row"
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "population",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "row-labels",
                     "role": "row-header",
                     "type": "group",
+                    "from": {
+                        "data": "row"
+                    },
+                    "encode": {
+                        "update": {
+                            "height": {
+                                "signal": "child_height"
+                            }
+                        }
+                    },
                     "marks": [
                         {
                             "type": "text",
-                            "role": "row-title",
+                            "role": "row-labels",
                             "encode": {
                                 "update": {
                                     "y": {
-                                        "signal": "0.5 * height"
+                                        "field": {
+                                            "group": "height"
+                                        },
+                                        "mult": 0.5
                                     },
-                                    "angle": {
-                                        "value": 270
+                                    "x": {
+                                        "value": -10
                                     },
                                     "text": {
-                                        "value": "gender"
+                                        "field": {
+                                            "parent": "gender"
+                                        }
                                     },
                                     "align": {
                                         "value": "right"
                                     },
                                     "fill": {
                                         "value": "black"
-                                    },
-                                    "fontWeight": {
-                                        "value": "bold"
                                     }
                                 }
                             }
                         }
                     ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "age",
-                        "sort": true
-                    },
-                    "range": {
-                        "step": 17
-                    },
-                    "round": true,
-                    "padding": 0.5
                 },
                 {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "sum_people_start",
-                            "sum_people_end"
-                        ]
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "gender"
+                            ]
+                        }
                     },
-                    "range": [
-                        200,
-                        0
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "width": {
+                                        "value": 16
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "sum_people_end"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "sum_people_start"
+                                    },
+                                    "fill": {
+                                        "scale": "color",
+                                        "field": "gender"
+                                    }
+                                }
+                            }
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "gender",
-                        "sort": true
-                    },
-                    "range": [
-                        "#EA98D2",
-                        "#659CCA"
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
+                        }
                     ]
                 }
-            ],
-            "legends": [
+            ]
+        },
+        {
+            "name": "row-title",
+            "role": "row-header",
+            "type": "group",
+            "marks": [
                 {
-                    "fill": "color",
-                    "title": "gender",
+                    "type": "text",
+                    "role": "row-title",
                     "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "square"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
-                                }
+                        "update": {
+                            "y": {
+                                "signal": "0.5 * height"
+                            },
+                            "angle": {
+                                "value": 270
+                            },
+                            "text": {
+                                "value": "gender"
+                            },
+                            "align": {
+                                "value": "right"
+                            },
+                            "fill": {
+                                "value": "black"
+                            },
+                            "fontWeight": {
+                                "value": "bold"
                             }
                         }
                     }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "age",
+                "sort": true
+            },
+            "range": {
+                "step": 17
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "sum_people_start",
+                    "sum_people_end"
+                ]
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "gender",
+                "sort": true
+            },
+            "range": [
+                "#EA98D2",
+                "#659CCA"
+            ]
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "gender",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "square"
+                        },
+                        "strokeWidth": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/examples/vg-specs/trellis_bar_histogram.vg.json
+++ b/examples/vg-specs/trellis_bar_histogram.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -82,50 +62,40 @@
                     ]
                 }
             ]
-        },
-        {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
-                {
-                    "type": "aggregate",
-                    "fields": [
-                        "Origin"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "child_width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "datum[\"child_width\"] + 5"
-                },
-                {
-                    "type": "formula",
-                    "as": "child_height",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "(datum[\"child_height\"] + 5) * datum[\"distinct_Origin\"]"
-                }
-            ]
         }
     ],
+    "signals": [
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        },
+        {
+            "name": "child_width",
+            "update": "200"
+        },
+        {
+            "name": "child_height",
+            "update": "200"
+        }
+    ],
+    "layout": {
+        "padding": {
+            "row": 10,
+            "column": 10,
+            "header": 10
+        },
+        "columns": 1,
+        "bounds": "full"
+    },
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "from": {
-                "data": "layout"
-            },
             "layout": {
                 "padding": {
                     "row": 10,
@@ -137,262 +107,239 @@
             },
             "marks": [
                 {
+                    "name": "x-axes",
                     "type": "group",
-                    "layout": {
-                        "padding": {
-                            "row": 10,
-                            "column": 10,
-                            "header": 10
-                        },
-                        "columns": 1,
-                        "bounds": "full"
-                    },
-                    "marks": [
+                    "role": "column-footer",
+                    "axes": [
                         {
-                            "name": "x-axes",
-                            "type": "group",
-                            "role": "column-footer",
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "format": "s",
-                                    "orient": "bottom",
-                                    "title": "BIN(Horsepower)",
-                                    "zindex": 1,
-                                    "encode": {
-                                        "labels": {
-                                            "update": {
-                                                "angle": {
-                                                    "value": 270
-                                                },
-                                                "align": {
-                                                    "value": "right"
-                                                },
-                                                "baseline": {
-                                                    "value": "middle"
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "y-axes",
-                            "type": "group",
-                            "role": "row-header",
-                            "from": {
-                                "data": "row"
-                            },
-                            "axes": [
-                                {
-                                    "scale": "y",
-                                    "format": "s",
-                                    "orient": "left",
-                                    "title": "Number of Records",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "row-labels",
-                            "role": "row-header",
-                            "type": "group",
-                            "from": {
-                                "data": "row"
-                            },
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "title": "BIN(Horsepower)",
+                            "zindex": 1,
                             "encode": {
-                                "update": {
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
+                                "labels": {
+                                    "update": {
+                                        "angle": {
+                                            "value": 270
+                                        },
+                                        "align": {
+                                            "value": "right"
+                                        },
+                                        "baseline": {
+                                            "value": "middle"
                                         }
                                     }
                                 }
-                            },
-                            "marks": [
-                                {
-                                    "type": "text",
-                                    "role": "row-labels",
-                                    "encode": {
-                                        "update": {
-                                            "y": {
-                                                "field": {
-                                                    "group": "height"
-                                                },
-                                                "mult": 0.5
-                                            },
-                                            "x": {
-                                                "value": -10
-                                            },
-                                            "text": {
-                                                "field": {
-                                                    "parent": "Origin"
-                                                }
-                                            },
-                                            "align": {
-                                                "value": "right"
-                                            },
-                                            "fill": {
-                                                "value": "black"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "cell",
-                            "type": "group",
-                            "from": {
-                                "facet": {
-                                    "name": "facet",
-                                    "data": "source_0",
-                                    "groupby": [
-                                        "Origin"
-                                    ]
-                                }
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    },
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
-                                        }
-                                    },
-                                    "stroke": {
-                                        "value": "#ccc"
-                                    },
-                                    "strokeWidth": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "transparent"
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "name": "child_marks",
-                                    "type": "rect",
-                                    "role": "bar",
-                                    "from": {
-                                        "data": "facet"
-                                    },
-                                    "encode": {
-                                        "update": {
-                                            "x2": {
-                                                "scale": "x",
-                                                "field": "bin_maxbins_15_Horsepower_start",
-                                                "offset": 1
-                                            },
-                                            "x": {
-                                                "scale": "x",
-                                                "field": "bin_maxbins_15_Horsepower_end"
-                                            },
-                                            "y": {
-                                                "scale": "y",
-                                                "field": "count_*"
-                                            },
-                                            "y2": {
-                                                "scale": "y",
-                                                "value": 0
-                                            },
-                                            "fill": {
-                                                "value": "#4c78a8"
-                                            }
-                                        }
-                                    }
-                                }
-                            ],
-                            "axes": [
-                                {
-                                    "scale": "y",
-                                    "domain": false,
-                                    "format": "s",
-                                    "grid": true,
-                                    "labels": false,
-                                    "orient": "left",
-                                    "ticks": false,
-                                    "zindex": 0,
-                                    "gridScale": "x"
-                                }
-                            ]
+                            }
                         }
                     ]
                 },
                 {
-                    "name": "row-title",
+                    "name": "y-axes",
+                    "type": "group",
+                    "role": "row-header",
+                    "from": {
+                        "data": "row"
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Number of Records",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "row-labels",
                     "role": "row-header",
                     "type": "group",
+                    "from": {
+                        "data": "row"
+                    },
+                    "encode": {
+                        "update": {
+                            "height": {
+                                "signal": "child_height"
+                            }
+                        }
+                    },
                     "marks": [
                         {
                             "type": "text",
-                            "role": "row-title",
+                            "role": "row-labels",
                             "encode": {
                                 "update": {
                                     "y": {
-                                        "signal": "0.5 * height"
+                                        "field": {
+                                            "group": "height"
+                                        },
+                                        "mult": 0.5
                                     },
-                                    "angle": {
-                                        "value": 270
+                                    "x": {
+                                        "value": -10
                                     },
                                     "text": {
-                                        "value": "Origin"
+                                        "field": {
+                                            "parent": "Origin"
+                                        }
                                     },
                                     "align": {
                                         "value": "right"
                                     },
                                     "fill": {
                                         "value": "black"
-                                    },
-                                    "fontWeight": {
-                                        "value": "bold"
                                     }
                                 }
                             }
                         }
                     ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(child_bin_maxbins_15_Horsepower_bins.start, child_bin_maxbins_15_Horsepower_bins.stop + child_bin_maxbins_15_Horsepower_bins.step, child_bin_maxbins_15_Horsepower_bins.step)"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true
                 },
                 {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "count_*"
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "Origin"
+                            ]
+                        }
                     },
-                    "range": [
-                        200,
-                        0
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "bin_maxbins_15_Horsepower_start",
+                                        "offset": 1
+                                    },
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "bin_maxbins_15_Horsepower_end"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "count_*"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
+                        }
+                    ]
                 }
             ]
+        },
+        {
+            "name": "row-title",
+            "role": "row-header",
+            "type": "group",
+            "marks": [
+                {
+                    "type": "text",
+                    "role": "row-title",
+                    "encode": {
+                        "update": {
+                            "y": {
+                                "signal": "0.5 * height"
+                            },
+                            "angle": {
+                                "value": 270
+                            },
+                            "text": {
+                                "value": "Origin"
+                            },
+                            "align": {
+                                "value": "right"
+                            },
+                            "fill": {
+                                "value": "black"
+                            },
+                            "fontWeight": {
+                                "value": "bold"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "bin-linear",
+            "domain": {
+                "signal": "sequence(child_bin_maxbins_15_Horsepower_bins.start, child_bin_maxbins_15_Horsepower_bins.stop + child_bin_maxbins_15_Horsepower_bins.step, child_bin_maxbins_15_Horsepower_bins.step)"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "count_*"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
         }
     ]
 }

--- a/examples/vg-specs/trellis_barley.vg.json
+++ b/examples/vg-specs/trellis_barley.vg.json
@@ -3,26 +3,6 @@
     "description": "The Trellis display by Becker et al. helped establish small multiples as a “powerful mechanism for understanding interactions in studies of how a response depends on explanatory variables”. Here we reproduce a trellis of Barley yields from the 1930s, complete with main-effects ordering to facilitate comparison.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -71,53 +51,40 @@
                     ]
                 }
             ]
-        },
-        {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
-                {
-                    "type": "aggregate",
-                    "fields": [
-                        "site",
-                        "variety"
-                    ],
-                    "ops": [
-                        "distinct",
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "child_width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "datum[\"child_width\"] + 5"
-                },
-                {
-                    "type": "formula",
-                    "as": "child_height",
-                    "expr": "max(datum[\"distinct_variety\"] - 1 + 2*0.5, 0) * 12"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "(datum[\"child_height\"] + 5) * datum[\"distinct_site\"]"
-                }
-            ]
         }
     ],
+    "signals": [
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        },
+        {
+            "name": "child_width",
+            "update": "200"
+        },
+        {
+            "name": "child_height",
+            "update": "bandspace(domain('y').length, 1, 0.5) * 12"
+        }
+    ],
+    "layout": {
+        "padding": {
+            "row": 10,
+            "column": 10,
+            "header": 10
+        },
+        "columns": 1,
+        "bounds": "full"
+    },
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "description": "The Trellis display by Becker et al. helped establish small multiples as a “powerful mechanism for understanding interactions in studies of how a response depends on explanatory variables”. Here we reproduce a trellis of Barley yields from the 1930s, complete with main-effects ordering to facilitate comparison.",
-            "from": {
-                "data": "layout"
-            },
             "layout": {
                 "padding": {
                     "row": 10,
@@ -129,285 +96,262 @@
             },
             "marks": [
                 {
+                    "name": "x-axes",
                     "type": "group",
-                    "layout": {
-                        "padding": {
-                            "row": 10,
-                            "column": 10,
-                            "header": 10
-                        },
-                        "columns": 1,
-                        "bounds": "full"
-                    },
-                    "marks": [
+                    "role": "column-footer",
+                    "axes": [
                         {
-                            "name": "x-axes",
-                            "type": "group",
-                            "role": "column-footer",
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "format": "s",
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "title": "MEDIAN(yield)",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "y-axes",
-                            "type": "group",
-                            "role": "row-header",
-                            "from": {
-                                "data": "row"
-                            },
-                            "axes": [
-                                {
-                                    "scale": "y",
-                                    "orient": "left",
-                                    "title": "variety",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "row-labels",
-                            "role": "row-header",
-                            "type": "group",
-                            "from": {
-                                "data": "row"
-                            },
-                            "encode": {
-                                "update": {
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
-                                        }
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "type": "text",
-                                    "role": "row-labels",
-                                    "encode": {
-                                        "update": {
-                                            "y": {
-                                                "field": {
-                                                    "group": "height"
-                                                },
-                                                "mult": 0.5
-                                            },
-                                            "x": {
-                                                "value": -10
-                                            },
-                                            "text": {
-                                                "field": {
-                                                    "parent": "site"
-                                                }
-                                            },
-                                            "align": {
-                                                "value": "right"
-                                            },
-                                            "fill": {
-                                                "value": "black"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "cell",
-                            "type": "group",
-                            "from": {
-                                "facet": {
-                                    "name": "facet",
-                                    "data": "source_0",
-                                    "groupby": [
-                                        "site"
-                                    ]
-                                }
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    },
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
-                                        }
-                                    },
-                                    "stroke": {
-                                        "value": "#ccc"
-                                    },
-                                    "strokeWidth": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "transparent"
-                                    }
-                                }
-                            },
-                            "data": [
-                                {
-                                    "source": "facet",
-                                    "name": "data_0",
-                                    "transform": [
-                                        {
-                                            "type": "aggregate",
-                                            "groupby": [
-                                                "variety",
-                                                "year"
-                                            ],
-                                            "ops": [
-                                                "median"
-                                            ],
-                                            "fields": [
-                                                "yield"
-                                            ]
-                                        }
-                                    ]
-                                }
-                            ],
-                            "marks": [
-                                {
-                                    "name": "child_marks",
-                                    "type": "symbol",
-                                    "role": "point",
-                                    "from": {
-                                        "data": "data_0"
-                                    },
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "scale": "x",
-                                                "field": "median_yield"
-                                            },
-                                            "y": {
-                                                "scale": "y",
-                                                "field": "variety"
-                                            },
-                                            "stroke": {
-                                                "scale": "color",
-                                                "field": "year"
-                                            },
-                                            "fill": {
-                                                "value": "transparent"
-                                            }
-                                        }
-                                    }
-                                }
-                            ],
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "domain": false,
-                                    "format": "s",
-                                    "grid": true,
-                                    "labels": false,
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "ticks": false,
-                                    "zindex": 0,
-                                    "gridScale": "y"
-                                }
-                            ]
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "MEDIAN(yield)",
+                            "zindex": 1
                         }
                     ]
                 },
                 {
-                    "name": "row-title",
+                    "name": "y-axes",
+                    "type": "group",
+                    "role": "row-header",
+                    "from": {
+                        "data": "row"
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "orient": "left",
+                            "title": "variety",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "row-labels",
                     "role": "row-header",
                     "type": "group",
+                    "from": {
+                        "data": "row"
+                    },
+                    "encode": {
+                        "update": {
+                            "height": {
+                                "signal": "child_height"
+                            }
+                        }
+                    },
                     "marks": [
                         {
                             "type": "text",
-                            "role": "row-title",
+                            "role": "row-labels",
                             "encode": {
                                 "update": {
                                     "y": {
-                                        "signal": "0.5 * height"
+                                        "field": {
+                                            "group": "height"
+                                        },
+                                        "mult": 0.5
                                     },
-                                    "angle": {
-                                        "value": 270
+                                    "x": {
+                                        "value": -10
                                     },
                                     "text": {
-                                        "value": "site"
+                                        "field": {
+                                            "parent": "site"
+                                        }
                                     },
                                     "align": {
                                         "value": "right"
                                     },
                                     "fill": {
                                         "value": "black"
-                                    },
-                                    "fontWeight": {
-                                        "value": "bold"
                                     }
                                 }
                             }
                         }
                     ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_1",
-                        "field": "median_yield"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
                 },
                 {
-                    "name": "y",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "variety",
-                        "sort": {
-                            "op": "median",
-                            "field": "yield"
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "site"
+                            ]
                         }
                     },
-                    "range": {
-                        "step": 12
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
                     },
-                    "round": true,
-                    "padding": 0.5,
-                    "reverse": true
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "data_1",
-                        "field": "year",
-                        "sort": true
-                    },
-                    "range": "category"
-                }
-            ],
-            "legends": [
-                {
-                    "stroke": "color",
-                    "title": "year"
+                    "data": [
+                        {
+                            "source": "facet",
+                            "name": "data_0",
+                            "transform": [
+                                {
+                                    "type": "aggregate",
+                                    "groupby": [
+                                        "variety",
+                                        "year"
+                                    ],
+                                    "ops": [
+                                        "median"
+                                    ],
+                                    "fields": [
+                                        "yield"
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "median_yield"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "variety"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "year"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "y"
+                        }
+                    ]
                 }
             ]
+        },
+        {
+            "name": "row-title",
+            "role": "row-header",
+            "type": "group",
+            "marks": [
+                {
+                    "type": "text",
+                    "role": "row-title",
+                    "encode": {
+                        "update": {
+                            "y": {
+                                "signal": "0.5 * height"
+                            },
+                            "angle": {
+                                "value": 270
+                            },
+                            "text": {
+                                "value": "site"
+                            },
+                            "align": {
+                                "value": "right"
+                            },
+                            "fill": {
+                                "value": "black"
+                            },
+                            "fontWeight": {
+                                "value": "bold"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "data_1",
+                "field": "median_yield"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": false
+        },
+        {
+            "name": "y",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "variety",
+                "sort": {
+                    "op": "median",
+                    "field": "yield"
+                }
+            },
+            "range": {
+                "step": 12
+            },
+            "round": true,
+            "padding": 0.5,
+            "reverse": true
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "data_1",
+                "field": "year",
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "legends": [
+        {
+            "stroke": "color",
+            "title": "year"
         }
     ]
 }

--- a/examples/vg-specs/trellis_row_column.vg.json
+++ b/examples/vg-specs/trellis_row_column.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -53,6 +33,21 @@
             ]
         },
         {
+            "name": "column-layout",
+            "source": "column",
+            "transform": [
+                {
+                    "type": "aggregate",
+                    "ops": [
+                        "distinct"
+                    ],
+                    "fields": [
+                        "Origin"
+                    ]
+                }
+            ]
+        },
+        {
             "name": "row",
             "source": "source_0",
             "transform": [
@@ -63,334 +58,126 @@
                     ]
                 }
             ]
-        },
-        {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
-                {
-                    "type": "aggregate",
-                    "fields": [
-                        "Origin",
-                        "Cylinders"
-                    ],
-                    "ops": [
-                        "distinct",
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "child_width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "(datum[\"child_width\"] + 5) * datum[\"distinct_Origin\"]"
-                },
-                {
-                    "type": "formula",
-                    "as": "child_height",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "(datum[\"child_height\"] + 5) * datum[\"distinct_Cylinders\"]"
-                }
-            ]
         }
     ],
+    "signals": [
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        },
+        {
+            "name": "child_width",
+            "update": "200"
+        },
+        {
+            "name": "child_height",
+            "update": "200"
+        }
+    ],
+    "layout": {
+        "padding": {
+            "row": 10,
+            "column": 10,
+            "header": 10
+        },
+        "columns": 1,
+        "bounds": "full"
+    },
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "from": {
-                "data": "layout"
-            },
-            "signals": [
-                {
-                    "name": "column",
-                    "update": "data('layout')[0].distinct_Origin"
-                }
-            ],
             "layout": {
                 "padding": {
                     "row": 10,
                     "column": 10,
                     "header": 10
                 },
-                "columns": 1,
+                "columns": {
+                    "signal": "data('column-layout')[0].distinct_Origin"
+                },
                 "bounds": "full"
             },
             "marks": [
                 {
+                    "name": "x-axes",
                     "type": "group",
-                    "layout": {
-                        "padding": {
-                            "row": 10,
-                            "column": 10,
-                            "header": 10
-                        },
-                        "columns": {
-                            "signal": "column"
-                        },
-                        "bounds": "full"
+                    "role": "column-footer",
+                    "from": {
+                        "data": "column"
                     },
-                    "marks": [
+                    "axes": [
                         {
-                            "name": "x-axes",
-                            "type": "group",
-                            "role": "column-footer",
-                            "from": {
-                                "data": "column"
-                            },
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "format": "s",
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "title": "Horsepower",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "y-axes",
-                            "type": "group",
-                            "role": "row-header",
-                            "from": {
-                                "data": "row"
-                            },
-                            "axes": [
-                                {
-                                    "scale": "y",
-                                    "format": "s",
-                                    "orient": "left",
-                                    "title": "Miles_per_Gallon",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "column-labels",
-                            "role": "column-header",
-                            "type": "group",
-                            "from": {
-                                "data": "column"
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "type": "text",
-                                    "role": "column-labels",
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "field": {
-                                                    "group": "width"
-                                                },
-                                                "mult": 0.5
-                                            },
-                                            "y": {
-                                                "value": -10
-                                            },
-                                            "text": {
-                                                "field": {
-                                                    "parent": "Origin"
-                                                }
-                                            },
-                                            "align": {
-                                                "value": "center"
-                                            },
-                                            "fill": {
-                                                "value": "black"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "row-labels",
-                            "role": "row-header",
-                            "type": "group",
-                            "from": {
-                                "data": "row"
-                            },
-                            "encode": {
-                                "update": {
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
-                                        }
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "type": "text",
-                                    "role": "row-labels",
-                                    "encode": {
-                                        "update": {
-                                            "y": {
-                                                "field": {
-                                                    "group": "height"
-                                                },
-                                                "mult": 0.5
-                                            },
-                                            "x": {
-                                                "value": -10
-                                            },
-                                            "text": {
-                                                "field": {
-                                                    "parent": "Cylinders"
-                                                }
-                                            },
-                                            "align": {
-                                                "value": "right"
-                                            },
-                                            "fill": {
-                                                "value": "black"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "cell",
-                            "type": "group",
-                            "from": {
-                                "facet": {
-                                    "name": "facet",
-                                    "data": "source_0",
-                                    "groupby": [
-                                        "Cylinders",
-                                        "Origin"
-                                    ]
-                                }
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    },
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
-                                        }
-                                    },
-                                    "stroke": {
-                                        "value": "#ccc"
-                                    },
-                                    "strokeWidth": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "transparent"
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "name": "child_marks",
-                                    "type": "symbol",
-                                    "role": "point",
-                                    "from": {
-                                        "data": "facet"
-                                    },
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "scale": "x",
-                                                "field": "Horsepower"
-                                            },
-                                            "y": {
-                                                "scale": "y",
-                                                "field": "Miles_per_Gallon"
-                                            },
-                                            "stroke": {
-                                                "value": "#4c78a8"
-                                            },
-                                            "fill": {
-                                                "value": "transparent"
-                                            },
-                                            "opacity": {
-                                                "value": 0.7
-                                            }
-                                        }
-                                    }
-                                }
-                            ],
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "domain": false,
-                                    "format": "s",
-                                    "grid": true,
-                                    "labels": false,
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "ticks": false,
-                                    "zindex": 0,
-                                    "gridScale": "y"
-                                },
-                                {
-                                    "scale": "y",
-                                    "domain": false,
-                                    "format": "s",
-                                    "grid": true,
-                                    "labels": false,
-                                    "orient": "left",
-                                    "ticks": false,
-                                    "zindex": 0,
-                                    "gridScale": "x"
-                                }
-                            ]
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "Horsepower",
+                            "zindex": 1
                         }
                     ]
                 },
                 {
-                    "name": "column-title",
+                    "name": "y-axes",
+                    "type": "group",
+                    "role": "row-header",
+                    "from": {
+                        "data": "row"
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Miles_per_Gallon",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "column-labels",
                     "role": "column-header",
                     "type": "group",
+                    "from": {
+                        "data": "column"
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
                     "marks": [
                         {
                             "type": "text",
-                            "role": "column-title",
+                            "role": "column-labels",
                             "encode": {
                                 "update": {
                                     "x": {
-                                        "signal": "0.5 * width"
+                                        "field": {
+                                            "group": "width"
+                                        },
+                                        "mult": 0.5
+                                    },
+                                    "y": {
+                                        "value": -10
                                     },
                                     "text": {
-                                        "value": "Origin"
+                                        "field": {
+                                            "parent": "Origin"
+                                        }
                                     },
                                     "align": {
                                         "value": "center"
                                     },
                                     "fill": {
                                         "value": "black"
-                                    },
-                                    "fontWeight": {
-                                        "value": "bold"
                                     }
                                 }
                             }
@@ -398,71 +185,235 @@
                     ]
                 },
                 {
-                    "name": "row-title",
+                    "name": "row-labels",
                     "role": "row-header",
                     "type": "group",
+                    "from": {
+                        "data": "row"
+                    },
+                    "encode": {
+                        "update": {
+                            "height": {
+                                "signal": "child_height"
+                            }
+                        }
+                    },
                     "marks": [
                         {
                             "type": "text",
-                            "role": "row-title",
+                            "role": "row-labels",
                             "encode": {
                                 "update": {
                                     "y": {
-                                        "signal": "0.5 * height"
+                                        "field": {
+                                            "group": "height"
+                                        },
+                                        "mult": 0.5
                                     },
-                                    "angle": {
-                                        "value": 270
+                                    "x": {
+                                        "value": -10
                                     },
                                     "text": {
-                                        "value": "Cylinders"
+                                        "field": {
+                                            "parent": "Cylinders"
+                                        }
                                     },
                                     "align": {
                                         "value": "right"
                                     },
                                     "fill": {
                                         "value": "black"
-                                    },
-                                    "fontWeight": {
-                                        "value": "bold"
                                     }
                                 }
                             }
                         }
                     ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
                 },
                 {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "Cylinders",
+                                "Origin"
+                            ]
+                        }
                     },
-                    "range": [
-                        200,
-                        0
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "Horsepower"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "Miles_per_Gallon"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "y"
+                        },
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
+                        }
+                    ]
                 }
             ]
+        },
+        {
+            "name": "column-title",
+            "role": "column-header",
+            "type": "group",
+            "marks": [
+                {
+                    "type": "text",
+                    "role": "column-title",
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "signal": "0.5 * width"
+                            },
+                            "text": {
+                                "value": "Origin"
+                            },
+                            "align": {
+                                "value": "center"
+                            },
+                            "fill": {
+                                "value": "black"
+                            },
+                            "fontWeight": {
+                                "value": "bold"
+                            }
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "row-title",
+            "role": "row-header",
+            "type": "group",
+            "marks": [
+                {
+                    "type": "text",
+                    "role": "row-title",
+                    "encode": {
+                        "update": {
+                            "y": {
+                                "signal": "0.5 * height"
+                            },
+                            "angle": {
+                                "value": 270
+                            },
+                            "text": {
+                                "value": "Cylinders"
+                            },
+                            "align": {
+                                "value": "right"
+                            },
+                            "fill": {
+                                "value": "black"
+                            },
+                            "fontWeight": {
+                                "value": "bold"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
         }
     ]
 }

--- a/examples/vg-specs/trellis_scatter.vg.json
+++ b/examples/vg-specs/trellis_scatter.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -53,317 +33,293 @@
             ]
         },
         {
-            "name": "layout",
-            "source": "source_0",
+            "name": "column-layout",
+            "source": "column",
             "transform": [
                 {
                     "type": "aggregate",
-                    "fields": [
-                        "MPAA_Rating"
-                    ],
                     "ops": [
                         "distinct"
+                    ],
+                    "fields": [
+                        "MPAA_Rating"
                     ]
-                },
-                {
-                    "type": "formula",
-                    "as": "child_width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "(datum[\"child_width\"] + 5) * datum[\"distinct_MPAA_Rating\"]"
-                },
-                {
-                    "type": "formula",
-                    "as": "child_height",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "datum[\"child_height\"] + 5"
                 }
             ]
         }
     ],
+    "signals": [
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        },
+        {
+            "name": "child_width",
+            "update": "200"
+        },
+        {
+            "name": "child_height",
+            "update": "200"
+        }
+    ],
+    "layout": {
+        "padding": {
+            "row": 10,
+            "column": 10,
+            "header": 10
+        },
+        "columns": 1,
+        "bounds": "full"
+    },
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "from": {
-                "data": "layout"
-            },
-            "signals": [
-                {
-                    "name": "column",
-                    "update": "data('layout')[0].distinct_MPAA_Rating"
-                }
-            ],
             "layout": {
                 "padding": {
                     "row": 10,
                     "column": 10,
                     "header": 10
                 },
-                "columns": 1,
+                "columns": {
+                    "signal": "data('column-layout')[0].distinct_MPAA_Rating"
+                },
                 "bounds": "full"
             },
             "marks": [
                 {
+                    "name": "x-axes",
                     "type": "group",
-                    "layout": {
-                        "padding": {
-                            "row": 10,
-                            "column": 10,
-                            "header": 10
-                        },
-                        "columns": {
-                            "signal": "column"
-                        },
-                        "bounds": "full"
+                    "role": "column-footer",
+                    "from": {
+                        "data": "column"
                     },
-                    "marks": [
+                    "axes": [
                         {
-                            "name": "x-axes",
-                            "type": "group",
-                            "role": "column-footer",
-                            "from": {
-                                "data": "column"
-                            },
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "format": "s",
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "title": "Worldwide_Gross",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "y-axes",
-                            "type": "group",
-                            "role": "row-header",
-                            "axes": [
-                                {
-                                    "scale": "y",
-                                    "format": "s",
-                                    "orient": "left",
-                                    "title": "US_DVD_Sales",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "column-labels",
-                            "role": "column-header",
-                            "type": "group",
-                            "from": {
-                                "data": "column"
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "type": "text",
-                                    "role": "column-labels",
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "field": {
-                                                    "group": "width"
-                                                },
-                                                "mult": 0.5
-                                            },
-                                            "y": {
-                                                "value": -10
-                                            },
-                                            "text": {
-                                                "field": {
-                                                    "parent": "MPAA_Rating"
-                                                }
-                                            },
-                                            "align": {
-                                                "value": "center"
-                                            },
-                                            "fill": {
-                                                "value": "black"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "cell",
-                            "type": "group",
-                            "from": {
-                                "facet": {
-                                    "name": "facet",
-                                    "data": "source_0",
-                                    "groupby": [
-                                        "MPAA_Rating"
-                                    ]
-                                }
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    },
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
-                                        }
-                                    },
-                                    "stroke": {
-                                        "value": "#ccc"
-                                    },
-                                    "strokeWidth": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "transparent"
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "name": "child_marks",
-                                    "type": "symbol",
-                                    "role": "point",
-                                    "from": {
-                                        "data": "facet"
-                                    },
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "scale": "x",
-                                                "field": "Worldwide_Gross"
-                                            },
-                                            "y": {
-                                                "scale": "y",
-                                                "field": "US_DVD_Sales"
-                                            },
-                                            "stroke": {
-                                                "value": "#4c78a8"
-                                            },
-                                            "fill": {
-                                                "value": "transparent"
-                                            },
-                                            "opacity": {
-                                                "value": 0.7
-                                            }
-                                        }
-                                    }
-                                }
-                            ],
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "domain": false,
-                                    "format": "s",
-                                    "grid": true,
-                                    "labels": false,
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "ticks": false,
-                                    "zindex": 0,
-                                    "gridScale": "y"
-                                },
-                                {
-                                    "scale": "y",
-                                    "domain": false,
-                                    "format": "s",
-                                    "grid": true,
-                                    "labels": false,
-                                    "orient": "left",
-                                    "ticks": false,
-                                    "zindex": 0,
-                                    "gridScale": "x"
-                                }
-                            ]
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "Worldwide_Gross",
+                            "zindex": 1
                         }
                     ]
                 },
                 {
-                    "name": "column-title",
+                    "name": "y-axes",
+                    "type": "group",
+                    "role": "row-header",
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "US_DVD_Sales",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "column-labels",
                     "role": "column-header",
                     "type": "group",
+                    "from": {
+                        "data": "column"
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
                     "marks": [
                         {
                             "type": "text",
-                            "role": "column-title",
+                            "role": "column-labels",
                             "encode": {
                                 "update": {
                                     "x": {
-                                        "signal": "0.5 * width"
+                                        "field": {
+                                            "group": "width"
+                                        },
+                                        "mult": 0.5
+                                    },
+                                    "y": {
+                                        "value": -10
                                     },
                                     "text": {
-                                        "value": "MPAA_Rating"
+                                        "field": {
+                                            "parent": "MPAA_Rating"
+                                        }
                                     },
                                     "align": {
                                         "value": "center"
                                     },
                                     "fill": {
                                         "value": "black"
-                                    },
-                                    "fontWeight": {
-                                        "value": "bold"
                                     }
                                 }
                             }
                         }
                     ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Worldwide_Gross"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
                 },
                 {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "US_DVD_Sales"
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "MPAA_Rating"
+                            ]
+                        }
                     },
-                    "range": [
-                        200,
-                        0
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "Worldwide_Gross"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "US_DVD_Sales"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "y"
+                        },
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
+                        }
+                    ]
                 }
             ]
+        },
+        {
+            "name": "column-title",
+            "role": "column-header",
+            "type": "group",
+            "marks": [
+                {
+                    "type": "text",
+                    "role": "column-title",
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "signal": "0.5 * width"
+                            },
+                            "text": {
+                                "value": "MPAA_Rating"
+                            },
+                            "align": {
+                                "value": "center"
+                            },
+                            "fill": {
+                                "value": "black"
+                            },
+                            "fontWeight": {
+                                "value": "bold"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Worldwide_Gross"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "US_DVD_Sales"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
         }
     ]
 }

--- a/examples/vg-specs/trellis_scatter_binned_row.vg.json
+++ b/examples/vg-specs/trellis_scatter_binned_row.vg.json
@@ -3,26 +3,6 @@
     "description": "A trellis scatterplot showing Horsepower and Miles per gallons, faceted by binned values of Acceleration.",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -80,51 +60,40 @@
                     ]
                 }
             ]
-        },
-        {
-            "name": "layout",
-            "source": "source_0",
-            "transform": [
-                {
-                    "type": "aggregate",
-                    "fields": [
-                        "bin_maxbins_6_Acceleration_range"
-                    ],
-                    "ops": [
-                        "distinct"
-                    ]
-                },
-                {
-                    "type": "formula",
-                    "as": "child_width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "datum[\"child_width\"] + 5"
-                },
-                {
-                    "type": "formula",
-                    "as": "child_height",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "(datum[\"child_height\"] + 5) * datum[\"distinct_bin_maxbins_6_Acceleration_range\"]"
-                }
-            ]
         }
     ],
+    "signals": [
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        },
+        {
+            "name": "child_width",
+            "update": "200"
+        },
+        {
+            "name": "child_height",
+            "update": "200"
+        }
+    ],
+    "layout": {
+        "padding": {
+            "row": 10,
+            "column": 10,
+            "header": 10
+        },
+        "columns": 1,
+        "bounds": "full"
+    },
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "description": "A trellis scatterplot showing Horsepower and Miles per gallons, faceted by binned values of Acceleration.",
-            "from": {
-                "data": "layout"
-            },
             "layout": {
                 "padding": {
                     "row": 10,
@@ -136,259 +105,236 @@
             },
             "marks": [
                 {
+                    "name": "x-axes",
                     "type": "group",
-                    "layout": {
-                        "padding": {
-                            "row": 10,
-                            "column": 10,
-                            "header": 10
-                        },
-                        "columns": 1,
-                        "bounds": "full"
-                    },
-                    "marks": [
+                    "role": "column-footer",
+                    "axes": [
                         {
-                            "name": "x-axes",
-                            "type": "group",
-                            "role": "column-footer",
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "format": "s",
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "title": "Horsepower",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "y-axes",
-                            "type": "group",
-                            "role": "row-header",
-                            "from": {
-                                "data": "row"
-                            },
-                            "axes": [
-                                {
-                                    "scale": "y",
-                                    "format": "s",
-                                    "orient": "left",
-                                    "title": "Miles_per_Gallon",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "row-labels",
-                            "role": "row-header",
-                            "type": "group",
-                            "from": {
-                                "data": "row"
-                            },
-                            "encode": {
-                                "update": {
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
-                                        }
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "type": "text",
-                                    "role": "row-labels",
-                                    "encode": {
-                                        "update": {
-                                            "y": {
-                                                "field": {
-                                                    "group": "height"
-                                                },
-                                                "mult": 0.5
-                                            },
-                                            "x": {
-                                                "value": -10
-                                            },
-                                            "text": {
-                                                "field": {
-                                                    "parent": "bin_maxbins_6_Acceleration_range"
-                                                }
-                                            },
-                                            "align": {
-                                                "value": "right"
-                                            },
-                                            "fill": {
-                                                "value": "black"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "cell",
-                            "type": "group",
-                            "from": {
-                                "facet": {
-                                    "name": "facet",
-                                    "data": "source_0",
-                                    "groupby": [
-                                        "bin_maxbins_6_Acceleration_range"
-                                    ]
-                                }
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    },
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
-                                        }
-                                    },
-                                    "stroke": {
-                                        "value": "#ccc"
-                                    },
-                                    "strokeWidth": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "transparent"
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "name": "child_marks",
-                                    "type": "symbol",
-                                    "role": "point",
-                                    "from": {
-                                        "data": "facet"
-                                    },
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "scale": "x",
-                                                "field": "Horsepower"
-                                            },
-                                            "y": {
-                                                "scale": "y",
-                                                "field": "Miles_per_Gallon"
-                                            },
-                                            "stroke": {
-                                                "value": "#4c78a8"
-                                            },
-                                            "fill": {
-                                                "value": "transparent"
-                                            },
-                                            "opacity": {
-                                                "value": 0.7
-                                            }
-                                        }
-                                    }
-                                }
-                            ],
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "domain": false,
-                                    "format": "s",
-                                    "grid": true,
-                                    "labels": false,
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "ticks": false,
-                                    "zindex": 0,
-                                    "gridScale": "y"
-                                },
-                                {
-                                    "scale": "y",
-                                    "domain": false,
-                                    "format": "s",
-                                    "grid": true,
-                                    "labels": false,
-                                    "orient": "left",
-                                    "ticks": false,
-                                    "zindex": 0,
-                                    "gridScale": "x"
-                                }
-                            ]
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "Horsepower",
+                            "zindex": 1
                         }
                     ]
                 },
                 {
-                    "name": "row-title",
+                    "name": "y-axes",
+                    "type": "group",
+                    "role": "row-header",
+                    "from": {
+                        "data": "row"
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Miles_per_Gallon",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "row-labels",
                     "role": "row-header",
                     "type": "group",
+                    "from": {
+                        "data": "row"
+                    },
+                    "encode": {
+                        "update": {
+                            "height": {
+                                "signal": "child_height"
+                            }
+                        }
+                    },
                     "marks": [
                         {
                             "type": "text",
-                            "role": "row-title",
+                            "role": "row-labels",
                             "encode": {
                                 "update": {
                                     "y": {
-                                        "signal": "0.5 * height"
+                                        "field": {
+                                            "group": "height"
+                                        },
+                                        "mult": 0.5
                                     },
-                                    "angle": {
-                                        "value": 270
+                                    "x": {
+                                        "value": -10
                                     },
                                     "text": {
-                                        "value": "BIN(Acceleration)"
+                                        "field": {
+                                            "parent": "bin_maxbins_6_Acceleration_range"
+                                        }
                                     },
                                     "align": {
                                         "value": "right"
                                     },
                                     "fill": {
                                         "value": "black"
-                                    },
-                                    "fontWeight": {
-                                        "value": "bold"
                                     }
                                 }
                             }
                         }
                     ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
                 },
                 {
-                    "name": "y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "Miles_per_Gallon"
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "bin_maxbins_6_Acceleration_range"
+                            ]
+                        }
                     },
-                    "range": [
-                        200,
-                        0
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "Horsepower"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "Miles_per_Gallon"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "y"
+                        },
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
+                        }
+                    ]
                 }
             ]
+        },
+        {
+            "name": "row-title",
+            "role": "row-header",
+            "type": "group",
+            "marks": [
+                {
+                    "type": "text",
+                    "role": "row-title",
+                    "encode": {
+                        "update": {
+                            "y": {
+                                "signal": "0.5 * height"
+                            },
+                            "angle": {
+                                "value": 270
+                            },
+                            "text": {
+                                "value": "BIN(Acceleration)"
+                            },
+                            "align": {
+                                "value": "right"
+                            },
+                            "fill": {
+                                "value": "black"
+                            },
+                            "fontWeight": {
+                                "value": "bold"
+                            }
+                        }
+                    }
+                }
+            ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Horsepower"
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
         }
     ]
 }

--- a/examples/vg-specs/trellis_stacked_bar.vg.json
+++ b/examples/vg-specs/trellis_stacked_bar.vg.json
@@ -2,26 +2,6 @@
     "$schema": "http://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
-    "signals": [
-        {
-            "name": "width",
-            "update": "data('layout')[0].width"
-        },
-        {
-            "name": "height",
-            "update": "data('layout')[0].height"
-        },
-        {
-            "name": "unit",
-            "value": {},
-            "on": [
-                {
-                    "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
-                }
-            ]
-        }
-    ],
     "data": [
         {
             "name": "source_0",
@@ -87,339 +67,313 @@
             ]
         },
         {
-            "name": "layout",
-            "source": "source_0",
+            "name": "column-layout",
+            "source": "column",
             "transform": [
                 {
                     "type": "aggregate",
-                    "fields": [
-                        "year",
-                        "variety"
-                    ],
                     "ops": [
-                        "distinct",
                         "distinct"
+                    ],
+                    "fields": [
+                        "year"
                     ]
-                },
-                {
-                    "type": "formula",
-                    "as": "child_width",
-                    "expr": "200"
-                },
-                {
-                    "type": "formula",
-                    "as": "width",
-                    "expr": "(datum[\"child_width\"] + 5) * datum[\"distinct_year\"]"
-                },
-                {
-                    "type": "formula",
-                    "as": "child_height",
-                    "expr": "max(datum[\"distinct_variety\"] - 1 + 2*0.5, 0) * 21"
-                },
-                {
-                    "type": "formula",
-                    "as": "height",
-                    "expr": "datum[\"child_height\"] + 5"
                 }
             ]
         }
     ],
+    "signals": [
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        },
+        {
+            "name": "child_width",
+            "update": "200"
+        },
+        {
+            "name": "child_height",
+            "update": "bandspace(domain('y').length, 1, 0.5) * 21"
+        }
+    ],
+    "layout": {
+        "padding": {
+            "row": 10,
+            "column": 10,
+            "header": 10
+        },
+        "columns": 1,
+        "bounds": "full"
+    },
     "marks": [
         {
-            "name": "main-group",
             "type": "group",
-            "from": {
-                "data": "layout"
-            },
-            "signals": [
-                {
-                    "name": "column",
-                    "update": "data('layout')[0].distinct_year"
-                }
-            ],
             "layout": {
                 "padding": {
                     "row": 10,
                     "column": 10,
                     "header": 10
                 },
-                "columns": 1,
+                "columns": {
+                    "signal": "data('column-layout')[0].distinct_year"
+                },
                 "bounds": "full"
             },
             "marks": [
                 {
+                    "name": "x-axes",
                     "type": "group",
-                    "layout": {
-                        "padding": {
-                            "row": 10,
-                            "column": 10,
-                            "header": 10
-                        },
-                        "columns": {
-                            "signal": "column"
-                        },
-                        "bounds": "full"
+                    "role": "column-footer",
+                    "from": {
+                        "data": "column"
                     },
-                    "marks": [
+                    "axes": [
                         {
-                            "name": "x-axes",
-                            "type": "group",
-                            "role": "column-footer",
-                            "from": {
-                                "data": "column"
-                            },
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "format": "s",
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "title": "SUM(yield)",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "y-axes",
-                            "type": "group",
-                            "role": "row-header",
-                            "axes": [
-                                {
-                                    "scale": "y",
-                                    "orient": "left",
-                                    "title": "variety",
-                                    "zindex": 1
-                                }
-                            ]
-                        },
-                        {
-                            "name": "column-labels",
-                            "role": "column-header",
-                            "type": "group",
-                            "from": {
-                                "data": "column"
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "type": "text",
-                                    "role": "column-labels",
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "field": {
-                                                    "group": "width"
-                                                },
-                                                "mult": 0.5
-                                            },
-                                            "y": {
-                                                "value": -10
-                                            },
-                                            "text": {
-                                                "field": {
-                                                    "parent": "year"
-                                                }
-                                            },
-                                            "align": {
-                                                "value": "center"
-                                            },
-                                            "fill": {
-                                                "value": "black"
-                                            }
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "name": "cell",
-                            "type": "group",
-                            "from": {
-                                "facet": {
-                                    "name": "facet",
-                                    "data": "source_0",
-                                    "groupby": [
-                                        "year"
-                                    ]
-                                }
-                            },
-                            "encode": {
-                                "update": {
-                                    "width": {
-                                        "field": {
-                                            "parent": "child_width",
-                                            "level": 2
-                                        }
-                                    },
-                                    "height": {
-                                        "field": {
-                                            "parent": "child_height",
-                                            "level": 2
-                                        }
-                                    },
-                                    "stroke": {
-                                        "value": "#ccc"
-                                    },
-                                    "strokeWidth": {
-                                        "value": 1
-                                    },
-                                    "fill": {
-                                        "value": "transparent"
-                                    }
-                                }
-                            },
-                            "marks": [
-                                {
-                                    "name": "child_marks",
-                                    "type": "rect",
-                                    "role": "bar",
-                                    "from": {
-                                        "data": "facet"
-                                    },
-                                    "encode": {
-                                        "update": {
-                                            "x": {
-                                                "scale": "x",
-                                                "field": "sum_yield_end"
-                                            },
-                                            "x2": {
-                                                "scale": "x",
-                                                "field": "sum_yield_start"
-                                            },
-                                            "yc": {
-                                                "scale": "y",
-                                                "field": "variety"
-                                            },
-                                            "height": {
-                                                "value": 20
-                                            },
-                                            "fill": {
-                                                "scale": "color",
-                                                "field": "site"
-                                            }
-                                        }
-                                    }
-                                }
-                            ],
-                            "axes": [
-                                {
-                                    "scale": "x",
-                                    "domain": false,
-                                    "format": "s",
-                                    "grid": true,
-                                    "labels": false,
-                                    "orient": "bottom",
-                                    "tickCount": 5,
-                                    "ticks": false,
-                                    "zindex": 0,
-                                    "gridScale": "y"
-                                }
-                            ]
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "SUM(yield)",
+                            "zindex": 1
                         }
                     ]
                 },
                 {
-                    "name": "column-title",
+                    "name": "y-axes",
+                    "type": "group",
+                    "role": "row-header",
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "orient": "left",
+                            "title": "variety",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "column-labels",
                     "role": "column-header",
                     "type": "group",
+                    "from": {
+                        "data": "column"
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
                     "marks": [
                         {
                             "type": "text",
-                            "role": "column-title",
+                            "role": "column-labels",
                             "encode": {
                                 "update": {
                                     "x": {
-                                        "signal": "0.5 * width"
+                                        "field": {
+                                            "group": "width"
+                                        },
+                                        "mult": 0.5
+                                    },
+                                    "y": {
+                                        "value": -10
                                     },
                                     "text": {
-                                        "value": "year"
+                                        "field": {
+                                            "parent": "year"
+                                        }
                                     },
                                     "align": {
                                         "value": "center"
                                     },
                                     "fill": {
                                         "value": "black"
-                                    },
-                                    "fontWeight": {
-                                        "value": "bold"
                                     }
                                 }
                             }
                         }
                     ]
-                }
-            ],
-            "scales": [
-                {
-                    "name": "x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "source_0",
-                        "fields": [
-                            "sum_yield_start",
-                            "sum_yield_end"
-                        ]
-                    },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
                 },
                 {
-                    "name": "y",
-                    "type": "point",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "variety",
-                        "sort": true
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "year"
+                            ]
+                        }
                     },
-                    "range": {
-                        "step": 21
-                    },
-                    "round": true,
-                    "padding": 0.5
-                },
-                {
-                    "name": "color",
-                    "type": "ordinal",
-                    "domain": {
-                        "data": "source_0",
-                        "field": "site",
-                        "sort": true
-                    },
-                    "range": "category"
-                }
-            ],
-            "legends": [
-                {
-                    "fill": "color",
-                    "title": "site",
                     "encode": {
-                        "symbols": {
-                            "update": {
-                                "shape": {
-                                    "value": "square"
-                                },
-                                "strokeWidth": {
-                                    "value": 0
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "sum_yield_end"
+                                    },
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "sum_yield_start"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "variety"
+                                    },
+                                    "height": {
+                                        "value": 20
+                                    },
+                                    "fill": {
+                                        "scale": "color",
+                                        "field": "site"
+                                    }
                                 }
+                            }
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "y"
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "column-title",
+            "role": "column-header",
+            "type": "group",
+            "marks": [
+                {
+                    "type": "text",
+                    "role": "column-title",
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "signal": "0.5 * width"
+                            },
+                            "text": {
+                                "value": "year"
+                            },
+                            "align": {
+                                "value": "center"
+                            },
+                            "fill": {
+                                "value": "black"
+                            },
+                            "fontWeight": {
+                                "value": "bold"
                             }
                         }
                     }
                 }
             ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "linear",
+            "domain": {
+                "data": "source_0",
+                "fields": [
+                    "sum_yield_start",
+                    "sum_yield_end"
+                ]
+            },
+            "range": [
+                0,
+                200
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "y",
+            "type": "point",
+            "domain": {
+                "data": "source_0",
+                "field": "variety",
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "site",
+                "sort": true
+            },
+            "range": "category"
+        }
+    ],
+    "legends": [
+        {
+            "fill": "color",
+            "title": "site",
+            "encode": {
+                "symbols": {
+                    "update": {
+                        "shape": {
+                            "value": "square"
+                        },
+                        "strokeWidth": {
+                            "value": 0
+                        }
+                    }
+                }
+            }
         }
     ]
 }

--- a/src/compile/data/facet.ts
+++ b/src/compile/data/facet.ts
@@ -62,6 +62,17 @@ export class FacetNode extends DataFlowNode {
           groupby: [this.columnField]
         }]
       });
+
+      // Column needs another data source to calculate cardinality as input to layout
+      data.push({
+        name: this.columnName + '-layout',
+        source: this.columnName,
+        transform: [{
+          type: 'aggregate',
+          ops: ['distinct'],
+          fields: [this.columnField]
+        }]
+      });
     }
 
     if (this.rowName) {

--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -78,13 +78,16 @@ Description of the dataflow (http://asciiflow.com/):
          |
          v
    +----------+
-   |   Main   +----> Layout
+   |   Main   |
    +----------+
          |
          v
      +-------+
-     | Facet |----> Child data...
+     | Facet |----> "column", "column-layout", and "row"
      +-------+
+         |
+         v
+  ...Child data...
 
 */
 

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -244,8 +244,8 @@ function clippedGroup(model: Model, marks: any[]): any[] {
     type: 'group',
     encode: {
       enter: {
-        width: {field: {group: 'width'}},
-        height: {field: {group: 'height'}},
+        width: model.getSizeSignalRef('width'),
+        height: model.getSizeSignalRef('height'),
         fill: {value: 'transparent'},
         clip: {value: true}
       }

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -92,6 +92,7 @@ export function parseUnitSelection(model: UnitModel, selDefs: Dict<SelectionDef>
   return selCmpts;
 }
 
+// FIXME: rename to assembleSelectionUnitSignals
 export function assembleUnitSignals(model: UnitModel, signals: any[]) {
   forEachSelection(model, (selCmpt, selCompiler) => {
     const name = selCmpt.name,
@@ -203,7 +204,7 @@ export function predicate(selCmpt: SelectionComponent, datum?: string): string {
   const store = stringValue(selCmpt.name + STORE),
         op = PREDICATES_OPS[selCmpt.resolve];
   datum = datum || 'datum';
-  return compiler(selCmpt).predicate + `(${store}, parent._id, ${datum}, ${op})`;
+  return compiler(selCmpt).predicate + `(${store}, datum._id, ${datum}, ${op})`;
 }
 
 // Utility functions

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -12,14 +12,15 @@ import {SortField, SortOrder} from '../sort';
 import {UnitSpec} from '../spec';
 import {stack, StackProperties} from '../stack';
 import {Dict, duplicate, extend, vals} from '../util';
-import {VgData, VgLayout} from '../vega.schema';
+import {VgData, VgLayout, VgSignal} from '../vega.schema';
 import {parseAxisComponent} from './axis/parse';
 import {applyConfig} from './common';
 import {assembleData} from './data/assemble';
 import {parseData} from './data/parse';
 import {FacetModel} from './facet';
 import {LayerModel} from './layer';
-import {assembleLayoutData, parseUnitLayout} from './layout';
+import {parseUnitLayout} from './layout';
+import {assembleLayoutUnitSignals} from './layout/index';
 import {parseLegendComponent} from './legend/parse';
 import {initEncoding, initMarkDef} from './mark/init';
 import {parseMark} from './mark/mark';
@@ -277,8 +278,8 @@ export class UnitModel extends ModelWithField {
     return [];
   }
 
-  public assembleSignals(signals: any[]): any[] {
-    return assembleUnitSignals(this, signals);
+  public assembleSignals(): VgSignal[] {
+    return assembleUnitSignals(this, []);
   }
 
   public assembleSelectionData(data: VgData[]): VgData[] {
@@ -289,9 +290,8 @@ export class UnitModel extends ModelWithField {
     return null;
   }
 
-
-  public assembleLayoutData(layoutData: VgData[]): VgData[] {
-    return assembleLayoutData(this, layoutData);
+  public assembleLayoutSignals(): VgSignal[] {
+    return assembleLayoutUnitSignals(this);
   }
 
   public assembleMarks() {

--- a/src/data.ts
+++ b/src/data.ts
@@ -91,9 +91,7 @@ export function isNamedData(data: Partial<Data>): data is NamedData {
   return !!data['name'];
 }
 
-export type DataSourceType = 'raw' | 'main' | 'layout' | 'row' | 'column';
-
+export type DataSourceType = 'raw' | 'main' | 'row' | 'column';
 
 export const MAIN: 'main' = 'main';
 export const RAW: 'raw' = 'raw';
-export const LAYOUT: 'layout' = 'layout';

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -135,6 +135,11 @@ export function isSignalRefDomain(domain: VgDomain): domain is VgSignalRef {
   return false;
 }
 
+export type VgSignal = {
+  name: string,
+  update: string
+};
+
 export type VgEncodeEntry = any;
 // TODO: make export interface VgEncodeEntry {
 //   x?: VgValueRef<number>
@@ -174,7 +179,7 @@ export interface VgFilterTransform {
 
 export interface VgAggregateTransform {
   type: 'aggregate';
-  groupby: VgFieldRef[];
+  groupby?: VgFieldRef[];
   fields?: VgFieldRef[];
   ops?: string[];
   as?: string[];

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -5,7 +5,7 @@ import {parseUnitModel} from '../util';
 
 import * as log from '../../src/log';
 
-import {assembleRootGroup, compile} from '../../src/compile/compile';
+import {compile} from '../../src/compile/compile';
 
 
 describe('Compile', function() {
@@ -30,11 +30,11 @@ describe('Compile', function() {
       assert.deepEqual(spec.signals, [
         {
           name: 'width',
-          update: "data('layout')[0].width"
+          update: "21"
         },
         {
           name: 'height',
-          update: "data('layout')[0].height"
+          update: "21"
         },
         {
           name: 'unit',
@@ -43,7 +43,7 @@ describe('Compile', function() {
         }
       ]);
 
-      assert.equal(spec.data.length, 2); // just source and layout
+      assert.equal(spec.data.length, 1); // just source
       assert.equal(spec.marks.length, 1); // just the root group
     });
 
@@ -62,11 +62,11 @@ describe('Compile', function() {
       assert.deepEqual(spec.signals, [
         {
           name: 'width',
-          update: "data('layout')[0].width"
+          update: "21"
         },
         {
           name: 'height',
-          update: "data('layout')[0].height"
+          update: "21"
         },
         {
           name: 'unit',
@@ -75,60 +75,8 @@ describe('Compile', function() {
         }
       ]);
 
-      assert.equal(spec.data.length, 2); // just source and layout
+      assert.equal(spec.data.length, 1); // just source.
       assert.equal(spec.marks.length, 1); // just the root group
     });
-  });
-
-  describe('assembleRootGroup()', function() {
-    it('produce correct from and size.', function() {
-      const model = parseUnitModel({
-        "description": "A simple bar chart with embedded data.",
-        "data": {
-          "values": [
-            {"a": "A","b": 28}, {"a": "B","b": 55}, {"a": "C","b": 43},
-            {"a": "D","b": 91}, {"a": "E","b": 81}, {"a": "F","b": 53},
-            {"a": "G","b": 19}, {"a": "H","b": 87}, {"a": "I","b": 52}
-          ]
-        },
-        "mark": "bar",
-        "encoding": {
-          "x": {"field": "a", "type": "ordinal"},
-          "y": {"field": "b", "type": "quantitative"}
-        }
-      });
-
-      const rootGroup = assembleRootGroup(model);
-
-      assert.deepEqual(rootGroup.from, {"data": "layout"});
-      assert.deepEqual(rootGroup.encode.update.width, {field: "width"});
-      assert.deepEqual(rootGroup.encode.update.height, {field: "height"});
-    });
-
-    it('produce correct from and size when a chart name is provided.', function() {
-      const model = parseUnitModel({
-        "name": "chart",
-        "description": "A simple bar chart with embedded data.",
-        "data": {
-          "values": [
-            {"a": "A","b": 28}, {"a": "B","b": 55}, {"a": "C","b": 43},
-            {"a": "D","b": 91}, {"a": "E","b": 81}, {"a": "F","b": 53},
-            {"a": "G","b": 19}, {"a": "H","b": 87}, {"a": "I","b": 52}
-          ]
-        },
-        "mark": "bar",
-        "encoding": {
-          "x": {"field": "a", "type": "ordinal"},
-          "y": {"field": "b", "type": "quantitative"}
-        }
-      });
-
-      const rootGroup = assembleRootGroup(model);
-
-      assert.deepEqual(rootGroup.from, {"data": "chart_layout"});
-      assert.deepEqual(rootGroup.encode.update.width, {field:"chart_width"});
-      assert.deepEqual(rootGroup.encode.update.height, {field:"chart_height"});
-    });
-
   });
 });

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -107,29 +107,6 @@ describe('FacetModel', function() {
     });
   });
 
-  describe('assembleSignals', () => {
-    it('includes signal for calculating column length when there is a column field', () => {
-      const model = parseFacetModel({
-        facet: {
-          column: {field: 'a', type: 'quantitative'}
-        },
-        spec: {
-          mark: 'point',
-          encoding: {
-            x: {field: 'b', type: 'quantitative'}
-          }
-        }
-      });
-      const signals = model.assembleSignals([]);
-      assert.includeDeepMembers(signals, [
-        {
-          name: 'column',
-          update: `data('layout')[0].distinct_a`
-        }
-      ]);
-    });
-  });
-
   describe('dataTable', () => {
     it('should return stacked if there is a stacked data component', () => {
       const model = parseFacetModel({
@@ -302,7 +279,7 @@ describe('compile/facet', () => {
           from: {data: 'column'},
           encode: {
             update: {
-              width: {field: {parent: 'child_width', level: 2}}
+              width: {signal: 'child_width'}
             }
           }
         });
@@ -339,7 +316,7 @@ describe('compile/facet', () => {
           from: {data: 'row'},
           encode: {
             update: {
-              height: {field: {parent: 'child_height', level: 2}}
+              height: {signal: 'child_height'}
             }
           }
         });

--- a/test/compile/layout/index.test.ts
+++ b/test/compile/layout/index.test.ts
@@ -3,7 +3,6 @@
 import {assert} from 'chai';
 import {parseUnitModel} from '../../util';
 
-
 import {X, Y} from '../../../src/channel';
 import {cardinalityExpr, unitSizeExpr} from '../../../src/compile/layout';
 import * as log from '../../../src/log';
@@ -43,8 +42,8 @@ describe('compile/layout', () => {
         }
       });
 
-      const sizeExpr = unitSizeExpr(model, X);
-      assert.equal(sizeExpr, 'max(datum["distinct_a"] - 1 + 2*0.5, 0) * 21');
+      const sizeExpr = unitSizeExpr(model, 'width');
+      assert.equal(sizeExpr, 'bandspace(domain(\'x\').length, 1, 0.5) * 21');
     });
 
     it('should return correct formula for ordinal-band scale with custom padding', () => {
@@ -55,8 +54,8 @@ describe('compile/layout', () => {
         }
       });
 
-      const sizeExpr = unitSizeExpr(model, X);
-      assert.equal(sizeExpr, 'max(datum["distinct_a"] - 0.3 + 2*0.3, 0) * 21');
+      const sizeExpr = unitSizeExpr(model, 'width');
+      assert.equal(sizeExpr, 'bandspace(domain(\'x\').length, 0.3, 0.3) * 21');
     });
 
     it('should return correct formula for ordinal-band scale with custom paddingInner', () => {
@@ -67,8 +66,8 @@ describe('compile/layout', () => {
         }
       });
 
-      const sizeExpr = unitSizeExpr(model, X);
-      assert.equal(sizeExpr, 'max(datum["distinct_a"] - 0.3 + 2*0.15, 0) * 21');
+      const sizeExpr = unitSizeExpr(model, 'width');
+      assert.equal(sizeExpr, 'bandspace(domain(\'x\').length, 0.3, 0.15) * 21');
     });
 
     it('should return static cell size for ordinal x-scale with null', () => {
@@ -79,7 +78,7 @@ describe('compile/layout', () => {
         }
       });
 
-      const sizeExpr = unitSizeExpr(model, X);
+      const sizeExpr = unitSizeExpr(model, 'width');
       assert.equal(sizeExpr, '200');
     });
 
@@ -92,7 +91,7 @@ describe('compile/layout', () => {
         }
       });
 
-      const sizeExpr = unitSizeExpr(model, Y);
+      const sizeExpr = unitSizeExpr(model, 'height');
       assert.equal(sizeExpr, '200');
     });
 
@@ -105,7 +104,7 @@ describe('compile/layout', () => {
         }
       });
 
-      const sizeExpr = unitSizeExpr(model, X);
+      const sizeExpr = unitSizeExpr(model, 'width');
       assert.equal(sizeExpr, '205');
     });
 
@@ -119,7 +118,7 @@ describe('compile/layout', () => {
           }
         });
 
-        const sizeExpr = unitSizeExpr(model, X);
+        const sizeExpr = unitSizeExpr(model, 'width');
         assert.equal(sizeExpr, '205');
         assert.equal(localLogger.warns[0], log.message.rangeStepDropped(X));
       });
@@ -133,7 +132,7 @@ describe('compile/layout', () => {
         }
       });
 
-      const sizeExpr = unitSizeExpr(model, X);
+      const sizeExpr = unitSizeExpr(model, 'width');
       assert.equal(sizeExpr, '200');
     });
 
@@ -146,7 +145,7 @@ describe('compile/layout', () => {
         }
       });
 
-      const sizeExpr = unitSizeExpr(model, Y);
+      const sizeExpr = unitSizeExpr(model, 'height');
       assert.equal(sizeExpr, '200');
     });
 
@@ -156,7 +155,7 @@ describe('compile/layout', () => {
         encoding: {},
         config: {scale: {rangeStep: 17}}
       });
-      const sizeExpr = unitSizeExpr(model, X);
+      const sizeExpr = unitSizeExpr(model, 'width');
       assert.equal(sizeExpr, '17');
     });
 
@@ -166,7 +165,7 @@ describe('compile/layout', () => {
         encoding: {},
         config: {scale: {textXRangeStep: 91}}
       });
-      const sizeExpr = unitSizeExpr(model, X);
+      const sizeExpr = unitSizeExpr(model, 'width');
       assert.equal(sizeExpr, '91');
     });
 

--- a/test/compile/selection/layers.test.ts
+++ b/test/compile/selection/layers.test.ts
@@ -112,14 +112,10 @@ describe('Layered Selections', function() {
       "encode": {
         "enter": {
           "width": {
-            "field": {
-              "group": "width"
-            }
+            "signal": "width"
           },
           "height": {
-            "field": {
-              "group": "height"
-            }
+            "signal": "height"
           },
           "fill": {
             "value": "transparent"

--- a/test/compile/selection/predicate.test.ts
+++ b/test/compile/selection/predicate.test.ts
@@ -41,14 +41,14 @@ describe('Selection Predicate', function() {
     const single = getModel({type: 'single'});
     assert.deepEqual(nonPosition('color', single), {
       color: [
-        {test: "!vlPoint(\"one_store\", parent._id, datum, \"union\", \"all\")", value: "grey"},
+        {test: "!vlPoint(\"one_store\", datum._id, datum, \"union\", \"all\")", value: "grey"},
         {scale: "color", field: "Cylinders"}
       ]
     });
 
     assert.deepEqual(nonPosition('opacity', single), {
       opacity: [
-        {test: "vlPoint(\"one_store\", parent._id, datum, \"union\", \"all\")", value: 0.5},
+        {test: "vlPoint(\"one_store\", datum._id, datum, \"union\", \"all\")", value: 0.5},
         {scale: "opacity", field: "Origin"}
       ]
     });
@@ -56,14 +56,14 @@ describe('Selection Predicate', function() {
     const multi = getModel({type: 'multi'});
     assert.deepEqual(nonPosition('color', multi), {
       color: [
-        {test: "!vlPoint(\"one_store\", parent._id, datum, \"union\", \"all\")", value: "grey"},
+        {test: "!vlPoint(\"one_store\", datum._id, datum, \"union\", \"all\")", value: "grey"},
         {scale: "color", field: "Cylinders"}
       ]
     });
 
     assert.deepEqual(nonPosition('opacity', multi), {
       opacity: [
-        {test: "vlPoint(\"one_store\", parent._id, datum, \"union\", \"all\")", value: 0.5},
+        {test: "vlPoint(\"one_store\", datum._id, datum, \"union\", \"all\")", value: 0.5},
         {scale: "opacity", field: "Origin"}
       ]
     });
@@ -71,14 +71,14 @@ describe('Selection Predicate', function() {
     const interval = getModel({type: 'interval'});
     assert.deepEqual(nonPosition('color', interval), {
       color: [
-        {test: "!vlInterval(\"one_store\", parent._id, datum, \"union\", \"all\")", value: "grey"},
+        {test: "!vlInterval(\"one_store\", datum._id, datum, \"union\", \"all\")", value: "grey"},
         {scale: "color", field: "Cylinders"}
       ]
     });
 
     assert.deepEqual(nonPosition('opacity', interval), {
       opacity: [
-        {test: "vlInterval(\"one_store\", parent._id, datum, \"union\", \"all\")", value: 0.5},
+        {test: "vlInterval(\"one_store\", datum._id, datum, \"union\", \"all\")", value: 0.5},
         {scale: "opacity", field: "Origin"}
       ]
     });


### PR DESCRIPTION
This PR get rid of LayoutData and use signal to compute layout of unit spec and faceted spec instead.

Note that this does not work with independent scale *under facet* yet.  (Independent scale under facet is more complicated than others as the scale all share the same name and is with a special scope.)  With the mix of shared and independent scale under facet, we probably have to do some parsing and merging logic. 

However, this is a good intermediate step to move forward, so let's merge this first. 


----

- [ ] unit
- [ ] facet of unit
- [ ] layer of unit
- [ ] facet of layer of unit


## Follow up Later

- [ ] Independent scale variation