### PR TITLE
Only add format parse when necessary. I also think we don’t need the …

### DIFF
--- a/examples/vg-specs/bar_filter_calc.vg.json
+++ b/examples/vg-specs/bar_filter_calc.vg.json
@@ -45,8 +45,7 @@
                 }
             ],
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             },
             "transform": [
                 {

--- a/examples/vg-specs/bar_size_default.vg.json
+++ b/examples/vg-specs/bar_size_default.vg.json
@@ -7,8 +7,7 @@
             "name": "source_0",
             "url": "data/cars.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             },
             "transform": [
                 {

--- a/examples/vg-specs/bar_size_explicit.vg.json
+++ b/examples/vg-specs/bar_size_explicit.vg.json
@@ -7,8 +7,7 @@
             "name": "source_0",
             "url": "data/cars.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             },
             "transform": [
                 {

--- a/examples/vg-specs/bar_size_explicit_bad.vg.json
+++ b/examples/vg-specs/bar_size_explicit_bad.vg.json
@@ -7,8 +7,7 @@
             "name": "source_0",
             "url": "data/cars.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             },
             "transform": [
                 {

--- a/examples/vg-specs/bar_size_fit.vg.json
+++ b/examples/vg-specs/bar_size_fit.vg.json
@@ -7,8 +7,7 @@
             "name": "source_0",
             "url": "data/cars.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             },
             "transform": [
                 {

--- a/examples/vg-specs/box_plot.vg.json
+++ b/examples/vg-specs/box_plot.vg.json
@@ -8,8 +8,7 @@
             "name": "source_0",
             "url": "data/population.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         },
         {

--- a/examples/vg-specs/errorbar_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_aggregate.vg.json
@@ -8,8 +8,7 @@
             "name": "source_0",
             "url": "data/population.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             },
             "transform": [
                 {

--- a/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
@@ -8,8 +8,7 @@
             "name": "source_0",
             "url": "data/population.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             },
             "transform": [
                 {

--- a/examples/vg-specs/layer_bar_line.vg.json
+++ b/examples/vg-specs/layer_bar_line.vg.json
@@ -44,8 +44,7 @@
                 }
             ],
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         },
         {

--- a/examples/vg-specs/layer_bar_line_union.vg.json
+++ b/examples/vg-specs/layer_bar_line_union.vg.json
@@ -53,8 +53,7 @@
                 }
             ],
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         },
         {

--- a/examples/vg-specs/layer_histogram.vg.json
+++ b/examples/vg-specs/layer_histogram.vg.json
@@ -7,8 +7,7 @@
             "name": "source_0",
             "url": "data/flights-2k.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         },
         {

--- a/examples/vg-specs/layer_line_color_rule.vg.json
+++ b/examples/vg-specs/layer_line_color_rule.vg.json
@@ -7,8 +7,7 @@
             "name": "source_0",
             "url": "data/stocks.csv",
             "format": {
-                "type": "csv",
-                "parse": {}
+                "type": "csv"
             }
         },
         {

--- a/examples/vg-specs/layer_overlay.vg.json
+++ b/examples/vg-specs/layer_overlay.vg.json
@@ -22,14 +22,20 @@
                 {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
-                },
+                }
+            ]
+        },
+        {
+            "name": "data_1",
+            "source": "data_0",
+            "transform": [
                 {
                     "type": "aggregate",
                     "groupby": [
                         "Cylinders"
                     ],
                     "ops": [
-                        "max"
+                        "min"
                     ],
                     "fields": [
                         "Horsepower"
@@ -41,33 +47,6 @@
                         "field": "Cylinders",
                         "order": "descending"
                     }
-                }
-            ]
-        },
-        {
-            "name": "data_1",
-            "source": "source_0",
-            "transform": [
-                {
-                    "type": "formula",
-                    "expr": "toNumber(datum[\"Horsepower\"])",
-                    "as": "Horsepower"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
-                },
-                {
-                    "type": "aggregate",
-                    "groupby": [
-                        "Cylinders"
-                    ],
-                    "ops": [
-                        "max"
-                    ],
-                    "fields": [
-                        "Horsepower"
-                    ]
                 }
             ]
         },
@@ -83,7 +62,13 @@
                 {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
-                },
+                }
+            ]
+        },
+        {
+            "name": "data_3",
+            "source": "data_2",
+            "transform": [
                 {
                     "type": "aggregate",
                     "groupby": [
@@ -95,18 +80,11 @@
                     "fields": [
                         "Horsepower"
                     ]
-                },
-                {
-                    "type": "collect",
-                    "sort": {
-                        "field": "Cylinders",
-                        "order": "descending"
-                    }
                 }
             ]
         },
         {
-            "name": "data_3",
+            "name": "data_4",
             "source": "source_0",
             "transform": [
                 {
@@ -124,7 +102,41 @@
                         "Cylinders"
                     ],
                     "ops": [
-                        "min"
+                        "max"
+                    ],
+                    "fields": [
+                        "Horsepower"
+                    ]
+                },
+                {
+                    "type": "collect",
+                    "sort": {
+                        "field": "Cylinders",
+                        "order": "descending"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "data_5",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "formula",
+                    "expr": "toNumber(datum[\"Horsepower\"])",
+                    "as": "Horsepower"
+                },
+                {
+                    "type": "filter",
+                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
+                },
+                {
+                    "type": "aggregate",
+                    "groupby": [
+                        "Cylinders"
+                    ],
+                    "ops": [
+                        "max"
                     ],
                     "fields": [
                         "Horsepower"
@@ -244,7 +256,7 @@
                             "name": "layer_0_layer_0_marks",
                             "type": "line",
                             "from": {
-                                "data": "data_0"
+                                "data": "data_4"
                             },
                             "encode": {
                                 "update": {
@@ -267,7 +279,7 @@
                             "type": "symbol",
                             "role": "pointOverlay",
                             "from": {
-                                "data": "data_1"
+                                "data": "data_5"
                             },
                             "encode": {
                                 "update": {
@@ -310,7 +322,7 @@
                             "name": "layer_1_layer_0_marks",
                             "type": "line",
                             "from": {
-                                "data": "data_2"
+                                "data": "data_1"
                             },
                             "encode": {
                                 "update": {
@@ -364,15 +376,15 @@
                 "fields": [
                     {
                         "field": "Cylinders",
-                        "data": "data_0"
+                        "data": "data_4"
+                    },
+                    {
+                        "field": "Cylinders",
+                        "data": "data_5"
                     },
                     {
                         "field": "Cylinders",
                         "data": "data_1"
-                    },
-                    {
-                        "field": "Cylinders",
-                        "data": "data_2"
                     },
                     {
                         "field": "Cylinders",
@@ -394,15 +406,15 @@
                 "fields": [
                     {
                         "field": "max_Horsepower",
-                        "data": "data_0"
+                        "data": "data_4"
                     },
                     {
                         "field": "max_Horsepower",
-                        "data": "data_1"
+                        "data": "data_5"
                     },
                     {
                         "field": "min_Horsepower",
-                        "data": "data_2"
+                        "data": "data_1"
                     },
                     {
                         "field": "min_Horsepower",

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -8,8 +8,7 @@
             "name": "source_0",
             "url": "data/cars.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         },
         {

--- a/examples/vg-specs/minimal.vg.json
+++ b/examples/vg-specs/minimal.vg.json
@@ -9,8 +9,7 @@
                 {}
             ],
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         }
     ],

--- a/examples/vg-specs/overlay_area_full.vg.json
+++ b/examples/vg-specs/overlay_area_full.vg.json
@@ -8,8 +8,7 @@
             "name": "source_0",
             "url": "data/stocks.csv",
             "format": {
-                "type": "csv",
-                "parse": {}
+                "type": "csv"
             },
             "transform": [
                 {

--- a/examples/vg-specs/overlay_area_short.vg.json
+++ b/examples/vg-specs/overlay_area_short.vg.json
@@ -8,8 +8,7 @@
             "name": "source_0",
             "url": "data/stocks.csv",
             "format": {
-                "type": "csv",
-                "parse": {}
+                "type": "csv"
             },
             "transform": [
                 {

--- a/examples/vg-specs/overlay_line_full.vg.json
+++ b/examples/vg-specs/overlay_line_full.vg.json
@@ -7,8 +7,7 @@
             "name": "source_0",
             "url": "data/stocks.csv",
             "format": {
-                "type": "csv",
-                "parse": {}
+                "type": "csv"
             },
             "transform": [
                 {

--- a/examples/vg-specs/overlay_line_short.vg.json
+++ b/examples/vg-specs/overlay_line_short.vg.json
@@ -8,8 +8,7 @@
             "name": "source_0",
             "url": "data/stocks.csv",
             "format": {
-                "type": "csv",
-                "parse": {}
+                "type": "csv"
             },
             "transform": [
                 {

--- a/examples/vg-specs/point_1d_array.vg.json
+++ b/examples/vg-specs/point_1d_array.vg.json
@@ -44,8 +44,7 @@
                 }
             ],
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         }
     ],

--- a/examples/vg-specs/point_color.vg.json
+++ b/examples/vg-specs/point_color.vg.json
@@ -11,8 +11,7 @@
                 }
             ],
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         }
     ],

--- a/examples/vg-specs/point_overlap.vg.json
+++ b/examples/vg-specs/point_overlap.vg.json
@@ -44,8 +44,7 @@
                 }
             ],
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         }
     ],

--- a/examples/vg-specs/repeat_splom_cars.vg.json
+++ b/examples/vg-specs/repeat_splom_cars.vg.json
@@ -7,8 +7,7 @@
             "name": "source_0",
             "url": "data/cars.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         },
         {

--- a/examples/vg-specs/repeat_splom_iris.vg.json
+++ b/examples/vg-specs/repeat_splom_iris.vg.json
@@ -7,8 +7,7 @@
             "name": "source_0",
             "url": "data/iris.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         },
         {

--- a/examples/vg-specs/scatter_connected.vg.json
+++ b/examples/vg-specs/scatter_connected.vg.json
@@ -7,8 +7,7 @@
             "name": "source_0",
             "url": "data/driving.json",
             "format": {
-                "type": "json",
-                "parse": {}
+                "type": "json"
             }
         },
         {

--- a/src/compile/data/formatparse.ts
+++ b/src/compile/data/formatparse.ts
@@ -104,6 +104,10 @@ export class ParseNode extends DataFlowNode {
       });
     }
 
+    if (keys(parse).length === 0) {
+      return null;
+    }
+
     return new ParseNode(parse);
   }
 

--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -100,8 +100,10 @@ export function parseData(model: Model): DataComponent {
   let head = root;
 
   const parse = ParseNode.make(model);
-  parse.parent = root;
-  head = parse;
+  if (parse) {
+    parse.parent = root;
+    head = parse;
+  }
 
   if (model.transforms.length > 0) {
     const {first, last} = parseTransformArray(model);


### PR DESCRIPTION
…`parse: {}` because Vega seems to not parse anything unless we specify it.
