### PR TITLE
Temporarily bring back the main group and Revert incorrect selection predicate fix

### DIFF
--- a/examples/vg-specs/area.vg.json
+++ b/examples/vg-specs/area.vg.json
@@ -67,33 +67,49 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "area",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "yearmonth_date"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "sum_count"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
-                    },
-                    "orient": {
-                        "value": "vertical"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "area",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "yearmonth_date"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "sum_count"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "orient": {
+                                "value": "vertical"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/area_vertical.vg.json
+++ b/examples/vg-specs/area_vertical.vg.json
@@ -68,33 +68,49 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "area",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "sum_Weight_in_lbs"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "year_Year"
-                    },
-                    "x2": {
-                        "scale": "x",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
-                    },
-                    "orient": {
-                        "value": "horizontal"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "area",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "sum_Weight_in_lbs"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "year_Year"
+                            },
+                            "x2": {
+                                "scale": "x",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "orient": {
+                                "value": "horizontal"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar.vg.json
+++ b/examples/vg-specs/bar.vg.json
@@ -80,34 +80,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "a"
-                    },
                     "width": {
-                        "value": 20
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "b"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "a"
+                            },
+                            "width": {
+                                "value": 20
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "b"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_1d.vg.json
+++ b/examples/vg-specs/bar_1d.vg.json
@@ -56,33 +56,49 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "sum_people"
-                    },
-                    "x2": {
-                        "scale": "x",
-                        "value": 0
-                    },
-                    "yc": {
-                        "value": 10.5
+                    "width": {
+                        "signal": "width"
                     },
                     "height": {
-                        "value": 20
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "sum_people"
+                            },
+                            "x2": {
+                                "scale": "x",
+                                "value": 0
+                            },
+                            "yc": {
+                                "value": 10.5
+                            },
+                            "height": {
+                                "value": 20
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_1d_rangestep_config.vg.json
+++ b/examples/vg-specs/bar_1d_rangestep_config.vg.json
@@ -56,33 +56,49 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "sum_people"
-                    },
-                    "x2": {
-                        "scale": "x",
-                        "value": 0
-                    },
-                    "yc": {
-                        "value": 10.5
+                    "width": {
+                        "signal": "width"
                     },
                     "height": {
-                        "value": 20
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "sum_people"
+                            },
+                            "x2": {
+                                "scale": "x",
+                                "value": 0
+                            },
+                            "yc": {
+                                "value": 10.5
+                            },
+                            "height": {
+                                "value": 20
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_aggregate.vg.json
+++ b/examples/vg-specs/bar_aggregate.vg.json
@@ -59,34 +59,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "sum_people"
-                    },
-                    "x2": {
-                        "scale": "x",
-                        "value": 0
-                    },
-                    "yc": {
-                        "scale": "y",
-                        "field": "age"
+                    "width": {
+                        "signal": "width"
                     },
                     "height": {
-                        "value": 16
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "sum_people"
+                            },
+                            "x2": {
+                                "scale": "x",
+                                "value": 0
+                            },
+                            "yc": {
+                                "scale": "y",
+                                "field": "age"
+                            },
+                            "height": {
+                                "value": 16
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_aggregate_count.vg.json
+++ b/examples/vg-specs/bar_aggregate_count.vg.json
@@ -73,36 +73,52 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x2": {
-                        "scale": "x",
-                        "field": "bin_maxbins_10_precipitation_start",
-                        "offset": 1
+                    "width": {
+                        "signal": "width"
                     },
-                    "x": {
-                        "scale": "x",
-                        "field": "bin_maxbins_10_precipitation_end"
-                    },
-                    "y": {
-                        "scale": "y",
-                        "field": "count_*"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x2": {
+                                "scale": "x",
+                                "field": "bin_maxbins_10_precipitation_start",
+                                "offset": 1
+                            },
+                            "x": {
+                                "scale": "x",
+                                "field": "bin_maxbins_10_precipitation_end"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "count_*"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_aggregate_size.vg.json
+++ b/examples/vg-specs/bar_aggregate_size.vg.json
@@ -59,34 +59,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "age"
-                    },
                     "width": {
-                        "value": 10
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "sum_people"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "age"
+                            },
+                            "width": {
+                                "value": 10
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "sum_people"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_aggregate_vertical.vg.json
+++ b/examples/vg-specs/bar_aggregate_vertical.vg.json
@@ -54,34 +54,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "Cylinders"
-                    },
                     "width": {
-                        "value": 20
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "mean_Acceleration"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "Cylinders"
+                            },
+                            "width": {
+                                "value": 20
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "mean_Acceleration"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_array_aggregate.vg.json
+++ b/examples/vg-specs/bar_array_aggregate.vg.json
@@ -91,34 +91,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "a"
-                    },
                     "width": {
-                        "value": 20
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "average_b"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "a"
+                            },
+                            "width": {
+                                "value": 20
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "average_b"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_filter_calc.vg.json
+++ b/examples/vg-specs/bar_filter_calc.vg.json
@@ -86,34 +86,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "a"
-                    },
                     "width": {
-                        "value": 20
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "b2"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "a"
+                            },
+                            "width": {
+                                "value": 20
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "b2"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_grouped.vg.json
+++ b/examples/vg-specs/bar_grouped.vg.json
@@ -110,204 +110,210 @@
             ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": {
-            "signal": "data('column_layout')[0].distinct_age"
-        },
-        "bounds": "full"
-    },
     "marks": [
         {
-            "name": "column-title",
-            "role": "column-title",
+            "name": "nested-main-group",
             "type": "group",
-            "marks": [
-                {
-                    "type": "text",
-                    "role": "column-title-text",
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "signal": "0.5 * width"
-                            },
-                            "align": {
-                                "value": "center"
-                            },
-                            "text": {
-                                "value": "age"
-                            },
-                            "fill": {
-                                "value": "black"
-                            },
-                            "fontWeight": {
-                                "value": "bold"
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "row-header",
-            "type": "group",
-            "role": "row-header",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_height"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "population",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "column-header",
-            "type": "group",
-            "role": "column-header",
-            "from": {
-                "data": "column"
-            },
-            "title": {
-                "text": {
-                    "signal": "parent['age']"
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
                 },
                 "offset": 10,
-                "orient": "top",
-                "encode": {
-                    "update": {
-                        "fontWeight": {
-                            "value": "normal"
-                        },
-                        "angle": {
-                            "value": 0
-                        },
-                        "fontSize": {
-                            "value": 10
-                        }
-                    }
-                }
+                "columns": {
+                    "signal": "data('column_layout')[0].distinct_age"
+                },
+                "bounds": "full"
             },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            }
-        },
-        {
-            "name": "column-footer",
-            "type": "group",
-            "role": "column-footer",
-            "from": {
-                "data": "column"
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            },
-            "axes": [
+            "marks": [
                 {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
+                    "name": "column-title",
+                    "role": "column-title",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "column-title-text",
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "signal": "0.5 * width"
+                                    },
+                                    "align": {
+                                        "value": "center"
+                                    },
+                                    "text": {
+                                        "value": "age"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    }
                                 }
                             }
                         }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "cell",
-            "type": "group",
-            "from": {
-                "facet": {
-                    "name": "facet",
-                    "data": "source_0",
-                    "groupby": [
-                        "age"
                     ]
-                }
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    },
-                    "height": {
-                        "signal": "child_height"
-                    },
-                    "stroke": {
-                        "value": "#ccc"
-                    },
-                    "strokeWidth": {
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
+                },
                 {
-                    "name": "child_marks",
-                    "type": "rect",
-                    "role": "bar",
+                    "name": "row-header",
+                    "type": "group",
+                    "role": "row-header",
+                    "encode": {
+                        "update": {
+                            "height": {
+                                "signal": "child_height"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "population",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "column-header",
+                    "type": "group",
+                    "role": "column-header",
                     "from": {
-                        "data": "facet"
+                        "data": "column"
+                    },
+                    "title": {
+                        "text": {
+                            "signal": "parent['age']"
+                        },
+                        "offset": 10,
+                        "orient": "top",
+                        "encode": {
+                            "update": {
+                                "fontWeight": {
+                                    "value": "normal"
+                                },
+                                "angle": {
+                                    "value": 0
+                                },
+                                "fontSize": {
+                                    "value": 10
+                                }
+                            }
+                        }
                     },
                     "encode": {
                         "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "gender"
-                            },
                             "width": {
-                                "value": 11
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "sum_people_end"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "sum_people_start"
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "gender"
+                                "signal": "child_width"
                             }
                         }
                     }
+                },
+                {
+                    "name": "column-footer",
+                    "type": "group",
+                    "role": "column-footer",
+                    "from": {
+                        "data": "column"
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "zindex": 1,
+                            "encode": {
+                                "labels": {
+                                    "update": {
+                                        "angle": {
+                                            "value": 270
+                                        },
+                                        "align": {
+                                            "value": "right"
+                                        },
+                                        "baseline": {
+                                            "value": "middle"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "age"
+                            ]
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "gender"
+                                    },
+                                    "width": {
+                                        "value": 11
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "sum_people_end"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "sum_people_start"
+                                    },
+                                    "fill": {
+                                        "scale": "color",
+                                        "field": "gender"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/bar_grouped_horizontal.vg.json
+++ b/examples/vg-specs/bar_grouped_horizontal.vg.json
@@ -95,174 +95,180 @@
             ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": 1,
-        "bounds": "full"
-    },
     "marks": [
         {
-            "name": "row-title",
-            "role": "row-title",
+            "name": "nested-main-group",
             "type": "group",
-            "marks": [
-                {
-                    "type": "text",
-                    "role": "row-title-text",
-                    "encode": {
-                        "update": {
-                            "y": {
-                                "signal": "0.5 * height"
-                            },
-                            "align": {
-                                "value": "right"
-                            },
-                            "text": {
-                                "value": "age"
-                            },
-                            "fill": {
-                                "value": "black"
-                            },
-                            "fontWeight": {
-                                "value": "bold"
-                            },
-                            "angle": {
-                                "value": 270
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "row-header",
-            "type": "group",
-            "role": "row-header",
-            "from": {
-                "data": "row"
-            },
-            "title": {
-                "text": {
-                    "signal": "parent['age']"
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
                 },
                 "offset": 10,
-                "orient": "left",
-                "encode": {
-                    "update": {
-                        "fontWeight": {
-                            "value": "normal"
-                        },
-                        "angle": {
-                            "value": 0
-                        },
-                        "fontSize": {
-                            "value": 10
-                        },
-                        "align": {
-                            "value": "right"
-                        },
-                        "baseline": {
-                            "value": "middle"
-                        }
-                    }
-                }
-            },
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_height"
-                    }
-                }
-            }
-        },
-        {
-            "name": "column-footer",
-            "type": "group",
-            "role": "column-footer",
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "population",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "cell",
-            "type": "group",
-            "from": {
-                "facet": {
-                    "name": "facet",
-                    "data": "source_0",
-                    "groupby": [
-                        "age"
-                    ]
-                }
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    },
-                    "height": {
-                        "signal": "child_height"
-                    },
-                    "stroke": {
-                        "value": "#ccc"
-                    },
-                    "strokeWidth": {
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
+                "columns": 1,
+                "bounds": "full"
             },
             "marks": [
                 {
-                    "name": "child_marks",
-                    "type": "rect",
-                    "role": "bar",
+                    "name": "row-title",
+                    "role": "row-title",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "row-title-text",
+                            "encode": {
+                                "update": {
+                                    "y": {
+                                        "signal": "0.5 * height"
+                                    },
+                                    "align": {
+                                        "value": "right"
+                                    },
+                                    "text": {
+                                        "value": "age"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    },
+                                    "angle": {
+                                        "value": 270
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "row-header",
+                    "type": "group",
+                    "role": "row-header",
                     "from": {
-                        "data": "facet"
+                        "data": "row"
+                    },
+                    "title": {
+                        "text": {
+                            "signal": "parent['age']"
+                        },
+                        "offset": 10,
+                        "orient": "left",
+                        "encode": {
+                            "update": {
+                                "fontWeight": {
+                                    "value": "normal"
+                                },
+                                "angle": {
+                                    "value": 0
+                                },
+                                "fontSize": {
+                                    "value": 10
+                                },
+                                "align": {
+                                    "value": "right"
+                                },
+                                "baseline": {
+                                    "value": "middle"
+                                }
+                            }
+                        }
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "sum_people_end"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "field": "sum_people_start"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "gender"
-                            },
                             "height": {
-                                "value": 5
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "gender"
+                                "signal": "child_height"
                             }
                         }
                     }
+                },
+                {
+                    "name": "column-footer",
+                    "type": "group",
+                    "role": "column-footer",
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "population",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "age"
+                            ]
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "sum_people_end"
+                                    },
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "sum_people_start"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "gender"
+                                    },
+                                    "height": {
+                                        "value": 5
+                                    },
+                                    "fill": {
+                                        "scale": "color",
+                                        "field": "gender"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/bar_layered_transparent.vg.json
+++ b/examples/vg-specs/bar_layered_transparent.vg.json
@@ -65,38 +65,54 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "age"
-                    },
                     "width": {
-                        "value": 16
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "sum_people"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "scale": "color",
-                        "field": "gender"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "age"
+                            },
+                            "width": {
+                                "value": 16
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "sum_people"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "scale": "color",
+                                "field": "gender"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_month.vg.json
+++ b/examples/vg-specs/bar_month.vg.json
@@ -60,34 +60,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "month_date"
-                    },
                     "width": {
-                        "value": 20
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "mean_temp"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "month_date"
+                            },
+                            "width": {
+                                "value": 20
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "mean_temp"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_size_default.vg.json
+++ b/examples/vg-specs/bar_size_default.vg.json
@@ -47,34 +47,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "Origin"
-                    },
                     "width": {
-                        "value": 24
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "count_*"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "Origin"
+                            },
+                            "width": {
+                                "value": 24
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "count_*"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_size_explicit.vg.json
+++ b/examples/vg-specs/bar_size_explicit.vg.json
@@ -47,35 +47,51 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Origin"
-                    },
                     "width": {
-                        "scale": "x",
-                        "band": true
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "count_*"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Origin"
+                            },
+                            "width": {
+                                "scale": "x",
+                                "band": true
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "count_*"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_size_explicit_bad.vg.json
+++ b/examples/vg-specs/bar_size_explicit_bad.vg.json
@@ -47,35 +47,51 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Name"
-                    },
                     "width": {
-                        "scale": "x",
-                        "band": true
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "count_*"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Name"
+                            },
+                            "width": {
+                                "scale": "x",
+                                "band": true
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "count_*"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_size_fit.vg.json
+++ b/examples/vg-specs/bar_size_fit.vg.json
@@ -47,35 +47,51 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Origin"
-                    },
                     "width": {
-                        "scale": "x",
-                        "band": true
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "count_*"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Origin"
+                            },
+                            "width": {
+                                "scale": "x",
+                                "band": true
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "count_*"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_size_rangestep_small.vg.json
+++ b/examples/vg-specs/bar_size_rangestep_small.vg.json
@@ -80,34 +80,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "a"
-                    },
                     "width": {
-                        "value": 10
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "b"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "a"
+                            },
+                            "width": {
+                                "value": 10
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "b"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_swap_axes.vg.json
+++ b/examples/vg-specs/bar_swap_axes.vg.json
@@ -91,34 +91,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "average_b"
-                    },
-                    "x2": {
-                        "scale": "x",
-                        "value": 0
-                    },
-                    "yc": {
-                        "scale": "y",
-                        "field": "a"
+                    "width": {
+                        "signal": "width"
                     },
                     "height": {
-                        "value": 20
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "average_b"
+                            },
+                            "x2": {
+                                "scale": "x",
+                                "value": 0
+                            },
+                            "yc": {
+                                "scale": "y",
+                                "field": "a"
+                            },
+                            "height": {
+                                "value": 20
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_swap_custom.vg.json
+++ b/examples/vg-specs/bar_swap_custom.vg.json
@@ -91,34 +91,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "average_b"
-                    },
-                    "x2": {
-                        "scale": "x",
-                        "value": 0
-                    },
-                    "yc": {
-                        "scale": "y",
-                        "field": "a"
+                    "width": {
+                        "signal": "width"
                     },
                     "height": {
-                        "value": 20
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "average_b"
+                            },
+                            "x2": {
+                                "scale": "x",
+                                "value": 0
+                            },
+                            "yc": {
+                                "scale": "y",
+                                "field": "a"
+                            },
+                            "height": {
+                                "value": 20
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bar_yearmonth.vg.json
+++ b/examples/vg-specs/bar_yearmonth.vg.json
@@ -61,34 +61,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "yearmonth_date"
-                    },
                     "width": {
-                        "value": 2
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "mean_temp"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "yearmonth_date"
+                            },
+                            "width": {
+                                "value": 2
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "mean_temp"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/box_plot_minmax_1D_horizontal_full.vg.json
+++ b/examples/vg-specs/box_plot_minmax_1D_horizontal_full.vg.json
@@ -172,132 +172,148 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rule",
-                    "role": "boxWhisker",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "min_people"
-                            },
-                            "y": {
-                                "value": 10.5
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "field": "q1_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "rule",
-                    "role": "boxWhisker",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "q3_people"
-                            },
-                            "y": {
-                                "value": 10.5
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "field": "max_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_2_marks",
-                    "type": "rect",
-                    "role": "box",
-                    "from": {
-                        "data": "data_2"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "q1_people"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "field": "q3_people"
-                            },
-                            "yc": {
-                                "value": 10.5
-                            },
-                            "height": {
-                                "value": 14
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_3_marks",
-                    "type": "rect",
-                    "role": "boxMid",
-                    "from": {
-                        "data": "data_3"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "median_people"
-                            },
-                            "yc": {
-                                "value": 10.5
-                            },
-                            "height": {
-                                "value": 14
-                            },
+                        "enter": {
                             "width": {
-                                "value": 1
+                                "signal": "width"
+                            },
+                            "height": {
+                                "signal": "height"
                             },
                             "fill": {
-                                "value": "white"
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rule",
+                            "role": "boxWhisker",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "min_people"
+                                    },
+                                    "y": {
+                                        "value": 10.5
+                                    },
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "q1_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "rule",
+                            "role": "boxWhisker",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "q3_people"
+                                    },
+                                    "y": {
+                                        "value": 10.5
+                                    },
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "max_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_2_marks",
+                            "type": "rect",
+                            "role": "box",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "q1_people"
+                                    },
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "q3_people"
+                                    },
+                                    "yc": {
+                                        "value": 10.5
+                                    },
+                                    "height": {
+                                        "value": 14
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_3_marks",
+                            "type": "rect",
+                            "role": "boxMid",
+                            "from": {
+                                "data": "data_3"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "median_people"
+                                    },
+                                    "yc": {
+                                        "value": 10.5
+                                    },
+                                    "height": {
+                                        "value": 14
+                                    },
+                                    "width": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "white"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/box_plot_minmax_1D_horizontal_short.vg.json
+++ b/examples/vg-specs/box_plot_minmax_1D_horizontal_short.vg.json
@@ -172,132 +172,148 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rule",
-                    "role": "boxWhisker",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "min_people"
-                            },
-                            "y": {
-                                "value": 10.5
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "field": "q1_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "rule",
-                    "role": "boxWhisker",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "q3_people"
-                            },
-                            "y": {
-                                "value": 10.5
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "field": "max_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_2_marks",
-                    "type": "rect",
-                    "role": "box",
-                    "from": {
-                        "data": "data_2"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "q1_people"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "field": "q3_people"
-                            },
-                            "yc": {
-                                "value": 10.5
-                            },
-                            "height": {
-                                "value": 14
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_3_marks",
-                    "type": "rect",
-                    "role": "boxMid",
-                    "from": {
-                        "data": "data_3"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "median_people"
-                            },
-                            "yc": {
-                                "value": 10.5
-                            },
-                            "height": {
-                                "value": 14
-                            },
+                        "enter": {
                             "width": {
-                                "value": 1
+                                "signal": "width"
+                            },
+                            "height": {
+                                "signal": "height"
                             },
                             "fill": {
-                                "value": "white"
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rule",
+                            "role": "boxWhisker",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "min_people"
+                                    },
+                                    "y": {
+                                        "value": 10.5
+                                    },
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "q1_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "rule",
+                            "role": "boxWhisker",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "q3_people"
+                                    },
+                                    "y": {
+                                        "value": 10.5
+                                    },
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "max_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_2_marks",
+                            "type": "rect",
+                            "role": "box",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "q1_people"
+                                    },
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "q3_people"
+                                    },
+                                    "yc": {
+                                        "value": 10.5
+                                    },
+                                    "height": {
+                                        "value": 14
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_3_marks",
+                            "type": "rect",
+                            "role": "boxMid",
+                            "from": {
+                                "data": "data_3"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "median_people"
+                                    },
+                                    "yc": {
+                                        "value": 10.5
+                                    },
+                                    "height": {
+                                        "value": 14
+                                    },
+                                    "width": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "white"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/box_plot_minmax_1D_vertical_short.vg.json
+++ b/examples/vg-specs/box_plot_minmax_1D_vertical_short.vg.json
@@ -172,132 +172,148 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rule",
-                    "role": "boxWhisker",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "value": 10.5
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "min_people"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "q1_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "rule",
-                    "role": "boxWhisker",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "value": 10.5
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "q3_people"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "max_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_2_marks",
-                    "type": "rect",
-                    "role": "box",
-                    "from": {
-                        "data": "data_2"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "value": 10.5
-                            },
+                        "enter": {
                             "width": {
-                                "value": 14
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "q1_people"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "q3_people"
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_3_marks",
-                    "type": "rect",
-                    "role": "boxMid",
-                    "from": {
-                        "data": "data_3"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "value": 10.5
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "median_people"
-                            },
-                            "width": {
-                                "value": 14
+                                "signal": "width"
                             },
                             "height": {
-                                "value": 1
+                                "signal": "height"
                             },
                             "fill": {
-                                "value": "white"
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rule",
+                            "role": "boxWhisker",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "value": 10.5
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "min_people"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "q1_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "rule",
+                            "role": "boxWhisker",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "value": 10.5
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "q3_people"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "max_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_2_marks",
+                            "type": "rect",
+                            "role": "box",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "value": 10.5
+                                    },
+                                    "width": {
+                                        "value": 14
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "q1_people"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "q3_people"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_3_marks",
+                            "type": "rect",
+                            "role": "boxMid",
+                            "from": {
+                                "data": "data_3"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "value": 10.5
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "median_people"
+                                    },
+                                    "width": {
+                                        "value": 14
+                                    },
+                                    "height": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "white"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/box_plot_minmax_2D_horizontal_short.vg.json
+++ b/examples/vg-specs/box_plot_minmax_2D_horizontal_short.vg.json
@@ -180,136 +180,152 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rule",
-                    "role": "boxWhisker",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "min_people"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "age"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "field": "q1_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "rule",
-                    "role": "boxWhisker",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "q3_people"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "age"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "field": "max_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_2_marks",
-                    "type": "rect",
-                    "role": "box",
-                    "from": {
-                        "data": "data_2"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "q1_people"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "field": "q3_people"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "age"
-                            },
-                            "height": {
-                                "value": 5
-                            },
-                            "fill": {
-                                "value": "skyblue"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_3_marks",
-                    "type": "rect",
-                    "role": "boxMid",
-                    "from": {
-                        "data": "data_3"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "median_people"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "age"
-                            },
-                            "height": {
-                                "value": 5
-                            },
+                        "enter": {
                             "width": {
-                                "value": 1
+                                "signal": "width"
+                            },
+                            "height": {
+                                "signal": "height"
                             },
                             "fill": {
-                                "value": "white"
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rule",
+                            "role": "boxWhisker",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "min_people"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "age"
+                                    },
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "q1_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "rule",
+                            "role": "boxWhisker",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "q3_people"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "age"
+                                    },
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "max_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_2_marks",
+                            "type": "rect",
+                            "role": "box",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "q1_people"
+                                    },
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "q3_people"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "age"
+                                    },
+                                    "height": {
+                                        "value": 5
+                                    },
+                                    "fill": {
+                                        "value": "skyblue"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_3_marks",
+                            "type": "rect",
+                            "role": "boxMid",
+                            "from": {
+                                "data": "data_3"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "median_people"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "age"
+                                    },
+                                    "height": {
+                                        "value": 5
+                                    },
+                                    "width": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "white"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/box_plot_minmax_2D_vertical_full.vg.json
+++ b/examples/vg-specs/box_plot_minmax_2D_vertical_full.vg.json
@@ -180,136 +180,152 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rule",
-                    "role": "boxWhisker",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "min_people"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "q1_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "rule",
-                    "role": "boxWhisker",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "q3_people"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "max_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_2_marks",
-                    "type": "rect",
-                    "role": "box",
-                    "from": {
-                        "data": "data_2"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
+                        "enter": {
                             "width": {
-                                "value": 5
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "q1_people"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "q3_people"
-                            },
-                            "fill": {
-                                "value": "skyblue"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_3_marks",
-                    "type": "rect",
-                    "role": "boxMid",
-                    "from": {
-                        "data": "data_3"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "median_people"
-                            },
-                            "width": {
-                                "value": 5
+                                "signal": "width"
                             },
                             "height": {
-                                "value": 1
+                                "signal": "height"
                             },
                             "fill": {
-                                "value": "white"
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rule",
+                            "role": "boxWhisker",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "min_people"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "q1_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "rule",
+                            "role": "boxWhisker",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "q3_people"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "max_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_2_marks",
+                            "type": "rect",
+                            "role": "box",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "width": {
+                                        "value": 5
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "q1_people"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "q3_people"
+                                    },
+                                    "fill": {
+                                        "value": "skyblue"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_3_marks",
+                            "type": "rect",
+                            "role": "boxMid",
+                            "from": {
+                                "data": "data_3"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "median_people"
+                                    },
+                                    "width": {
+                                        "value": 5
+                                    },
+                                    "height": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "white"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/box_plot_minmax_2D_vertical_short.vg.json
+++ b/examples/vg-specs/box_plot_minmax_2D_vertical_short.vg.json
@@ -180,136 +180,152 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rule",
-                    "role": "boxWhisker",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "min_people"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "q1_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "rule",
-                    "role": "boxWhisker",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "q3_people"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "max_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_2_marks",
-                    "type": "rect",
-                    "role": "box",
-                    "from": {
-                        "data": "data_2"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
+                        "enter": {
                             "width": {
-                                "value": 5
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "q1_people"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "q3_people"
-                            },
-                            "fill": {
-                                "value": "skyblue"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_3_marks",
-                    "type": "rect",
-                    "role": "boxMid",
-                    "from": {
-                        "data": "data_3"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "median_people"
-                            },
-                            "width": {
-                                "value": 5
+                                "signal": "width"
                             },
                             "height": {
-                                "value": 1
+                                "signal": "height"
                             },
                             "fill": {
-                                "value": "white"
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rule",
+                            "role": "boxWhisker",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "min_people"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "q1_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "rule",
+                            "role": "boxWhisker",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "q3_people"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "max_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_2_marks",
+                            "type": "rect",
+                            "role": "box",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "width": {
+                                        "value": 5
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "q1_people"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "q3_people"
+                                    },
+                                    "fill": {
+                                        "value": "skyblue"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_3_marks",
+                            "type": "rect",
+                            "role": "boxMid",
+                            "from": {
+                                "data": "data_3"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "median_people"
+                                    },
+                                    "width": {
+                                        "value": 5
+                                    },
+                                    "height": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "white"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -43,390 +43,408 @@
                     "update": "group()._id ? group() : unit"
                 }
             ]
-        },
-        {
-            "name": "brush_x",
-            "value": [],
-            "on": [
-                {
-                    "events": {
-                        "source": "scope",
-                        "type": "mousedown",
-                        "filter": [
-                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                        ]
-                    },
-                    "update": "invert(\"x\", [x(unit), x(unit)])"
-                },
-                {
-                    "events": {
-                        "source": "window",
-                        "type": "mousemove",
-                        "consume": true,
-                        "between": [
-                            {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                ]
-                            },
-                            {
-                                "source": "window",
-                                "type": "mouseup"
-                            }
-                        ]
-                    },
-                    "update": "[brush_x[0], invert(\"x\", clamp(x(unit), 0, width))]"
-                },
-                {
-                    "events": {
-                        "signal": "brush_translate_delta"
-                    },
-                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
-                },
-                {
-                    "events": {
-                        "signal": "brush_zoom_delta"
-                    },
-                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
-                }
-            ]
-        },
-        {
-            "name": "brush_y",
-            "value": [],
-            "on": [
-                {
-                    "events": {
-                        "source": "scope",
-                        "type": "mousedown",
-                        "filter": [
-                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                        ]
-                    },
-                    "update": "invert(\"y\", [y(unit), y(unit)])"
-                },
-                {
-                    "events": {
-                        "source": "window",
-                        "type": "mousemove",
-                        "consume": true,
-                        "between": [
-                            {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                ]
-                            },
-                            {
-                                "source": "window",
-                                "type": "mouseup"
-                            }
-                        ]
-                    },
-                    "update": "[brush_y[0], invert(\"y\", clamp(y(unit), 0, height))]"
-                },
-                {
-                    "events": {
-                        "signal": "brush_translate_delta"
-                    },
-                    "update": "clampRange([brush_translate_anchor.extent_y[0] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height, brush_translate_anchor.extent_y[1] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
-                },
-                {
-                    "events": {
-                        "signal": "brush_zoom_delta"
-                    },
-                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
-                }
-            ]
-        },
-        {
-            "name": "brush_size",
-            "value": [],
-            "on": [
-                {
-                    "events": {
-                        "source": "scope",
-                        "type": "mousedown",
-                        "filter": [
-                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                        ]
-                    },
-                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                },
-                {
-                    "events": {
-                        "source": "window",
-                        "type": "mousemove",
-                        "consume": true,
-                        "between": [
-                            {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                ]
-                            },
-                            {
-                                "source": "window",
-                                "type": "mouseup"
-                            }
-                        ]
-                    },
-                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                },
-                {
-                    "events": {
-                        "signal": "brush_zoom_delta"
-                    },
-                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
-                }
-            ]
-        },
-        {
-            "name": "brush",
-            "update": "[{field: \"Horsepower\", extent: brush_x}, {field: \"Miles_per_Gallon\", extent: brush_y}]"
-        },
-        {
-            "name": "brush_translate_anchor",
-            "value": {},
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "mousedown",
-                            "markname": "brush_brush"
-                        }
-                    ],
-                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_x), extent_y: slice(brush_y), }"
-                }
-            ]
-        },
-        {
-            "name": "brush_translate_delta",
-            "value": {},
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "window",
-                            "type": "mousemove",
-                            "consume": true,
-                            "between": [
-                                {
-                                    "source": "scope",
-                                    "type": "mousedown",
-                                    "markname": "brush_brush"
-                                },
-                                {
-                                    "source": "window",
-                                    "type": "mouseup"
-                                }
-                            ]
-                        }
-                    ],
-                    "update": "{x: x(unit) - brush_translate_anchor.x, y: y(unit) - brush_translate_anchor.y}"
-                }
-            ]
-        },
-        {
-            "name": "brush_zoom_anchor",
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "wheel",
-                            "markname": "brush_brush"
-                        }
-                    ],
-                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
-                }
-            ]
-        },
-        {
-            "name": "brush_zoom_delta",
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "wheel",
-                            "markname": "brush_brush"
-                        }
-                    ],
-                    "force": true,
-                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-                }
-            ]
-        },
-        {
-            "name": "brush_tuple",
-            "on": [
-                {
-                    "events": {
-                        "signal": "brush"
-                    },
-                    "update": "{unit: unit.datum && unit.datum._id, intervals: brush}"
-                }
-            ]
-        },
-        {
-            "name": "brush_modify",
-            "on": [
-                {
-                    "events": {
-                        "signal": "brush"
-                    },
-                    "update": "modify(\"brush_store\", brush_tuple, true)"
-                }
-            ]
         }
     ],
     "marks": [
         {
-            "type": "rect",
-            "encode": {
-                "enter": {
-                    "fill": {
-                        "value": "#eee"
-                    }
+            "name": "nested-main-group",
+            "type": "group",
+            "signals": [
+                {
+                    "name": "brush_x",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                ]
+                            },
+                            "update": "invert(\"x\", [x(unit), x(unit)])"
+                        },
+                        {
+                            "events": {
+                                "source": "window",
+                                "type": "mousemove",
+                                "consume": true,
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                        ]
+                                    },
+                                    {
+                                        "source": "window",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "[brush_x[0], invert(\"x\", clamp(x(unit), 0, width))]"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_translate_delta"
+                            },
+                            "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_zoom_delta"
+                            },
+                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+                        }
+                    ]
                 },
-                "update": {
-                    "x": [
+                {
+                    "name": "brush_y",
+                    "value": [],
+                    "on": [
                         {
-                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                            "scale": "x",
-                            "signal": "brush[0].extent[0]"
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                ]
+                            },
+                            "update": "invert(\"y\", [y(unit), y(unit)])"
                         },
                         {
-                            "value": 0
+                            "events": {
+                                "source": "window",
+                                "type": "mousemove",
+                                "consume": true,
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                        ]
+                                    },
+                                    {
+                                        "source": "window",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "[brush_y[0], invert(\"y\", clamp(y(unit), 0, height))]"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_translate_delta"
+                            },
+                            "update": "clampRange([brush_translate_anchor.extent_y[0] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height, brush_translate_anchor.extent_y[1] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_zoom_delta"
+                            },
+                            "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
                         }
-                    ],
-                    "x2": [
+                    ]
+                },
+                {
+                    "name": "brush_size",
+                    "value": [],
+                    "on": [
                         {
-                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                            "scale": "x",
-                            "signal": "brush[0].extent[1]"
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                ]
+                            },
+                            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
                         },
                         {
-                            "value": 0
+                            "events": {
+                                "source": "window",
+                                "type": "mousemove",
+                                "consume": true,
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                        ]
+                                    },
+                                    {
+                                        "source": "window",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_zoom_delta"
+                            },
+                            "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
                         }
-                    ],
-                    "y": [
+                    ]
+                },
+                {
+                    "name": "brush",
+                    "update": "[{field: \"Horsepower\", extent: brush_x}, {field: \"Miles_per_Gallon\", extent: brush_y}]"
+                },
+                {
+                    "name": "brush_translate_anchor",
+                    "value": {},
+                    "on": [
                         {
-                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                            "scale": "y",
-                            "signal": "brush[1].extent[0]"
-                        },
-                        {
-                            "value": 0
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousedown",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_x), extent_y: slice(brush_y), }"
                         }
-                    ],
-                    "y2": [
+                    ]
+                },
+                {
+                    "name": "brush_translate_delta",
+                    "value": {},
+                    "on": [
                         {
-                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                            "scale": "y",
-                            "signal": "brush[1].extent[1]"
-                        },
+                            "events": [
+                                {
+                                    "source": "window",
+                                    "type": "mousemove",
+                                    "consume": true,
+                                    "between": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "markname": "brush_brush"
+                                        },
+                                        {
+                                            "source": "window",
+                                            "type": "mouseup"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "update": "{x: x(unit) - brush_translate_anchor.x, y: y(unit) - brush_translate_anchor.y}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_anchor",
+                    "on": [
                         {
-                            "value": 0
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_delta",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "force": true,
+                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_tuple",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "brush"
+                            },
+                            "update": "{unit: unit.datum && unit.datum._id, intervals: brush}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_modify",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "brush"
+                            },
+                            "update": "modify(\"brush_store\", brush_tuple, true)"
                         }
                     ]
                 }
-            }
-        },
-        {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
+            ],
+            "encode": {
+                "update": {
+                    "width": {
+                        "signal": "width"
+                    },
+                    "height": {
+                        "signal": "height"
+                    }
+                }
             },
-            "encode": {
-                "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
-                    },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "stroke": [
-                        {
-                            "test": "!vlInterval(\"brush_store\", datum._id, datum, \"union\", \"all\")",
-                            "value": "grey"
+            "marks": [
+                {
+                    "type": "rect",
+                    "encode": {
+                        "enter": {
+                            "fill": {
+                                "value": "#eee"
+                            }
                         },
-                        {
-                            "scale": "color",
-                            "field": "Cylinders"
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "scale": "x",
+                                    "signal": "brush[0].extent[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "scale": "x",
+                                    "signal": "brush[0].extent[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "scale": "y",
+                                    "signal": "brush[1].extent[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "scale": "y",
+                                    "signal": "brush[1].extent[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ]
                         }
-                    ],
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
-                    }
-                }
-            }
-        },
-        {
-            "name": "brush_brush",
-            "type": "rect",
-            "encode": {
-                "enter": {
-                    "fill": {
-                        "value": "transparent"
                     }
                 },
-                "update": {
-                    "x": [
-                        {
-                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                            "scale": "x",
-                            "signal": "brush[0].extent[0]"
-                        },
-                        {
-                            "value": 0
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": [
+                                {
+                                    "test": "!vlInterval(\"brush_store\", parent._id, datum, \"union\", \"all\")",
+                                    "value": "grey"
+                                },
+                                {
+                                    "scale": "color",
+                                    "field": "Cylinders"
+                                }
+                            ],
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
                         }
-                    ],
-                    "x2": [
-                        {
-                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                            "scale": "x",
-                            "signal": "brush[0].extent[1]"
+                    }
+                },
+                {
+                    "name": "brush_brush",
+                    "type": "rect",
+                    "encode": {
+                        "enter": {
+                            "fill": {
+                                "value": "transparent"
+                            }
                         },
-                        {
-                            "value": 0
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "scale": "x",
+                                    "signal": "brush[0].extent[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "scale": "x",
+                                    "signal": "brush[0].extent[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "scale": "y",
+                                    "signal": "brush[1].extent[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "scale": "y",
+                                    "signal": "brush[1].extent[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ]
                         }
-                    ],
-                    "y": [
-                        {
-                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                            "scale": "y",
-                            "signal": "brush[1].extent[0]"
-                        },
-                        {
-                            "value": 0
-                        }
-                    ],
-                    "y2": [
-                        {
-                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                            "scale": "y",
-                            "signal": "brush[1].extent[1]"
-                        },
-                        {
-                            "value": 0
-                        }
-                    ]
+                    }
                 }
-            }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/bubble_health_income.vg.json
+++ b/examples/vg-specs/bubble_health_income.vg.json
@@ -49,37 +49,53 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "circle",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "income"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "health"
-                    },
-                    "fill": {
-                        "value": "#000"
-                    },
-                    "size": {
-                        "scale": "size",
-                        "field": "population"
-                    },
-                    "shape": {
-                        "value": "circle"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "circle",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "income"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "health"
+                            },
+                            "fill": {
+                                "value": "#000"
+                            },
+                            "size": {
+                                "scale": "size",
+                                "field": "population"
+                            },
+                            "shape": {
+                                "value": "circle"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/circle.vg.json
+++ b/examples/vg-specs/circle.vg.json
@@ -43,33 +43,49 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "circle",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
-                    },
-                    "shape": {
-                        "value": "circle"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "circle",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "shape": {
+                                "value": "circle"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/diverging_color_points.vg.json
+++ b/examples/vg-specs/diverging_color_points.vg.json
@@ -45,34 +45,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "stroke": {
-                        "scale": "color",
-                        "field": "Weight_in_lbs"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": {
+                                "scale": "color",
+                                "field": "Weight_in_lbs"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/errorbar_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_aggregate.vg.json
@@ -182,136 +182,152 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rule",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "min_people"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "max_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "rect",
-                    "role": "tick",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "min_people"
-                            },
+                        "enter": {
                             "width": {
-                                "value": 5
+                                "signal": "width"
                             },
                             "height": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_2_marks",
-                    "type": "rect",
-                    "role": "tick",
-                    "from": {
-                        "data": "data_2"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "max_people"
-                            },
-                            "width": {
-                                "value": 5
-                            },
-                            "height": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_3_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_3"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "mean_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
+                                "signal": "height"
                             },
                             "fill": {
                                 "value": "transparent"
                             },
-                            "size": {
-                                "value": 2
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rule",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "min_people"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "max_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "rect",
+                            "role": "tick",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "min_people"
+                                    },
+                                    "width": {
+                                        "value": 5
+                                    },
+                                    "height": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_2_marks",
+                            "type": "rect",
+                            "role": "tick",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "max_people"
+                                    },
+                                    "width": {
+                                        "value": 5
+                                    },
+                                    "height": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_3_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_3"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "mean_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "size": {
+                                        "value": 2
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
@@ -182,136 +182,152 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rule",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "min_people"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "age"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "field": "max_people"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "rect",
-                    "role": "tick",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "min_people"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "age"
+                        "enter": {
+                            "width": {
+                                "signal": "width"
                             },
                             "height": {
-                                "value": 5
-                            },
-                            "width": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_2_marks",
-                    "type": "rect",
-                    "role": "tick",
-                    "from": {
-                        "data": "data_2"
-                    },
-                    "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "max_people"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "age"
-                            },
-                            "height": {
-                                "value": 5
-                            },
-                            "width": {
-                                "value": 1
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_3_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_3"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "mean_people"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "age"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
+                                "signal": "height"
                             },
                             "fill": {
                                 "value": "transparent"
                             },
-                            "size": {
-                                "value": 2
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rule",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "min_people"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "age"
+                                    },
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "max_people"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "rect",
+                            "role": "tick",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "min_people"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "age"
+                                    },
+                                    "height": {
+                                        "value": 5
+                                    },
+                                    "width": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_2_marks",
+                            "type": "rect",
+                            "role": "tick",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "max_people"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "age"
+                                    },
+                                    "height": {
+                                        "value": 5
+                                    },
+                                    "width": {
+                                        "value": 1
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_3_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_3"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "mean_people"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "age"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "size": {
+                                        "value": 2
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -104,520 +104,22 @@
         {
             "name": "child_xenc",
             "update": "data(\"child_xenc_store\")[0]"
-        },
-        {
-            "name": "child_brush_x",
-            "value": [],
-            "on": [
-                {
-                    "events": {
-                        "source": "scope",
-                        "type": "mousedown",
-                        "filter": [
-                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")",
-                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
-                        ]
-                    },
-                    "update": "invert(\"x\", [x(unit), x(unit)])"
-                },
-                {
-                    "events": {
-                        "source": "window",
-                        "type": "mousemove",
-                        "consume": true,
-                        "between": [
-                            {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")",
-                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
-                                ]
-                            },
-                            {
-                                "source": "window",
-                                "type": "mouseup"
-                            }
-                        ]
-                    },
-                    "update": "[child_brush_x[0], invert(\"x\", clamp(x(unit), 0, width))]"
-                },
-                {
-                    "events": {
-                        "signal": "child_brush_translate_delta"
-                    },
-                    "update": "clampRange([child_brush_translate_anchor.extent_x[0] + abs(span(child_brush_translate_anchor.extent_x)) * child_brush_translate_delta.x / child_brush_translate_anchor.width, child_brush_translate_anchor.extent_x[1] + abs(span(child_brush_translate_anchor.extent_x)) * child_brush_translate_delta.x / child_brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
-                },
-                {
-                    "events": {
-                        "signal": "child_brush_zoom_delta"
-                    },
-                    "update": "clampRange([child_brush_zoom_anchor.x + (child_brush_x[0] - child_brush_zoom_anchor.x) * child_brush_zoom_delta, child_brush_zoom_anchor.x + (child_brush_x[1] - child_brush_zoom_anchor.x) * child_brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
-                }
-            ]
-        },
-        {
-            "name": "child_brush_size",
-            "value": [],
-            "on": [
-                {
-                    "events": {
-                        "source": "scope",
-                        "type": "mousedown",
-                        "filter": [
-                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")",
-                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
-                        ]
-                    },
-                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                },
-                {
-                    "events": {
-                        "source": "window",
-                        "type": "mousemove",
-                        "consume": true,
-                        "between": [
-                            {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")",
-                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
-                                ]
-                            },
-                            {
-                                "source": "window",
-                                "type": "mouseup"
-                            }
-                        ]
-                    },
-                    "update": "{x: child_brush_size.x, y: child_brush_size.y, width: abs(x(unit) - child_brush_size.x), height: abs(y(unit) - child_brush_size.y)}"
-                },
-                {
-                    "events": {
-                        "signal": "child_brush_zoom_delta"
-                    },
-                    "update": "{x: child_brush_size.x, y: child_brush_size.y, width: child_brush_size.width * child_brush_zoom_delta , height: child_brush_size.height * child_brush_zoom_delta}"
-                }
-            ]
-        },
-        {
-            "name": "child_brush",
-            "update": "[{field: \"X\", extent: child_brush_x}]"
-        },
-        {
-            "name": "child_brush_translate_anchor",
-            "value": {},
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "mousedown",
-                            "markname": "child_brush_brush"
-                        }
-                    ],
-                    "update": "{x: x(unit), y: y(unit), width: child_brush_size.width, height: child_brush_size.height, extent_x: slice(child_brush_x), }"
-                }
-            ]
-        },
-        {
-            "name": "child_brush_translate_delta",
-            "value": {},
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "window",
-                            "type": "mousemove",
-                            "consume": true,
-                            "between": [
-                                {
-                                    "source": "scope",
-                                    "type": "mousedown",
-                                    "markname": "child_brush_brush"
-                                },
-                                {
-                                    "source": "window",
-                                    "type": "mouseup"
-                                }
-                            ]
-                        }
-                    ],
-                    "update": "{x: x(unit) - child_brush_translate_anchor.x, y: y(unit) - child_brush_translate_anchor.y}"
-                }
-            ]
-        },
-        {
-            "name": "child_brush_zoom_anchor",
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "wheel",
-                            "markname": "child_brush_brush"
-                        }
-                    ],
-                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
-                }
-            ]
-        },
-        {
-            "name": "child_brush_zoom_delta",
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "wheel",
-                            "markname": "child_brush_brush"
-                        }
-                    ],
-                    "force": true,
-                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-                }
-            ]
-        },
-        {
-            "name": "child_brush_tuple",
-            "on": [
-                {
-                    "events": {
-                        "signal": "child_brush"
-                    },
-                    "update": "{unit: unit.datum && unit.datum._id, intervals: child_brush}"
-                }
-            ]
-        },
-        {
-            "name": "child_brush_modify",
-            "on": [
-                {
-                    "events": {
-                        "signal": "child_brush"
-                    },
-                    "update": "modify(\"child_brush_store\", child_brush_tuple, {unit: child_brush_tuple.unit})"
-                }
-            ]
-        },
-        {
-            "name": "child_grid_x",
-            "on": [
-                {
-                    "events": {
-                        "signal": "child_grid_translate_delta"
-                    },
-                    "update": "[child_grid_translate_anchor.extent_x[0] - abs(span(child_grid_translate_anchor.extent_x)) * child_grid_translate_delta.x / child_grid_translate_anchor.width, child_grid_translate_anchor.extent_x[1] - abs(span(child_grid_translate_anchor.extent_x)) * child_grid_translate_delta.x / child_grid_translate_anchor.width]"
-                },
-                {
-                    "events": {
-                        "signal": "child_grid_zoom_delta"
-                    },
-                    "update": "[child_grid_zoom_anchor.x + (domain(\"x\")[0] - child_grid_zoom_anchor.x) * child_grid_zoom_delta, child_grid_zoom_anchor.x + (domain(\"x\")[1] - child_grid_zoom_anchor.x) * child_grid_zoom_delta]"
-                }
-            ],
-            "push": "outer"
-        },
-        {
-            "name": "child_grid_y",
-            "on": [
-                {
-                    "events": {
-                        "signal": "child_grid_translate_delta"
-                    },
-                    "update": "[child_grid_translate_anchor.extent_y[0] + abs(span(child_grid_translate_anchor.extent_y)) * child_grid_translate_delta.y / child_grid_translate_anchor.height, child_grid_translate_anchor.extent_y[1] + abs(span(child_grid_translate_anchor.extent_y)) * child_grid_translate_delta.y / child_grid_translate_anchor.height]"
-                },
-                {
-                    "events": {
-                        "signal": "child_grid_zoom_delta"
-                    },
-                    "update": "[child_grid_zoom_anchor.y + (domain(\"y\")[0] - child_grid_zoom_anchor.y) * child_grid_zoom_delta, child_grid_zoom_anchor.y + (domain(\"y\")[1] - child_grid_zoom_anchor.y) * child_grid_zoom_delta]"
-                }
-            ],
-            "push": "outer"
-        },
-        {
-            "name": "child_grid",
-            "update": "[{field: \"X\", extent: child_grid_x}, {field: \"Y\", extent: child_grid_y}]"
-        },
-        {
-            "name": "child_grid_translate_anchor",
-            "value": {},
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "mousedown",
-                            "filter": [
-                                "event.shiftKey"
-                            ]
-                        }
-                    ],
-                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
-                }
-            ]
-        },
-        {
-            "name": "child_grid_translate_delta",
-            "value": {},
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "mousemove",
-                            "between": [
-                                {
-                                    "source": "scope",
-                                    "type": "mousedown",
-                                    "filter": [
-                                        "event.shiftKey"
-                                    ]
-                                },
-                                {
-                                    "source": "scope",
-                                    "type": "mouseup"
-                                }
-                            ]
-                        }
-                    ],
-                    "update": "{x: x(unit) - child_grid_translate_anchor.x, y: y(unit) - child_grid_translate_anchor.y}"
-                }
-            ]
-        },
-        {
-            "name": "child_grid_zoom_anchor",
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "wheel"
-                        }
-                    ],
-                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
-                }
-            ]
-        },
-        {
-            "name": "child_grid_zoom_delta",
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "wheel"
-                        }
-                    ],
-                    "force": true,
-                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-                }
-            ]
-        },
-        {
-            "name": "child_grid_tuple",
-            "on": [
-                {
-                    "events": {
-                        "signal": "child_grid"
-                    },
-                    "update": "{unit: unit.datum && unit.datum._id, intervals: child_grid}"
-                }
-            ]
-        },
-        {
-            "name": "child_grid_modify",
-            "on": [
-                {
-                    "events": {
-                        "signal": "child_grid"
-                    },
-                    "update": "modify(\"child_grid_store\", child_grid_tuple, true)"
-                }
-            ]
-        },
-        {
-            "name": "child_xenc",
-            "update": "{fields: [\"X\"], values: [child_xenc_X]}"
-        },
-        {
-            "name": "child_xenc_tuple",
-            "on": [
-                {
-                    "events": {
-                        "signal": "child_xenc"
-                    },
-                    "update": "{unit: unit.datum && unit.datum._id, fields: child_xenc.fields, values: child_xenc.values, X: child_xenc.values[0]}"
-                }
-            ]
-        },
-        {
-            "name": "child_xenc_modify",
-            "on": [
-                {
-                    "events": {
-                        "signal": "child_xenc"
-                    },
-                    "update": "modify(\"child_xenc_store\", child_xenc_tuple, true)"
-                }
-            ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": {
-            "signal": "data('column_layout')[0].distinct_Series"
-        },
-        "bounds": "full"
-    },
     "marks": [
         {
-            "name": "column-title",
-            "role": "column-title",
+            "name": "nested-main-group",
             "type": "group",
-            "marks": [
-                {
-                    "type": "text",
-                    "role": "column-title-text",
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "signal": "0.5 * width"
-                            },
-                            "align": {
-                                "value": "center"
-                            },
-                            "text": {
-                                "value": "Series"
-                            },
-                            "fill": {
-                                "value": "black"
-                            },
-                            "fontWeight": {
-                                "value": "bold"
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "row-header",
-            "type": "group",
-            "role": "row-header",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_height"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Y",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "column-header",
-            "type": "group",
-            "role": "column-header",
-            "from": {
-                "data": "column"
-            },
-            "title": {
-                "text": {
-                    "signal": "parent['Series']"
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
                 },
                 "offset": 10,
-                "orient": "top",
-                "encode": {
-                    "update": {
-                        "fontWeight": {
-                            "value": "normal"
-                        },
-                        "angle": {
-                            "value": 0
-                        },
-                        "fontSize": {
-                            "value": 10
-                        }
-                    }
-                }
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            }
-        },
-        {
-            "name": "column-footer",
-            "type": "group",
-            "role": "column-footer",
-            "from": {
-                "data": "column"
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "X",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "cell",
-            "type": "group",
-            "from": {
-                "facet": {
-                    "name": "facet",
-                    "data": "source_0",
-                    "groupby": [
-                        "Series"
-                    ]
-                }
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    },
-                    "height": {
-                        "signal": "child_height"
-                    },
-                    "stroke": {
-                        "value": "#ccc"
-                    },
-                    "strokeWidth": {
-                        "value": 1
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
+                "columns": {
+                    "signal": "data('column_layout')[0].distinct_Series"
+                },
+                "bounds": "full"
             },
             "signals": [
                 {
@@ -982,186 +484,692 @@
             ],
             "marks": [
                 {
+                    "name": "column-title",
+                    "role": "column-title",
                     "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "column-title-text",
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "signal": "0.5 * width"
+                                    },
+                                    "align": {
+                                        "value": "center"
+                                    },
+                                    "text": {
+                                        "value": "Series"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "row-header",
+                    "type": "group",
+                    "role": "row-header",
                     "encode": {
-                        "enter": {
+                        "update": {
+                            "height": {
+                                "signal": "child_height"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Y",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "column-header",
+                    "type": "group",
+                    "role": "column-header",
+                    "from": {
+                        "data": "column"
+                    },
+                    "title": {
+                        "text": {
+                            "signal": "parent['Series']"
+                        },
+                        "offset": 10,
+                        "orient": "top",
+                        "encode": {
+                            "update": {
+                                "fontWeight": {
+                                    "value": "normal"
+                                },
+                                "angle": {
+                                    "value": 0
+                                },
+                                "fontSize": {
+                                    "value": 10
+                                }
+                            }
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "column-footer",
+                    "type": "group",
+                    "role": "column-footer",
+                    "from": {
+                        "data": "column"
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "X",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "Series"
+                            ]
+                        }
+                    },
+                    "encode": {
+                        "update": {
                             "width": {
                                 "signal": "child_width"
                             },
                             "height": {
                                 "signal": "child_height"
                             },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
+                            },
                             "fill": {
                                 "value": "transparent"
-                            },
-                            "clip": {
-                                "value": true
                             }
                         }
                     },
-                    "marks": [
+                    "signals": [
                         {
-                            "type": "rect",
-                            "encode": {
-                                "enter": {
-                                    "fill": {
-                                        "value": "#eee"
-                                    }
-                                },
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "signal": "child_brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "x",
-                                        "signal": "child_brush[0].extent[1]"
-                                    },
-                                    "y": {
-                                        "value": 0
-                                    },
-                                    "y2": {
-                                        "field": {
-                                            "group": "height"
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "child_marks",
-                            "type": "symbol",
-                            "role": "circle",
-                            "from": {
-                                "data": "facet"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "X"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "Y"
-                                    },
-                                    "fill": [
-                                        {
-                                            "test": "vlPoint(\"child_xenc_store\", datum._id, datum, \"union\", \"all\")",
-                                            "value": "red"
-                                        },
-                                        {
-                                            "value": "steelblue"
-                                        }
-                                    ],
-                                    "size": [
-                                        {
-                                            "test": "vlInterval(\"child_brush_store\", datum._id, datum, \"intersect\", \"all\")",
-                                            "value": 250
-                                        },
-                                        {
-                                            "value": 100
-                                        }
-                                    ],
-                                    "shape": {
-                                        "value": "circle"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "child_voronoi",
-                            "type": "path",
-                            "from": {
-                                "data": "child_marks"
-                            },
-                            "encode": {
-                                "enter": {
-                                    "fill": {
-                                        "value": "transparent"
-                                    },
-                                    "strokeWidth": {
-                                        "value": 0.35
-                                    },
-                                    "stroke": {
-                                        "value": "transparent"
-                                    },
-                                    "isVoronoi": {
-                                        "value": true
-                                    }
-                                }
-                            },
-                            "transform": [
+                            "name": "child_brush_x",
+                            "value": [],
+                            "on": [
                                 {
-                                    "type": "voronoi",
-                                    "x": "datum.x",
-                                    "y": "datum.y",
-                                    "size": [
-                                        {
-                                            "signal": "width"
-                                        },
-                                        {
-                                            "signal": "height"
-                                        }
-                                    ]
+                                    "events": {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")",
+                                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
+                                        ]
+                                    },
+                                    "update": "invert(\"x\", [x(unit), x(unit)])"
+                                },
+                                {
+                                    "events": {
+                                        "source": "window",
+                                        "type": "mousemove",
+                                        "consume": true,
+                                        "between": [
+                                            {
+                                                "source": "scope",
+                                                "type": "mousedown",
+                                                "filter": [
+                                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")",
+                                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
+                                                ]
+                                            },
+                                            {
+                                                "source": "window",
+                                                "type": "mouseup"
+                                            }
+                                        ]
+                                    },
+                                    "update": "[child_brush_x[0], invert(\"x\", clamp(x(unit), 0, width))]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "child_brush_translate_delta"
+                                    },
+                                    "update": "clampRange([child_brush_translate_anchor.extent_x[0] + abs(span(child_brush_translate_anchor.extent_x)) * child_brush_translate_delta.x / child_brush_translate_anchor.width, child_brush_translate_anchor.extent_x[1] + abs(span(child_brush_translate_anchor.extent_x)) * child_brush_translate_delta.x / child_brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "child_brush_zoom_delta"
+                                    },
+                                    "update": "clampRange([child_brush_zoom_anchor.x + (child_brush_x[0] - child_brush_zoom_anchor.x) * child_brush_zoom_delta, child_brush_zoom_anchor.x + (child_brush_x[1] - child_brush_zoom_anchor.x) * child_brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
                                 }
                             ]
                         },
                         {
-                            "name": "child_brush_brush",
-                            "type": "rect",
+                            "name": "child_brush_size",
+                            "value": [],
+                            "on": [
+                                {
+                                    "events": {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")",
+                                            "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
+                                        ]
+                                    },
+                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
+                                },
+                                {
+                                    "events": {
+                                        "source": "window",
+                                        "type": "mousemove",
+                                        "consume": true,
+                                        "between": [
+                                            {
+                                                "source": "scope",
+                                                "type": "mousedown",
+                                                "filter": [
+                                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")",
+                                                    "!event.item || (event.item && event.item.mark.name !== \"child_brush_brush\")"
+                                                ]
+                                            },
+                                            {
+                                                "source": "window",
+                                                "type": "mouseup"
+                                            }
+                                        ]
+                                    },
+                                    "update": "{x: child_brush_size.x, y: child_brush_size.y, width: abs(x(unit) - child_brush_size.x), height: abs(y(unit) - child_brush_size.y)}"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "child_brush_zoom_delta"
+                                    },
+                                    "update": "{x: child_brush_size.x, y: child_brush_size.y, width: child_brush_size.width * child_brush_zoom_delta , height: child_brush_size.height * child_brush_zoom_delta}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush",
+                            "update": "[{field: \"X\", extent: child_brush_x}]"
+                        },
+                        {
+                            "name": "child_brush_translate_anchor",
+                            "value": {},
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "markname": "child_brush_brush"
+                                        }
+                                    ],
+                                    "update": "{x: x(unit), y: y(unit), width: child_brush_size.width, height: child_brush_size.height, extent_x: slice(child_brush_x), }"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_translate_delta",
+                            "value": {},
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "window",
+                                            "type": "mousemove",
+                                            "consume": true,
+                                            "between": [
+                                                {
+                                                    "source": "scope",
+                                                    "type": "mousedown",
+                                                    "markname": "child_brush_brush"
+                                                },
+                                                {
+                                                    "source": "window",
+                                                    "type": "mouseup"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "update": "{x: x(unit) - child_brush_translate_anchor.x, y: y(unit) - child_brush_translate_anchor.y}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_zoom_anchor",
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "wheel",
+                                            "markname": "child_brush_brush"
+                                        }
+                                    ],
+                                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_zoom_delta",
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "wheel",
+                                            "markname": "child_brush_brush"
+                                        }
+                                    ],
+                                    "force": true,
+                                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_tuple",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_brush"
+                                    },
+                                    "update": "{unit: unit.datum && unit.datum._id, intervals: child_brush}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_brush_modify",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_brush"
+                                    },
+                                    "update": "modify(\"child_brush_store\", child_brush_tuple, {unit: child_brush_tuple.unit})"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_x",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_grid_translate_delta"
+                                    },
+                                    "update": "[child_grid_translate_anchor.extent_x[0] - abs(span(child_grid_translate_anchor.extent_x)) * child_grid_translate_delta.x / child_grid_translate_anchor.width, child_grid_translate_anchor.extent_x[1] - abs(span(child_grid_translate_anchor.extent_x)) * child_grid_translate_delta.x / child_grid_translate_anchor.width]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "child_grid_zoom_delta"
+                                    },
+                                    "update": "[child_grid_zoom_anchor.x + (domain(\"x\")[0] - child_grid_zoom_anchor.x) * child_grid_zoom_delta, child_grid_zoom_anchor.x + (domain(\"x\")[1] - child_grid_zoom_anchor.x) * child_grid_zoom_delta]"
+                                }
+                            ],
+                            "push": "outer"
+                        },
+                        {
+                            "name": "child_grid_y",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_grid_translate_delta"
+                                    },
+                                    "update": "[child_grid_translate_anchor.extent_y[0] + abs(span(child_grid_translate_anchor.extent_y)) * child_grid_translate_delta.y / child_grid_translate_anchor.height, child_grid_translate_anchor.extent_y[1] + abs(span(child_grid_translate_anchor.extent_y)) * child_grid_translate_delta.y / child_grid_translate_anchor.height]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "child_grid_zoom_delta"
+                                    },
+                                    "update": "[child_grid_zoom_anchor.y + (domain(\"y\")[0] - child_grid_zoom_anchor.y) * child_grid_zoom_delta, child_grid_zoom_anchor.y + (domain(\"y\")[1] - child_grid_zoom_anchor.y) * child_grid_zoom_delta]"
+                                }
+                            ],
+                            "push": "outer"
+                        },
+                        {
+                            "name": "child_grid",
+                            "update": "[{field: \"X\", extent: child_grid_x}, {field: \"Y\", extent: child_grid_y}]"
+                        },
+                        {
+                            "name": "child_grid_translate_anchor",
+                            "value": {},
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ]
+                                        }
+                                    ],
+                                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_translate_delta",
+                            "value": {},
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousemove",
+                                            "between": [
+                                                {
+                                                    "source": "scope",
+                                                    "type": "mousedown",
+                                                    "filter": [
+                                                        "event.shiftKey"
+                                                    ]
+                                                },
+                                                {
+                                                    "source": "scope",
+                                                    "type": "mouseup"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "update": "{x: x(unit) - child_grid_translate_anchor.x, y: y(unit) - child_grid_translate_anchor.y}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_zoom_anchor",
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "wheel"
+                                        }
+                                    ],
+                                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_zoom_delta",
+                            "on": [
+                                {
+                                    "events": [
+                                        {
+                                            "source": "scope",
+                                            "type": "wheel"
+                                        }
+                                    ],
+                                    "force": true,
+                                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_tuple",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_grid"
+                                    },
+                                    "update": "{unit: unit.datum && unit.datum._id, intervals: child_grid}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_grid_modify",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_grid"
+                                    },
+                                    "update": "modify(\"child_grid_store\", child_grid_tuple, true)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_xenc",
+                            "update": "{fields: [\"X\"], values: [child_xenc_X]}"
+                        },
+                        {
+                            "name": "child_xenc_tuple",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_xenc"
+                                    },
+                                    "update": "{unit: unit.datum && unit.datum._id, fields: child_xenc.fields, values: child_xenc.values, X: child_xenc.values[0]}"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "child_xenc_modify",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "child_xenc"
+                                    },
+                                    "update": "modify(\"child_xenc_store\", child_xenc_tuple, true)"
+                                }
+                            ]
+                        }
+                    ],
+                    "marks": [
+                        {
+                            "type": "group",
                             "encode": {
                                 "enter": {
+                                    "width": {
+                                        "signal": "child_width"
+                                    },
+                                    "height": {
+                                        "signal": "child_height"
+                                    },
                                     "fill": {
                                         "value": "transparent"
+                                    },
+                                    "clip": {
+                                        "value": true
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "type": "rect",
+                                    "encode": {
+                                        "enter": {
+                                            "fill": {
+                                                "value": "#eee"
+                                            }
+                                        },
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "signal": "child_brush[0].extent[0]"
+                                            },
+                                            "x2": {
+                                                "scale": "x",
+                                                "signal": "child_brush[0].extent[1]"
+                                            },
+                                            "y": {
+                                                "value": 0
+                                            },
+                                            "y2": {
+                                                "field": {
+                                                    "group": "height"
+                                                }
+                                            }
+                                        }
                                     }
                                 },
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "signal": "child_brush[0].extent[0]"
+                                {
+                                    "name": "child_marks",
+                                    "type": "symbol",
+                                    "role": "circle",
+                                    "from": {
+                                        "data": "facet"
                                     },
-                                    "x2": {
-                                        "scale": "x",
-                                        "signal": "child_brush[0].extent[1]"
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "X"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "Y"
+                                            },
+                                            "fill": [
+                                                {
+                                                    "test": "vlPoint(\"child_xenc_store\", parent._id, datum, \"union\", \"all\")",
+                                                    "value": "red"
+                                                },
+                                                {
+                                                    "value": "steelblue"
+                                                }
+                                            ],
+                                            "size": [
+                                                {
+                                                    "test": "vlInterval(\"child_brush_store\", parent._id, datum, \"intersect\", \"all\")",
+                                                    "value": 250
+                                                },
+                                                {
+                                                    "value": 100
+                                                }
+                                            ],
+                                            "shape": {
+                                                "value": "circle"
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "name": "child_voronoi",
+                                    "type": "path",
+                                    "from": {
+                                        "data": "child_marks"
                                     },
-                                    "y": {
-                                        "value": 0
+                                    "encode": {
+                                        "enter": {
+                                            "fill": {
+                                                "value": "transparent"
+                                            },
+                                            "strokeWidth": {
+                                                "value": 0.35
+                                            },
+                                            "stroke": {
+                                                "value": "transparent"
+                                            },
+                                            "isVoronoi": {
+                                                "value": true
+                                            }
+                                        }
                                     },
-                                    "y2": {
-                                        "field": {
-                                            "group": "height"
+                                    "transform": [
+                                        {
+                                            "type": "voronoi",
+                                            "x": "datum.x",
+                                            "y": "datum.y",
+                                            "size": [
+                                                {
+                                                    "signal": "width"
+                                                },
+                                                {
+                                                    "signal": "height"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "name": "child_brush_brush",
+                                    "type": "rect",
+                                    "encode": {
+                                        "enter": {
+                                            "fill": {
+                                                "value": "transparent"
+                                            }
+                                        },
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "signal": "child_brush[0].extent[0]"
+                                            },
+                                            "x2": {
+                                                "scale": "x",
+                                                "signal": "child_brush[0].extent[1]"
+                                            },
+                                            "y": {
+                                                "value": 0
+                                            },
+                                            "y2": {
+                                                "field": {
+                                                    "group": "height"
+                                                }
+                                            }
                                         }
                                     }
                                 }
-                            }
+                            ]
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "y"
+                        },
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
                         }
                     ]
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
                 }
             ]
         }

--- a/examples/vg-specs/field_spaces.vg.json
+++ b/examples/vg-specs/field_spaces.vg.json
@@ -84,33 +84,49 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "a b"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "c d"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "a b"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "c d"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/github_punchcard.vg.json
+++ b/examples/vg-specs/github_punchcard.vg.json
@@ -66,34 +66,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "circle",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "hours_time"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "day_time"
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
-                    },
-                    "size": {
-                        "scale": "size",
-                        "field": "sum_count"
-                    },
-                    "shape": {
-                        "value": "circle"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "circle",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "hours_time"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "day_time"
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "size": {
+                                "scale": "size",
+                                "field": "sum_count"
+                            },
+                            "shape": {
+                                "value": "circle"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/histogram.vg.json
+++ b/examples/vg-specs/histogram.vg.json
@@ -73,36 +73,52 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x2": {
-                        "scale": "x",
-                        "field": "bin_maxbins_10_IMDB_Rating_start",
-                        "offset": 1
+                    "width": {
+                        "signal": "width"
                     },
-                    "x": {
-                        "scale": "x",
-                        "field": "bin_maxbins_10_IMDB_Rating_end"
-                    },
-                    "y": {
-                        "scale": "y",
-                        "field": "count_*"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x2": {
+                                "scale": "x",
+                                "field": "bin_maxbins_10_IMDB_Rating_start",
+                                "offset": 1
+                            },
+                            "x": {
+                                "scale": "x",
+                                "field": "bin_maxbins_10_IMDB_Rating_end"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "count_*"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/histogram_bin_change.vg.json
+++ b/examples/vg-specs/histogram_bin_change.vg.json
@@ -73,36 +73,52 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x2": {
-                        "scale": "x",
-                        "field": "bin_maxbins_30_IMDB_Rating_start",
-                        "offset": 1
+                    "width": {
+                        "signal": "width"
                     },
-                    "x": {
-                        "scale": "x",
-                        "field": "bin_maxbins_30_IMDB_Rating_end"
-                    },
-                    "y": {
-                        "scale": "y",
-                        "field": "count_*"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x2": {
+                                "scale": "x",
+                                "field": "bin_maxbins_30_IMDB_Rating_start",
+                                "offset": 1
+                            },
+                            "x": {
+                                "scale": "x",
+                                "field": "bin_maxbins_30_IMDB_Rating_end"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "count_*"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/histogram_no_spacing.vg.json
+++ b/examples/vg-specs/histogram_no_spacing.vg.json
@@ -73,35 +73,51 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x2": {
-                        "scale": "x",
-                        "field": "bin_maxbins_10_IMDB_Rating_start"
+                    "width": {
+                        "signal": "width"
                     },
-                    "x": {
-                        "scale": "x",
-                        "field": "bin_maxbins_10_IMDB_Rating_end"
-                    },
-                    "y": {
-                        "scale": "y",
-                        "field": "count_*"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "value": 0
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x2": {
+                                "scale": "x",
+                                "field": "bin_maxbins_10_IMDB_Rating_start"
+                            },
+                            "x": {
+                                "scale": "x",
+                                "field": "bin_maxbins_10_IMDB_Rating_end"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "count_*"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "value": 0
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/histogram_sort_mean.vg.json
+++ b/examples/vg-specs/histogram_sort_mean.vg.json
@@ -60,34 +60,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "data_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "mean_Horsepower"
-                    },
-                    "x2": {
-                        "scale": "x",
-                        "value": 0
-                    },
-                    "yc": {
-                        "scale": "y",
-                        "field": "Origin"
+                    "width": {
+                        "signal": "width"
                     },
                     "height": {
-                        "value": 20
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "data_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "mean_Horsepower"
+                            },
+                            "x2": {
+                                "scale": "x",
+                                "value": 0
+                            },
+                            "yc": {
+                                "scale": "y",
+                                "field": "Origin"
+                            },
+                            "height": {
+                                "value": 20
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/layer_bar_line.vg.json
+++ b/examples/vg-specs/layer_bar_line.vg.json
@@ -123,75 +123,91 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "a"
-                            },
+                        "enter": {
                             "width": {
-                                "value": 20
+                                "signal": "width"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "b"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
+                            "height": {
+                                "signal": "height"
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "line",
-                    "from": {
-                        "data": "data_1"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "a"
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "data_0"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "b"
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "a"
+                                    },
+                                    "width": {
+                                        "value": 20
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "b"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "line",
+                            "from": {
+                                "data": "data_1"
                             },
-                            "stroke": {
-                                "value": "red"
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "a"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "b"
+                                    },
+                                    "stroke": {
+                                        "value": "red"
+                                    }
+                                }
                             }
                         }
-                    }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/layer_bar_line_union.vg.json
+++ b/examples/vg-specs/layer_bar_line_union.vg.json
@@ -132,75 +132,91 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "a"
-                            },
+                        "enter": {
                             "width": {
-                                "value": 20
+                                "signal": "width"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "c"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
+                            "height": {
+                                "signal": "height"
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "line",
-                    "from": {
-                        "data": "data_1"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "b"
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "data_0"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "c"
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "a"
+                                    },
+                                    "width": {
+                                        "value": 20
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "c"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "line",
+                            "from": {
+                                "data": "data_1"
                             },
-                            "stroke": {
-                                "value": "red"
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "b"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "c"
+                                    },
+                                    "stroke": {
+                                        "value": "red"
+                                    }
+                                }
                             }
                         }
-                    }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/layer_histogram.vg.json
+++ b/examples/vg-specs/layer_histogram.vg.json
@@ -145,87 +145,103 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x2": {
-                                "scale": "layer_0_x",
-                                "field": "bin_maxbins_10_distance_start",
-                                "offset": 1
+                        "enter": {
+                            "width": {
+                                "signal": "width"
                             },
-                            "x": {
-                                "scale": "layer_0_x",
-                                "field": "bin_maxbins_10_distance_end"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "count_*"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
+                            "height": {
+                                "signal": "height"
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "data_1"
                     },
-                    "encode": {
-                        "update": {
-                            "x2": {
-                                "scale": "layer_1_x",
-                                "field": "bin_maxbins_10_distance_start",
-                                "offset": 1
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "data_0"
                             },
-                            "x": {
-                                "scale": "layer_1_x",
-                                "field": "bin_maxbins_10_distance_end"
+                            "encode": {
+                                "update": {
+                                    "x2": {
+                                        "scale": "layer_0_x",
+                                        "field": "bin_maxbins_10_distance_start",
+                                        "offset": 1
+                                    },
+                                    "x": {
+                                        "scale": "layer_0_x",
+                                        "field": "bin_maxbins_10_distance_end"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "count_*"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "data_1"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "count_*"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "goldenrod"
+                            "encode": {
+                                "update": {
+                                    "x2": {
+                                        "scale": "layer_1_x",
+                                        "field": "bin_maxbins_10_distance_start",
+                                        "offset": 1
+                                    },
+                                    "x": {
+                                        "scale": "layer_1_x",
+                                        "field": "bin_maxbins_10_distance_end"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "count_*"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "goldenrod"
+                                    }
+                                }
                             }
                         }
-                    }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/layer_line_color_rule.vg.json
+++ b/examples/vg-specs/layer_line_color_rule.vg.json
@@ -103,108 +103,124 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_pathgroup",
                     "type": "group",
-                    "from": {
-                        "facet": {
-                            "name": "faceted-path-layer_0_main",
-                            "data": "data_0",
-                            "groupby": [
-                                "symbol"
-                            ]
-                        }
-                    },
                     "encode": {
-                        "update": {
+                        "enter": {
                             "width": {
-                                "field": {
-                                    "group": "width"
-                                }
+                                "signal": "width"
                             },
                             "height": {
-                                "field": {
-                                    "group": "height"
-                                }
+                                "signal": "height"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "clip": {
+                                "value": true
                             }
                         }
                     },
                     "marks": [
                         {
-                            "name": "layer_0_marks",
-                            "type": "line",
+                            "name": "layer_0_pathgroup",
+                            "type": "group",
                             "from": {
-                                "data": "faceted-path-layer_0_main"
+                                "facet": {
+                                    "name": "faceted-path-layer_0_main",
+                                    "data": "data_0",
+                                    "groupby": [
+                                        "symbol"
+                                    ]
+                                }
+                            },
+                            "encode": {
+                                "update": {
+                                    "width": {
+                                        "field": {
+                                            "group": "width"
+                                        }
+                                    },
+                                    "height": {
+                                        "field": {
+                                            "group": "height"
+                                        }
+                                    }
+                                }
+                            },
+                            "marks": [
+                                {
+                                    "name": "layer_0_marks",
+                                    "type": "line",
+                                    "from": {
+                                        "data": "faceted-path-layer_0_main"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "date"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "price"
+                                            },
+                                            "stroke": {
+                                                "scale": "color",
+                                                "field": "symbol"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "rule",
+                            "from": {
+                                "data": "data_1"
                             },
                             "encode": {
                                 "update": {
                                     "x": {
-                                        "scale": "x",
-                                        "field": "date"
+                                        "value": 0
                                     },
                                     "y": {
                                         "scale": "y",
-                                        "field": "price"
+                                        "field": "mean_price"
+                                    },
+                                    "x2": {
+                                        "field": {
+                                            "group": "width"
+                                        }
                                     },
                                     "stroke": {
                                         "scale": "color",
                                         "field": "symbol"
+                                    },
+                                    "opacity": {
+                                        "value": 0.5
+                                    },
+                                    "strokeWidth": {
+                                        "value": 2
                                     }
                                 }
                             }
                         }
                     ]
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "rule",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "value": 0
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "mean_price"
-                            },
-                            "x2": {
-                                "field": {
-                                    "group": "width"
-                                }
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "symbol"
-                            },
-                            "opacity": {
-                                "value": 0.5
-                            },
-                            "strokeWidth": {
-                                "value": 2
-                            }
-                        }
-                    }
                 }
             ]
         }

--- a/examples/vg-specs/layer_overlay.vg.json
+++ b/examples/vg-specs/layer_overlay.vg.json
@@ -215,20 +215,15 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
@@ -238,10 +233,10 @@
                     "encode": {
                         "enter": {
                             "width": {
-                                "signal": "layer_0_width"
+                                "signal": "width"
                             },
                             "height": {
-                                "signal": "layer_0_height"
+                                "signal": "height"
                             },
                             "fill": {
                                 "value": "transparent"
@@ -253,115 +248,136 @@
                     },
                     "marks": [
                         {
-                            "name": "layer_0_layer_0_marks",
-                            "type": "line",
-                            "from": {
-                                "data": "data_4"
-                            },
+                            "type": "group",
                             "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "Cylinders"
+                                "enter": {
+                                    "width": {
+                                        "signal": "layer_0_width"
                                     },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "max_Horsepower"
-                                    },
-                                    "stroke": {
-                                        "value": "darkred"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "name": "layer_0_layer_1_marks",
-                            "type": "symbol",
-                            "role": "pointOverlay",
-                            "from": {
-                                "data": "data_5"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "Cylinders"
-                                    },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "max_Horsepower"
+                                    "height": {
+                                        "signal": "layer_0_height"
                                     },
                                     "fill": {
-                                        "value": "darkred"
+                                        "value": "transparent"
+                                    },
+                                    "clip": {
+                                        "value": true
                                     }
                                 }
-                            }
-                        }
-                    ]
-                },
-                {
-                    "type": "group",
-                    "encode": {
-                        "enter": {
-                            "width": {
-                                "signal": "layer_1_width"
                             },
-                            "height": {
-                                "signal": "layer_1_height"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "clip": {
-                                "value": true
-                            }
-                        }
-                    },
-                    "marks": [
-                        {
-                            "name": "layer_1_layer_0_marks",
-                            "type": "line",
-                            "from": {
-                                "data": "data_1"
-                            },
-                            "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "Cylinders"
+                            "marks": [
+                                {
+                                    "name": "layer_0_layer_0_marks",
+                                    "type": "line",
+                                    "from": {
+                                        "data": "data_4"
                                     },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "min_Horsepower"
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "Cylinders"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "max_Horsepower"
+                                            },
+                                            "stroke": {
+                                                "value": "darkred"
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "name": "layer_0_layer_1_marks",
+                                    "type": "symbol",
+                                    "role": "pointOverlay",
+                                    "from": {
+                                        "data": "data_5"
                                     },
-                                    "stroke": {
-                                        "value": "#4c78a8"
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "Cylinders"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "max_Horsepower"
+                                            },
+                                            "fill": {
+                                                "value": "darkred"
+                                            }
+                                        }
                                     }
                                 }
-                            }
+                            ]
                         },
                         {
-                            "name": "layer_1_layer_1_marks",
-                            "type": "symbol",
-                            "role": "pointOverlay",
-                            "from": {
-                                "data": "data_3"
-                            },
+                            "type": "group",
                             "encode": {
-                                "update": {
-                                    "x": {
-                                        "scale": "x",
-                                        "field": "Cylinders"
+                                "enter": {
+                                    "width": {
+                                        "signal": "layer_1_width"
                                     },
-                                    "y": {
-                                        "scale": "y",
-                                        "field": "min_Horsepower"
+                                    "height": {
+                                        "signal": "layer_1_height"
                                     },
                                     "fill": {
-                                        "value": "#4c78a8"
+                                        "value": "transparent"
+                                    },
+                                    "clip": {
+                                        "value": true
                                     }
                                 }
-                            }
+                            },
+                            "marks": [
+                                {
+                                    "name": "layer_1_layer_0_marks",
+                                    "type": "line",
+                                    "from": {
+                                        "data": "data_1"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "Cylinders"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "min_Horsepower"
+                                            },
+                                            "stroke": {
+                                                "value": "#4c78a8"
+                                            }
+                                        }
+                                    }
+                                },
+                                {
+                                    "name": "layer_1_layer_1_marks",
+                                    "type": "symbol",
+                                    "role": "pointOverlay",
+                                    "from": {
+                                        "data": "data_3"
+                                    },
+                                    "encode": {
+                                        "update": {
+                                            "x": {
+                                                "scale": "x",
+                                                "field": "Cylinders"
+                                            },
+                                            "y": {
+                                                "scale": "y",
+                                                "field": "min_Horsepower"
+                                            },
+                                            "fill": {
+                                                "value": "#4c78a8"
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
                         }
                     ]
                 }

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -126,347 +126,330 @@
         {
             "name": "layer_0_cyl",
             "update": "data(\"layer_0_cyl_store\")[0]"
-        },
+        }
+    ],
+    "marks": [
         {
-            "name": "layer_0_grid_x",
-            "on": [
+            "name": "nested-main-group",
+            "type": "group",
+            "signals": [
                 {
-                    "events": {
-                        "signal": "layer_0_grid_translate_delta"
-                    },
-                    "update": "[layer_0_grid_translate_anchor.extent_x[0] - abs(span(layer_0_grid_translate_anchor.extent_x)) * layer_0_grid_translate_delta.x / layer_0_grid_translate_anchor.width, layer_0_grid_translate_anchor.extent_x[1] - abs(span(layer_0_grid_translate_anchor.extent_x)) * layer_0_grid_translate_delta.x / layer_0_grid_translate_anchor.width]"
-                },
-                {
-                    "events": {
-                        "signal": "layer_0_grid_zoom_delta"
-                    },
-                    "update": "[layer_0_grid_zoom_anchor.x + (domain(\"x\")[0] - layer_0_grid_zoom_anchor.x) * layer_0_grid_zoom_delta, layer_0_grid_zoom_anchor.x + (domain(\"x\")[1] - layer_0_grid_zoom_anchor.x) * layer_0_grid_zoom_delta]"
-                }
-            ],
-            "push": "outer"
-        },
-        {
-            "name": "layer_0_grid_y",
-            "on": [
-                {
-                    "events": {
-                        "signal": "layer_0_grid_translate_delta"
-                    },
-                    "update": "[layer_0_grid_translate_anchor.extent_y[0] + abs(span(layer_0_grid_translate_anchor.extent_y)) * layer_0_grid_translate_delta.y / layer_0_grid_translate_anchor.height, layer_0_grid_translate_anchor.extent_y[1] + abs(span(layer_0_grid_translate_anchor.extent_y)) * layer_0_grid_translate_delta.y / layer_0_grid_translate_anchor.height]"
-                },
-                {
-                    "events": {
-                        "signal": "layer_0_grid_zoom_delta"
-                    },
-                    "update": "[layer_0_grid_zoom_anchor.y + (domain(\"y\")[0] - layer_0_grid_zoom_anchor.y) * layer_0_grid_zoom_delta, layer_0_grid_zoom_anchor.y + (domain(\"y\")[1] - layer_0_grid_zoom_anchor.y) * layer_0_grid_zoom_delta]"
-                }
-            ],
-            "push": "outer"
-        },
-        {
-            "name": "layer_0_grid",
-            "update": "[{field: \"Horsepower\", extent: layer_0_grid_x}, {field: \"Miles_per_Gallon\", extent: layer_0_grid_y}]"
-        },
-        {
-            "name": "layer_0_grid_translate_anchor",
-            "value": {},
-            "on": [
-                {
-                    "events": [
+                    "name": "layer_0_grid_x",
+                    "on": [
                         {
-                            "source": "scope",
-                            "type": "mousedown",
-                            "filter": [
-                                "!event.shiftKey"
-                            ]
+                            "events": {
+                                "signal": "layer_0_grid_translate_delta"
+                            },
+                            "update": "[layer_0_grid_translate_anchor.extent_x[0] - abs(span(layer_0_grid_translate_anchor.extent_x)) * layer_0_grid_translate_delta.x / layer_0_grid_translate_anchor.width, layer_0_grid_translate_anchor.extent_x[1] - abs(span(layer_0_grid_translate_anchor.extent_x)) * layer_0_grid_translate_delta.x / layer_0_grid_translate_anchor.width]"
+                        },
+                        {
+                            "events": {
+                                "signal": "layer_0_grid_zoom_delta"
+                            },
+                            "update": "[layer_0_grid_zoom_anchor.x + (domain(\"x\")[0] - layer_0_grid_zoom_anchor.x) * layer_0_grid_zoom_delta, layer_0_grid_zoom_anchor.x + (domain(\"x\")[1] - layer_0_grid_zoom_anchor.x) * layer_0_grid_zoom_delta]"
                         }
                     ],
-                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
-                }
-            ]
-        },
-        {
-            "name": "layer_0_grid_translate_delta",
-            "value": {},
-            "on": [
+                    "push": "outer"
+                },
                 {
-                    "events": [
+                    "name": "layer_0_grid_y",
+                    "on": [
                         {
-                            "source": "scope",
-                            "type": "mousemove",
-                            "between": [
+                            "events": {
+                                "signal": "layer_0_grid_translate_delta"
+                            },
+                            "update": "[layer_0_grid_translate_anchor.extent_y[0] + abs(span(layer_0_grid_translate_anchor.extent_y)) * layer_0_grid_translate_delta.y / layer_0_grid_translate_anchor.height, layer_0_grid_translate_anchor.extent_y[1] + abs(span(layer_0_grid_translate_anchor.extent_y)) * layer_0_grid_translate_delta.y / layer_0_grid_translate_anchor.height]"
+                        },
+                        {
+                            "events": {
+                                "signal": "layer_0_grid_zoom_delta"
+                            },
+                            "update": "[layer_0_grid_zoom_anchor.y + (domain(\"y\")[0] - layer_0_grid_zoom_anchor.y) * layer_0_grid_zoom_delta, layer_0_grid_zoom_anchor.y + (domain(\"y\")[1] - layer_0_grid_zoom_anchor.y) * layer_0_grid_zoom_delta]"
+                        }
+                    ],
+                    "push": "outer"
+                },
+                {
+                    "name": "layer_0_grid",
+                    "update": "[{field: \"Horsepower\", extent: layer_0_grid_x}, {field: \"Miles_per_Gallon\", extent: layer_0_grid_y}]"
+                },
+                {
+                    "name": "layer_0_grid_translate_anchor",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
                                 {
                                     "source": "scope",
                                     "type": "mousedown",
                                     "filter": [
                                         "!event.shiftKey"
                                     ]
-                                },
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_0_grid_translate_delta",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
                                 {
                                     "source": "scope",
-                                    "type": "mouseup"
+                                    "type": "mousemove",
+                                    "between": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
+                                        },
+                                        {
+                                            "source": "scope",
+                                            "type": "mouseup"
+                                        }
+                                    ]
                                 }
-                            ]
-                        }
-                    ],
-                    "update": "{x: x(unit) - layer_0_grid_translate_anchor.x, y: y(unit) - layer_0_grid_translate_anchor.y}"
-                }
-            ]
-        },
-        {
-            "name": "layer_0_grid_zoom_anchor",
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "wheel"
-                        }
-                    ],
-                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
-                }
-            ]
-        },
-        {
-            "name": "layer_0_grid_zoom_delta",
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "wheel"
-                        }
-                    ],
-                    "force": true,
-                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-                }
-            ]
-        },
-        {
-            "name": "layer_0_grid_tuple",
-            "on": [
-                {
-                    "events": {
-                        "signal": "layer_0_grid"
-                    },
-                    "update": "{unit: unit.datum && unit.datum._id, intervals: layer_0_grid}"
-                }
-            ]
-        },
-        {
-            "name": "layer_0_grid_modify",
-            "on": [
-                {
-                    "events": {
-                        "signal": "layer_0_grid"
-                    },
-                    "update": "modify(\"layer_0_grid_store\", layer_0_grid_tuple, true)"
-                }
-            ]
-        },
-        {
-            "name": "layer_0_cyl",
-            "update": "{fields: [\"Cylinders\"], values: [layer_0_cyl_Cylinders]}"
-        },
-        {
-            "name": "layer_0_cyl_tuple",
-            "on": [
-                {
-                    "events": {
-                        "signal": "layer_0_cyl"
-                    },
-                    "update": "{unit: unit.datum && unit.datum._id, fields: layer_0_cyl.fields, values: layer_0_cyl.values, Cylinders: layer_0_cyl.values[0]}"
-                }
-            ]
-        },
-        {
-            "name": "layer_0_cyl_modify",
-            "on": [
-                {
-                    "events": {
-                        "signal": "layer_0_cyl"
-                    },
-                    "update": "modify(\"layer_0_cyl_store\", layer_0_cyl_tuple, true)"
-                }
-            ]
-        },
-        {
-            "name": "layer_1_brush_x",
-            "value": [],
-            "on": [
-                {
-                    "events": {
-                        "source": "scope",
-                        "type": "mousedown",
-                        "filter": [
-                            "event.shiftKey",
-                            "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
-                        ]
-                    },
-                    "update": "invert(\"x\", [x(unit), x(unit)])"
-                },
-                {
-                    "events": {
-                        "source": "scope",
-                        "type": "mousemove",
-                        "between": [
-                            {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "event.shiftKey",
-                                    "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
-                                ]
-                            },
-                            {
-                                "source": "scope",
-                                "type": "mouseup"
-                            }
-                        ]
-                    },
-                    "update": "[layer_1_brush_x[0], invert(\"x\", clamp(x(unit), 0, width))]"
-                },
-                {
-                    "events": {
-                        "signal": "layer_1_brush_translate_delta"
-                    },
-                    "update": "clampRange([layer_1_brush_translate_anchor.extent_x[0] + abs(span(layer_1_brush_translate_anchor.extent_x)) * layer_1_brush_translate_delta.x / layer_1_brush_translate_anchor.width, layer_1_brush_translate_anchor.extent_x[1] + abs(span(layer_1_brush_translate_anchor.extent_x)) * layer_1_brush_translate_delta.x / layer_1_brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
-                },
-                {
-                    "events": {
-                        "signal": "layer_1_brush_zoom_delta"
-                    },
-                    "update": "clampRange([layer_1_brush_zoom_anchor.x + (layer_1_brush_x[0] - layer_1_brush_zoom_anchor.x) * layer_1_brush_zoom_delta, layer_1_brush_zoom_anchor.x + (layer_1_brush_x[1] - layer_1_brush_zoom_anchor.x) * layer_1_brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
-                }
-            ]
-        },
-        {
-            "name": "layer_1_brush_y",
-            "value": [],
-            "on": [
-                {
-                    "events": {
-                        "source": "scope",
-                        "type": "mousedown",
-                        "filter": [
-                            "event.shiftKey",
-                            "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
-                        ]
-                    },
-                    "update": "invert(\"y\", [y(unit), y(unit)])"
-                },
-                {
-                    "events": {
-                        "source": "scope",
-                        "type": "mousemove",
-                        "between": [
-                            {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "event.shiftKey",
-                                    "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
-                                ]
-                            },
-                            {
-                                "source": "scope",
-                                "type": "mouseup"
-                            }
-                        ]
-                    },
-                    "update": "[layer_1_brush_y[0], invert(\"y\", clamp(y(unit), 0, height))]"
-                },
-                {
-                    "events": {
-                        "signal": "layer_1_brush_translate_delta"
-                    },
-                    "update": "clampRange([layer_1_brush_translate_anchor.extent_y[0] - abs(span(layer_1_brush_translate_anchor.extent_y)) * layer_1_brush_translate_delta.y / layer_1_brush_translate_anchor.height, layer_1_brush_translate_anchor.extent_y[1] - abs(span(layer_1_brush_translate_anchor.extent_y)) * layer_1_brush_translate_delta.y / layer_1_brush_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
-                },
-                {
-                    "events": {
-                        "signal": "layer_1_brush_zoom_delta"
-                    },
-                    "update": "clampRange([layer_1_brush_zoom_anchor.y + (layer_1_brush_y[0] - layer_1_brush_zoom_anchor.y) * layer_1_brush_zoom_delta, layer_1_brush_zoom_anchor.y + (layer_1_brush_y[1] - layer_1_brush_zoom_anchor.y) * layer_1_brush_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
-                }
-            ]
-        },
-        {
-            "name": "layer_1_brush_size",
-            "value": [],
-            "on": [
-                {
-                    "events": {
-                        "source": "scope",
-                        "type": "mousedown",
-                        "filter": [
-                            "event.shiftKey",
-                            "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
-                        ]
-                    },
-                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                },
-                {
-                    "events": {
-                        "source": "scope",
-                        "type": "mousemove",
-                        "between": [
-                            {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "event.shiftKey",
-                                    "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
-                                ]
-                            },
-                            {
-                                "source": "scope",
-                                "type": "mouseup"
-                            }
-                        ]
-                    },
-                    "update": "{x: layer_1_brush_size.x, y: layer_1_brush_size.y, width: abs(x(unit) - layer_1_brush_size.x), height: abs(y(unit) - layer_1_brush_size.y)}"
-                },
-                {
-                    "events": {
-                        "signal": "layer_1_brush_zoom_delta"
-                    },
-                    "update": "{x: layer_1_brush_size.x, y: layer_1_brush_size.y, width: layer_1_brush_size.width * layer_1_brush_zoom_delta , height: layer_1_brush_size.height * layer_1_brush_zoom_delta}"
-                }
-            ]
-        },
-        {
-            "name": "layer_1_brush",
-            "update": "[{field: \"Horsepower\", extent: layer_1_brush_x}, {field: \"Miles_per_Gallon\", extent: layer_1_brush_y}]"
-        },
-        {
-            "name": "layer_1_brush_translate_anchor",
-            "value": {},
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "mousedown",
-                            "filter": [
-                                "event.shiftKey"
                             ],
-                            "markname": "layer_1_brush_brush"
+                            "update": "{x: x(unit) - layer_0_grid_translate_anchor.x, y: y(unit) - layer_0_grid_translate_anchor.y}"
                         }
-                    ],
-                    "update": "{x: x(unit), y: y(unit), width: layer_1_brush_size.width, height: layer_1_brush_size.height, extent_x: slice(layer_1_brush_x), extent_y: slice(layer_1_brush_y), }"
-                }
-            ]
-        },
-        {
-            "name": "layer_1_brush_translate_delta",
-            "value": {},
-            "on": [
+                    ]
+                },
                 {
-                    "events": [
+                    "name": "layer_0_grid_zoom_anchor",
+                    "on": [
                         {
-                            "source": "scope",
-                            "type": "mousemove",
-                            "between": [
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel"
+                                }
+                            ],
+                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_0_grid_zoom_delta",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel"
+                                }
+                            ],
+                            "force": true,
+                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_0_grid_tuple",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "layer_0_grid"
+                            },
+                            "update": "{unit: unit.datum && unit.datum._id, intervals: layer_0_grid}"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_0_grid_modify",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "layer_0_grid"
+                            },
+                            "update": "modify(\"layer_0_grid_store\", layer_0_grid_tuple, true)"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_0_cyl",
+                    "update": "{fields: [\"Cylinders\"], values: [layer_0_cyl_Cylinders]}"
+                },
+                {
+                    "name": "layer_0_cyl_tuple",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "layer_0_cyl"
+                            },
+                            "update": "{unit: unit.datum && unit.datum._id, fields: layer_0_cyl.fields, values: layer_0_cyl.values, Cylinders: layer_0_cyl.values[0]}"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_0_cyl_modify",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "layer_0_cyl"
+                            },
+                            "update": "modify(\"layer_0_cyl_store\", layer_0_cyl_tuple, true)"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_1_brush_x",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "event.shiftKey",
+                                    "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                                ]
+                            },
+                            "update": "invert(\"x\", [x(unit), x(unit)])"
+                        },
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousemove",
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "event.shiftKey",
+                                            "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                                        ]
+                                    },
+                                    {
+                                        "source": "scope",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "[layer_1_brush_x[0], invert(\"x\", clamp(x(unit), 0, width))]"
+                        },
+                        {
+                            "events": {
+                                "signal": "layer_1_brush_translate_delta"
+                            },
+                            "update": "clampRange([layer_1_brush_translate_anchor.extent_x[0] + abs(span(layer_1_brush_translate_anchor.extent_x)) * layer_1_brush_translate_delta.x / layer_1_brush_translate_anchor.width, layer_1_brush_translate_anchor.extent_x[1] + abs(span(layer_1_brush_translate_anchor.extent_x)) * layer_1_brush_translate_delta.x / layer_1_brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+                        },
+                        {
+                            "events": {
+                                "signal": "layer_1_brush_zoom_delta"
+                            },
+                            "update": "clampRange([layer_1_brush_zoom_anchor.x + (layer_1_brush_x[0] - layer_1_brush_zoom_anchor.x) * layer_1_brush_zoom_delta, layer_1_brush_zoom_anchor.x + (layer_1_brush_x[1] - layer_1_brush_zoom_anchor.x) * layer_1_brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_1_brush_y",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "event.shiftKey",
+                                    "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                                ]
+                            },
+                            "update": "invert(\"y\", [y(unit), y(unit)])"
+                        },
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousemove",
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "event.shiftKey",
+                                            "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                                        ]
+                                    },
+                                    {
+                                        "source": "scope",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "[layer_1_brush_y[0], invert(\"y\", clamp(y(unit), 0, height))]"
+                        },
+                        {
+                            "events": {
+                                "signal": "layer_1_brush_translate_delta"
+                            },
+                            "update": "clampRange([layer_1_brush_translate_anchor.extent_y[0] - abs(span(layer_1_brush_translate_anchor.extent_y)) * layer_1_brush_translate_delta.y / layer_1_brush_translate_anchor.height, layer_1_brush_translate_anchor.extent_y[1] - abs(span(layer_1_brush_translate_anchor.extent_y)) * layer_1_brush_translate_delta.y / layer_1_brush_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
+                        },
+                        {
+                            "events": {
+                                "signal": "layer_1_brush_zoom_delta"
+                            },
+                            "update": "clampRange([layer_1_brush_zoom_anchor.y + (layer_1_brush_y[0] - layer_1_brush_zoom_anchor.y) * layer_1_brush_zoom_delta, layer_1_brush_zoom_anchor.y + (layer_1_brush_y[1] - layer_1_brush_zoom_anchor.y) * layer_1_brush_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_1_brush_size",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "event.shiftKey",
+                                    "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                                ]
+                            },
+                            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
+                        },
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousemove",
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "event.shiftKey",
+                                            "!event.item || (event.item && event.item.mark.name !== \"layer_1_brush_brush\")"
+                                        ]
+                                    },
+                                    {
+                                        "source": "scope",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "{x: layer_1_brush_size.x, y: layer_1_brush_size.y, width: abs(x(unit) - layer_1_brush_size.x), height: abs(y(unit) - layer_1_brush_size.y)}"
+                        },
+                        {
+                            "events": {
+                                "signal": "layer_1_brush_zoom_delta"
+                            },
+                            "update": "{x: layer_1_brush_size.x, y: layer_1_brush_size.y, width: layer_1_brush_size.width * layer_1_brush_zoom_delta , height: layer_1_brush_size.height * layer_1_brush_zoom_delta}"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_1_brush",
+                    "update": "[{field: \"Horsepower\", extent: layer_1_brush_x}, {field: \"Miles_per_Gallon\", extent: layer_1_brush_y}]"
+                },
+                {
+                    "name": "layer_1_brush_translate_anchor",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
                                 {
                                     "source": "scope",
                                     "type": "mousedown",
@@ -474,280 +457,315 @@
                                         "event.shiftKey"
                                     ],
                                     "markname": "layer_1_brush_brush"
-                                },
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit), width: layer_1_brush_size.width, height: layer_1_brush_size.height, extent_x: slice(layer_1_brush_x), extent_y: slice(layer_1_brush_y), }"
+                        }
+                    ]
+                },
+                {
+                    "name": "layer_1_brush_translate_delta",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
                                 {
                                     "source": "scope",
-                                    "type": "mouseup"
+                                    "type": "mousemove",
+                                    "between": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
+                                            "markname": "layer_1_brush_brush"
+                                        },
+                                        {
+                                            "source": "scope",
+                                            "type": "mouseup"
+                                        }
+                                    ]
                                 }
-                            ]
+                            ],
+                            "update": "{x: x(unit) - layer_1_brush_translate_anchor.x, y: y(unit) - layer_1_brush_translate_anchor.y}"
                         }
-                    ],
-                    "update": "{x: x(unit) - layer_1_brush_translate_anchor.x, y: y(unit) - layer_1_brush_translate_anchor.y}"
-                }
-            ]
-        },
-        {
-            "name": "layer_1_brush_zoom_anchor",
-            "on": [
+                    ]
+                },
                 {
-                    "events": [
+                    "name": "layer_1_brush_zoom_anchor",
+                    "on": [
                         {
-                            "source": "scope",
-                            "type": "wheel",
-                            "markname": "layer_1_brush_brush"
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "markname": "layer_1_brush_brush"
+                                }
+                            ],
+                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
                         }
-                    ],
-                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
-                }
-            ]
-        },
-        {
-            "name": "layer_1_brush_zoom_delta",
-            "on": [
+                    ]
+                },
                 {
-                    "events": [
+                    "name": "layer_1_brush_zoom_delta",
+                    "on": [
                         {
-                            "source": "scope",
-                            "type": "wheel",
-                            "markname": "layer_1_brush_brush"
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "markname": "layer_1_brush_brush"
+                                }
+                            ],
+                            "force": true,
+                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
                         }
-                    ],
-                    "force": true,
-                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-                }
-            ]
-        },
-        {
-            "name": "layer_1_brush_tuple",
-            "on": [
+                    ]
+                },
                 {
-                    "events": {
-                        "signal": "layer_1_brush"
-                    },
-                    "update": "{unit: unit.datum && unit.datum._id, intervals: layer_1_brush}"
-                }
-            ]
-        },
-        {
-            "name": "layer_1_brush_modify",
-            "on": [
+                    "name": "layer_1_brush_tuple",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "layer_1_brush"
+                            },
+                            "update": "{unit: unit.datum && unit.datum._id, intervals: layer_1_brush}"
+                        }
+                    ]
+                },
                 {
-                    "events": {
-                        "signal": "layer_1_brush"
-                    },
-                    "update": "modify(\"layer_1_brush_store\", layer_1_brush_tuple, true)"
+                    "name": "layer_1_brush_modify",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "layer_1_brush"
+                            },
+                            "update": "modify(\"layer_1_brush_store\", layer_1_brush_tuple, true)"
+                        }
+                    ]
                 }
-            ]
-        }
-    ],
-    "marks": [
-        {
-            "type": "group",
+            ],
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "type": "rect",
+                    "type": "group",
                     "encode": {
                         "enter": {
-                            "fill": {
-                                "value": "#eee"
-                            }
-                        },
-                        "update": {
-                            "x": [
-                                {
-                                    "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "layer_1_brush[0].extent[0]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "x2": [
-                                {
-                                    "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "layer_1_brush[0].extent[1]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "y": [
-                                {
-                                    "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "layer_1_brush[1].extent[0]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "y2": [
-                                {
-                                    "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "layer_1_brush[1].extent[1]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ]
-                        }
-                    }
-                },
-                {
-                    "name": "layer_0_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_0"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
+                            "width": {
+                                "signal": "width"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
+                            "height": {
+                                "signal": "height"
                             },
-                            "stroke": [
-                                {
-                                    "test": "vlInterval(\"layer_1_brush_store\", datum._id, datum, \"union\", \"all\")",
-                                    "value": "grey"
-                                },
-                                {
-                                    "scale": "color",
-                                    "field": "Cylinders"
-                                }
-                            ],
                             "fill": {
                                 "value": "transparent"
                             },
-                            "size": {
-                                "value": 100
-                            },
-                            "opacity": {
-                                "value": 0.7
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "symbol",
-                    "role": "square",
-                    "from": {
-                        "data": "data_1"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "fill": [
-                                {
-                                    "test": "!vlInterval(\"layer_1_brush_store\", datum._id, datum, \"union\", \"all\")",
-                                    "value": "grey"
+                    "marks": [
+                        {
+                            "type": "rect",
+                            "encode": {
+                                "enter": {
+                                    "fill": {
+                                        "value": "#eee"
+                                    }
                                 },
-                                {
-                                    "scale": "color",
-                                    "field": "Cylinders"
+                                "update": {
+                                    "x": [
+                                        {
+                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                            "scale": "x",
+                                            "signal": "layer_1_brush[0].extent[0]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                            "scale": "x",
+                                            "signal": "layer_1_brush[0].extent[1]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "y": [
+                                        {
+                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                            "scale": "y",
+                                            "signal": "layer_1_brush[1].extent[0]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "y2": [
+                                        {
+                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                            "scale": "y",
+                                            "signal": "layer_1_brush[1].extent[1]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ]
                                 }
-                            ],
-                            "size": [
-                                {
-                                    "test": "vlPoint(\"layer_0_cyl_store\", datum._id, datum, \"union\", \"all\")",
-                                    "value": 150
-                                },
-                                {
-                                    "value": 50
-                                }
-                            ],
-                            "shape": {
-                                "value": "square"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_brush_brush",
-                    "type": "rect",
-                    "encode": {
-                        "enter": {
-                            "fill": {
-                                "value": "transparent"
                             }
                         },
-                        "update": {
-                            "x": [
-                                {
-                                    "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "layer_1_brush[0].extent[0]"
-                                },
-                                {
-                                    "value": 0
+                        {
+                            "name": "layer_0_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "Horsepower"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "Miles_per_Gallon"
+                                    },
+                                    "stroke": [
+                                        {
+                                            "test": "vlInterval(\"layer_1_brush_store\", parent._id, datum, \"union\", \"all\")",
+                                            "value": "grey"
+                                        },
+                                        {
+                                            "scale": "color",
+                                            "field": "Cylinders"
+                                        }
+                                    ],
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "size": {
+                                        "value": 100
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
                                 }
-                            ],
-                            "x2": [
-                                {
-                                    "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "layer_1_brush[0].extent[1]"
-                                },
-                                {
-                                    "value": 0
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "symbol",
+                            "role": "square",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "Horsepower"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "Miles_per_Gallon"
+                                    },
+                                    "fill": [
+                                        {
+                                            "test": "!vlInterval(\"layer_1_brush_store\", parent._id, datum, \"union\", \"all\")",
+                                            "value": "grey"
+                                        },
+                                        {
+                                            "scale": "color",
+                                            "field": "Cylinders"
+                                        }
+                                    ],
+                                    "size": [
+                                        {
+                                            "test": "vlPoint(\"layer_0_cyl_store\", parent._id, datum, \"union\", \"all\")",
+                                            "value": 150
+                                        },
+                                        {
+                                            "value": 50
+                                        }
+                                    ],
+                                    "shape": {
+                                        "value": "square"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
                                 }
-                            ],
-                            "y": [
-                                {
-                                    "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "layer_1_brush[1].extent[0]"
+                            }
+                        },
+                        {
+                            "name": "layer_1_brush_brush",
+                            "type": "rect",
+                            "encode": {
+                                "enter": {
+                                    "fill": {
+                                        "value": "transparent"
+                                    }
                                 },
-                                {
-                                    "value": 0
+                                "update": {
+                                    "x": [
+                                        {
+                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                            "scale": "x",
+                                            "signal": "layer_1_brush[0].extent[0]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                            "scale": "x",
+                                            "signal": "layer_1_brush[0].extent[1]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "y": [
+                                        {
+                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                            "scale": "y",
+                                            "signal": "layer_1_brush[1].extent[0]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "y2": [
+                                        {
+                                            "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
+                                            "scale": "y",
+                                            "signal": "layer_1_brush[1].extent[1]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ]
                                 }
-                            ],
-                            "y2": [
-                                {
-                                    "test": "data(\"layer_1_brush_store\").length && layer_1_brush_tuple && layer_1_brush_tuple.unit === data(\"layer_1_brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "layer_1_brush[1].extent[1]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ]
+                            }
                         }
-                    }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/line.vg.json
+++ b/examples/vg-specs/line.vg.json
@@ -55,26 +55,42 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "line",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "date"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "price"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "line",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "date"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "price"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/line_calculate.vg.json
+++ b/examples/vg-specs/line_calculate.vg.json
@@ -71,26 +71,42 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "line",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "month_date"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "mean_temp_range"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "line",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "month_date"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "mean_temp_range"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/line_color.vg.json
+++ b/examples/vg-specs/line_color.vg.json
@@ -51,54 +51,70 @@
     ],
     "marks": [
         {
-            "name": "pathgroup",
+            "name": "nested-main-group",
             "type": "group",
-            "from": {
-                "facet": {
-                    "name": "faceted-path-main",
-                    "data": "source_0",
-                    "groupby": [
-                        "symbol"
-                    ]
-                }
-            },
             "encode": {
                 "update": {
                     "width": {
-                        "field": {
-                            "group": "width"
-                        }
+                        "signal": "width"
                     },
                     "height": {
-                        "field": {
-                            "group": "height"
-                        }
+                        "signal": "height"
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "marks",
-                    "type": "line",
+                    "name": "pathgroup",
+                    "type": "group",
                     "from": {
-                        "data": "faceted-path-main"
+                        "facet": {
+                            "name": "faceted-path-main",
+                            "data": "source_0",
+                            "groupby": [
+                                "symbol"
+                            ]
+                        }
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "symbol"
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "marks",
+                            "type": "line",
+                            "from": {
+                                "data": "faceted-path-main"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "symbol"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/line_detail.vg.json
+++ b/examples/vg-specs/line_detail.vg.json
@@ -51,53 +51,69 @@
     ],
     "marks": [
         {
-            "name": "pathgroup",
+            "name": "nested-main-group",
             "type": "group",
-            "from": {
-                "facet": {
-                    "name": "faceted-path-main",
-                    "data": "source_0",
-                    "groupby": [
-                        "symbol"
-                    ]
-                }
-            },
             "encode": {
                 "update": {
                     "width": {
-                        "field": {
-                            "group": "width"
-                        }
+                        "signal": "width"
                     },
                     "height": {
-                        "field": {
-                            "group": "height"
-                        }
+                        "signal": "height"
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "marks",
-                    "type": "line",
+                    "name": "pathgroup",
+                    "type": "group",
                     "from": {
-                        "data": "faceted-path-main"
+                        "facet": {
+                            "name": "faceted-path-main",
+                            "data": "source_0",
+                            "groupby": [
+                                "symbol"
+                            ]
+                        }
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "marks",
+                            "type": "line",
+                            "from": {
+                                "data": "faceted-path-main"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/line_max_year.vg.json
+++ b/examples/vg-specs/line_max_year.vg.json
@@ -67,26 +67,42 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "line",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "yearmonth_date"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "max_temp_max"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "line",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "yearmonth_date"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "max_temp_max"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/line_mean_month.vg.json
+++ b/examples/vg-specs/line_mean_month.vg.json
@@ -67,26 +67,42 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "line",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "month_date"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "mean_precipitation"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "line",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "month_date"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "mean_precipitation"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/line_mean_year.vg.json
+++ b/examples/vg-specs/line_mean_year.vg.json
@@ -67,26 +67,42 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "line",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "year_date"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "mean_temp_max"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "line",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "year_date"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "mean_temp_max"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/line_monotone.vg.json
+++ b/examples/vg-specs/line_monotone.vg.json
@@ -54,26 +54,42 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "line",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "date"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "price"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "line",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "date"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "price"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/line_month.vg.json
+++ b/examples/vg-specs/line_month.vg.json
@@ -67,26 +67,42 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "line",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "month_date"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "mean_temp"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "line",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "month_date"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "mean_temp"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/line_quarter.vg.json
+++ b/examples/vg-specs/line_quarter.vg.json
@@ -97,217 +97,223 @@
             ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": {
-            "signal": "data('column_layout')[0].distinct_year_date"
-        },
-        "bounds": "full"
-    },
     "marks": [
         {
-            "name": "column-title",
-            "role": "column-title",
+            "name": "nested-main-group",
             "type": "group",
-            "marks": [
-                {
-                    "type": "text",
-                    "role": "column-title-text",
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "signal": "0.5 * width"
-                            },
-                            "align": {
-                                "value": "center"
-                            },
-                            "text": {
-                                "value": "YEAR(date)"
-                            },
-                            "fill": {
-                                "value": "black"
-                            },
-                            "fontWeight": {
-                                "value": "bold"
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "row-header",
-            "type": "group",
-            "role": "row-header",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_height"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "MEAN(price)",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "column-header",
-            "type": "group",
-            "role": "column-header",
-            "from": {
-                "data": "column"
-            },
-            "title": {
-                "text": {
-                    "signal": "parent['year_date']"
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
                 },
                 "offset": 10,
-                "orient": "top",
-                "encode": {
-                    "update": {
-                        "fontWeight": {
-                            "value": "normal"
-                        },
-                        "angle": {
-                            "value": 0
-                        },
-                        "fontSize": {
-                            "value": 10
-                        }
-                    }
-                }
+                "columns": {
+                    "signal": "data('column_layout')[0].distinct_year_date"
+                },
+                "bounds": "full"
             },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            }
-        },
-        {
-            "name": "column-footer",
-            "type": "group",
-            "role": "column-footer",
-            "from": {
-                "data": "column"
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            },
-            "axes": [
+            "marks": [
                 {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "QUARTER(date)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "'Q' + quarter(datum.value)"
-                                },
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
+                    "name": "column-title",
+                    "role": "column-title",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "column-title-text",
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "signal": "0.5 * width"
+                                    },
+                                    "align": {
+                                        "value": "center"
+                                    },
+                                    "text": {
+                                        "value": "YEAR(date)"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    }
                                 }
                             }
                         }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "cell",
-            "type": "group",
-            "from": {
-                "facet": {
-                    "name": "facet",
-                    "data": "source_0",
-                    "groupby": [
-                        "year_date"
                     ]
-                }
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    },
-                    "height": {
-                        "signal": "child_height"
-                    },
-                    "stroke": {
-                        "value": "#ccc"
-                    },
-                    "strokeWidth": {
-                        "value": 1
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
+                },
                 {
-                    "name": "child_marks",
-                    "type": "symbol",
-                    "role": "point",
+                    "name": "row-header",
+                    "type": "group",
+                    "role": "row-header",
+                    "encode": {
+                        "update": {
+                            "height": {
+                                "signal": "child_height"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "MEAN(price)",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "column-header",
+                    "type": "group",
+                    "role": "column-header",
                     "from": {
-                        "data": "facet"
+                        "data": "column"
+                    },
+                    "title": {
+                        "text": {
+                            "signal": "parent['year_date']"
+                        },
+                        "offset": 10,
+                        "orient": "top",
+                        "encode": {
+                            "update": {
+                                "fontWeight": {
+                                    "value": "normal"
+                                },
+                                "angle": {
+                                    "value": 0
+                                },
+                                "fontSize": {
+                                    "value": 10
+                                }
+                            }
+                        }
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "quarter_date"
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "column-footer",
+                    "type": "group",
+                    "role": "column-footer",
+                    "from": {
+                        "data": "column"
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "QUARTER(date)",
+                            "zindex": 1,
+                            "encode": {
+                                "labels": {
+                                    "update": {
+                                        "text": {
+                                            "signal": "'Q' + quarter(datum.value)"
+                                        },
+                                        "angle": {
+                                            "value": 270
+                                        },
+                                        "align": {
+                                            "value": "right"
+                                        },
+                                        "baseline": {
+                                            "value": "middle"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "year_date"
+                            ]
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "mean_price"
+                            "height": {
+                                "signal": "child_height"
                             },
                             "stroke": {
-                                "scale": "color",
-                                "field": "symbol"
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
                             },
                             "fill": {
                                 "value": "transparent"
                             }
                         }
-                    }
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "quarter_date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "mean_price"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "symbol"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/line_quarter_legend.vg.json
+++ b/examples/vg-specs/line_quarter_legend.vg.json
@@ -74,54 +74,70 @@
     ],
     "marks": [
         {
-            "name": "pathgroup",
+            "name": "nested-main-group",
             "type": "group",
-            "from": {
-                "facet": {
-                    "name": "faceted-path-main",
-                    "data": "source_0",
-                    "groupby": [
-                        "quarter_date"
-                    ]
-                }
-            },
             "encode": {
                 "update": {
                     "width": {
-                        "field": {
-                            "group": "width"
-                        }
+                        "signal": "width"
                     },
                     "height": {
-                        "field": {
-                            "group": "height"
-                        }
+                        "signal": "height"
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "marks",
-                    "type": "line",
+                    "name": "pathgroup",
+                    "type": "group",
                     "from": {
-                        "data": "faceted-path-main"
+                        "facet": {
+                            "name": "faceted-path-main",
+                            "data": "source_0",
+                            "groupby": [
+                                "quarter_date"
+                            ]
+                        }
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "year_date"
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "mean_price"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "quarter_date"
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "marks",
+                            "type": "line",
+                            "from": {
+                                "data": "faceted-path-main"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "year_date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "mean_price"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "quarter_date"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/line_slope.vg.json
+++ b/examples/vg-specs/line_slope.vg.json
@@ -63,54 +63,70 @@
     ],
     "marks": [
         {
-            "name": "pathgroup",
+            "name": "nested-main-group",
             "type": "group",
-            "from": {
-                "facet": {
-                    "name": "faceted-path-main",
-                    "data": "source_0",
-                    "groupby": [
-                        "site"
-                    ]
-                }
-            },
             "encode": {
                 "update": {
                     "width": {
-                        "field": {
-                            "group": "width"
-                        }
+                        "signal": "width"
                     },
                     "height": {
-                        "field": {
-                            "group": "height"
-                        }
+                        "signal": "height"
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "marks",
-                    "type": "line",
+                    "name": "pathgroup",
+                    "type": "group",
                     "from": {
-                        "data": "faceted-path-main"
+                        "facet": {
+                            "name": "faceted-path-main",
+                            "data": "source_0",
+                            "groupby": [
+                                "site"
+                            ]
+                        }
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "year"
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "median_yield"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "site"
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "marks",
+                            "type": "line",
+                            "from": {
+                                "data": "faceted-path-main"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "year"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "median_yield"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "site"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/line_step.vg.json
+++ b/examples/vg-specs/line_step.vg.json
@@ -55,26 +55,42 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "line",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "date"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "price"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "line",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "date"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "price"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/minimal.vg.json
+++ b/examples/vg-specs/minimal.vg.json
@@ -35,31 +35,47 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "value": 10.5
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "value": 10.5
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "value": 10.5
+                            },
+                            "y": {
+                                "value": 10.5
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ]
 }

--- a/examples/vg-specs/overlay_area_full.vg.json
+++ b/examples/vg-specs/overlay_area_full.vg.json
@@ -138,100 +138,116 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "area",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
+                        "enter": {
+                            "width": {
+                                "signal": "width"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
+                            "height": {
+                                "signal": "height"
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
                             },
-                            "orient": {
-                                "value": "vertical"
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "line",
-                    "from": {
-                        "data": "data_1"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "area",
+                            "from": {
+                                "data": "data_0"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "orient": {
+                                        "value": "vertical"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "line",
+                            "from": {
+                                "data": "data_1"
                             },
-                            "fill": {
-                                "value": "#4c78a8"
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_2_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_2_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_2"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/overlay_area_short.vg.json
+++ b/examples/vg-specs/overlay_area_short.vg.json
@@ -138,100 +138,116 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "area",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
+                        "enter": {
+                            "width": {
+                                "signal": "width"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
+                            "height": {
+                                "signal": "height"
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
                             },
-                            "orient": {
-                                "value": "vertical"
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "line",
-                    "from": {
-                        "data": "data_1"
                     },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "area",
+                            "from": {
+                                "data": "data_0"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "orient": {
+                                        "value": "vertical"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "line",
+                            "from": {
+                                "data": "data_1"
                             },
-                            "stroke": {
-                                "value": "#4c78a8"
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_2_marks",
+                            "type": "symbol",
+                            "role": "pointOverlay",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
                             }
                         }
-                    }
-                },
-                {
-                    "name": "layer_2_marks",
-                    "type": "symbol",
-                    "role": "pointOverlay",
-                    "from": {
-                        "data": "data_2"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
-                        }
-                    }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/overlay_line_full.vg.json
+++ b/examples/vg-specs/overlay_line_full.vg.json
@@ -102,71 +102,87 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "line",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
+                        "enter": {
+                            "width": {
+                                "signal": "width"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
+                            "height": {
+                                "signal": "height"
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
                             },
-                            "opacity": {
-                                "value": 0.7
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "line",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/overlay_line_short.vg.json
+++ b/examples/vg-specs/overlay_line_short.vg.json
@@ -103,71 +103,87 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "line",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
+                        "enter": {
+                            "width": {
+                                "signal": "width"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "symbol",
-                    "role": "pointOverlay",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "date"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "price"
+                            "height": {
+                                "signal": "height"
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
                             },
-                            "opacity": {
-                                "value": 0.7
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "line",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "symbol",
+                            "role": "pointOverlay",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "price"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/overview_detail.vg.json
+++ b/examples/vg-specs/overview_detail.vg.json
@@ -93,253 +93,259 @@
             ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": 1,
-        "bounds": "full",
-        "align": "all"
-    },
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
-            "name": "concat_0_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "concat_0_height"
-                    },
-                    "width": {
-                        "signal": "concat_0_width"
-                    }
-                }
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
+                },
+                "offset": 10,
+                "columns": 1,
+                "bounds": "full",
+                "align": "all"
             },
             "marks": [
                 {
-                    "name": "concat_0_marks",
-                    "type": "area",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
+                    "name": "concat_0_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "concat_0_x",
-                                "field": "DATE"
+                            "height": {
+                                "signal": "concat_0_height"
                             },
-                            "y": {
-                                "scale": "concat_0_y",
-                                "field": "VALUE"
-                            },
-                            "y2": {
-                                "scale": "concat_0_y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "orient": {
-                                "value": "vertical"
+                            "width": {
+                                "signal": "concat_0_width"
                             }
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "concat_0_x",
-                    "type": "time",
-                    "domain": {
-                        "data": "data_0",
-                        "field": "DATE"
                     },
-                    "range": [
-                        0,
-                        480
-                    ],
-                    "round": true
-                },
-                {
-                    "name": "concat_0_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_0",
-                        "field": "VALUE"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "concat_0_x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%b %d, %Y')"
-                                },
-                                "angle": {
-                                    "value": 0
+                    "marks": [
+                        {
+                            "name": "concat_0_marks",
+                            "type": "area",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "concat_0_x",
+                                        "field": "DATE"
+                                    },
+                                    "y": {
+                                        "scale": "concat_0_y",
+                                        "field": "VALUE"
+                                    },
+                                    "y2": {
+                                        "scale": "concat_0_y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "orient": {
+                                        "value": "vertical"
+                                    }
                                 }
                             }
                         }
-                    }
-                },
-                {
-                    "scale": "concat_0_x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "concat_0_y"
-                },
-                {
-                    "scale": "concat_0_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "VALUE",
-                    "zindex": 1
-                },
-                {
-                    "scale": "concat_0_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "concat_0_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "concat_1_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "concat_1_height"
-                    },
-                    "width": {
-                        "signal": "concat_1_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "concat_1_marks",
-                    "type": "area",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "concat_1_x",
+                    ],
+                    "scales": [
+                        {
+                            "name": "concat_0_x",
+                            "type": "time",
+                            "domain": {
+                                "data": "data_0",
                                 "field": "DATE"
                             },
-                            "y": {
-                                "scale": "concat_1_y",
+                            "range": [
+                                0,
+                                480
+                            ],
+                            "round": true
+                        },
+                        {
+                            "name": "concat_0_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_0",
                                 "field": "VALUE"
                             },
-                            "y2": {
-                                "scale": "concat_1_y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "orient": {
-                                "value": "vertical"
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": true
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "concat_1_x",
-                    "type": "time",
-                    "domain": {
-                        "data": "data_1",
-                        "field": "DATE"
-                    },
-                    "range": [
-                        0,
-                        480
                     ],
-                    "round": true
+                    "axes": [
+                        {
+                            "scale": "concat_0_x",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "zindex": 1,
+                            "encode": {
+                                "labels": {
+                                    "update": {
+                                        "text": {
+                                            "signal": "timeFormat(datum.value, '%b %d, %Y')"
+                                        },
+                                        "angle": {
+                                            "value": 0
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "scale": "concat_0_x",
+                            "domain": false,
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "concat_0_y"
+                        },
+                        {
+                            "scale": "concat_0_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "VALUE",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "concat_0_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "concat_0_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "concat_1_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_1",
-                        "field": "VALUE"
-                    },
-                    "range": [
-                        60,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "concat_1_x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "DATE",
-                    "zindex": 1,
+                    "type": "group",
+                    "name": "concat_1_group",
                     "encode": {
-                        "labels": {
-                            "update": {
-                                "text": {
-                                    "signal": "timeFormat(datum.value, '%Y')"
-                                },
-                                "angle": {
-                                    "value": 0
+                        "update": {
+                            "height": {
+                                "signal": "concat_1_height"
+                            },
+                            "width": {
+                                "signal": "concat_1_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "concat_1_marks",
+                            "type": "area",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "concat_1_x",
+                                        "field": "DATE"
+                                    },
+                                    "y": {
+                                        "scale": "concat_1_y",
+                                        "field": "VALUE"
+                                    },
+                                    "y2": {
+                                        "scale": "concat_1_y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "orient": {
+                                        "value": "vertical"
+                                    }
                                 }
                             }
                         }
-                    }
-                },
-                {
-                    "scale": "concat_1_x",
-                    "domain": false,
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "concat_1_y"
-                },
-                {
-                    "scale": "concat_1_y",
-                    "format": "s",
-                    "orient": "left",
-                    "tickCount": 3,
-                    "title": "VALUE",
-                    "zindex": 1
+                    ],
+                    "scales": [
+                        {
+                            "name": "concat_1_x",
+                            "type": "time",
+                            "domain": {
+                                "data": "data_1",
+                                "field": "DATE"
+                            },
+                            "range": [
+                                0,
+                                480
+                            ],
+                            "round": true
+                        },
+                        {
+                            "name": "concat_1_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_1",
+                                "field": "VALUE"
+                            },
+                            "range": [
+                                60,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": true
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "concat_1_x",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "DATE",
+                            "zindex": 1,
+                            "encode": {
+                                "labels": {
+                                    "update": {
+                                        "text": {
+                                            "signal": "timeFormat(datum.value, '%Y')"
+                                        },
+                                        "angle": {
+                                            "value": 0
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "scale": "concat_1_x",
+                            "domain": false,
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "concat_1_y"
+                        },
+                        {
+                            "scale": "concat_1_y",
+                            "format": "s",
+                            "orient": "left",
+                            "tickCount": 3,
+                            "title": "VALUE",
+                            "zindex": 1
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/paintbrush.vg.json
+++ b/examples/vg-specs/paintbrush.vg.json
@@ -43,132 +43,150 @@
                     "update": "group()._id ? group() : unit"
                 }
             ]
-        },
-        {
-            "name": "paintbrush",
-            "value": {},
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "mouseover"
-                        }
-                    ],
-                    "update": "{fields: [\"_id\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_id\"]]}"
-                }
-            ]
-        },
-        {
-            "name": "paintbrush_toggle",
-            "value": false,
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "mouseover"
-                        }
-                    ],
-                    "update": "event.shiftKey"
-                }
-            ]
-        },
-        {
-            "name": "paintbrush_tuple",
-            "on": [
-                {
-                    "events": {
-                        "signal": "paintbrush"
-                    },
-                    "update": "{unit: unit.datum && unit.datum._id, fields: paintbrush.fields, values: paintbrush.values}"
-                }
-            ]
-        },
-        {
-            "name": "paintbrush_modify",
-            "on": [
-                {
-                    "events": {
-                        "signal": "paintbrush"
-                    },
-                    "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
-                }
-            ]
         }
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
+            "signals": [
+                {
+                    "name": "paintbrush",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "mouseover"
+                                }
+                            ],
+                            "update": "{fields: [\"_id\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_id\"]]}"
+                        }
+                    ]
+                },
+                {
+                    "name": "paintbrush_toggle",
+                    "value": false,
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "mouseover"
+                                }
+                            ],
+                            "update": "event.shiftKey"
+                        }
+                    ]
+                },
+                {
+                    "name": "paintbrush_tuple",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "paintbrush"
+                            },
+                            "update": "{unit: unit.datum && unit.datum._id, fields: paintbrush.fields, values: paintbrush.values}"
+                        }
+                    ]
+                },
+                {
+                    "name": "paintbrush_modify",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "paintbrush"
+                            },
+                            "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+                        }
+                    ]
+                }
+            ],
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "size": [
-                        {
-                            "test": "vlPoint(\"paintbrush_store\", datum._id, datum, \"union\", \"all\")",
-                            "value": 300
-                        },
-                        {
-                            "value": 50
-                        }
-                    ],
-                    "opacity": {
-                        "value": 0.7
-                    }
-                }
-            }
-        },
-        {
-            "name": "voronoi",
-            "type": "path",
-            "from": {
-                "data": "marks"
-            },
-            "encode": {
-                "enter": {
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "strokeWidth": {
-                        "value": 0.35
-                    },
-                    "stroke": {
-                        "value": "transparent"
-                    },
-                    "isVoronoi": {
-                        "value": true
+                    "height": {
+                        "signal": "height"
                     }
                 }
             },
-            "transform": [
+            "marks": [
                 {
-                    "type": "voronoi",
-                    "x": "datum.x",
-                    "y": "datum.y",
-                    "size": [
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "size": [
+                                {
+                                    "test": "vlPoint(\"paintbrush_store\", parent._id, datum, \"union\", \"all\")",
+                                    "value": 300
+                                },
+                                {
+                                    "value": 50
+                                }
+                            ],
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "voronoi",
+                    "type": "path",
+                    "from": {
+                        "data": "marks"
+                    },
+                    "encode": {
+                        "enter": {
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "strokeWidth": {
+                                "value": 0.35
+                            },
+                            "stroke": {
+                                "value": "transparent"
+                            },
+                            "isVoronoi": {
+                                "value": true
+                            }
+                        }
+                    },
+                    "transform": [
                         {
-                            "signal": "width"
-                        },
-                        {
-                            "signal": "height"
+                            "type": "voronoi",
+                            "x": "datum.x",
+                            "y": "datum.y",
+                            "size": [
+                                {
+                                    "signal": "width"
+                                },
+                                {
+                                    "signal": "height"
+                                }
+                            ]
                         }
                     ]
                 }

--- a/examples/vg-specs/panzoom_scatter.vg.json
+++ b/examples/vg-specs/panzoom_scatter.vg.json
@@ -49,192 +49,210 @@
         },
         {
             "name": "grid_y"
-        },
-        {
-            "name": "grid_x",
-            "on": [
-                {
-                    "events": {
-                        "signal": "grid_translate_delta"
-                    },
-                    "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
-                },
-                {
-                    "events": {
-                        "signal": "grid_zoom_delta"
-                    },
-                    "update": "[grid_zoom_anchor.x + (domain(\"x\")[0] - grid_zoom_anchor.x) * grid_zoom_delta, grid_zoom_anchor.x + (domain(\"x\")[1] - grid_zoom_anchor.x) * grid_zoom_delta]"
-                }
-            ],
-            "push": "outer"
-        },
-        {
-            "name": "grid_y",
-            "on": [
-                {
-                    "events": {
-                        "signal": "grid_translate_delta"
-                    },
-                    "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
-                },
-                {
-                    "events": {
-                        "signal": "grid_zoom_delta"
-                    },
-                    "update": "[grid_zoom_anchor.y + (domain(\"y\")[0] - grid_zoom_anchor.y) * grid_zoom_delta, grid_zoom_anchor.y + (domain(\"y\")[1] - grid_zoom_anchor.y) * grid_zoom_delta]"
-                }
-            ],
-            "push": "outer"
-        },
-        {
-            "name": "grid",
-            "update": "[{field: \"Horsepower\", extent: grid_x}, {field: \"Miles_per_Gallon\", extent: grid_y}]"
-        },
-        {
-            "name": "grid_translate_anchor",
-            "value": {},
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "mousedown"
-                        }
-                    ],
-                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
-                }
-            ]
-        },
-        {
-            "name": "grid_translate_delta",
-            "value": {},
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "window",
-                            "type": "mousemove",
-                            "consume": true,
-                            "between": [
-                                {
-                                    "source": "scope",
-                                    "type": "mousedown"
-                                },
-                                {
-                                    "source": "window",
-                                    "type": "mouseup"
-                                }
-                            ]
-                        }
-                    ],
-                    "update": "{x: x(unit) - grid_translate_anchor.x, y: y(unit) - grid_translate_anchor.y}"
-                }
-            ]
-        },
-        {
-            "name": "grid_zoom_anchor",
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "wheel"
-                        }
-                    ],
-                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
-                }
-            ]
-        },
-        {
-            "name": "grid_zoom_delta",
-            "on": [
-                {
-                    "events": [
-                        {
-                            "source": "scope",
-                            "type": "wheel"
-                        }
-                    ],
-                    "force": true,
-                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-                }
-            ]
-        },
-        {
-            "name": "grid_tuple",
-            "on": [
-                {
-                    "events": {
-                        "signal": "grid"
-                    },
-                    "update": "{unit: unit.datum && unit.datum._id, intervals: grid}"
-                }
-            ]
-        },
-        {
-            "name": "grid_modify",
-            "on": [
-                {
-                    "events": {
-                        "signal": "grid"
-                    },
-                    "update": "modify(\"grid_store\", grid_tuple, true)"
-                }
-            ]
         }
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
+            "signals": [
+                {
+                    "name": "grid_x",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "grid_translate_delta"
+                            },
+                            "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
+                        },
+                        {
+                            "events": {
+                                "signal": "grid_zoom_delta"
+                            },
+                            "update": "[grid_zoom_anchor.x + (domain(\"x\")[0] - grid_zoom_anchor.x) * grid_zoom_delta, grid_zoom_anchor.x + (domain(\"x\")[1] - grid_zoom_anchor.x) * grid_zoom_delta]"
+                        }
+                    ],
+                    "push": "outer"
+                },
+                {
+                    "name": "grid_y",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "grid_translate_delta"
+                            },
+                            "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                        },
+                        {
+                            "events": {
+                                "signal": "grid_zoom_delta"
+                            },
+                            "update": "[grid_zoom_anchor.y + (domain(\"y\")[0] - grid_zoom_anchor.y) * grid_zoom_delta, grid_zoom_anchor.y + (domain(\"y\")[1] - grid_zoom_anchor.y) * grid_zoom_delta]"
+                        }
+                    ],
+                    "push": "outer"
+                },
+                {
+                    "name": "grid",
+                    "update": "[{field: \"Horsepower\", extent: grid_x}, {field: \"Miles_per_Gallon\", extent: grid_y}]"
+                },
+                {
+                    "name": "grid_translate_anchor",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousedown"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
+                        }
+                    ]
+                },
+                {
+                    "name": "grid_translate_delta",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "window",
+                                    "type": "mousemove",
+                                    "consume": true,
+                                    "between": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown"
+                                        },
+                                        {
+                                            "source": "window",
+                                            "type": "mouseup"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "update": "{x: x(unit) - grid_translate_anchor.x, y: y(unit) - grid_translate_anchor.y}"
+                        }
+                    ]
+                },
+                {
+                    "name": "grid_zoom_anchor",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel"
+                                }
+                            ],
+                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                        }
+                    ]
+                },
+                {
+                    "name": "grid_zoom_delta",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel"
+                                }
+                            ],
+                            "force": true,
+                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                        }
+                    ]
+                },
+                {
+                    "name": "grid_tuple",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "grid"
+                            },
+                            "update": "{unit: unit.datum && unit.datum._id, intervals: grid}"
+                        }
+                    ]
+                },
+                {
+                    "name": "grid_modify",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "grid"
+                            },
+                            "update": "modify(\"grid_store\", grid_tuple, true)"
+                        }
+                    ]
+                }
+            ],
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "marks",
-                    "type": "symbol",
-                    "role": "circle",
-                    "from": {
-                        "data": "source_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
+                        "enter": {
+                            "width": {
+                                "signal": "width"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
+                            "height": {
+                                "signal": "height"
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
                             },
-                            "size": {
-                                "scale": "size",
-                                "field": "Cylinders"
-                            },
-                            "shape": {
-                                "value": "circle"
-                            },
-                            "opacity": {
-                                "value": 0.7
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "marks",
+                            "type": "symbol",
+                            "role": "circle",
+                            "from": {
+                                "data": "source_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "Horsepower"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "Miles_per_Gallon"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "size": {
+                                        "scale": "size",
+                                        "field": "Cylinders"
+                                    },
+                                    "shape": {
+                                        "value": "circle"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/point_1d.vg.json
+++ b/examples/vg-specs/point_1d.vg.json
@@ -42,32 +42,48 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "IMDB_Rating"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "value": 10.5
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "IMDB_Rating"
+                            },
+                            "y": {
+                                "value": 10.5
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/point_1d_array.vg.json
+++ b/examples/vg-specs/point_1d_array.vg.json
@@ -70,32 +70,48 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "a"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "value": 10.5
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "a"
+                            },
+                            "y": {
+                                "value": 10.5
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/point_1d_bin.vg.json
+++ b/examples/vg-specs/point_1d_bin.vg.json
@@ -60,31 +60,47 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "signal": "(scale(\"x\", datum[\"bin_maxbins_10_IMDB_Rating_start\"]) + scale(\"x\", datum[\"bin_maxbins_10_IMDB_Rating_end\"]))/2"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "value": 10.5
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "signal": "(scale(\"x\", datum[\"bin_maxbins_10_IMDB_Rating_start\"]) + scale(\"x\", datum[\"bin_maxbins_10_IMDB_Rating_end\"]))/2"
+                            },
+                            "y": {
+                                "value": 10.5
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/point_2d_aggregate.vg.json
+++ b/examples/vg-specs/point_2d_aggregate.vg.json
@@ -91,30 +91,46 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "a"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "average_b"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
-                    "fill": {
-                        "value": "transparent"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "a"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "average_b"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/point_2d_array.vg.json
+++ b/examples/vg-specs/point_2d_array.vg.json
@@ -79,33 +79,49 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "a"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "b"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "a"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "b"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/point_color.vg.json
+++ b/examples/vg-specs/point_color.vg.json
@@ -37,31 +37,47 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "value": 10.5
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "value": 10.5
-                    },
-                    "stroke": {
-                        "value": "purple"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "value": 10.5
+                            },
+                            "y": {
+                                "value": 10.5
+                            },
+                            "stroke": {
+                                "value": "purple"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ]
 }

--- a/examples/vg-specs/point_dot_timeunit_color.vg.json
+++ b/examples/vg-specs/point_dot_timeunit_color.vg.json
@@ -60,30 +60,46 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "mean_temp"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "value": 10.5
-                    },
-                    "stroke": {
-                        "scale": "color",
-                        "field": "yearmonth_date"
-                    },
-                    "fill": {
-                        "value": "transparent"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "mean_temp"
+                            },
+                            "y": {
+                                "value": 10.5
+                            },
+                            "stroke": {
+                                "scale": "color",
+                                "field": "yearmonth_date"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/point_filled.vg.json
+++ b/examples/vg-specs/point_filled.vg.json
@@ -43,30 +43,46 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/point_ordinal_color.vg.json
+++ b/examples/vg-specs/point_ordinal_color.vg.json
@@ -74,34 +74,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "x"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "y"
-                    },
-                    "stroke": {
-                        "scale": "color",
-                        "field": "a"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "x"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "y"
+                            },
+                            "stroke": {
+                                "scale": "color",
+                                "field": "a"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/point_overlap.vg.json
+++ b/examples/vg-specs/point_overlap.vg.json
@@ -70,31 +70,47 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "value": 10.5
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "value": 10.5
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "value": 10.5
+                            },
+                            "y": {
+                                "value": 10.5
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ]
 }

--- a/examples/vg-specs/query_widgets.vg.json
+++ b/examples/vg-specs/query_widgets.vg.json
@@ -94,70 +94,88 @@
         {
             "name": "CylYr",
             "update": "data(\"CylYr_store\")[0]"
-        },
-        {
-            "name": "CylYr",
-            "update": "{fields: [\"Cylinders\", \"Year\"], values: [CylYr_Cylinders, CylYr_Year]}"
-        },
-        {
-            "name": "CylYr_tuple",
-            "on": [
-                {
-                    "events": {
-                        "signal": "CylYr"
-                    },
-                    "update": "{unit: unit.datum && unit.datum._id, fields: CylYr.fields, values: CylYr.values, Cylinders: CylYr.values[0], Year: CylYr.values[1]}"
-                }
-            ]
-        },
-        {
-            "name": "CylYr_modify",
-            "on": [
-                {
-                    "events": {
-                        "signal": "CylYr"
-                    },
-                    "update": "modify(\"CylYr_store\", CylYr_tuple, true)"
-                }
-            ]
         }
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "circle",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
+            "signals": [
+                {
+                    "name": "CylYr",
+                    "update": "{fields: [\"Cylinders\", \"Year\"], values: [CylYr_Cylinders, CylYr_Year]}"
+                },
+                {
+                    "name": "CylYr_tuple",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "CylYr"
+                            },
+                            "update": "{unit: unit.datum && unit.datum._id, fields: CylYr.fields, values: CylYr.values, Cylinders: CylYr.values[0], Year: CylYr.values[1]}"
+                        }
+                    ]
+                },
+                {
+                    "name": "CylYr_modify",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "CylYr"
+                            },
+                            "update": "modify(\"CylYr_store\", CylYr_tuple, true)"
+                        }
+                    ]
+                }
+            ],
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "fill": [
-                        {
-                            "test": "!vlPoint(\"CylYr_store\", datum._id, datum, \"union\", \"all\")",
-                            "value": "grey"
-                        },
-                        {
-                            "scale": "color",
-                            "field": "Origin"
-                        }
-                    ],
-                    "shape": {
-                        "value": "circle"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "circle",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "fill": [
+                                {
+                                    "test": "!vlPoint(\"CylYr_store\", parent._id, datum, \"union\", \"all\")",
+                                    "value": "grey"
+                                },
+                                {
+                                    "scale": "color",
+                                    "field": "Origin"
+                                }
+                            ],
+                            "shape": {
+                                "value": "circle"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/rect_heatmap.vg.json
+++ b/examples/vg-specs/rect_heatmap.vg.json
@@ -55,35 +55,51 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Cylinders"
-                    },
                     "width": {
-                        "scale": "x",
-                        "band": true
-                    },
-                    "y": {
-                        "scale": "y",
-                        "field": "Origin"
+                        "signal": "width"
                     },
                     "height": {
-                        "scale": "y",
-                        "band": true
-                    },
-                    "fill": {
-                        "scale": "color",
-                        "field": "mean_Horsepower"
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Cylinders"
+                            },
+                            "width": {
+                                "scale": "x",
+                                "band": true
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Origin"
+                            },
+                            "height": {
+                                "scale": "y",
+                                "band": true
+                            },
+                            "fill": {
+                                "scale": "color",
+                                "field": "mean_Horsepower"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/repeat_histogram.vg.json
+++ b/examples/vg-specs/repeat_histogram.vg.json
@@ -251,386 +251,392 @@
             ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": 1,
-        "bounds": "full",
-        "align": "all"
-    },
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
-            "name": "child_Horsepower_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_Horsepower_height"
-                    },
-                    "width": {
-                        "signal": "child_Horsepower_width"
-                    }
-                }
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
+                },
+                "offset": 10,
+                "columns": 1,
+                "bounds": "full",
+                "align": "all"
             },
             "marks": [
                 {
-                    "name": "child_Horsepower_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
+                    "name": "child_Horsepower_group",
                     "encode": {
                         "update": {
-                            "x2": {
-                                "scale": "child_Horsepower_x",
-                                "field": "bin_maxbins_10_Horsepower_start",
-                                "offset": 1
+                            "height": {
+                                "signal": "child_Horsepower_height"
                             },
-                            "x": {
-                                "scale": "child_Horsepower_x",
-                                "field": "bin_maxbins_10_Horsepower_end"
-                            },
-                            "y": {
-                                "scale": "child_Horsepower_y",
-                                "field": "count_*_end"
-                            },
-                            "y2": {
-                                "scale": "child_Horsepower_y",
-                                "field": "count_*_start"
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "Origin"
+                            "width": {
+                                "signal": "child_Horsepower_width"
                             }
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_Horsepower_x",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(child_Horsepower_bin_maxbins_10_Horsepower_bins.start, child_Horsepower_bin_maxbins_10_Horsepower_bins.stop + child_Horsepower_bin_maxbins_10_Horsepower_bins.step, child_Horsepower_bin_maxbins_10_Horsepower_bins.step)"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true
-                },
-                {
-                    "name": "child_Horsepower_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_0",
-                        "fields": [
-                            "count_*_start",
-                            "count_*_end"
-                        ]
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_Horsepower_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "title": "BIN(Horsepower)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
+                    "marks": [
+                        {
+                            "name": "child_Horsepower_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x2": {
+                                        "scale": "child_Horsepower_x",
+                                        "field": "bin_maxbins_10_Horsepower_start",
+                                        "offset": 1
+                                    },
+                                    "x": {
+                                        "scale": "child_Horsepower_x",
+                                        "field": "bin_maxbins_10_Horsepower_end"
+                                    },
+                                    "y": {
+                                        "scale": "child_Horsepower_y",
+                                        "field": "count_*_end"
+                                    },
+                                    "y2": {
+                                        "scale": "child_Horsepower_y",
+                                        "field": "count_*_start"
+                                    },
+                                    "fill": {
+                                        "scale": "color",
+                                        "field": "Origin"
+                                    }
                                 }
                             }
                         }
-                    }
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_Horsepower_x",
+                            "type": "bin-linear",
+                            "domain": {
+                                "signal": "sequence(child_Horsepower_bin_maxbins_10_Horsepower_bins.start, child_Horsepower_bin_maxbins_10_Horsepower_bins.stop + child_Horsepower_bin_maxbins_10_Horsepower_bins.step, child_Horsepower_bin_maxbins_10_Horsepower_bins.step)"
+                            },
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true
+                        },
+                        {
+                            "name": "child_Horsepower_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_0",
+                                "fields": [
+                                    "count_*_start",
+                                    "count_*_end"
+                                ]
+                            },
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": true
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "child_Horsepower_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "title": "BIN(Horsepower)",
+                            "zindex": 1,
+                            "encode": {
+                                "labels": {
+                                    "update": {
+                                        "angle": {
+                                            "value": 270
+                                        },
+                                        "align": {
+                                            "value": "right"
+                                        },
+                                        "baseline": {
+                                            "value": "middle"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "scale": "child_Horsepower_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Number of Records",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_Horsepower_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_Horsepower_x"
+                        }
+                    ]
                 },
                 {
-                    "scale": "child_Horsepower_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_Horsepower_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_Horsepower_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_Miles_per_Gallon_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_Miles_per_Gallon_height"
-                    },
-                    "width": {
-                        "signal": "child_Miles_per_Gallon_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_Miles_per_Gallon_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "data_1"
-                    },
+                    "type": "group",
+                    "name": "child_Miles_per_Gallon_group",
                     "encode": {
                         "update": {
-                            "x2": {
-                                "scale": "child_Miles_per_Gallon_x",
-                                "field": "bin_maxbins_10_Miles_per_Gallon_start",
-                                "offset": 1
+                            "height": {
+                                "signal": "child_Miles_per_Gallon_height"
                             },
-                            "x": {
-                                "scale": "child_Miles_per_Gallon_x",
-                                "field": "bin_maxbins_10_Miles_per_Gallon_end"
-                            },
-                            "y": {
-                                "scale": "child_Miles_per_Gallon_y",
-                                "field": "count_*_end"
-                            },
-                            "y2": {
-                                "scale": "child_Miles_per_Gallon_y",
-                                "field": "count_*_start"
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "Origin"
+                            "width": {
+                                "signal": "child_Miles_per_Gallon_width"
                             }
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_Miles_per_Gallon_x",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(child_Miles_per_Gallon_bin_maxbins_10_Miles_per_Gallon_bins.start, child_Miles_per_Gallon_bin_maxbins_10_Miles_per_Gallon_bins.stop + child_Miles_per_Gallon_bin_maxbins_10_Miles_per_Gallon_bins.step, child_Miles_per_Gallon_bin_maxbins_10_Miles_per_Gallon_bins.step)"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true
-                },
-                {
-                    "name": "child_Miles_per_Gallon_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_1",
-                        "fields": [
-                            "count_*_start",
-                            "count_*_end"
-                        ]
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_Miles_per_Gallon_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "title": "BIN(Miles_per_Gallon)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
+                    "marks": [
+                        {
+                            "name": "child_Miles_per_Gallon_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x2": {
+                                        "scale": "child_Miles_per_Gallon_x",
+                                        "field": "bin_maxbins_10_Miles_per_Gallon_start",
+                                        "offset": 1
+                                    },
+                                    "x": {
+                                        "scale": "child_Miles_per_Gallon_x",
+                                        "field": "bin_maxbins_10_Miles_per_Gallon_end"
+                                    },
+                                    "y": {
+                                        "scale": "child_Miles_per_Gallon_y",
+                                        "field": "count_*_end"
+                                    },
+                                    "y2": {
+                                        "scale": "child_Miles_per_Gallon_y",
+                                        "field": "count_*_start"
+                                    },
+                                    "fill": {
+                                        "scale": "color",
+                                        "field": "Origin"
+                                    }
                                 }
                             }
                         }
-                    }
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_Miles_per_Gallon_x",
+                            "type": "bin-linear",
+                            "domain": {
+                                "signal": "sequence(child_Miles_per_Gallon_bin_maxbins_10_Miles_per_Gallon_bins.start, child_Miles_per_Gallon_bin_maxbins_10_Miles_per_Gallon_bins.stop + child_Miles_per_Gallon_bin_maxbins_10_Miles_per_Gallon_bins.step, child_Miles_per_Gallon_bin_maxbins_10_Miles_per_Gallon_bins.step)"
+                            },
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true
+                        },
+                        {
+                            "name": "child_Miles_per_Gallon_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_1",
+                                "fields": [
+                                    "count_*_start",
+                                    "count_*_end"
+                                ]
+                            },
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": true
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "child_Miles_per_Gallon_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "title": "BIN(Miles_per_Gallon)",
+                            "zindex": 1,
+                            "encode": {
+                                "labels": {
+                                    "update": {
+                                        "angle": {
+                                            "value": 270
+                                        },
+                                        "align": {
+                                            "value": "right"
+                                        },
+                                        "baseline": {
+                                            "value": "middle"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "scale": "child_Miles_per_Gallon_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Number of Records",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_Miles_per_Gallon_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_Miles_per_Gallon_x"
+                        }
+                    ]
                 },
                 {
-                    "scale": "child_Miles_per_Gallon_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_Miles_per_Gallon_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_Miles_per_Gallon_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_Acceleration_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_Acceleration_height"
-                    },
-                    "width": {
-                        "signal": "child_Acceleration_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_Acceleration_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "data_2"
-                    },
+                    "type": "group",
+                    "name": "child_Acceleration_group",
                     "encode": {
                         "update": {
-                            "x2": {
-                                "scale": "child_Acceleration_x",
-                                "field": "bin_maxbins_10_Acceleration_start",
-                                "offset": 1
+                            "height": {
+                                "signal": "child_Acceleration_height"
                             },
-                            "x": {
-                                "scale": "child_Acceleration_x",
-                                "field": "bin_maxbins_10_Acceleration_end"
-                            },
-                            "y": {
-                                "scale": "child_Acceleration_y",
-                                "field": "count_*_end"
-                            },
-                            "y2": {
-                                "scale": "child_Acceleration_y",
-                                "field": "count_*_start"
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "Origin"
+                            "width": {
+                                "signal": "child_Acceleration_width"
                             }
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_Acceleration_x",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(child_Acceleration_bin_maxbins_10_Acceleration_bins.start, child_Acceleration_bin_maxbins_10_Acceleration_bins.stop + child_Acceleration_bin_maxbins_10_Acceleration_bins.step, child_Acceleration_bin_maxbins_10_Acceleration_bins.step)"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true
-                },
-                {
-                    "name": "child_Acceleration_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_2",
-                        "fields": [
-                            "count_*_start",
-                            "count_*_end"
-                        ]
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_Acceleration_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "title": "BIN(Acceleration)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
+                    "marks": [
+                        {
+                            "name": "child_Acceleration_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x2": {
+                                        "scale": "child_Acceleration_x",
+                                        "field": "bin_maxbins_10_Acceleration_start",
+                                        "offset": 1
+                                    },
+                                    "x": {
+                                        "scale": "child_Acceleration_x",
+                                        "field": "bin_maxbins_10_Acceleration_end"
+                                    },
+                                    "y": {
+                                        "scale": "child_Acceleration_y",
+                                        "field": "count_*_end"
+                                    },
+                                    "y2": {
+                                        "scale": "child_Acceleration_y",
+                                        "field": "count_*_start"
+                                    },
+                                    "fill": {
+                                        "scale": "color",
+                                        "field": "Origin"
+                                    }
                                 }
                             }
                         }
-                    }
-                },
-                {
-                    "scale": "child_Acceleration_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_Acceleration_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_Acceleration_x"
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_Acceleration_x",
+                            "type": "bin-linear",
+                            "domain": {
+                                "signal": "sequence(child_Acceleration_bin_maxbins_10_Acceleration_bins.start, child_Acceleration_bin_maxbins_10_Acceleration_bins.stop + child_Acceleration_bin_maxbins_10_Acceleration_bins.step, child_Acceleration_bin_maxbins_10_Acceleration_bins.step)"
+                            },
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true
+                        },
+                        {
+                            "name": "child_Acceleration_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_2",
+                                "fields": [
+                                    "count_*_start",
+                                    "count_*_end"
+                                ]
+                            },
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": true
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "child_Acceleration_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "title": "BIN(Acceleration)",
+                            "zindex": 1,
+                            "encode": {
+                                "labels": {
+                                    "update": {
+                                        "angle": {
+                                            "value": 270
+                                        },
+                                        "align": {
+                                            "value": "right"
+                                        },
+                                        "baseline": {
+                                            "value": "middle"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "scale": "child_Acceleration_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Number of Records",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_Acceleration_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_Acceleration_x"
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/repeat_histogram_flights.vg.json
+++ b/examples/vg-specs/repeat_histogram_flights.vg.json
@@ -195,374 +195,380 @@
             ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": 3,
-        "bounds": "full",
-        "align": "all"
-    },
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
-            "name": "child_distance_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_distance_height"
-                    },
-                    "width": {
-                        "signal": "child_distance_width"
-                    }
-                }
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
+                },
+                "offset": 10,
+                "columns": 3,
+                "bounds": "full",
+                "align": "all"
             },
             "marks": [
                 {
-                    "name": "child_distance_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
+                    "name": "child_distance_group",
                     "encode": {
                         "update": {
-                            "x2": {
-                                "scale": "child_distance_x",
-                                "field": "bin_maxbins_20_distance_start",
-                                "offset": 1
+                            "height": {
+                                "signal": "child_distance_height"
                             },
-                            "x": {
-                                "scale": "child_distance_x",
-                                "field": "bin_maxbins_20_distance_end"
-                            },
-                            "y": {
-                                "scale": "child_distance_y",
-                                "field": "count_*"
-                            },
-                            "y2": {
-                                "scale": "child_distance_y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
+                            "width": {
+                                "signal": "child_distance_width"
                             }
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_distance_x",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(child_distance_bin_maxbins_20_distance_bins.start, child_distance_bin_maxbins_20_distance_bins.stop + child_distance_bin_maxbins_20_distance_bins.step, child_distance_bin_maxbins_20_distance_bins.step)"
                     },
-                    "range": [
-                        0,
-                        200
-                    ],
-                    "round": true,
-                    "nice": true
-                },
-                {
-                    "name": "child_distance_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_0",
-                        "field": "count_*"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_distance_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "title": "BIN(distance)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
+                    "marks": [
+                        {
+                            "name": "child_distance_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x2": {
+                                        "scale": "child_distance_x",
+                                        "field": "bin_maxbins_20_distance_start",
+                                        "offset": 1
+                                    },
+                                    "x": {
+                                        "scale": "child_distance_x",
+                                        "field": "bin_maxbins_20_distance_end"
+                                    },
+                                    "y": {
+                                        "scale": "child_distance_y",
+                                        "field": "count_*"
+                                    },
+                                    "y2": {
+                                        "scale": "child_distance_y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
                                 }
                             }
                         }
-                    }
-                },
-                {
-                    "scale": "child_distance_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_distance_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_distance_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_delay_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_delay_height"
-                    },
-                    "width": {
-                        "signal": "child_delay_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_delay_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x2": {
-                                "scale": "child_delay_x",
-                                "field": "bin_maxbins_20_delay_start",
-                                "offset": 1
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_distance_x",
+                            "type": "bin-linear",
+                            "domain": {
+                                "signal": "sequence(child_distance_bin_maxbins_20_distance_bins.start, child_distance_bin_maxbins_20_distance_bins.stop + child_distance_bin_maxbins_20_distance_bins.step, child_distance_bin_maxbins_20_distance_bins.step)"
                             },
-                            "x": {
-                                "scale": "child_delay_x",
-                                "field": "bin_maxbins_20_delay_end"
-                            },
-                            "y": {
-                                "scale": "child_delay_y",
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true
+                        },
+                        {
+                            "name": "child_distance_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_0",
                                 "field": "count_*"
                             },
-                            "y2": {
-                                "scale": "child_delay_y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": true
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_delay_x",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(child_delay_bin_maxbins_20_delay_bins.start, child_delay_bin_maxbins_20_delay_bins.stop + child_delay_bin_maxbins_20_delay_bins.step, child_delay_bin_maxbins_20_delay_bins.step)"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true
+                    "axes": [
+                        {
+                            "scale": "child_distance_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "title": "BIN(distance)",
+                            "zindex": 1,
+                            "encode": {
+                                "labels": {
+                                    "update": {
+                                        "angle": {
+                                            "value": 270
+                                        },
+                                        "align": {
+                                            "value": "right"
+                                        },
+                                        "baseline": {
+                                            "value": "middle"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "scale": "child_distance_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Number of Records",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_distance_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_distance_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "child_delay_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_1",
-                        "field": "count_*"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_delay_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "title": "BIN(delay)",
-                    "zindex": 1,
+                    "type": "group",
+                    "name": "child_delay_group",
                     "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
+                        "update": {
+                            "height": {
+                                "signal": "child_delay_height"
+                            },
+                            "width": {
+                                "signal": "child_delay_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_delay_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x2": {
+                                        "scale": "child_delay_x",
+                                        "field": "bin_maxbins_20_delay_start",
+                                        "offset": 1
+                                    },
+                                    "x": {
+                                        "scale": "child_delay_x",
+                                        "field": "bin_maxbins_20_delay_end"
+                                    },
+                                    "y": {
+                                        "scale": "child_delay_y",
+                                        "field": "count_*"
+                                    },
+                                    "y2": {
+                                        "scale": "child_delay_y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
                                 }
                             }
                         }
-                    }
-                },
-                {
-                    "scale": "child_delay_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_delay_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_delay_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_time_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_time_height"
-                    },
-                    "width": {
-                        "signal": "child_time_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_time_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "data_2"
-                    },
-                    "encode": {
-                        "update": {
-                            "x2": {
-                                "scale": "child_time_x",
-                                "field": "bin_maxbins_20_time_start",
-                                "offset": 1
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_delay_x",
+                            "type": "bin-linear",
+                            "domain": {
+                                "signal": "sequence(child_delay_bin_maxbins_20_delay_bins.start, child_delay_bin_maxbins_20_delay_bins.stop + child_delay_bin_maxbins_20_delay_bins.step, child_delay_bin_maxbins_20_delay_bins.step)"
                             },
-                            "x": {
-                                "scale": "child_time_x",
-                                "field": "bin_maxbins_20_time_end"
-                            },
-                            "y": {
-                                "scale": "child_time_y",
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true
+                        },
+                        {
+                            "name": "child_delay_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_1",
                                 "field": "count_*"
                             },
-                            "y2": {
-                                "scale": "child_time_y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": true
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_time_x",
-                    "type": "bin-linear",
-                    "domain": {
-                        "signal": "sequence(child_time_bin_maxbins_20_time_bins.start, child_time_bin_maxbins_20_time_bins.stop + child_time_bin_maxbins_20_time_bins.step, child_time_bin_maxbins_20_time_bins.step)"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true
+                    "axes": [
+                        {
+                            "scale": "child_delay_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "title": "BIN(delay)",
+                            "zindex": 1,
+                            "encode": {
+                                "labels": {
+                                    "update": {
+                                        "angle": {
+                                            "value": 270
+                                        },
+                                        "align": {
+                                            "value": "right"
+                                        },
+                                        "baseline": {
+                                            "value": "middle"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "scale": "child_delay_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Number of Records",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_delay_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_delay_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "child_time_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_2",
-                        "field": "count_*"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_time_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "title": "BIN(time)",
-                    "zindex": 1,
+                    "type": "group",
+                    "name": "child_time_group",
                     "encode": {
-                        "labels": {
-                            "update": {
-                                "angle": {
-                                    "value": 270
-                                },
-                                "align": {
-                                    "value": "right"
-                                },
-                                "baseline": {
-                                    "value": "middle"
+                        "update": {
+                            "height": {
+                                "signal": "child_time_height"
+                            },
+                            "width": {
+                                "signal": "child_time_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_time_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x2": {
+                                        "scale": "child_time_x",
+                                        "field": "bin_maxbins_20_time_start",
+                                        "offset": 1
+                                    },
+                                    "x": {
+                                        "scale": "child_time_x",
+                                        "field": "bin_maxbins_20_time_end"
+                                    },
+                                    "y": {
+                                        "scale": "child_time_y",
+                                        "field": "count_*"
+                                    },
+                                    "y2": {
+                                        "scale": "child_time_y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
                                 }
                             }
                         }
-                    }
-                },
-                {
-                    "scale": "child_time_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_time_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_time_x"
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_time_x",
+                            "type": "bin-linear",
+                            "domain": {
+                                "signal": "sequence(child_time_bin_maxbins_20_time_bins.start, child_time_bin_maxbins_20_time_bins.stop + child_time_bin_maxbins_20_time_bins.step, child_time_bin_maxbins_20_time_bins.step)"
+                            },
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true
+                        },
+                        {
+                            "name": "child_time_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_2",
+                                "field": "count_*"
+                            },
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": true
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "child_time_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "title": "BIN(time)",
+                            "zindex": 1,
+                            "encode": {
+                                "labels": {
+                                    "update": {
+                                        "angle": {
+                                            "value": 270
+                                        },
+                                        "align": {
+                                            "value": "right"
+                                        },
+                                        "baseline": {
+                                            "value": "middle"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "scale": "child_time_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Number of Records",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_time_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_time_x"
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/repeat_splom_cars.vg.json
+++ b/examples/vg-specs/repeat_splom_cars.vg.json
@@ -130,486 +130,492 @@
             ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": 2,
-        "bounds": "full",
-        "align": "all"
-    },
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
-            "name": "child_Displacement_Horsepower_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_Displacement_Horsepower_height"
-                    },
-                    "width": {
-                        "signal": "child_Displacement_Horsepower_width"
-                    }
-                }
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
+                },
+                "offset": 10,
+                "columns": 2,
+                "bounds": "full",
+                "align": "all"
             },
             "marks": [
                 {
-                    "name": "child_Displacement_Horsepower_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
+                    "name": "child_Displacement_Horsepower_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_Displacement_Horsepower_x",
+                            "height": {
+                                "signal": "child_Displacement_Horsepower_height"
+                            },
+                            "width": {
+                                "signal": "child_Displacement_Horsepower_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_Displacement_Horsepower_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_Displacement_Horsepower_x",
+                                        "field": "Horsepower"
+                                    },
+                                    "y": {
+                                        "scale": "child_Displacement_Horsepower_y",
+                                        "field": "Displacement"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "Origin"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_Displacement_Horsepower_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_0",
                                 "field": "Horsepower"
                             },
-                            "y": {
-                                "scale": "child_Displacement_Horsepower_y",
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": true
+                        },
+                        {
+                            "name": "child_Displacement_Horsepower_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_0",
                                 "field": "Displacement"
                             },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": true
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_Displacement_Horsepower_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_0",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "axes": [
+                        {
+                            "scale": "child_Displacement_Horsepower_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "Horsepower",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_Displacement_Horsepower_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_Displacement_Horsepower_y"
+                        },
+                        {
+                            "scale": "child_Displacement_Horsepower_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Displacement",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_Displacement_Horsepower_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_Displacement_Horsepower_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "child_Displacement_Horsepower_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_0",
-                        "field": "Displacement"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_Displacement_Horsepower_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_Displacement_Horsepower_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_Displacement_Horsepower_y"
-                },
-                {
-                    "scale": "child_Displacement_Horsepower_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Displacement",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_Displacement_Horsepower_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_Displacement_Horsepower_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_Displacement_Miles_per_Gallon_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_Displacement_Miles_per_Gallon_height"
-                    },
-                    "width": {
-                        "signal": "child_Displacement_Miles_per_Gallon_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_Displacement_Miles_per_Gallon_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_1"
-                    },
+                    "type": "group",
+                    "name": "child_Displacement_Miles_per_Gallon_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_Displacement_Miles_per_Gallon_x",
+                            "height": {
+                                "signal": "child_Displacement_Miles_per_Gallon_height"
+                            },
+                            "width": {
+                                "signal": "child_Displacement_Miles_per_Gallon_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_Displacement_Miles_per_Gallon_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_Displacement_Miles_per_Gallon_x",
+                                        "field": "Miles_per_Gallon"
+                                    },
+                                    "y": {
+                                        "scale": "child_Displacement_Miles_per_Gallon_y",
+                                        "field": "Displacement"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "Origin"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_Displacement_Miles_per_Gallon_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_1",
                                 "field": "Miles_per_Gallon"
                             },
-                            "y": {
-                                "scale": "child_Displacement_Miles_per_Gallon_y",
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": true
+                        },
+                        {
+                            "name": "child_Displacement_Miles_per_Gallon_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_1",
                                 "field": "Displacement"
                             },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": true
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_Displacement_Miles_per_Gallon_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_1",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "axes": [
+                        {
+                            "scale": "child_Displacement_Miles_per_Gallon_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "Miles_per_Gallon",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_Displacement_Miles_per_Gallon_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_Displacement_Miles_per_Gallon_y"
+                        },
+                        {
+                            "scale": "child_Displacement_Miles_per_Gallon_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Displacement",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_Displacement_Miles_per_Gallon_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_Displacement_Miles_per_Gallon_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "child_Displacement_Miles_per_Gallon_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_1",
-                        "field": "Displacement"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_Displacement_Miles_per_Gallon_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_Displacement_Miles_per_Gallon_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_Displacement_Miles_per_Gallon_y"
-                },
-                {
-                    "scale": "child_Displacement_Miles_per_Gallon_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Displacement",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_Displacement_Miles_per_Gallon_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_Displacement_Miles_per_Gallon_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_Miles_per_Gallon_Horsepower_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_Miles_per_Gallon_Horsepower_height"
-                    },
-                    "width": {
-                        "signal": "child_Miles_per_Gallon_Horsepower_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_Miles_per_Gallon_Horsepower_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_2"
-                    },
+                    "type": "group",
+                    "name": "child_Miles_per_Gallon_Horsepower_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_Miles_per_Gallon_Horsepower_x",
+                            "height": {
+                                "signal": "child_Miles_per_Gallon_Horsepower_height"
+                            },
+                            "width": {
+                                "signal": "child_Miles_per_Gallon_Horsepower_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_Miles_per_Gallon_Horsepower_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_Miles_per_Gallon_Horsepower_x",
+                                        "field": "Horsepower"
+                                    },
+                                    "y": {
+                                        "scale": "child_Miles_per_Gallon_Horsepower_y",
+                                        "field": "Miles_per_Gallon"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "Origin"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_Miles_per_Gallon_Horsepower_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_2",
                                 "field": "Horsepower"
                             },
-                            "y": {
-                                "scale": "child_Miles_per_Gallon_Horsepower_y",
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": true
+                        },
+                        {
+                            "name": "child_Miles_per_Gallon_Horsepower_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_2",
                                 "field": "Miles_per_Gallon"
                             },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": true
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_Miles_per_Gallon_Horsepower_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_2",
-                        "field": "Horsepower"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
+                    "axes": [
+                        {
+                            "scale": "child_Miles_per_Gallon_Horsepower_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "Horsepower",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_Miles_per_Gallon_Horsepower_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_Miles_per_Gallon_Horsepower_y"
+                        },
+                        {
+                            "scale": "child_Miles_per_Gallon_Horsepower_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Miles_per_Gallon",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_Miles_per_Gallon_Horsepower_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_Miles_per_Gallon_Horsepower_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "child_Miles_per_Gallon_Horsepower_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_2",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_Miles_per_Gallon_Horsepower_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_Miles_per_Gallon_Horsepower_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_Miles_per_Gallon_Horsepower_y"
-                },
-                {
-                    "scale": "child_Miles_per_Gallon_Horsepower_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_Miles_per_Gallon_Horsepower_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_Miles_per_Gallon_Horsepower_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_Miles_per_Gallon_Miles_per_Gallon_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_Miles_per_Gallon_Miles_per_Gallon_height"
-                    },
-                    "width": {
-                        "signal": "child_Miles_per_Gallon_Miles_per_Gallon_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_Miles_per_Gallon_Miles_per_Gallon_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_3"
-                    },
+                    "type": "group",
+                    "name": "child_Miles_per_Gallon_Miles_per_Gallon_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",
-                                "field": "Miles_per_Gallon"
+                            "height": {
+                                "signal": "child_Miles_per_Gallon_Miles_per_Gallon_height"
                             },
-                            "y": {
-                                "scale": "child_Miles_per_Gallon_Miles_per_Gallon_y",
-                                "field": "Miles_per_Gallon"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
+                            "width": {
+                                "signal": "child_Miles_per_Gallon_Miles_per_Gallon_width"
                             }
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_Miles_per_Gallon_Miles_per_Gallon_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_3",
-                        "field": "Miles_per_Gallon"
                     },
-                    "range": [
-                        0,
-                        200
+                    "marks": [
+                        {
+                            "name": "child_Miles_per_Gallon_Miles_per_Gallon_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_3"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",
+                                        "field": "Miles_per_Gallon"
+                                    },
+                                    "y": {
+                                        "scale": "child_Miles_per_Gallon_Miles_per_Gallon_y",
+                                        "field": "Miles_per_Gallon"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "Origin"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                },
-                {
-                    "name": "child_Miles_per_Gallon_Miles_per_Gallon_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_3",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "range": [
-                        200,
-                        0
+                    "scales": [
+                        {
+                            "name": "child_Miles_per_Gallon_Miles_per_Gallon_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_3",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": true
+                        },
+                        {
+                            "name": "child_Miles_per_Gallon_Miles_per_Gallon_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_3",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": true
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": true
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_Miles_per_Gallon_Miles_per_Gallon_y"
-                },
-                {
-                    "scale": "child_Miles_per_Gallon_Miles_per_Gallon_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_Miles_per_Gallon_Miles_per_Gallon_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_Miles_per_Gallon_Miles_per_Gallon_x"
+                    "axes": [
+                        {
+                            "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "Miles_per_Gallon",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_Miles_per_Gallon_Miles_per_Gallon_y"
+                        },
+                        {
+                            "scale": "child_Miles_per_Gallon_Miles_per_Gallon_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Miles_per_Gallon",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_Miles_per_Gallon_Miles_per_Gallon_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_Miles_per_Gallon_Miles_per_Gallon_x"
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/repeat_splom_iris.vg.json
+++ b/examples/vg-specs/repeat_splom_iris.vg.json
@@ -451,1902 +451,1908 @@
             ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": 4,
-        "bounds": "full",
-        "align": "all"
-    },
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
-            "name": "child_petalWidth_sepalLength_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_petalWidth_sepalLength_height"
-                    },
-                    "width": {
-                        "signal": "child_petalWidth_sepalLength_width"
-                    }
-                }
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
+                },
+                "offset": 10,
+                "columns": 4,
+                "bounds": "full",
+                "align": "all"
             },
             "marks": [
                 {
-                    "name": "child_petalWidth_sepalLength_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
+                    "name": "child_petalWidth_sepalLength_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_petalWidth_sepalLength_x",
+                            "height": {
+                                "signal": "child_petalWidth_sepalLength_height"
+                            },
+                            "width": {
+                                "signal": "child_petalWidth_sepalLength_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_petalWidth_sepalLength_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_petalWidth_sepalLength_x",
+                                        "field": "sepalLength"
+                                    },
+                                    "y": {
+                                        "scale": "child_petalWidth_sepalLength_y",
+                                        "field": "petalWidth"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "species"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_petalWidth_sepalLength_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_0",
                                 "field": "sepalLength"
                             },
-                            "y": {
-                                "scale": "child_petalWidth_sepalLength_y",
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        },
+                        {
+                            "name": "child_petalWidth_sepalLength_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_0",
                                 "field": "petalWidth"
                             },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_petalWidth_sepalLength_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_0",
-                        "field": "sepalLength"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
+                    "axes": [
+                        {
+                            "scale": "child_petalWidth_sepalLength_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "sepalLength",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_petalWidth_sepalLength_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_petalWidth_sepalLength_y"
+                        },
+                        {
+                            "scale": "child_petalWidth_sepalLength_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "petalWidth",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_petalWidth_sepalLength_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_petalWidth_sepalLength_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "child_petalWidth_sepalLength_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_0",
-                        "field": "petalWidth"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_petalWidth_sepalLength_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "sepalLength",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_petalWidth_sepalLength_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_petalWidth_sepalLength_y"
-                },
-                {
-                    "scale": "child_petalWidth_sepalLength_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "petalWidth",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_petalWidth_sepalLength_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_petalWidth_sepalLength_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_petalWidth_sepalWidth_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_petalWidth_sepalWidth_height"
-                    },
-                    "width": {
-                        "signal": "child_petalWidth_sepalWidth_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_petalWidth_sepalWidth_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_1"
-                    },
+                    "type": "group",
+                    "name": "child_petalWidth_sepalWidth_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_petalWidth_sepalWidth_x",
+                            "height": {
+                                "signal": "child_petalWidth_sepalWidth_height"
+                            },
+                            "width": {
+                                "signal": "child_petalWidth_sepalWidth_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_petalWidth_sepalWidth_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_petalWidth_sepalWidth_x",
+                                        "field": "sepalWidth"
+                                    },
+                                    "y": {
+                                        "scale": "child_petalWidth_sepalWidth_y",
+                                        "field": "petalWidth"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "species"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_petalWidth_sepalWidth_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_1",
                                 "field": "sepalWidth"
                             },
-                            "y": {
-                                "scale": "child_petalWidth_sepalWidth_y",
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        },
+                        {
+                            "name": "child_petalWidth_sepalWidth_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_1",
                                 "field": "petalWidth"
                             },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_petalWidth_sepalWidth_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_1",
-                        "field": "sepalWidth"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
+                    "axes": [
+                        {
+                            "scale": "child_petalWidth_sepalWidth_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "sepalWidth",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_petalWidth_sepalWidth_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_petalWidth_sepalWidth_y"
+                        },
+                        {
+                            "scale": "child_petalWidth_sepalWidth_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "petalWidth",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_petalWidth_sepalWidth_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_petalWidth_sepalWidth_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "child_petalWidth_sepalWidth_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_1",
-                        "field": "petalWidth"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_petalWidth_sepalWidth_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "sepalWidth",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_petalWidth_sepalWidth_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_petalWidth_sepalWidth_y"
-                },
-                {
-                    "scale": "child_petalWidth_sepalWidth_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "petalWidth",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_petalWidth_sepalWidth_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_petalWidth_sepalWidth_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_petalWidth_petalLength_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_petalWidth_petalLength_height"
-                    },
-                    "width": {
-                        "signal": "child_petalWidth_petalLength_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_petalWidth_petalLength_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_2"
-                    },
+                    "type": "group",
+                    "name": "child_petalWidth_petalLength_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_petalWidth_petalLength_x",
+                            "height": {
+                                "signal": "child_petalWidth_petalLength_height"
+                            },
+                            "width": {
+                                "signal": "child_petalWidth_petalLength_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_petalWidth_petalLength_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_2"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_petalWidth_petalLength_x",
+                                        "field": "petalLength"
+                                    },
+                                    "y": {
+                                        "scale": "child_petalWidth_petalLength_y",
+                                        "field": "petalWidth"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "species"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_petalWidth_petalLength_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_2",
                                 "field": "petalLength"
                             },
-                            "y": {
-                                "scale": "child_petalWidth_petalLength_y",
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        },
+                        {
+                            "name": "child_petalWidth_petalLength_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_2",
                                 "field": "petalWidth"
                             },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_petalWidth_petalLength_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_2",
-                        "field": "petalLength"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
+                    "axes": [
+                        {
+                            "scale": "child_petalWidth_petalLength_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "petalLength",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_petalWidth_petalLength_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_petalWidth_petalLength_y"
+                        },
+                        {
+                            "scale": "child_petalWidth_petalLength_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "petalWidth",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_petalWidth_petalLength_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_petalWidth_petalLength_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "child_petalWidth_petalLength_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_2",
-                        "field": "petalWidth"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_petalWidth_petalLength_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "petalLength",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_petalWidth_petalLength_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_petalWidth_petalLength_y"
-                },
-                {
-                    "scale": "child_petalWidth_petalLength_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "petalWidth",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_petalWidth_petalLength_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_petalWidth_petalLength_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_petalWidth_petalWidth_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_petalWidth_petalWidth_height"
-                    },
-                    "width": {
-                        "signal": "child_petalWidth_petalWidth_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_petalWidth_petalWidth_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_3"
-                    },
+                    "type": "group",
+                    "name": "child_petalWidth_petalWidth_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_petalWidth_petalWidth_x",
-                                "field": "petalWidth"
+                            "height": {
+                                "signal": "child_petalWidth_petalWidth_height"
                             },
-                            "y": {
-                                "scale": "child_petalWidth_petalWidth_y",
-                                "field": "petalWidth"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
+                            "width": {
+                                "signal": "child_petalWidth_petalWidth_width"
                             }
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_petalWidth_petalWidth_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_3",
-                        "field": "petalWidth"
                     },
-                    "range": [
-                        0,
-                        200
+                    "marks": [
+                        {
+                            "name": "child_petalWidth_petalWidth_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_3"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_petalWidth_petalWidth_x",
+                                        "field": "petalWidth"
+                                    },
+                                    "y": {
+                                        "scale": "child_petalWidth_petalWidth_y",
+                                        "field": "petalWidth"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "species"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                },
-                {
-                    "name": "child_petalWidth_petalWidth_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_3",
-                        "field": "petalWidth"
-                    },
-                    "range": [
-                        200,
-                        0
+                    "scales": [
+                        {
+                            "name": "child_petalWidth_petalWidth_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_3",
+                                "field": "petalWidth"
+                            },
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        },
+                        {
+                            "name": "child_petalWidth_petalWidth_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_3",
+                                "field": "petalWidth"
+                            },
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_petalWidth_petalWidth_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "petalWidth",
-                    "zindex": 1
+                    "axes": [
+                        {
+                            "scale": "child_petalWidth_petalWidth_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "petalWidth",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_petalWidth_petalWidth_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_petalWidth_petalWidth_y"
+                        },
+                        {
+                            "scale": "child_petalWidth_petalWidth_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "petalWidth",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_petalWidth_petalWidth_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_petalWidth_petalWidth_x"
+                        }
+                    ]
                 },
                 {
-                    "scale": "child_petalWidth_petalWidth_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_petalWidth_petalWidth_y"
-                },
-                {
-                    "scale": "child_petalWidth_petalWidth_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "petalWidth",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_petalWidth_petalWidth_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_petalWidth_petalWidth_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_petalLength_sepalLength_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_petalLength_sepalLength_height"
-                    },
-                    "width": {
-                        "signal": "child_petalLength_sepalLength_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_petalLength_sepalLength_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_4"
-                    },
+                    "type": "group",
+                    "name": "child_petalLength_sepalLength_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_petalLength_sepalLength_x",
+                            "height": {
+                                "signal": "child_petalLength_sepalLength_height"
+                            },
+                            "width": {
+                                "signal": "child_petalLength_sepalLength_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_petalLength_sepalLength_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_4"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_petalLength_sepalLength_x",
+                                        "field": "sepalLength"
+                                    },
+                                    "y": {
+                                        "scale": "child_petalLength_sepalLength_y",
+                                        "field": "petalLength"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "species"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_petalLength_sepalLength_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_4",
                                 "field": "sepalLength"
                             },
-                            "y": {
-                                "scale": "child_petalLength_sepalLength_y",
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        },
+                        {
+                            "name": "child_petalLength_sepalLength_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_4",
                                 "field": "petalLength"
                             },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_petalLength_sepalLength_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_4",
-                        "field": "sepalLength"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
+                    "axes": [
+                        {
+                            "scale": "child_petalLength_sepalLength_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "sepalLength",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_petalLength_sepalLength_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_petalLength_sepalLength_y"
+                        },
+                        {
+                            "scale": "child_petalLength_sepalLength_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "petalLength",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_petalLength_sepalLength_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_petalLength_sepalLength_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "child_petalLength_sepalLength_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_4",
-                        "field": "petalLength"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_petalLength_sepalLength_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "sepalLength",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_petalLength_sepalLength_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_petalLength_sepalLength_y"
-                },
-                {
-                    "scale": "child_petalLength_sepalLength_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "petalLength",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_petalLength_sepalLength_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_petalLength_sepalLength_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_petalLength_sepalWidth_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_petalLength_sepalWidth_height"
-                    },
-                    "width": {
-                        "signal": "child_petalLength_sepalWidth_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_petalLength_sepalWidth_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_5"
-                    },
+                    "type": "group",
+                    "name": "child_petalLength_sepalWidth_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_petalLength_sepalWidth_x",
+                            "height": {
+                                "signal": "child_petalLength_sepalWidth_height"
+                            },
+                            "width": {
+                                "signal": "child_petalLength_sepalWidth_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_petalLength_sepalWidth_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_5"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_petalLength_sepalWidth_x",
+                                        "field": "sepalWidth"
+                                    },
+                                    "y": {
+                                        "scale": "child_petalLength_sepalWidth_y",
+                                        "field": "petalLength"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "species"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_petalLength_sepalWidth_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_5",
                                 "field": "sepalWidth"
                             },
-                            "y": {
-                                "scale": "child_petalLength_sepalWidth_y",
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        },
+                        {
+                            "name": "child_petalLength_sepalWidth_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_5",
                                 "field": "petalLength"
                             },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_petalLength_sepalWidth_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_5",
-                        "field": "sepalWidth"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
+                    "axes": [
+                        {
+                            "scale": "child_petalLength_sepalWidth_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "sepalWidth",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_petalLength_sepalWidth_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_petalLength_sepalWidth_y"
+                        },
+                        {
+                            "scale": "child_petalLength_sepalWidth_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "petalLength",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_petalLength_sepalWidth_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_petalLength_sepalWidth_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "child_petalLength_sepalWidth_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_5",
-                        "field": "petalLength"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_petalLength_sepalWidth_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "sepalWidth",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_petalLength_sepalWidth_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_petalLength_sepalWidth_y"
-                },
-                {
-                    "scale": "child_petalLength_sepalWidth_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "petalLength",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_petalLength_sepalWidth_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_petalLength_sepalWidth_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_petalLength_petalLength_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_petalLength_petalLength_height"
-                    },
-                    "width": {
-                        "signal": "child_petalLength_petalLength_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_petalLength_petalLength_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_6"
-                    },
+                    "type": "group",
+                    "name": "child_petalLength_petalLength_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_petalLength_petalLength_x",
-                                "field": "petalLength"
+                            "height": {
+                                "signal": "child_petalLength_petalLength_height"
                             },
-                            "y": {
-                                "scale": "child_petalLength_petalLength_y",
-                                "field": "petalLength"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
+                            "width": {
+                                "signal": "child_petalLength_petalLength_width"
                             }
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_petalLength_petalLength_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_6",
-                        "field": "petalLength"
                     },
-                    "range": [
-                        0,
-                        200
+                    "marks": [
+                        {
+                            "name": "child_petalLength_petalLength_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_6"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_petalLength_petalLength_x",
+                                        "field": "petalLength"
+                                    },
+                                    "y": {
+                                        "scale": "child_petalLength_petalLength_y",
+                                        "field": "petalLength"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "species"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                },
-                {
-                    "name": "child_petalLength_petalLength_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_6",
-                        "field": "petalLength"
-                    },
-                    "range": [
-                        200,
-                        0
+                    "scales": [
+                        {
+                            "name": "child_petalLength_petalLength_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_6",
+                                "field": "petalLength"
+                            },
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        },
+                        {
+                            "name": "child_petalLength_petalLength_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_6",
+                                "field": "petalLength"
+                            },
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_petalLength_petalLength_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "petalLength",
-                    "zindex": 1
+                    "axes": [
+                        {
+                            "scale": "child_petalLength_petalLength_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "petalLength",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_petalLength_petalLength_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_petalLength_petalLength_y"
+                        },
+                        {
+                            "scale": "child_petalLength_petalLength_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "petalLength",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_petalLength_petalLength_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_petalLength_petalLength_x"
+                        }
+                    ]
                 },
                 {
-                    "scale": "child_petalLength_petalLength_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_petalLength_petalLength_y"
-                },
-                {
-                    "scale": "child_petalLength_petalLength_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "petalLength",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_petalLength_petalLength_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_petalLength_petalLength_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_petalLength_petalWidth_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_petalLength_petalWidth_height"
-                    },
-                    "width": {
-                        "signal": "child_petalLength_petalWidth_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_petalLength_petalWidth_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_7"
-                    },
+                    "type": "group",
+                    "name": "child_petalLength_petalWidth_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_petalLength_petalWidth_x",
+                            "height": {
+                                "signal": "child_petalLength_petalWidth_height"
+                            },
+                            "width": {
+                                "signal": "child_petalLength_petalWidth_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_petalLength_petalWidth_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_7"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_petalLength_petalWidth_x",
+                                        "field": "petalWidth"
+                                    },
+                                    "y": {
+                                        "scale": "child_petalLength_petalWidth_y",
+                                        "field": "petalLength"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "species"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_petalLength_petalWidth_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_7",
                                 "field": "petalWidth"
                             },
-                            "y": {
-                                "scale": "child_petalLength_petalWidth_y",
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        },
+                        {
+                            "name": "child_petalLength_petalWidth_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_7",
                                 "field": "petalLength"
                             },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_petalLength_petalWidth_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_7",
-                        "field": "petalWidth"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
+                    "axes": [
+                        {
+                            "scale": "child_petalLength_petalWidth_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "petalWidth",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_petalLength_petalWidth_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_petalLength_petalWidth_y"
+                        },
+                        {
+                            "scale": "child_petalLength_petalWidth_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "petalLength",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_petalLength_petalWidth_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_petalLength_petalWidth_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "child_petalLength_petalWidth_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_7",
-                        "field": "petalLength"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_petalLength_petalWidth_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "petalWidth",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_petalLength_petalWidth_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_petalLength_petalWidth_y"
-                },
-                {
-                    "scale": "child_petalLength_petalWidth_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "petalLength",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_petalLength_petalWidth_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_petalLength_petalWidth_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_sepalWidth_sepalLength_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_sepalWidth_sepalLength_height"
-                    },
-                    "width": {
-                        "signal": "child_sepalWidth_sepalLength_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_sepalWidth_sepalLength_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_8"
-                    },
+                    "type": "group",
+                    "name": "child_sepalWidth_sepalLength_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_sepalWidth_sepalLength_x",
+                            "height": {
+                                "signal": "child_sepalWidth_sepalLength_height"
+                            },
+                            "width": {
+                                "signal": "child_sepalWidth_sepalLength_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_sepalWidth_sepalLength_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_8"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_sepalWidth_sepalLength_x",
+                                        "field": "sepalLength"
+                                    },
+                                    "y": {
+                                        "scale": "child_sepalWidth_sepalLength_y",
+                                        "field": "sepalWidth"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "species"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_sepalWidth_sepalLength_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_8",
                                 "field": "sepalLength"
                             },
-                            "y": {
-                                "scale": "child_sepalWidth_sepalLength_y",
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        },
+                        {
+                            "name": "child_sepalWidth_sepalLength_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_8",
                                 "field": "sepalWidth"
                             },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_sepalWidth_sepalLength_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_8",
-                        "field": "sepalLength"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
+                    "axes": [
+                        {
+                            "scale": "child_sepalWidth_sepalLength_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "sepalLength",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_sepalWidth_sepalLength_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_sepalWidth_sepalLength_y"
+                        },
+                        {
+                            "scale": "child_sepalWidth_sepalLength_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "sepalWidth",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_sepalWidth_sepalLength_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_sepalWidth_sepalLength_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "child_sepalWidth_sepalLength_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_8",
-                        "field": "sepalWidth"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_sepalWidth_sepalLength_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "sepalLength",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_sepalWidth_sepalLength_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_sepalWidth_sepalLength_y"
-                },
-                {
-                    "scale": "child_sepalWidth_sepalLength_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "sepalWidth",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_sepalWidth_sepalLength_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_sepalWidth_sepalLength_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_sepalWidth_sepalWidth_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_sepalWidth_sepalWidth_height"
-                    },
-                    "width": {
-                        "signal": "child_sepalWidth_sepalWidth_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_sepalWidth_sepalWidth_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_9"
-                    },
+                    "type": "group",
+                    "name": "child_sepalWidth_sepalWidth_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_sepalWidth_sepalWidth_x",
-                                "field": "sepalWidth"
+                            "height": {
+                                "signal": "child_sepalWidth_sepalWidth_height"
                             },
-                            "y": {
-                                "scale": "child_sepalWidth_sepalWidth_y",
-                                "field": "sepalWidth"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
+                            "width": {
+                                "signal": "child_sepalWidth_sepalWidth_width"
                             }
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_sepalWidth_sepalWidth_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_9",
-                        "field": "sepalWidth"
                     },
-                    "range": [
-                        0,
-                        200
+                    "marks": [
+                        {
+                            "name": "child_sepalWidth_sepalWidth_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_9"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_sepalWidth_sepalWidth_x",
+                                        "field": "sepalWidth"
+                                    },
+                                    "y": {
+                                        "scale": "child_sepalWidth_sepalWidth_y",
+                                        "field": "sepalWidth"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "species"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                },
-                {
-                    "name": "child_sepalWidth_sepalWidth_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_9",
-                        "field": "sepalWidth"
-                    },
-                    "range": [
-                        200,
-                        0
+                    "scales": [
+                        {
+                            "name": "child_sepalWidth_sepalWidth_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_9",
+                                "field": "sepalWidth"
+                            },
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        },
+                        {
+                            "name": "child_sepalWidth_sepalWidth_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_9",
+                                "field": "sepalWidth"
+                            },
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_sepalWidth_sepalWidth_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "sepalWidth",
-                    "zindex": 1
+                    "axes": [
+                        {
+                            "scale": "child_sepalWidth_sepalWidth_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "sepalWidth",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_sepalWidth_sepalWidth_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_sepalWidth_sepalWidth_y"
+                        },
+                        {
+                            "scale": "child_sepalWidth_sepalWidth_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "sepalWidth",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_sepalWidth_sepalWidth_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_sepalWidth_sepalWidth_x"
+                        }
+                    ]
                 },
                 {
-                    "scale": "child_sepalWidth_sepalWidth_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_sepalWidth_sepalWidth_y"
-                },
-                {
-                    "scale": "child_sepalWidth_sepalWidth_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "sepalWidth",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_sepalWidth_sepalWidth_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_sepalWidth_sepalWidth_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_sepalWidth_petalLength_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_sepalWidth_petalLength_height"
-                    },
-                    "width": {
-                        "signal": "child_sepalWidth_petalLength_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_sepalWidth_petalLength_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_10"
-                    },
+                    "type": "group",
+                    "name": "child_sepalWidth_petalLength_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_sepalWidth_petalLength_x",
+                            "height": {
+                                "signal": "child_sepalWidth_petalLength_height"
+                            },
+                            "width": {
+                                "signal": "child_sepalWidth_petalLength_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_sepalWidth_petalLength_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_10"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_sepalWidth_petalLength_x",
+                                        "field": "petalLength"
+                                    },
+                                    "y": {
+                                        "scale": "child_sepalWidth_petalLength_y",
+                                        "field": "sepalWidth"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "species"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_sepalWidth_petalLength_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_10",
                                 "field": "petalLength"
                             },
-                            "y": {
-                                "scale": "child_sepalWidth_petalLength_y",
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        },
+                        {
+                            "name": "child_sepalWidth_petalLength_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_10",
                                 "field": "sepalWidth"
                             },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_sepalWidth_petalLength_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_10",
-                        "field": "petalLength"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
+                    "axes": [
+                        {
+                            "scale": "child_sepalWidth_petalLength_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "petalLength",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_sepalWidth_petalLength_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_sepalWidth_petalLength_y"
+                        },
+                        {
+                            "scale": "child_sepalWidth_petalLength_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "sepalWidth",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_sepalWidth_petalLength_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_sepalWidth_petalLength_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "child_sepalWidth_petalLength_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_10",
-                        "field": "sepalWidth"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_sepalWidth_petalLength_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "petalLength",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_sepalWidth_petalLength_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_sepalWidth_petalLength_y"
-                },
-                {
-                    "scale": "child_sepalWidth_petalLength_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "sepalWidth",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_sepalWidth_petalLength_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_sepalWidth_petalLength_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_sepalWidth_petalWidth_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_sepalWidth_petalWidth_height"
-                    },
-                    "width": {
-                        "signal": "child_sepalWidth_petalWidth_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_sepalWidth_petalWidth_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_11"
-                    },
+                    "type": "group",
+                    "name": "child_sepalWidth_petalWidth_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_sepalWidth_petalWidth_x",
+                            "height": {
+                                "signal": "child_sepalWidth_petalWidth_height"
+                            },
+                            "width": {
+                                "signal": "child_sepalWidth_petalWidth_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_sepalWidth_petalWidth_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_11"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_sepalWidth_petalWidth_x",
+                                        "field": "petalWidth"
+                                    },
+                                    "y": {
+                                        "scale": "child_sepalWidth_petalWidth_y",
+                                        "field": "sepalWidth"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "species"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_sepalWidth_petalWidth_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_11",
                                 "field": "petalWidth"
                             },
-                            "y": {
-                                "scale": "child_sepalWidth_petalWidth_y",
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        },
+                        {
+                            "name": "child_sepalWidth_petalWidth_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_11",
                                 "field": "sepalWidth"
                             },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_sepalWidth_petalWidth_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_11",
-                        "field": "petalWidth"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
+                    "axes": [
+                        {
+                            "scale": "child_sepalWidth_petalWidth_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "petalWidth",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_sepalWidth_petalWidth_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_sepalWidth_petalWidth_y"
+                        },
+                        {
+                            "scale": "child_sepalWidth_petalWidth_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "sepalWidth",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_sepalWidth_petalWidth_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_sepalWidth_petalWidth_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "child_sepalWidth_petalWidth_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_11",
-                        "field": "sepalWidth"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_sepalWidth_petalWidth_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "petalWidth",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_sepalWidth_petalWidth_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_sepalWidth_petalWidth_y"
-                },
-                {
-                    "scale": "child_sepalWidth_petalWidth_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "sepalWidth",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_sepalWidth_petalWidth_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_sepalWidth_petalWidth_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_sepalLength_sepalLength_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_sepalLength_sepalLength_height"
-                    },
-                    "width": {
-                        "signal": "child_sepalLength_sepalLength_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_sepalLength_sepalLength_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_12"
-                    },
+                    "type": "group",
+                    "name": "child_sepalLength_sepalLength_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_sepalLength_sepalLength_x",
-                                "field": "sepalLength"
+                            "height": {
+                                "signal": "child_sepalLength_sepalLength_height"
                             },
-                            "y": {
-                                "scale": "child_sepalLength_sepalLength_y",
-                                "field": "sepalLength"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
+                            "width": {
+                                "signal": "child_sepalLength_sepalLength_width"
                             }
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_sepalLength_sepalLength_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_12",
-                        "field": "sepalLength"
                     },
-                    "range": [
-                        0,
-                        200
+                    "marks": [
+                        {
+                            "name": "child_sepalLength_sepalLength_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_12"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_sepalLength_sepalLength_x",
+                                        "field": "sepalLength"
+                                    },
+                                    "y": {
+                                        "scale": "child_sepalLength_sepalLength_y",
+                                        "field": "sepalLength"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "species"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                },
-                {
-                    "name": "child_sepalLength_sepalLength_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_12",
-                        "field": "sepalLength"
-                    },
-                    "range": [
-                        200,
-                        0
+                    "scales": [
+                        {
+                            "name": "child_sepalLength_sepalLength_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_12",
+                                "field": "sepalLength"
+                            },
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        },
+                        {
+                            "name": "child_sepalLength_sepalLength_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_12",
+                                "field": "sepalLength"
+                            },
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_sepalLength_sepalLength_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "sepalLength",
-                    "zindex": 1
+                    "axes": [
+                        {
+                            "scale": "child_sepalLength_sepalLength_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "sepalLength",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_sepalLength_sepalLength_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_sepalLength_sepalLength_y"
+                        },
+                        {
+                            "scale": "child_sepalLength_sepalLength_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "sepalLength",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_sepalLength_sepalLength_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_sepalLength_sepalLength_x"
+                        }
+                    ]
                 },
                 {
-                    "scale": "child_sepalLength_sepalLength_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_sepalLength_sepalLength_y"
-                },
-                {
-                    "scale": "child_sepalLength_sepalLength_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "sepalLength",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_sepalLength_sepalLength_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_sepalLength_sepalLength_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_sepalLength_sepalWidth_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_sepalLength_sepalWidth_height"
-                    },
-                    "width": {
-                        "signal": "child_sepalLength_sepalWidth_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_sepalLength_sepalWidth_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_13"
-                    },
+                    "type": "group",
+                    "name": "child_sepalLength_sepalWidth_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_sepalLength_sepalWidth_x",
+                            "height": {
+                                "signal": "child_sepalLength_sepalWidth_height"
+                            },
+                            "width": {
+                                "signal": "child_sepalLength_sepalWidth_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_sepalLength_sepalWidth_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_13"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_sepalLength_sepalWidth_x",
+                                        "field": "sepalWidth"
+                                    },
+                                    "y": {
+                                        "scale": "child_sepalLength_sepalWidth_y",
+                                        "field": "sepalLength"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "species"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_sepalLength_sepalWidth_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_13",
                                 "field": "sepalWidth"
                             },
-                            "y": {
-                                "scale": "child_sepalLength_sepalWidth_y",
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        },
+                        {
+                            "name": "child_sepalLength_sepalWidth_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_13",
                                 "field": "sepalLength"
                             },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_sepalLength_sepalWidth_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_13",
-                        "field": "sepalWidth"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
+                    "axes": [
+                        {
+                            "scale": "child_sepalLength_sepalWidth_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "sepalWidth",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_sepalLength_sepalWidth_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_sepalLength_sepalWidth_y"
+                        },
+                        {
+                            "scale": "child_sepalLength_sepalWidth_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "sepalLength",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_sepalLength_sepalWidth_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_sepalLength_sepalWidth_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "child_sepalLength_sepalWidth_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_13",
-                        "field": "sepalLength"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_sepalLength_sepalWidth_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "sepalWidth",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_sepalLength_sepalWidth_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_sepalLength_sepalWidth_y"
-                },
-                {
-                    "scale": "child_sepalLength_sepalWidth_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "sepalLength",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_sepalLength_sepalWidth_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_sepalLength_sepalWidth_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_sepalLength_petalLength_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_sepalLength_petalLength_height"
-                    },
-                    "width": {
-                        "signal": "child_sepalLength_petalLength_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_sepalLength_petalLength_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_14"
-                    },
+                    "type": "group",
+                    "name": "child_sepalLength_petalLength_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_sepalLength_petalLength_x",
+                            "height": {
+                                "signal": "child_sepalLength_petalLength_height"
+                            },
+                            "width": {
+                                "signal": "child_sepalLength_petalLength_width"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_sepalLength_petalLength_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_14"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_sepalLength_petalLength_x",
+                                        "field": "petalLength"
+                                    },
+                                    "y": {
+                                        "scale": "child_sepalLength_petalLength_y",
+                                        "field": "sepalLength"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "species"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "scales": [
+                        {
+                            "name": "child_sepalLength_petalLength_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_14",
                                 "field": "petalLength"
                             },
-                            "y": {
-                                "scale": "child_sepalLength_petalLength_y",
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        },
+                        {
+                            "name": "child_sepalLength_petalLength_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_14",
                                 "field": "sepalLength"
                             },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
-                            }
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_sepalLength_petalLength_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_14",
-                        "field": "petalLength"
-                    },
-                    "range": [
-                        0,
-                        200
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
+                    "axes": [
+                        {
+                            "scale": "child_sepalLength_petalLength_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "petalLength",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_sepalLength_petalLength_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_sepalLength_petalLength_y"
+                        },
+                        {
+                            "scale": "child_sepalLength_petalLength_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "sepalLength",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_sepalLength_petalLength_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_sepalLength_petalLength_x"
+                        }
+                    ]
                 },
                 {
-                    "name": "child_sepalLength_petalLength_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_14",
-                        "field": "sepalLength"
-                    },
-                    "range": [
-                        200,
-                        0
-                    ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_sepalLength_petalLength_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "petalLength",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_sepalLength_petalLength_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_sepalLength_petalLength_y"
-                },
-                {
-                    "scale": "child_sepalLength_petalLength_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "sepalLength",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_sepalLength_petalLength_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_sepalLength_petalLength_x"
-                }
-            ]
-        },
-        {
-            "type": "group",
-            "name": "child_sepalLength_petalWidth_group",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_sepalLength_petalWidth_height"
-                    },
-                    "width": {
-                        "signal": "child_sepalLength_petalWidth_width"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_sepalLength_petalWidth_marks",
-                    "type": "symbol",
-                    "role": "point",
-                    "from": {
-                        "data": "data_15"
-                    },
+                    "type": "group",
+                    "name": "child_sepalLength_petalWidth_group",
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "child_sepalLength_petalWidth_x",
-                                "field": "petalWidth"
+                            "height": {
+                                "signal": "child_sepalLength_petalWidth_height"
                             },
-                            "y": {
-                                "scale": "child_sepalLength_petalWidth_y",
-                                "field": "sepalLength"
-                            },
-                            "stroke": {
-                                "scale": "color",
-                                "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
+                            "width": {
+                                "signal": "child_sepalLength_petalWidth_width"
                             }
                         }
-                    }
-                }
-            ],
-            "scales": [
-                {
-                    "name": "child_sepalLength_petalWidth_x",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_15",
-                        "field": "petalWidth"
                     },
-                    "range": [
-                        0,
-                        200
+                    "marks": [
+                        {
+                            "name": "child_sepalLength_petalWidth_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_15"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "child_sepalLength_petalWidth_x",
+                                        "field": "petalWidth"
+                                    },
+                                    "y": {
+                                        "scale": "child_sepalLength_petalWidth_y",
+                                        "field": "sepalLength"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "species"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                },
-                {
-                    "name": "child_sepalLength_petalWidth_y",
-                    "type": "linear",
-                    "domain": {
-                        "data": "data_15",
-                        "field": "sepalLength"
-                    },
-                    "range": [
-                        200,
-                        0
+                    "scales": [
+                        {
+                            "name": "child_sepalLength_petalWidth_x",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_15",
+                                "field": "petalWidth"
+                            },
+                            "range": [
+                                0,
+                                200
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        },
+                        {
+                            "name": "child_sepalLength_petalWidth_y",
+                            "type": "linear",
+                            "domain": {
+                                "data": "data_15",
+                                "field": "sepalLength"
+                            },
+                            "range": [
+                                200,
+                                0
+                            ],
+                            "round": true,
+                            "nice": true,
+                            "zero": false
+                        }
                     ],
-                    "round": true,
-                    "nice": true,
-                    "zero": false
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "child_sepalLength_petalWidth_x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "petalWidth",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_sepalLength_petalWidth_x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_sepalLength_petalWidth_y"
-                },
-                {
-                    "scale": "child_sepalLength_petalWidth_y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "sepalLength",
-                    "zindex": 1
-                },
-                {
-                    "scale": "child_sepalLength_petalWidth_y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "child_sepalLength_petalWidth_x"
+                    "axes": [
+                        {
+                            "scale": "child_sepalLength_petalWidth_x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "petalWidth",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_sepalLength_petalWidth_x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_sepalLength_petalWidth_y"
+                        },
+                        {
+                            "scale": "child_sepalLength_petalWidth_y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "sepalLength",
+                            "zindex": 1
+                        },
+                        {
+                            "scale": "child_sepalLength_petalWidth_y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "child_sepalLength_petalWidth_x"
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/scatter.vg.json
+++ b/examples/vg-specs/scatter.vg.json
@@ -44,33 +44,49 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_aggregate_detail.vg.json
+++ b/examples/vg-specs/scatter_aggregate_detail.vg.json
@@ -58,30 +58,46 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "mean_Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "mean_Displacement"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
-                    "fill": {
-                        "value": "transparent"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "mean_Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "mean_Displacement"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_binned.vg.json
+++ b/examples/vg-specs/scatter_binned.vg.json
@@ -94,32 +94,48 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "circle",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "signal": "(scale(\"x\", datum[\"bin_maxbins_10_IMDB_Rating_start\"]) + scale(\"x\", datum[\"bin_maxbins_10_IMDB_Rating_end\"]))/2"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "signal": "(scale(\"y\", datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_start\"]) + scale(\"y\", datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_end\"]))/2"
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
-                    },
-                    "size": {
-                        "scale": "size",
-                        "field": "count_*"
-                    },
-                    "shape": {
-                        "value": "circle"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "circle",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "signal": "(scale(\"x\", datum[\"bin_maxbins_10_IMDB_Rating_start\"]) + scale(\"x\", datum[\"bin_maxbins_10_IMDB_Rating_end\"]))/2"
+                            },
+                            "y": {
+                                "signal": "(scale(\"y\", datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_start\"]) + scale(\"y\", datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_end\"]))/2"
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "size": {
+                                "scale": "size",
+                                "field": "count_*"
+                            },
+                            "shape": {
+                                "value": "circle"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_binned_color.vg.json
+++ b/examples/vg-specs/scatter_binned_color.vg.json
@@ -68,34 +68,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "stroke": {
-                        "scale": "color",
-                        "field": "bin_maxbins_5_Acceleration_start"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": {
+                                "scale": "color",
+                                "field": "bin_maxbins_5_Acceleration_start"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_binned_opacity.vg.json
+++ b/examples/vg-specs/scatter_binned_opacity.vg.json
@@ -63,34 +63,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "scale": "opacity",
-                        "field": "bin_maxbins_10_Acceleration_start"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "scale": "opacity",
+                                "field": "bin_maxbins_10_Acceleration_start"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_binned_size.vg.json
+++ b/examples/vg-specs/scatter_binned_size.vg.json
@@ -63,37 +63,53 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "size": {
-                        "scale": "size",
-                        "field": "bin_maxbins_6_Acceleration_start"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "size": {
+                                "scale": "size",
+                                "field": "bin_maxbins_6_Acceleration_start"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_bubble.vg.json
+++ b/examples/vg-specs/scatter_bubble.vg.json
@@ -45,37 +45,53 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "size": {
-                        "scale": "size",
-                        "field": "Acceleration"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "size": {
+                                "scale": "size",
+                                "field": "Acceleration"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_color.vg.json
+++ b/examples/vg-specs/scatter_color.vg.json
@@ -43,34 +43,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "stroke": {
-                        "scale": "color",
-                        "field": "Origin"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": {
+                                "scale": "color",
+                                "field": "Origin"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_color_custom.vg.json
+++ b/examples/vg-specs/scatter_color_custom.vg.json
@@ -43,34 +43,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "stroke": {
-                        "scale": "color",
-                        "field": "Origin"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": {
+                                "scale": "color",
+                                "field": "Origin"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_color_ordinal.vg.json
+++ b/examples/vg-specs/scatter_color_ordinal.vg.json
@@ -43,34 +43,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "stroke": {
-                        "scale": "color",
-                        "field": "Cylinders"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": {
+                                "scale": "color",
+                                "field": "Cylinders"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_color_ordinal_custom.vg.json
+++ b/examples/vg-specs/scatter_color_ordinal_custom.vg.json
@@ -43,34 +43,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "stroke": {
-                        "scale": "color",
-                        "field": "Cylinders"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": {
+                                "scale": "color",
+                                "field": "Cylinders"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_color_quantitative.vg.json
+++ b/examples/vg-specs/scatter_color_quantitative.vg.json
@@ -44,34 +44,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "stroke": {
-                        "scale": "color",
-                        "field": "Displacement"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": {
+                                "scale": "color",
+                                "field": "Displacement"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_color_shape_constant.vg.json
+++ b/examples/vg-specs/scatter_color_shape_constant.vg.json
@@ -43,36 +43,52 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "stroke": {
-                        "value": "#ff9900"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "shape": {
-                        "value": "square"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": {
+                                "value": "#ff9900"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "shape": {
+                                "value": "square"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_colored_with_shape.vg.json
+++ b/examples/vg-specs/scatter_colored_with_shape.vg.json
@@ -44,38 +44,54 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "stroke": {
-                        "scale": "color",
-                        "field": "Origin"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "shape": {
-                        "scale": "shape",
-                        "field": "Origin"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": {
+                                "scale": "color",
+                                "field": "Origin"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "shape": {
+                                "scale": "shape",
+                                "field": "Origin"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_connected.vg.json
+++ b/examples/vg-specs/scatter_connected.vg.json
@@ -110,71 +110,87 @@
     ],
     "marks": [
         {
+            "name": "nested-main-group",
             "type": "group",
             "encode": {
-                "enter": {
+                "update": {
                     "width": {
                         "signal": "width"
                     },
                     "height": {
                         "signal": "height"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "clip": {
-                        "value": true
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "layer_0_marks",
-                    "type": "line",
-                    "from": {
-                        "data": "data_0"
-                    },
+                    "type": "group",
                     "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "miles"
+                        "enter": {
+                            "width": {
+                                "signal": "width"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "gas"
-                            },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            }
-                        }
-                    }
-                },
-                {
-                    "name": "layer_1_marks",
-                    "type": "symbol",
-                    "role": "pointOverlay",
-                    "from": {
-                        "data": "data_1"
-                    },
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "miles"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "gas"
+                            "height": {
+                                "signal": "height"
                             },
                             "fill": {
-                                "value": "#4c78a8"
+                                "value": "transparent"
                             },
-                            "opacity": {
-                                "value": 0.7
+                            "clip": {
+                                "value": true
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "layer_0_marks",
+                            "type": "line",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "miles"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "gas"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "layer_1_marks",
+                            "type": "symbol",
+                            "role": "pointOverlay",
+                            "from": {
+                                "data": "data_1"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "miles"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "gas"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/scatter_log.vg.json
+++ b/examples/vg-specs/scatter_log.vg.json
@@ -80,33 +80,49 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "x"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "y"
-                    },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "x"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "y"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_opacity.vg.json
+++ b/examples/vg-specs/scatter_opacity.vg.json
@@ -43,34 +43,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "circle",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
-                    },
-                    "shape": {
-                        "value": "circle"
-                    },
-                    "opacity": {
-                        "scale": "opacity",
-                        "field": "Miles_per_Gallon"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "circle",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "shape": {
+                                "value": "circle"
+                            },
+                            "opacity": {
+                                "scale": "opacity",
+                                "field": "Miles_per_Gallon"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_shape_custom.vg.json
+++ b/examples/vg-specs/scatter_shape_custom.vg.json
@@ -45,41 +45,57 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "point",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "stroke": {
-                        "scale": "color",
-                        "field": "Cylinders"
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    },
-                    "size": {
-                        "scale": "size",
-                        "field": "Weight_in_lbs"
-                    },
-                    "shape": {
-                        "value": "M0,0.2L0.2351,0.3236 0.1902,0.0618 0.3804,-0.1236 0.1175,-0.1618 0,-0.4 -0.1175,-0.1618 -0.3804,-0.1236 -0.1902,0.0618 -0.2351,0.3236 0,0.2Z"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "stroke": {
+                                "scale": "color",
+                                "field": "Cylinders"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "size": {
+                                "scale": "size",
+                                "field": "Weight_in_lbs"
+                            },
+                            "shape": {
+                                "value": "M0,0.2L0.2351,0.3236 0.1902,0.0618 0.3804,-0.1236 0.1175,-0.1618 0,-0.4 -0.1175,-0.1618 -0.3804,-0.1236 -0.1902,0.0618 -0.2351,0.3236 0,0.2Z"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/square.vg.json
+++ b/examples/vg-specs/square.vg.json
@@ -43,33 +43,49 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "symbol",
-            "role": "square",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
-                    },
-                    "shape": {
-                        "value": "square"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "symbol",
+                    "role": "square",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "shape": {
+                                "value": "square"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/stacked_area.vg.json
+++ b/examples/vg-specs/stacked_area.vg.json
@@ -101,61 +101,77 @@
     ],
     "marks": [
         {
-            "name": "pathgroup",
+            "name": "nested-main-group",
             "type": "group",
-            "from": {
-                "facet": {
-                    "name": "faceted-path-main",
-                    "data": "source_0",
-                    "groupby": [
-                        "series"
-                    ]
-                }
-            },
             "encode": {
                 "update": {
                     "width": {
-                        "field": {
-                            "group": "width"
-                        }
+                        "signal": "width"
                     },
                     "height": {
-                        "field": {
-                            "group": "height"
-                        }
+                        "signal": "height"
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "marks",
-                    "type": "area",
+                    "name": "pathgroup",
+                    "type": "group",
                     "from": {
-                        "data": "faceted-path-main"
+                        "facet": {
+                            "name": "faceted-path-main",
+                            "data": "source_0",
+                            "groupby": [
+                                "series"
+                            ]
+                        }
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "yearmonth_date"
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "sum_count_end"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "sum_count_start"
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "series"
-                            },
-                            "orient": {
-                                "value": "vertical"
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "marks",
+                            "type": "area",
+                            "from": {
+                                "data": "faceted-path-main"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "yearmonth_date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "sum_count_end"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "sum_count_start"
+                                    },
+                                    "fill": {
+                                        "scale": "color",
+                                        "field": "series"
+                                    },
+                                    "orient": {
+                                        "value": "vertical"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/stacked_area_binned.vg.json
+++ b/examples/vg-specs/stacked_area_binned.vg.json
@@ -116,60 +116,76 @@
     ],
     "marks": [
         {
-            "name": "pathgroup",
+            "name": "nested-main-group",
             "type": "group",
-            "from": {
-                "facet": {
-                    "name": "faceted-path-main",
-                    "data": "source_0",
-                    "groupby": [
-                        "Cylinders"
-                    ]
-                }
-            },
             "encode": {
                 "update": {
                     "width": {
-                        "field": {
-                            "group": "width"
-                        }
+                        "signal": "width"
                     },
                     "height": {
-                        "field": {
-                            "group": "height"
-                        }
+                        "signal": "height"
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "marks",
-                    "type": "area",
+                    "name": "pathgroup",
+                    "type": "group",
                     "from": {
-                        "data": "faceted-path-main"
+                        "facet": {
+                            "name": "faceted-path-main",
+                            "data": "source_0",
+                            "groupby": [
+                                "Cylinders"
+                            ]
+                        }
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "signal": "(scale(\"x\", datum[\"bin_maxbins_10_Acceleration_start\"]) + scale(\"x\", datum[\"bin_maxbins_10_Acceleration_end\"]))/2"
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "sum_Horsepower_end"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "sum_Horsepower_start"
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "Cylinders"
-                            },
-                            "orient": {
-                                "value": "vertical"
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "marks",
+                            "type": "area",
+                            "from": {
+                                "data": "faceted-path-main"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "signal": "(scale(\"x\", datum[\"bin_maxbins_10_Acceleration_start\"]) + scale(\"x\", datum[\"bin_maxbins_10_Acceleration_end\"]))/2"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "sum_Horsepower_end"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "sum_Horsepower_start"
+                                    },
+                                    "fill": {
+                                        "scale": "color",
+                                        "field": "Cylinders"
+                                    },
+                                    "orient": {
+                                        "value": "vertical"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/stacked_area_normalize.vg.json
+++ b/examples/vg-specs/stacked_area_normalize.vg.json
@@ -100,61 +100,77 @@
     ],
     "marks": [
         {
-            "name": "pathgroup",
+            "name": "nested-main-group",
             "type": "group",
-            "from": {
-                "facet": {
-                    "name": "faceted-path-main",
-                    "data": "source_0",
-                    "groupby": [
-                        "series"
-                    ]
-                }
-            },
             "encode": {
                 "update": {
                     "width": {
-                        "field": {
-                            "group": "width"
-                        }
+                        "signal": "width"
                     },
                     "height": {
-                        "field": {
-                            "group": "height"
-                        }
+                        "signal": "height"
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "marks",
-                    "type": "area",
+                    "name": "pathgroup",
+                    "type": "group",
                     "from": {
-                        "data": "faceted-path-main"
+                        "facet": {
+                            "name": "faceted-path-main",
+                            "data": "source_0",
+                            "groupby": [
+                                "series"
+                            ]
+                        }
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "yearmonth_date"
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "sum_count_end"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "sum_count_start"
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "series"
-                            },
-                            "orient": {
-                                "value": "vertical"
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "marks",
+                            "type": "area",
+                            "from": {
+                                "data": "faceted-path-main"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "yearmonth_date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "sum_count_end"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "sum_count_start"
+                                    },
+                                    "fill": {
+                                        "scale": "color",
+                                        "field": "series"
+                                    },
+                                    "orient": {
+                                        "value": "vertical"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/stacked_area_ordinal.vg.json
+++ b/examples/vg-specs/stacked_area_ordinal.vg.json
@@ -100,61 +100,77 @@
     ],
     "marks": [
         {
-            "name": "pathgroup",
+            "name": "nested-main-group",
             "type": "group",
-            "from": {
-                "facet": {
-                    "name": "faceted-path-main",
-                    "data": "source_0",
-                    "groupby": [
-                        "Cylinders"
-                    ]
-                }
-            },
             "encode": {
                 "update": {
                     "width": {
-                        "field": {
-                            "group": "width"
-                        }
+                        "signal": "width"
                     },
                     "height": {
-                        "field": {
-                            "group": "height"
-                        }
+                        "signal": "height"
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "marks",
-                    "type": "area",
+                    "name": "pathgroup",
+                    "type": "group",
                     "from": {
-                        "data": "faceted-path-main"
+                        "facet": {
+                            "name": "faceted-path-main",
+                            "data": "source_0",
+                            "groupby": [
+                                "Cylinders"
+                            ]
+                        }
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "year_Year"
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "sum_Weight_in_lbs_end"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "sum_Weight_in_lbs_start"
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "Cylinders"
-                            },
-                            "orient": {
-                                "value": "vertical"
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "marks",
+                            "type": "area",
+                            "from": {
+                                "data": "faceted-path-main"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "year_Year"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "sum_Weight_in_lbs_end"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "sum_Weight_in_lbs_start"
+                                    },
+                                    "fill": {
+                                        "scale": "color",
+                                        "field": "Cylinders"
+                                    },
+                                    "orient": {
+                                        "value": "vertical"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/stacked_area_stream.vg.json
+++ b/examples/vg-specs/stacked_area_stream.vg.json
@@ -100,61 +100,77 @@
     ],
     "marks": [
         {
-            "name": "pathgroup",
+            "name": "nested-main-group",
             "type": "group",
-            "from": {
-                "facet": {
-                    "name": "faceted-path-main",
-                    "data": "source_0",
-                    "groupby": [
-                        "series"
-                    ]
-                }
-            },
             "encode": {
                 "update": {
                     "width": {
-                        "field": {
-                            "group": "width"
-                        }
+                        "signal": "width"
                     },
                     "height": {
-                        "field": {
-                            "group": "height"
-                        }
+                        "signal": "height"
                     }
                 }
             },
             "marks": [
                 {
-                    "name": "marks",
-                    "type": "area",
+                    "name": "pathgroup",
+                    "type": "group",
                     "from": {
-                        "data": "faceted-path-main"
+                        "facet": {
+                            "name": "faceted-path-main",
+                            "data": "source_0",
+                            "groupby": [
+                                "series"
+                            ]
+                        }
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "yearmonth_date"
+                            "width": {
+                                "field": {
+                                    "group": "width"
+                                }
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "sum_count_end"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "sum_count_start"
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "series"
-                            },
-                            "orient": {
-                                "value": "vertical"
+                            "height": {
+                                "field": {
+                                    "group": "height"
+                                }
                             }
                         }
-                    }
+                    },
+                    "marks": [
+                        {
+                            "name": "marks",
+                            "type": "area",
+                            "from": {
+                                "data": "faceted-path-main"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "yearmonth_date"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "sum_count_end"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "sum_count_start"
+                                    },
+                                    "fill": {
+                                        "scale": "color",
+                                        "field": "series"
+                                    },
+                                    "orient": {
+                                        "value": "vertical"
+                                    }
+                                }
+                            }
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/stacked_bar_1d.vg.json
+++ b/examples/vg-specs/stacked_bar_1d.vg.json
@@ -72,34 +72,50 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "sum_Acceleration_end"
-                    },
-                    "x2": {
-                        "scale": "x",
-                        "field": "sum_Acceleration_start"
-                    },
-                    "yc": {
-                        "value": 10.5
+                    "width": {
+                        "signal": "width"
                     },
                     "height": {
-                        "value": 20
-                    },
-                    "fill": {
-                        "scale": "color",
-                        "field": "Origin"
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "sum_Acceleration_end"
+                            },
+                            "x2": {
+                                "scale": "x",
+                                "field": "sum_Acceleration_start"
+                            },
+                            "yc": {
+                                "value": 10.5
+                            },
+                            "height": {
+                                "value": 20
+                            },
+                            "fill": {
+                                "scale": "color",
+                                "field": "Origin"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/stacked_bar_count.vg.json
+++ b/examples/vg-specs/stacked_bar_count.vg.json
@@ -80,35 +80,51 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "month_date"
-                    },
                     "width": {
-                        "value": 20
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "count_*_end"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "field": "count_*_start"
-                    },
-                    "fill": {
-                        "scale": "color",
-                        "field": "weather"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "month_date"
+                            },
+                            "width": {
+                                "value": 20
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "count_*_end"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "field": "count_*_start"
+                            },
+                            "fill": {
+                                "scale": "color",
+                                "field": "weather"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/stacked_bar_h.vg.json
+++ b/examples/vg-specs/stacked_bar_h.vg.json
@@ -75,35 +75,51 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "sum_yield_end"
-                    },
-                    "x2": {
-                        "scale": "x",
-                        "field": "sum_yield_start"
-                    },
-                    "yc": {
-                        "scale": "y",
-                        "field": "variety"
+                    "width": {
+                        "signal": "width"
                     },
                     "height": {
-                        "value": 20
-                    },
-                    "fill": {
-                        "scale": "color",
-                        "field": "site"
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "sum_yield_end"
+                            },
+                            "x2": {
+                                "scale": "x",
+                                "field": "sum_yield_start"
+                            },
+                            "yc": {
+                                "scale": "y",
+                                "field": "variety"
+                            },
+                            "height": {
+                                "value": 20
+                            },
+                            "fill": {
+                                "scale": "color",
+                                "field": "site"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/stacked_bar_h_order.vg.json
+++ b/examples/vg-specs/stacked_bar_h_order.vg.json
@@ -75,35 +75,51 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "sum_yield_end"
-                    },
-                    "x2": {
-                        "scale": "x",
-                        "field": "sum_yield_start"
-                    },
-                    "yc": {
-                        "scale": "y",
-                        "field": "variety"
+                    "width": {
+                        "signal": "width"
                     },
                     "height": {
-                        "value": 20
-                    },
-                    "fill": {
-                        "scale": "color",
-                        "field": "site"
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "sum_yield_end"
+                            },
+                            "x2": {
+                                "scale": "x",
+                                "field": "sum_yield_start"
+                            },
+                            "yc": {
+                                "scale": "y",
+                                "field": "variety"
+                            },
+                            "height": {
+                                "value": 20
+                            },
+                            "fill": {
+                                "scale": "color",
+                                "field": "site"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/stacked_bar_normalize.vg.json
+++ b/examples/vg-specs/stacked_bar_normalize.vg.json
@@ -84,35 +84,51 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "age"
-                    },
                     "width": {
-                        "value": 16
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "sum_people_end"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "field": "sum_people_start"
-                    },
-                    "fill": {
-                        "scale": "color",
-                        "field": "gender"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "age"
+                            },
+                            "width": {
+                                "value": 16
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "sum_people_end"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "field": "sum_people_start"
+                            },
+                            "fill": {
+                                "scale": "color",
+                                "field": "gender"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/stacked_bar_population.vg.json
+++ b/examples/vg-specs/stacked_bar_population.vg.json
@@ -85,35 +85,51 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "age"
-                    },
                     "width": {
-                        "value": 16
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "sum_people_end"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "field": "sum_people_start"
-                    },
-                    "fill": {
-                        "scale": "color",
-                        "field": "gender"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "age"
+                            },
+                            "width": {
+                                "value": 16
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "sum_people_end"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "field": "sum_people_start"
+                            },
+                            "fill": {
+                                "scale": "color",
+                                "field": "gender"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/stacked_bar_size.vg.json
+++ b/examples/vg-specs/stacked_bar_size.vg.json
@@ -80,35 +80,51 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "month_date"
-                    },
                     "width": {
-                        "scale": "size",
-                        "field": "weather"
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "count_*_end"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "field": "count_*_start"
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "month_date"
+                            },
+                            "width": {
+                                "scale": "size",
+                                "field": "weather"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "count_*_end"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "field": "count_*_start"
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/stacked_bar_sum_opacity.vg.json
+++ b/examples/vg-specs/stacked_bar_sum_opacity.vg.json
@@ -85,38 +85,54 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "age"
-                    },
                     "width": {
-                        "value": 16
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "sum_people_end"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "field": "sum_people_start"
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
-                    },
-                    "opacity": {
-                        "scale": "opacity",
-                        "field": "people"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "age"
+                            },
+                            "width": {
+                                "value": 16
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "sum_people_end"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "field": "sum_people_start"
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "opacity": {
+                                "scale": "opacity",
+                                "field": "people"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/stacked_bar_v.vg.json
+++ b/examples/vg-specs/stacked_bar_v.vg.json
@@ -75,35 +75,51 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "variety"
-                    },
                     "width": {
-                        "value": 20
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "sum_yield_end"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "field": "sum_yield_start"
-                    },
-                    "fill": {
-                        "scale": "color",
-                        "field": "site"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "variety"
+                            },
+                            "width": {
+                                "value": 20
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "sum_yield_end"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "field": "sum_yield_start"
+                            },
+                            "fill": {
+                                "scale": "color",
+                                "field": "site"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/stacked_bar_weather.vg.json
+++ b/examples/vg-specs/stacked_bar_weather.vg.json
@@ -80,35 +80,51 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "bar",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "month_date"
-                    },
                     "width": {
-                        "value": 20
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "count_*_end"
-                    },
-                    "y2": {
-                        "scale": "y",
-                        "field": "count_*_start"
-                    },
-                    "fill": {
-                        "scale": "color",
-                        "field": "weather"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "month_date"
+                            },
+                            "width": {
+                                "value": 20
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "count_*_end"
+                            },
+                            "y2": {
+                                "scale": "y",
+                                "field": "count_*_start"
+                            },
+                            "fill": {
+                                "scale": "color",
+                                "field": "weather"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/text_scatter_colored.vg.json
+++ b/examples/vg-specs/text_scatter_colored.vg.json
@@ -48,33 +48,49 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "text",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "x": {
-                        "scale": "x",
-                        "field": "Horsepower"
+                    "width": {
+                        "signal": "width"
                     },
-                    "y": {
-                        "scale": "y",
-                        "field": "Miles_per_Gallon"
-                    },
-                    "text": {
-                        "field": "OriginInitial"
-                    },
-                    "fill": {
-                        "scale": "color",
-                        "field": "Origin"
-                    },
-                    "align": {
-                        "value": "center"
+                    "height": {
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "text",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "y": {
+                                "scale": "y",
+                                "field": "Miles_per_Gallon"
+                            },
+                            "text": {
+                                "field": "OriginInitial"
+                            },
+                            "fill": {
+                                "scale": "color",
+                                "field": "Origin"
+                            },
+                            "align": {
+                                "value": "center"
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/tick_dot.vg.json
+++ b/examples/vg-specs/tick_dot.vg.json
@@ -42,35 +42,51 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "tick",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "precipitation"
-                    },
-                    "yc": {
-                        "value": 10.5
+                    "width": {
+                        "signal": "width"
                     },
                     "height": {
-                        "value": 14
-                    },
-                    "width": {
-                        "value": 1
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "tick",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "precipitation"
+                            },
+                            "yc": {
+                                "value": 10.5
+                            },
+                            "height": {
+                                "value": 14
+                            },
+                            "width": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/tick_dot_thickness.vg.json
+++ b/examples/vg-specs/tick_dot_thickness.vg.json
@@ -42,35 +42,51 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "tick",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "Horsepower"
-                    },
-                    "yc": {
-                        "value": 10.5
+                    "width": {
+                        "signal": "width"
                     },
                     "height": {
-                        "value": 10
-                    },
-                    "width": {
-                        "value": 2
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "tick",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "yc": {
+                                "value": 10.5
+                            },
+                            "height": {
+                                "value": 10
+                            },
+                            "width": {
+                                "value": 2
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/tick_sort.vg.json
+++ b/examples/vg-specs/tick_sort.vg.json
@@ -42,35 +42,51 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "tick",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "Horsepower"
-                    },
-                    "yc": {
-                        "value": 10.5
+                    "width": {
+                        "signal": "width"
                     },
                     "height": {
-                        "value": 14
-                    },
-                    "width": {
-                        "value": 1
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "tick",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "yc": {
+                                "value": 10.5
+                            },
+                            "height": {
+                                "value": 14
+                            },
+                            "width": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/tick_strip.vg.json
+++ b/examples/vg-specs/tick_strip.vg.json
@@ -43,36 +43,52 @@
     ],
     "marks": [
         {
-            "name": "marks",
-            "type": "rect",
-            "role": "tick",
-            "from": {
-                "data": "source_0"
-            },
+            "name": "nested-main-group",
+            "type": "group",
             "encode": {
                 "update": {
-                    "xc": {
-                        "scale": "x",
-                        "field": "Horsepower"
-                    },
-                    "yc": {
-                        "scale": "y",
-                        "field": "Cylinders"
+                    "width": {
+                        "signal": "width"
                     },
                     "height": {
-                        "value": 14
-                    },
-                    "width": {
-                        "value": 1
-                    },
-                    "fill": {
-                        "value": "#4c78a8"
-                    },
-                    "opacity": {
-                        "value": 0.7
+                        "signal": "height"
                     }
                 }
-            }
+            },
+            "marks": [
+                {
+                    "name": "marks",
+                    "type": "rect",
+                    "role": "tick",
+                    "from": {
+                        "data": "source_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "xc": {
+                                "scale": "x",
+                                "field": "Horsepower"
+                            },
+                            "yc": {
+                                "scale": "y",
+                                "field": "Cylinders"
+                            },
+                            "height": {
+                                "value": 14
+                            },
+                            "width": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "#4c78a8"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/trellis_anscombe.vg.json
+++ b/examples/vg-specs/trellis_anscombe.vg.json
@@ -69,211 +69,217 @@
             ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": {
-            "signal": "data('column_layout')[0].distinct_Series"
-        },
-        "bounds": "full"
-    },
     "marks": [
         {
-            "name": "column-title",
-            "role": "column-title",
+            "name": "nested-main-group",
             "type": "group",
-            "marks": [
-                {
-                    "type": "text",
-                    "role": "column-title-text",
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "signal": "0.5 * width"
-                            },
-                            "align": {
-                                "value": "center"
-                            },
-                            "text": {
-                                "value": "Series"
-                            },
-                            "fill": {
-                                "value": "black"
-                            },
-                            "fontWeight": {
-                                "value": "bold"
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "row-header",
-            "type": "group",
-            "role": "row-header",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_height"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Y",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "column-header",
-            "type": "group",
-            "role": "column-header",
-            "from": {
-                "data": "column"
-            },
-            "title": {
-                "text": {
-                    "signal": "parent['Series']"
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
                 },
                 "offset": 10,
-                "orient": "top",
-                "encode": {
-                    "update": {
-                        "fontWeight": {
-                            "value": "normal"
-                        },
-                        "angle": {
-                            "value": 0
-                        },
-                        "fontSize": {
-                            "value": 10
-                        }
-                    }
-                }
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            }
-        },
-        {
-            "name": "column-footer",
-            "type": "group",
-            "role": "column-footer",
-            "from": {
-                "data": "column"
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "X",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "cell",
-            "type": "group",
-            "from": {
-                "facet": {
-                    "name": "facet",
-                    "data": "source_0",
-                    "groupby": [
-                        "Series"
-                    ]
-                }
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    },
-                    "height": {
-                        "signal": "child_height"
-                    },
-                    "stroke": {
-                        "value": "#ccc"
-                    },
-                    "strokeWidth": {
-                        "value": 1
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
+                "columns": {
+                    "signal": "data('column_layout')[0].distinct_Series"
+                },
+                "bounds": "full"
             },
             "marks": [
                 {
-                    "name": "child_marks",
-                    "type": "symbol",
-                    "role": "circle",
+                    "name": "column-title",
+                    "role": "column-title",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "column-title-text",
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "signal": "0.5 * width"
+                                    },
+                                    "align": {
+                                        "value": "center"
+                                    },
+                                    "text": {
+                                        "value": "Series"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "row-header",
+                    "type": "group",
+                    "role": "row-header",
+                    "encode": {
+                        "update": {
+                            "height": {
+                                "signal": "child_height"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Y",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "column-header",
+                    "type": "group",
+                    "role": "column-header",
                     "from": {
-                        "data": "facet"
+                        "data": "column"
+                    },
+                    "title": {
+                        "text": {
+                            "signal": "parent['Series']"
+                        },
+                        "offset": 10,
+                        "orient": "top",
+                        "encode": {
+                            "update": {
+                                "fontWeight": {
+                                    "value": "normal"
+                                },
+                                "angle": {
+                                    "value": 0
+                                },
+                                "fontSize": {
+                                    "value": 10
+                                }
+                            }
+                        }
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "X"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "Y"
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
-                            },
-                            "shape": {
-                                "value": "circle"
+                            "width": {
+                                "signal": "child_width"
                             }
                         }
                     }
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
                 },
                 {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
+                    "name": "column-footer",
+                    "type": "group",
+                    "role": "column-footer",
+                    "from": {
+                        "data": "column"
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "X",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "Series"
+                            ]
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "symbol",
+                            "role": "circle",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "X"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "Y"
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "shape": {
+                                        "value": "circle"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "y"
+                        },
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/trellis_bar.vg.json
+++ b/examples/vg-specs/trellis_bar.vg.json
@@ -96,122 +96,76 @@
             ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": 1,
-        "bounds": "full"
-    },
     "marks": [
         {
-            "name": "row-title",
-            "role": "row-title",
+            "name": "nested-main-group",
             "type": "group",
-            "marks": [
-                {
-                    "type": "text",
-                    "role": "row-title-text",
-                    "encode": {
-                        "update": {
-                            "y": {
-                                "signal": "0.5 * height"
-                            },
-                            "align": {
-                                "value": "right"
-                            },
-                            "text": {
-                                "value": "gender"
-                            },
-                            "fill": {
-                                "value": "black"
-                            },
-                            "fontWeight": {
-                                "value": "bold"
-                            },
-                            "angle": {
-                                "value": 270
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "row-header",
-            "type": "group",
-            "role": "row-header",
-            "from": {
-                "data": "row"
-            },
-            "title": {
-                "text": {
-                    "signal": "parent['gender']"
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
                 },
                 "offset": 10,
-                "orient": "left",
-                "encode": {
-                    "update": {
-                        "fontWeight": {
-                            "value": "normal"
-                        },
-                        "angle": {
-                            "value": 0
-                        },
-                        "fontSize": {
-                            "value": 10
-                        },
-                        "align": {
-                            "value": "right"
-                        },
-                        "baseline": {
-                            "value": "middle"
+                "columns": 1,
+                "bounds": "full"
+            },
+            "marks": [
+                {
+                    "name": "row-title",
+                    "role": "row-title",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "row-title-text",
+                            "encode": {
+                                "update": {
+                                    "y": {
+                                        "signal": "0.5 * height"
+                                    },
+                                    "align": {
+                                        "value": "right"
+                                    },
+                                    "text": {
+                                        "value": "gender"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    },
+                                    "angle": {
+                                        "value": 270
+                                    }
+                                }
+                            }
                         }
-                    }
-                }
-            },
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_height"
-                    }
-                }
-            },
-            "axes": [
+                    ]
+                },
                 {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "population",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "column-footer",
-            "type": "group",
-            "role": "column-footer",
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "x",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "age",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
+                    "name": "row-header",
+                    "type": "group",
+                    "role": "row-header",
+                    "from": {
+                        "data": "row"
+                    },
+                    "title": {
+                        "text": {
+                            "signal": "parent['gender']"
+                        },
+                        "offset": 10,
+                        "orient": "left",
+                        "encode": {
                             "update": {
+                                "fontWeight": {
+                                    "value": "normal"
+                                },
                                 "angle": {
-                                    "value": 270
+                                    "value": 0
+                                },
+                                "fontSize": {
+                                    "value": 10
                                 },
                                 "align": {
                                     "value": "right"
@@ -221,85 +175,137 @@
                                 }
                             }
                         }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "cell",
-            "type": "group",
-            "from": {
-                "facet": {
-                    "name": "facet",
-                    "data": "source_0",
-                    "groupby": [
-                        "gender"
-                    ]
-                }
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    },
-                    "height": {
-                        "signal": "child_height"
-                    },
-                    "stroke": {
-                        "value": "#ccc"
-                    },
-                    "strokeWidth": {
-                        "value": 1
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "facet"
                     },
                     "encode": {
                         "update": {
-                            "xc": {
-                                "scale": "x",
-                                "field": "age"
-                            },
-                            "width": {
-                                "value": 16
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "sum_people_end"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "field": "sum_people_start"
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "gender"
+                            "height": {
+                                "signal": "child_height"
                             }
                         }
-                    }
-                }
-            ],
-            "axes": [
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "population",
+                            "zindex": 1
+                        }
+                    ]
+                },
                 {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
+                    "name": "column-footer",
+                    "type": "group",
+                    "role": "column-footer",
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "age",
+                            "zindex": 1,
+                            "encode": {
+                                "labels": {
+                                    "update": {
+                                        "angle": {
+                                            "value": 270
+                                        },
+                                        "align": {
+                                            "value": "right"
+                                        },
+                                        "baseline": {
+                                            "value": "middle"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "gender"
+                            ]
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "xc": {
+                                        "scale": "x",
+                                        "field": "age"
+                                    },
+                                    "width": {
+                                        "value": 16
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "sum_people_end"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "field": "sum_people_start"
+                                    },
+                                    "fill": {
+                                        "scale": "color",
+                                        "field": "gender"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/trellis_bar_histogram.vg.json
+++ b/examples/vg-specs/trellis_bar_histogram.vg.json
@@ -84,122 +84,76 @@
             ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": 1,
-        "bounds": "full"
-    },
     "marks": [
         {
-            "name": "row-title",
-            "role": "row-title",
+            "name": "nested-main-group",
             "type": "group",
-            "marks": [
-                {
-                    "type": "text",
-                    "role": "row-title-text",
-                    "encode": {
-                        "update": {
-                            "y": {
-                                "signal": "0.5 * height"
-                            },
-                            "align": {
-                                "value": "right"
-                            },
-                            "text": {
-                                "value": "Origin"
-                            },
-                            "fill": {
-                                "value": "black"
-                            },
-                            "fontWeight": {
-                                "value": "bold"
-                            },
-                            "angle": {
-                                "value": 270
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "row-header",
-            "type": "group",
-            "role": "row-header",
-            "from": {
-                "data": "row"
-            },
-            "title": {
-                "text": {
-                    "signal": "parent['Origin']"
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
                 },
                 "offset": 10,
-                "orient": "left",
-                "encode": {
-                    "update": {
-                        "fontWeight": {
-                            "value": "normal"
-                        },
-                        "angle": {
-                            "value": 0
-                        },
-                        "fontSize": {
-                            "value": 10
-                        },
-                        "align": {
-                            "value": "right"
-                        },
-                        "baseline": {
-                            "value": "middle"
+                "columns": 1,
+                "bounds": "full"
+            },
+            "marks": [
+                {
+                    "name": "row-title",
+                    "role": "row-title",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "row-title-text",
+                            "encode": {
+                                "update": {
+                                    "y": {
+                                        "signal": "0.5 * height"
+                                    },
+                                    "align": {
+                                        "value": "right"
+                                    },
+                                    "text": {
+                                        "value": "Origin"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    },
+                                    "angle": {
+                                        "value": 270
+                                    }
+                                }
+                            }
                         }
-                    }
-                }
-            },
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_height"
-                    }
-                }
-            },
-            "axes": [
+                    ]
+                },
                 {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Number of Records",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "column-footer",
-            "type": "group",
-            "role": "column-footer",
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "title": "BIN(Horsepower)",
-                    "zindex": 1,
-                    "encode": {
-                        "labels": {
+                    "name": "row-header",
+                    "type": "group",
+                    "role": "row-header",
+                    "from": {
+                        "data": "row"
+                    },
+                    "title": {
+                        "text": {
+                            "signal": "parent['Origin']"
+                        },
+                        "offset": 10,
+                        "orient": "left",
+                        "encode": {
                             "update": {
+                                "fontWeight": {
+                                    "value": "normal"
+                                },
                                 "angle": {
-                                    "value": 270
+                                    "value": 0
+                                },
+                                "fontSize": {
+                                    "value": 10
                                 },
                                 "align": {
                                     "value": "right"
@@ -209,86 +163,138 @@
                                 }
                             }
                         }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "cell",
-            "type": "group",
-            "from": {
-                "facet": {
-                    "name": "facet",
-                    "data": "source_0",
-                    "groupby": [
-                        "Origin"
-                    ]
-                }
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    },
-                    "height": {
-                        "signal": "child_height"
-                    },
-                    "stroke": {
-                        "value": "#ccc"
-                    },
-                    "strokeWidth": {
-                        "value": 1
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_marks",
-                    "type": "rect",
-                    "role": "bar",
-                    "from": {
-                        "data": "facet"
                     },
                     "encode": {
                         "update": {
-                            "x2": {
-                                "scale": "x",
-                                "field": "bin_maxbins_15_Horsepower_start",
-                                "offset": 1
-                            },
-                            "x": {
-                                "scale": "x",
-                                "field": "bin_maxbins_15_Horsepower_end"
-                            },
-                            "y": {
-                                "scale": "y",
-                                "field": "count_*"
-                            },
-                            "y2": {
-                                "scale": "y",
-                                "value": 0
-                            },
-                            "fill": {
-                                "value": "#4c78a8"
+                            "height": {
+                                "signal": "child_height"
                             }
                         }
-                    }
-                }
-            ],
-            "axes": [
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Number of Records",
+                            "zindex": 1
+                        }
+                    ]
+                },
                 {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
+                    "name": "column-footer",
+                    "type": "group",
+                    "role": "column-footer",
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "title": "BIN(Horsepower)",
+                            "zindex": 1,
+                            "encode": {
+                                "labels": {
+                                    "update": {
+                                        "angle": {
+                                            "value": 270
+                                        },
+                                        "align": {
+                                            "value": "right"
+                                        },
+                                        "baseline": {
+                                            "value": "middle"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "Origin"
+                            ]
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "bin_maxbins_15_Horsepower_start",
+                                        "offset": 1
+                                    },
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "bin_maxbins_15_Horsepower_end"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "count_*"
+                                    },
+                                    "y2": {
+                                        "scale": "y",
+                                        "value": 0
+                                    },
+                                    "fill": {
+                                        "value": "#4c78a8"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/trellis_barley.vg.json
+++ b/examples/vg-specs/trellis_barley.vg.json
@@ -73,213 +73,219 @@
             ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": 1,
-        "bounds": "full"
-    },
     "marks": [
         {
-            "name": "row-title",
-            "role": "row-title",
+            "name": "nested-main-group",
             "type": "group",
-            "marks": [
-                {
-                    "type": "text",
-                    "role": "row-title-text",
-                    "encode": {
-                        "update": {
-                            "y": {
-                                "signal": "0.5 * height"
-                            },
-                            "align": {
-                                "value": "right"
-                            },
-                            "text": {
-                                "value": "site"
-                            },
-                            "fill": {
-                                "value": "black"
-                            },
-                            "fontWeight": {
-                                "value": "bold"
-                            },
-                            "angle": {
-                                "value": 270
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "row-header",
-            "type": "group",
-            "role": "row-header",
-            "from": {
-                "data": "row"
-            },
-            "title": {
-                "text": {
-                    "signal": "parent['site']"
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
                 },
                 "offset": 10,
-                "orient": "left",
-                "encode": {
-                    "update": {
-                        "fontWeight": {
-                            "value": "normal"
-                        },
-                        "angle": {
-                            "value": 0
-                        },
-                        "fontSize": {
-                            "value": 10
-                        },
-                        "align": {
-                            "value": "right"
-                        },
-                        "baseline": {
-                            "value": "middle"
-                        }
-                    }
-                }
-            },
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_height"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "y",
-                    "orient": "left",
-                    "title": "variety",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "column-footer",
-            "type": "group",
-            "role": "column-footer",
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "MEDIAN(yield)",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "data": [
-                {
-                    "source": "facet",
-                    "name": "data_0",
-                    "transform": [
-                        {
-                            "type": "aggregate",
-                            "groupby": [
-                                "variety",
-                                "year"
-                            ],
-                            "ops": [
-                                "median"
-                            ],
-                            "fields": [
-                                "yield"
-                            ]
-                        }
-                    ]
-                }
-            ],
-            "name": "cell",
-            "type": "group",
-            "from": {
-                "facet": {
-                    "name": "facet",
-                    "data": "source_0",
-                    "groupby": [
-                        "site"
-                    ]
-                }
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    },
-                    "height": {
-                        "signal": "child_height"
-                    },
-                    "stroke": {
-                        "value": "#ccc"
-                    },
-                    "strokeWidth": {
-                        "value": 1
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
+                "columns": 1,
+                "bounds": "full"
             },
             "marks": [
                 {
-                    "name": "child_marks",
-                    "type": "symbol",
-                    "role": "point",
+                    "name": "row-title",
+                    "role": "row-title",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "row-title-text",
+                            "encode": {
+                                "update": {
+                                    "y": {
+                                        "signal": "0.5 * height"
+                                    },
+                                    "align": {
+                                        "value": "right"
+                                    },
+                                    "text": {
+                                        "value": "site"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    },
+                                    "angle": {
+                                        "value": 270
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "row-header",
+                    "type": "group",
+                    "role": "row-header",
                     "from": {
-                        "data": "data_0"
+                        "data": "row"
+                    },
+                    "title": {
+                        "text": {
+                            "signal": "parent['site']"
+                        },
+                        "offset": 10,
+                        "orient": "left",
+                        "encode": {
+                            "update": {
+                                "fontWeight": {
+                                    "value": "normal"
+                                },
+                                "angle": {
+                                    "value": 0
+                                },
+                                "fontSize": {
+                                    "value": 10
+                                },
+                                "align": {
+                                    "value": "right"
+                                },
+                                "baseline": {
+                                    "value": "middle"
+                                }
+                            }
+                        }
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "median_yield"
+                            "height": {
+                                "signal": "child_height"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "orient": "left",
+                            "title": "variety",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "column-footer",
+                    "type": "group",
+                    "role": "column-footer",
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "MEDIAN(yield)",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "data": [
+                        {
+                            "source": "facet",
+                            "name": "data_0",
+                            "transform": [
+                                {
+                                    "type": "aggregate",
+                                    "groupby": [
+                                        "variety",
+                                        "year"
+                                    ],
+                                    "ops": [
+                                        "median"
+                                    ],
+                                    "fields": [
+                                        "yield"
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "site"
+                            ]
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "variety"
+                            "height": {
+                                "signal": "child_height"
                             },
                             "stroke": {
-                                "scale": "color",
-                                "field": "year"
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
                             },
                             "fill": {
                                 "value": "transparent"
                             }
                         }
-                    }
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "data_0"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "median_yield"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "variety"
+                                    },
+                                    "stroke": {
+                                        "scale": "color",
+                                        "field": "year"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "y"
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/trellis_row_column.vg.json
+++ b/examples/vg-specs/trellis_row_column.vg.json
@@ -80,277 +80,283 @@
             ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": {
-            "signal": "data('column_layout')[0].distinct_Origin"
-        },
-        "bounds": "full"
-    },
     "marks": [
         {
-            "name": "row-title",
-            "role": "row-title",
+            "name": "nested-main-group",
             "type": "group",
-            "marks": [
-                {
-                    "type": "text",
-                    "role": "row-title-text",
-                    "encode": {
-                        "update": {
-                            "y": {
-                                "signal": "0.5 * height"
-                            },
-                            "align": {
-                                "value": "right"
-                            },
-                            "text": {
-                                "value": "Cylinders"
-                            },
-                            "fill": {
-                                "value": "black"
-                            },
-                            "fontWeight": {
-                                "value": "bold"
-                            },
-                            "angle": {
-                                "value": 270
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "column-title",
-            "role": "column-title",
-            "type": "group",
-            "marks": [
-                {
-                    "type": "text",
-                    "role": "column-title-text",
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "signal": "0.5 * width"
-                            },
-                            "align": {
-                                "value": "center"
-                            },
-                            "text": {
-                                "value": "Origin"
-                            },
-                            "fill": {
-                                "value": "black"
-                            },
-                            "fontWeight": {
-                                "value": "bold"
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "row-header",
-            "type": "group",
-            "role": "row-header",
-            "from": {
-                "data": "row"
-            },
-            "title": {
-                "text": {
-                    "signal": "parent['Cylinders']"
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
                 },
                 "offset": 10,
-                "orient": "left",
-                "encode": {
-                    "update": {
-                        "fontWeight": {
-                            "value": "normal"
-                        },
-                        "angle": {
-                            "value": 0
-                        },
-                        "fontSize": {
-                            "value": 10
-                        },
-                        "align": {
-                            "value": "right"
-                        },
-                        "baseline": {
-                            "value": "middle"
-                        }
-                    }
-                }
-            },
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_height"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "column-header",
-            "type": "group",
-            "role": "column-header",
-            "from": {
-                "data": "column"
-            },
-            "title": {
-                "text": {
-                    "signal": "parent['Origin']"
+                "columns": {
+                    "signal": "data('column_layout')[0].distinct_Origin"
                 },
-                "offset": 10,
-                "orient": "top",
-                "encode": {
-                    "update": {
-                        "fontWeight": {
-                            "value": "normal"
-                        },
-                        "angle": {
-                            "value": 0
-                        },
-                        "fontSize": {
-                            "value": 10
-                        }
-                    }
-                }
+                "bounds": "full"
             },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            }
-        },
-        {
-            "name": "column-footer",
-            "type": "group",
-            "role": "column-footer",
-            "from": {
-                "data": "column"
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            },
-            "axes": [
+            "marks": [
                 {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "cell",
-            "type": "group",
-            "from": {
-                "facet": {
-                    "name": "facet",
-                    "data": "source_0",
-                    "groupby": [
-                        "Cylinders",
-                        "Origin"
+                    "name": "row-title",
+                    "role": "row-title",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "row-title-text",
+                            "encode": {
+                                "update": {
+                                    "y": {
+                                        "signal": "0.5 * height"
+                                    },
+                                    "align": {
+                                        "value": "right"
+                                    },
+                                    "text": {
+                                        "value": "Cylinders"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    },
+                                    "angle": {
+                                        "value": 270
+                                    }
+                                }
+                            }
+                        }
                     ]
-                }
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    },
-                    "height": {
-                        "signal": "child_height"
-                    },
-                    "stroke": {
-                        "value": "#ccc"
-                    },
-                    "strokeWidth": {
-                        "value": 1
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
+                },
                 {
-                    "name": "child_marks",
-                    "type": "symbol",
-                    "role": "point",
+                    "name": "column-title",
+                    "role": "column-title",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "column-title-text",
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "signal": "0.5 * width"
+                                    },
+                                    "align": {
+                                        "value": "center"
+                                    },
+                                    "text": {
+                                        "value": "Origin"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "row-header",
+                    "type": "group",
+                    "role": "row-header",
                     "from": {
-                        "data": "facet"
+                        "data": "row"
+                    },
+                    "title": {
+                        "text": {
+                            "signal": "parent['Cylinders']"
+                        },
+                        "offset": 10,
+                        "orient": "left",
+                        "encode": {
+                            "update": {
+                                "fontWeight": {
+                                    "value": "normal"
+                                },
+                                "angle": {
+                                    "value": 0
+                                },
+                                "fontSize": {
+                                    "value": 10
+                                },
+                                "align": {
+                                    "value": "right"
+                                },
+                                "baseline": {
+                                    "value": "middle"
+                                }
+                            }
+                        }
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
+                            "height": {
+                                "signal": "child_height"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Miles_per_Gallon",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "column-header",
+                    "type": "group",
+                    "role": "column-header",
+                    "from": {
+                        "data": "column"
+                    },
+                    "title": {
+                        "text": {
+                            "signal": "parent['Origin']"
+                        },
+                        "offset": 10,
+                        "orient": "top",
+                        "encode": {
+                            "update": {
+                                "fontWeight": {
+                                    "value": "normal"
+                                },
+                                "angle": {
+                                    "value": 0
+                                },
+                                "fontSize": {
+                                    "value": 10
+                                }
+                            }
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "column-footer",
+                    "type": "group",
+                    "role": "column-footer",
+                    "from": {
+                        "data": "column"
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "Horsepower",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "Cylinders",
+                                "Origin"
+                            ]
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
+                            "height": {
+                                "signal": "child_height"
                             },
                             "stroke": {
-                                "value": "#4c78a8"
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
                             },
                             "fill": {
                                 "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
                             }
                         }
-                    }
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "Horsepower"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "Miles_per_Gallon"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "y"
+                        },
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/trellis_scatter.vg.json
+++ b/examples/vg-specs/trellis_scatter.vg.json
@@ -68,214 +68,220 @@
             ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": {
-            "signal": "data('column_layout')[0].distinct_MPAA_Rating"
-        },
-        "bounds": "full"
-    },
     "marks": [
         {
-            "name": "column-title",
-            "role": "column-title",
+            "name": "nested-main-group",
             "type": "group",
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
+                },
+                "offset": 10,
+                "columns": {
+                    "signal": "data('column_layout')[0].distinct_MPAA_Rating"
+                },
+                "bounds": "full"
+            },
             "marks": [
                 {
-                    "type": "text",
-                    "role": "column-title-text",
+                    "name": "column-title",
+                    "role": "column-title",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "column-title-text",
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "signal": "0.5 * width"
+                                    },
+                                    "align": {
+                                        "value": "center"
+                                    },
+                                    "text": {
+                                        "value": "MPAA_Rating"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "row-header",
+                    "type": "group",
+                    "role": "row-header",
                     "encode": {
                         "update": {
-                            "x": {
-                                "signal": "0.5 * width"
-                            },
-                            "align": {
-                                "value": "center"
-                            },
-                            "text": {
-                                "value": "MPAA_Rating"
-                            },
-                            "fill": {
-                                "value": "black"
-                            },
-                            "fontWeight": {
-                                "value": "bold"
+                            "height": {
+                                "signal": "child_height"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "US_DVD_Sales",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "column-header",
+                    "type": "group",
+                    "role": "column-header",
+                    "from": {
+                        "data": "column"
+                    },
+                    "title": {
+                        "text": {
+                            "signal": "parent['MPAA_Rating']"
+                        },
+                        "offset": 10,
+                        "orient": "top",
+                        "encode": {
+                            "update": {
+                                "fontWeight": {
+                                    "value": "normal"
+                                },
+                                "angle": {
+                                    "value": 0
+                                },
+                                "fontSize": {
+                                    "value": 10
+                                }
+                            }
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
                             }
                         }
                     }
-                }
-            ]
-        },
-        {
-            "name": "row-header",
-            "type": "group",
-            "role": "row-header",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_height"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "US_DVD_Sales",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "column-header",
-            "type": "group",
-            "role": "column-header",
-            "from": {
-                "data": "column"
-            },
-            "title": {
-                "text": {
-                    "signal": "parent['MPAA_Rating']"
                 },
-                "offset": 10,
-                "orient": "top",
-                "encode": {
-                    "update": {
-                        "fontWeight": {
-                            "value": "normal"
-                        },
-                        "angle": {
-                            "value": 0
-                        },
-                        "fontSize": {
-                            "value": 10
-                        }
-                    }
-                }
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            }
-        },
-        {
-            "name": "column-footer",
-            "type": "group",
-            "role": "column-footer",
-            "from": {
-                "data": "column"
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            },
-            "axes": [
                 {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Worldwide_Gross",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "cell",
-            "type": "group",
-            "from": {
-                "facet": {
-                    "name": "facet",
-                    "data": "source_0",
-                    "groupby": [
-                        "MPAA_Rating"
-                    ]
-                }
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    },
-                    "height": {
-                        "signal": "child_height"
-                    },
-                    "stroke": {
-                        "value": "#ccc"
-                    },
-                    "strokeWidth": {
-                        "value": 1
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
-            },
-            "marks": [
-                {
-                    "name": "child_marks",
-                    "type": "symbol",
-                    "role": "point",
+                    "name": "column-footer",
+                    "type": "group",
+                    "role": "column-footer",
                     "from": {
-                        "data": "facet"
+                        "data": "column"
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Worldwide_Gross"
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "Worldwide_Gross",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "MPAA_Rating"
+                            ]
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "US_DVD_Sales"
+                            "height": {
+                                "signal": "child_height"
                             },
                             "stroke": {
-                                "value": "#4c78a8"
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
                             },
                             "fill": {
                                 "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
                             }
                         }
-                    }
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "Worldwide_Gross"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "US_DVD_Sales"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "y"
+                        },
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/trellis_scatter_binned_row.vg.json
+++ b/examples/vg-specs/trellis_scatter_binned_row.vg.json
@@ -82,206 +82,212 @@
             ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": 1,
-        "bounds": "full"
-    },
     "marks": [
         {
-            "name": "row-title",
-            "role": "row-title",
+            "name": "nested-main-group",
             "type": "group",
-            "marks": [
-                {
-                    "type": "text",
-                    "role": "row-title-text",
-                    "encode": {
-                        "update": {
-                            "y": {
-                                "signal": "0.5 * height"
-                            },
-                            "align": {
-                                "value": "right"
-                            },
-                            "text": {
-                                "value": "BIN(Acceleration)"
-                            },
-                            "fill": {
-                                "value": "black"
-                            },
-                            "fontWeight": {
-                                "value": "bold"
-                            },
-                            "angle": {
-                                "value": 270
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "row-header",
-            "type": "group",
-            "role": "row-header",
-            "from": {
-                "data": "row"
-            },
-            "title": {
-                "text": {
-                    "signal": "parent['bin_maxbins_6_Acceleration_range']"
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
                 },
                 "offset": 10,
-                "orient": "left",
-                "encode": {
-                    "update": {
-                        "fontWeight": {
-                            "value": "normal"
-                        },
-                        "angle": {
-                            "value": 0
-                        },
-                        "fontSize": {
-                            "value": 10
-                        },
-                        "align": {
-                            "value": "right"
-                        },
-                        "baseline": {
-                            "value": "middle"
-                        }
-                    }
-                }
-            },
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_height"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "y",
-                    "format": "s",
-                    "orient": "left",
-                    "title": "Miles_per_Gallon",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "column-footer",
-            "type": "group",
-            "role": "column-footer",
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "Horsepower",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "cell",
-            "type": "group",
-            "from": {
-                "facet": {
-                    "name": "facet",
-                    "data": "source_0",
-                    "groupby": [
-                        "bin_maxbins_6_Acceleration_range"
-                    ]
-                }
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    },
-                    "height": {
-                        "signal": "child_height"
-                    },
-                    "stroke": {
-                        "value": "#ccc"
-                    },
-                    "strokeWidth": {
-                        "value": 1
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
+                "columns": 1,
+                "bounds": "full"
             },
             "marks": [
                 {
-                    "name": "child_marks",
-                    "type": "symbol",
-                    "role": "point",
+                    "name": "row-title",
+                    "role": "row-title",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "row-title-text",
+                            "encode": {
+                                "update": {
+                                    "y": {
+                                        "signal": "0.5 * height"
+                                    },
+                                    "align": {
+                                        "value": "right"
+                                    },
+                                    "text": {
+                                        "value": "BIN(Acceleration)"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    },
+                                    "angle": {
+                                        "value": 270
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "row-header",
+                    "type": "group",
+                    "role": "row-header",
                     "from": {
-                        "data": "facet"
+                        "data": "row"
+                    },
+                    "title": {
+                        "text": {
+                            "signal": "parent['bin_maxbins_6_Acceleration_range']"
+                        },
+                        "offset": 10,
+                        "orient": "left",
+                        "encode": {
+                            "update": {
+                                "fontWeight": {
+                                    "value": "normal"
+                                },
+                                "angle": {
+                                    "value": 0
+                                },
+                                "fontSize": {
+                                    "value": 10
+                                },
+                                "align": {
+                                    "value": "right"
+                                },
+                                "baseline": {
+                                    "value": "middle"
+                                }
+                            }
+                        }
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "Horsepower"
+                            "height": {
+                                "signal": "child_height"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "format": "s",
+                            "orient": "left",
+                            "title": "Miles_per_Gallon",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "column-footer",
+                    "type": "group",
+                    "role": "column-footer",
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "Horsepower",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "bin_maxbins_6_Acceleration_range"
+                            ]
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
                             },
-                            "y": {
-                                "scale": "y",
-                                "field": "Miles_per_Gallon"
+                            "height": {
+                                "signal": "child_height"
                             },
                             "stroke": {
-                                "value": "#4c78a8"
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
                             },
                             "fill": {
                                 "value": "transparent"
-                            },
-                            "opacity": {
-                                "value": 0.7
                             }
                         }
-                    }
-                }
-            ],
-            "axes": [
-                {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
-                },
-                {
-                    "scale": "y",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "left",
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "x"
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "symbol",
+                            "role": "point",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "Horsepower"
+                                    },
+                                    "y": {
+                                        "scale": "y",
+                                        "field": "Miles_per_Gallon"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
+                                    },
+                                    "fill": {
+                                        "value": "transparent"
+                                    },
+                                    "opacity": {
+                                        "value": 0.7
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "y"
+                        },
+                        {
+                            "scale": "y",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "left",
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "x"
+                        }
+                    ]
                 }
             ]
         }

--- a/examples/vg-specs/trellis_stacked_bar.vg.json
+++ b/examples/vg-specs/trellis_stacked_bar.vg.json
@@ -102,204 +102,210 @@
             ]
         }
     ],
-    "layout": {
-        "padding": {
-            "row": 10,
-            "column": 10
-        },
-        "offset": 10,
-        "columns": {
-            "signal": "data('column_layout')[0].distinct_year"
-        },
-        "bounds": "full"
-    },
     "marks": [
         {
-            "name": "column-title",
-            "role": "column-title",
+            "name": "nested-main-group",
             "type": "group",
-            "marks": [
-                {
-                    "type": "text",
-                    "role": "column-title-text",
-                    "encode": {
-                        "update": {
-                            "x": {
-                                "signal": "0.5 * width"
-                            },
-                            "align": {
-                                "value": "center"
-                            },
-                            "text": {
-                                "value": "year"
-                            },
-                            "fill": {
-                                "value": "black"
-                            },
-                            "fontWeight": {
-                                "value": "bold"
-                            }
-                        }
-                    }
-                }
-            ]
-        },
-        {
-            "name": "row-header",
-            "type": "group",
-            "role": "row-header",
-            "encode": {
-                "update": {
-                    "height": {
-                        "signal": "child_height"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "y",
-                    "orient": "left",
-                    "title": "variety",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "column-header",
-            "type": "group",
-            "role": "column-header",
-            "from": {
-                "data": "column"
-            },
-            "title": {
-                "text": {
-                    "signal": "parent['year']"
+            "layout": {
+                "padding": {
+                    "row": 10,
+                    "column": 10
                 },
                 "offset": 10,
-                "orient": "top",
-                "encode": {
-                    "update": {
-                        "fontWeight": {
-                            "value": "normal"
-                        },
-                        "angle": {
-                            "value": 0
-                        },
-                        "fontSize": {
-                            "value": 10
-                        }
-                    }
-                }
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            }
-        },
-        {
-            "name": "column-footer",
-            "type": "group",
-            "role": "column-footer",
-            "from": {
-                "data": "column"
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    }
-                }
-            },
-            "axes": [
-                {
-                    "scale": "x",
-                    "format": "s",
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "title": "SUM(yield)",
-                    "zindex": 1
-                }
-            ]
-        },
-        {
-            "name": "cell",
-            "type": "group",
-            "from": {
-                "facet": {
-                    "name": "facet",
-                    "data": "source_0",
-                    "groupby": [
-                        "year"
-                    ]
-                }
-            },
-            "encode": {
-                "update": {
-                    "width": {
-                        "signal": "child_width"
-                    },
-                    "height": {
-                        "signal": "child_height"
-                    },
-                    "stroke": {
-                        "value": "#ccc"
-                    },
-                    "strokeWidth": {
-                        "value": 1
-                    },
-                    "fill": {
-                        "value": "transparent"
-                    }
-                }
+                "columns": {
+                    "signal": "data('column_layout')[0].distinct_year"
+                },
+                "bounds": "full"
             },
             "marks": [
                 {
-                    "name": "child_marks",
-                    "type": "rect",
-                    "role": "bar",
+                    "name": "column-title",
+                    "role": "column-title",
+                    "type": "group",
+                    "marks": [
+                        {
+                            "type": "text",
+                            "role": "column-title-text",
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "signal": "0.5 * width"
+                                    },
+                                    "align": {
+                                        "value": "center"
+                                    },
+                                    "text": {
+                                        "value": "year"
+                                    },
+                                    "fill": {
+                                        "value": "black"
+                                    },
+                                    "fontWeight": {
+                                        "value": "bold"
+                                    }
+                                }
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "row-header",
+                    "type": "group",
+                    "role": "row-header",
+                    "encode": {
+                        "update": {
+                            "height": {
+                                "signal": "child_height"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "y",
+                            "orient": "left",
+                            "title": "variety",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "column-header",
+                    "type": "group",
+                    "role": "column-header",
                     "from": {
-                        "data": "facet"
+                        "data": "column"
+                    },
+                    "title": {
+                        "text": {
+                            "signal": "parent['year']"
+                        },
+                        "offset": 10,
+                        "orient": "top",
+                        "encode": {
+                            "update": {
+                                "fontWeight": {
+                                    "value": "normal"
+                                },
+                                "angle": {
+                                    "value": 0
+                                },
+                                "fontSize": {
+                                    "value": 10
+                                }
+                            }
+                        }
                     },
                     "encode": {
                         "update": {
-                            "x": {
-                                "scale": "x",
-                                "field": "sum_yield_end"
-                            },
-                            "x2": {
-                                "scale": "x",
-                                "field": "sum_yield_start"
-                            },
-                            "yc": {
-                                "scale": "y",
-                                "field": "variety"
-                            },
-                            "height": {
-                                "value": 20
-                            },
-                            "fill": {
-                                "scale": "color",
-                                "field": "site"
+                            "width": {
+                                "signal": "child_width"
                             }
                         }
                     }
-                }
-            ],
-            "axes": [
+                },
                 {
-                    "scale": "x",
-                    "domain": false,
-                    "format": "s",
-                    "grid": true,
-                    "labels": false,
-                    "orient": "bottom",
-                    "tickCount": 5,
-                    "ticks": false,
-                    "zindex": 0,
-                    "gridScale": "y"
+                    "name": "column-footer",
+                    "type": "group",
+                    "role": "column-footer",
+                    "from": {
+                        "data": "column"
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            }
+                        }
+                    },
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "format": "s",
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "title": "SUM(yield)",
+                            "zindex": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "cell",
+                    "type": "group",
+                    "from": {
+                        "facet": {
+                            "name": "facet",
+                            "data": "source_0",
+                            "groupby": [
+                                "year"
+                            ]
+                        }
+                    },
+                    "encode": {
+                        "update": {
+                            "width": {
+                                "signal": "child_width"
+                            },
+                            "height": {
+                                "signal": "child_height"
+                            },
+                            "stroke": {
+                                "value": "#ccc"
+                            },
+                            "strokeWidth": {
+                                "value": 1
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            }
+                        }
+                    },
+                    "marks": [
+                        {
+                            "name": "child_marks",
+                            "type": "rect",
+                            "role": "bar",
+                            "from": {
+                                "data": "facet"
+                            },
+                            "encode": {
+                                "update": {
+                                    "x": {
+                                        "scale": "x",
+                                        "field": "sum_yield_end"
+                                    },
+                                    "x2": {
+                                        "scale": "x",
+                                        "field": "sum_yield_start"
+                                    },
+                                    "yc": {
+                                        "scale": "y",
+                                        "field": "variety"
+                                    },
+                                    "height": {
+                                        "value": 20
+                                    },
+                                    "fill": {
+                                        "scale": "color",
+                                        "field": "site"
+                                    }
+                                }
+                            }
+                        }
+                    ],
+                    "axes": [
+                        {
+                            "scale": "x",
+                            "domain": false,
+                            "format": "s",
+                            "grid": true,
+                            "labels": false,
+                            "orient": "bottom",
+                            "tickCount": 5,
+                            "ticks": false,
+                            "zindex": 0,
+                            "gridScale": "y"
+                        }
+                    ]
                 }
             ]
         }

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -203,7 +203,7 @@ export function predicate(selCmpt: SelectionComponent, datum?: string): string {
   const store = stringValue(selCmpt.name + STORE),
         op = PREDICATES_OPS[selCmpt.resolve];
   datum = datum || 'datum';
-  return compiler(selCmpt).predicate + `(${store}, datum._id, ${datum}, ${op})`;
+  return compiler(selCmpt).predicate + `(${store}, parent._id, ${datum}, ${op})`;
 }
 
 // Utility functions

--- a/test/compile/selection/predicate.test.ts
+++ b/test/compile/selection/predicate.test.ts
@@ -41,14 +41,14 @@ describe('Selection Predicate', function() {
     const single = getModel({type: 'single'});
     assert.deepEqual(nonPosition('color', single), {
       color: [
-        {test: "!vlPoint(\"one_store\", datum._id, datum, \"union\", \"all\")", value: "grey"},
+        {test: "!vlPoint(\"one_store\", parent._id, datum, \"union\", \"all\")", value: "grey"},
         {scale: "color", field: "Cylinders"}
       ]
     });
 
     assert.deepEqual(nonPosition('opacity', single), {
       opacity: [
-        {test: "vlPoint(\"one_store\", datum._id, datum, \"union\", \"all\")", value: 0.5},
+        {test: "vlPoint(\"one_store\", parent._id, datum, \"union\", \"all\")", value: 0.5},
         {scale: "opacity", field: "Origin"}
       ]
     });
@@ -56,14 +56,14 @@ describe('Selection Predicate', function() {
     const multi = getModel({type: 'multi'});
     assert.deepEqual(nonPosition('color', multi), {
       color: [
-        {test: "!vlPoint(\"one_store\", datum._id, datum, \"union\", \"all\")", value: "grey"},
+        {test: "!vlPoint(\"one_store\", parent._id, datum, \"union\", \"all\")", value: "grey"},
         {scale: "color", field: "Cylinders"}
       ]
     });
 
     assert.deepEqual(nonPosition('opacity', multi), {
       opacity: [
-        {test: "vlPoint(\"one_store\", datum._id, datum, \"union\", \"all\")", value: 0.5},
+        {test: "vlPoint(\"one_store\", parent._id, datum, \"union\", \"all\")", value: 0.5},
         {scale: "opacity", field: "Origin"}
       ]
     });
@@ -71,14 +71,14 @@ describe('Selection Predicate', function() {
     const interval = getModel({type: 'interval'});
     assert.deepEqual(nonPosition('color', interval), {
       color: [
-        {test: "!vlInterval(\"one_store\", datum._id, datum, \"union\", \"all\")", value: "grey"},
+        {test: "!vlInterval(\"one_store\", parent._id, datum, \"union\", \"all\")", value: "grey"},
         {scale: "color", field: "Cylinders"}
       ]
     });
 
     assert.deepEqual(nonPosition('opacity', interval), {
       opacity: [
-        {test: "vlInterval(\"one_store\", datum._id, datum, \"union\", \"all\")", value: 0.5},
+        {test: "vlInterval(\"one_store\", parent._id, datum, \"union\", \"all\")", value: 0.5},
         {scale: "opacity", field: "Origin"}
       ]
     });


### PR DESCRIPTION
@arvind 

This makes `query_widgets` works  and allow us to revert  a2e88d2


But `faceted_selection` still seems funky.  I think the problem for  `faceted_selection` seems not relate to main-group, so I'll leave it up to you to figure out since you better understand how it works.  

(Please merge https://github.com/vega/vega-lite/pull/2237 first.)