### PR TITLE
Resolve

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -214,6 +214,16 @@
                     "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle. This can be a single number or an object with `\"top\"`, `\"left\"`, `\"right\"`, `\"bottom\"` properties.\n\n__Default value__: `5`",
                     "minimum": 0
                 },
+                "resolve": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/{ color?: NonspatialResolve; opacity?: NonspatialResolve; size?: NonspatialResolve; shape?: Nonsp..."
+                        },
+                        {
+                            "$ref": "#/definitions/{ x?: SpatialResolve; y?: SpatialResolve; }"
+                        }
+                    ]
+                },
                 "transform": {
                     "description": "An array of data transformations such as filter and new field calculation.",
                     "items": {
@@ -2692,6 +2702,16 @@
                     "description": "Name of the visualization for later reference.",
                     "type": "string"
                 },
+                "resolve": {
+                    "anyOf": [
+                        {
+                            "$ref": "#/definitions/{ color?: NonspatialResolve; opacity?: NonspatialResolve; size?: NonspatialResolve; shape?: Nonsp..."
+                        },
+                        {
+                            "$ref": "#/definitions/{ x?: SpatialResolve; y?: SpatialResolve; }"
+                        }
+                    ]
+                },
                 "transform": {
                     "description": "An array of data transformations such as filter and new field calculation.",
                     "items": {
@@ -5010,6 +5030,16 @@
                 },
                 "title": {
                 }
+            },
+            "type": "object"
+        },
+        "{ color?: NonspatialResolve; opacity?: NonspatialResolve; size?: NonspatialResolve; shape?: Nonsp...": {
+            "properties": {
+            },
+            "type": "object"
+        },
+        "{ x?: SpatialResolve; y?: SpatialResolve; }": {
+            "properties": {
             },
             "type": "object"
         }

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -215,14 +215,28 @@
                     "minimum": 0
                 },
                 "resolve": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/{ color?: NonspatialResolve; opacity?: NonspatialResolve; size?: NonspatialResolve; shape?: Nonsp..."
+                    "additionalProperties": false,
+                    "properties": {
+                        "color": {
+                            "$ref": "#/definitions/NonspatialResolve"
                         },
-                        {
-                            "$ref": "#/definitions/{ x?: SpatialResolve; y?: SpatialResolve; }"
+                        "opacity": {
+                            "$ref": "#/definitions/NonspatialResolve"
+                        },
+                        "shape": {
+                            "$ref": "#/definitions/NonspatialResolve"
+                        },
+                        "size": {
+                            "$ref": "#/definitions/NonspatialResolve"
+                        },
+                        "x": {
+                            "$ref": "#/definitions/SpatialResolve"
+                        },
+                        "y": {
+                            "$ref": "#/definitions/SpatialResolve"
                         }
-                    ]
+                    },
+                    "type": "object"
                 },
                 "transform": {
                     "description": "An array of data transformations such as filter and new field calculation.",
@@ -2703,14 +2717,28 @@
                     "type": "string"
                 },
                 "resolve": {
-                    "anyOf": [
-                        {
-                            "$ref": "#/definitions/{ color?: NonspatialResolve; opacity?: NonspatialResolve; size?: NonspatialResolve; shape?: Nonsp..."
+                    "additionalProperties": false,
+                    "properties": {
+                        "color": {
+                            "$ref": "#/definitions/NonspatialResolve"
                         },
-                        {
-                            "$ref": "#/definitions/{ x?: SpatialResolve; y?: SpatialResolve; }"
+                        "opacity": {
+                            "$ref": "#/definitions/NonspatialResolve"
+                        },
+                        "shape": {
+                            "$ref": "#/definitions/NonspatialResolve"
+                        },
+                        "size": {
+                            "$ref": "#/definitions/NonspatialResolve"
+                        },
+                        "x": {
+                            "$ref": "#/definitions/SpatialResolve"
+                        },
+                        "y": {
+                            "$ref": "#/definitions/SpatialResolve"
                         }
-                    ]
+                    },
+                    "type": "object"
                 },
                 "transform": {
                     "description": "An array of data transformations such as filter and new field calculation.",
@@ -3572,6 +3600,18 @@
             ],
             "type": "object"
         },
+        "NonspatialResolve": {
+            "additionalProperties": false,
+            "properties": {
+                "legend": {
+                    "$ref": "#/definitions/ResolveMode"
+                },
+                "scale": {
+                    "$ref": "#/definitions/ResolveMode"
+                }
+            },
+            "type": "object"
+        },
         "OneOfFilter": {
             "additionalProperties": false,
             "properties": {
@@ -3884,6 +3924,13 @@
                 }
             },
             "type": "object"
+        },
+        "ResolveMode": {
+            "enum": [
+                "independent",
+                "shared"
+            ],
+            "type": "string"
         },
         "Scale": {
             "additionalProperties": false,
@@ -4535,6 +4582,18 @@
             ],
             "type": "string"
         },
+        "SpatialResolve": {
+            "additionalProperties": false,
+            "properties": {
+                "axis": {
+                    "$ref": "#/definitions/ResolveMode"
+                },
+                "scale": {
+                    "$ref": "#/definitions/ResolveMode"
+                }
+            },
+            "type": "object"
+        },
         "StackOffset": {
             "enum": [
                 "center",
@@ -5030,16 +5089,6 @@
                 },
                 "title": {
                 }
-            },
-            "type": "object"
-        },
-        "{ color?: NonspatialResolve; opacity?: NonspatialResolve; size?: NonspatialResolve; shape?: Nonsp...": {
-            "properties": {
-            },
-            "type": "object"
-        },
-        "{ x?: SpatialResolve; y?: SpatialResolve; }": {
-            "properties": {
             },
             "type": "object"
         }

--- a/examples/specs/layer_bar_dual_axis.vl.json
+++ b/examples/specs/layer_bar_dual_axis.vl.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+  "data": {"url": "data/seattle-weather.csv"},
+  "layer": [
+    {
+      "mark": "line",
+      "encoding": {
+        "x": {
+          "timeUnit": "month",
+          "field": "date",
+          "type": "temporal"
+        },
+        "y": {
+          "aggregate": "mean",
+          "field": "precipitation",
+          "type": "quantitative",
+          "axis": {
+            "grid": false
+          }
+        }
+      }
+    },
+    {
+      "mark": "line",
+      "encoding": {
+        "x": {
+          "timeUnit": "month",
+          "field": "date",
+          "type": "temporal"
+        },
+        "y": {
+          "aggregate": "mean",
+          "field": "temp_max",
+          "type": "quantitative"
+        },
+        "color": {"value": "firebrick"}
+      }
+    }
+  ],
+  "resolve": {"y": {"scale": "independent"}}
+}

--- a/examples/specs/layer_bar_dual_axis.vl.json
+++ b/examples/specs/layer_bar_dual_axis.vl.json
@@ -31,7 +31,10 @@
         "y": {
           "aggregate": "mean",
           "field": "temp_max",
-          "type": "quantitative"
+          "type": "quantitative",
+          "axis": {
+            "grid": false
+          }
         },
         "color": {"value": "firebrick"}
       }

--- a/examples/vg-specs/layer_bar_dual_axis.vg.json
+++ b/examples/vg-specs/layer_bar_dual_axis.vg.json
@@ -295,17 +295,6 @@
             "orient": "right",
             "title": "MEAN(temp_max)",
             "zindex": 1
-        },
-        {
-            "scale": "layer_1_y",
-            "domain": false,
-            "format": "s",
-            "grid": true,
-            "labels": false,
-            "orient": "left",
-            "ticks": false,
-            "zindex": 0,
-            "gridScale": "x"
         }
     ]
 }

--- a/examples/vg-specs/layer_bar_dual_axis.vg.json
+++ b/examples/vg-specs/layer_bar_dual_axis.vg.json
@@ -1,0 +1,311 @@
+{
+    "$schema": "http://vega.github.io/schema/vega/v3.0.json",
+    "autosize": "pad",
+    "padding": 5,
+    "data": [
+        {
+            "name": "source_0",
+            "url": "data/seattle-weather.csv",
+            "format": {
+                "type": "csv"
+            }
+        },
+        {
+            "name": "data_0",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "formula",
+                    "expr": "toDate(datum[\"date\"])",
+                    "as": "date"
+                },
+                {
+                    "type": "formula",
+                    "expr": "toNumber(datum[\"precipitation\"])",
+                    "as": "precipitation"
+                },
+                {
+                    "type": "filter",
+                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"precipitation\"] !== null && !isNaN(datum[\"precipitation\"])"
+                },
+                {
+                    "type": "formula",
+                    "as": "month_date",
+                    "expr": "datetime(0, month(datum[\"date\"]), 1, 0, 0, 0, 0)"
+                },
+                {
+                    "type": "aggregate",
+                    "groupby": [
+                        "month_date"
+                    ],
+                    "ops": [
+                        "mean"
+                    ],
+                    "fields": [
+                        "precipitation"
+                    ]
+                },
+                {
+                    "type": "collect",
+                    "sort": {
+                        "field": "month_date",
+                        "order": "descending"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "data_1",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "formula",
+                    "expr": "toDate(datum[\"date\"])",
+                    "as": "date"
+                },
+                {
+                    "type": "formula",
+                    "expr": "toNumber(datum[\"temp_max\"])",
+                    "as": "temp_max"
+                },
+                {
+                    "type": "filter",
+                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"temp_max\"] !== null && !isNaN(datum[\"temp_max\"])"
+                },
+                {
+                    "type": "formula",
+                    "as": "month_date",
+                    "expr": "datetime(0, month(datum[\"date\"]), 1, 0, 0, 0, 0)"
+                },
+                {
+                    "type": "aggregate",
+                    "groupby": [
+                        "month_date"
+                    ],
+                    "ops": [
+                        "mean"
+                    ],
+                    "fields": [
+                        "temp_max"
+                    ]
+                },
+                {
+                    "type": "collect",
+                    "sort": {
+                        "field": "month_date",
+                        "order": "descending"
+                    }
+                }
+            ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "width",
+            "update": "max(layer_0_width, layer_1_width)"
+        },
+        {
+            "name": "height",
+            "update": "max(layer_0_height, layer_1_height)"
+        },
+        {
+            "name": "layer_0_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_0_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_width",
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+        },
+        {
+            "name": "layer_1_height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        }
+    ],
+    "marks": [
+        {
+            "name": "nested_main_group",
+            "type": "group",
+            "encode": {
+                "update": {
+                    "width": {
+                        "signal": "width"
+                    },
+                    "height": {
+                        "signal": "height"
+                    },
+                    "fill": {
+                        "value": "transparent"
+                    }
+                }
+            },
+            "marks": [
+                {
+                    "name": "layer_0_marks",
+                    "type": "line",
+                    "from": {
+                        "data": "data_0"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "month_date"
+                            },
+                            "y": {
+                                "scale": "layer_0_y",
+                                "field": "mean_precipitation"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
+                            }
+                        }
+                    },
+                    "clip": true
+                },
+                {
+                    "name": "layer_1_marks",
+                    "type": "line",
+                    "from": {
+                        "data": "data_1"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "x",
+                                "field": "month_date"
+                            },
+                            "y": {
+                                "scale": "layer_1_y",
+                                "field": "mean_temp_max"
+                            },
+                            "stroke": {
+                                "value": "firebrick"
+                            }
+                        }
+                    },
+                    "clip": true
+                }
+            ]
+        }
+    ],
+    "scales": [
+        {
+            "name": "x",
+            "type": "point",
+            "domain": {
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "month_date"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "month_date"
+                    }
+                ],
+                "sort": true
+            },
+            "range": {
+                "step": 21
+            },
+            "round": true,
+            "padding": 0.5
+        },
+        {
+            "name": "layer_0_y",
+            "type": "linear",
+            "domain": {
+                "data": "data_0",
+                "field": "mean_precipitation"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        },
+        {
+            "name": "layer_1_y",
+            "type": "linear",
+            "domain": {
+                "data": "data_1",
+                "field": "mean_temp_max"
+            },
+            "range": [
+                200,
+                0
+            ],
+            "round": true,
+            "nice": true,
+            "zero": true
+        }
+    ],
+    "axes": [
+        {
+            "scale": "x",
+            "orient": "bottom",
+            "tickCount": 5,
+            "title": "MONTH(date)",
+            "zindex": 1,
+            "encode": {
+                "labels": {
+                    "update": {
+                        "text": {
+                            "signal": "timeFormat(datum.value, '%b')"
+                        },
+                        "angle": {
+                            "value": 270
+                        },
+                        "align": {
+                            "value": "right"
+                        },
+                        "baseline": {
+                            "value": "middle"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "scale": "layer_0_y",
+            "format": "s",
+            "orient": "left",
+            "title": "MEAN(precipitation)",
+            "zindex": 1
+        },
+        {
+            "scale": "layer_1_y",
+            "format": "s",
+            "orient": "right",
+            "title": "MEAN(temp_max)",
+            "zindex": 1
+        },
+        {
+            "scale": "layer_1_y",
+            "domain": false,
+            "format": "s",
+            "grid": true,
+            "labels": false,
+            "orient": "left",
+            "ticks": false,
+            "zindex": 0,
+            "gridScale": "x"
+        }
+    ]
+}

--- a/examples/vl-examples.json
+++ b/examples/vl-examples.json
@@ -174,6 +174,10 @@
     {
       "name": "layer_precipitation_mean",
       "title": "Mean overlay over pecipitation chart"
+    },
+    {
+      "name": "layer_bar_dual_axis",
+      "title": "Dual axis chart created using independent y-scales"
     }
   ],
   "Interactive": [

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -67,12 +67,18 @@ export const UNIT_SCALE_CHANNELS = [X, Y, SIZE, SHAPE, COLOR, OPACITY];
 
 // UNIT_SCALE_CHANNELS with ROW, COLUMN
 export const SCALE_CHANNELS = [X, Y, SIZE, SHAPE, COLOR, OPACITY, ROW, COLUMN];
+export type ScaleChannel = typeof SCALE_CHANNELS[0];
 
 // UNIT_CHANNELS without X, Y, X2, Y2;
 export const NONSPATIAL_CHANNELS = [SIZE, SHAPE, COLOR, ORDER, OPACITY, TEXT, DETAIL, TOOLTIP];
 
+// X and Y;
+export const SPATIAL_SCALE_CHANNELS = [X, Y];
+export type SpatialScaleChannel = typeof SPATIAL_SCALE_CHANNELS[0];
+
 // UNIT_SCALE_CHANNELS without X, Y;
 export const NONSPATIAL_SCALE_CHANNELS = [SIZE, SHAPE, COLOR, OPACITY];
+export type NonspatialScaleChannel = typeof NONSPATIAL_SCALE_CHANNELS[0];
 
 export const LEVEL_OF_DETAIL_CHANNELS = without(NONSPATIAL_CHANNELS, ['order'] as Channel[]);
 
@@ -138,7 +144,6 @@ export function getSupportedMark(channel: Channel): SupportedMark {
     case TEXT:
       return {text: true};
   }
-  return {};
 }
 
 export function hasScale(channel: Channel) {

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -1,7 +1,7 @@
 import {NonspatialScaleChannel, ScaleChannel, SpatialScaleChannel} from '../channel';
 import {Config} from '../config';
 import {FILL_STROKE_CONFIG} from '../mark';
-import {initLayerResolve, ResolveMapping} from '../resolve';
+import {initLayerResolve, NonspatialResolve, ResolveMapping, SpatialResolve} from '../resolve';
 import {LayerSpec, UnitSize} from '../spec';
 import {Dict, flatten, keys, vals} from '../util';
 import {isSignalRefDomain, VgData, VgEncodeEntry, VgLayout, VgScale, VgSignal} from '../vega.schema';
@@ -112,7 +112,7 @@ export class LayerModel extends Model {
     for (const child of this.children) {
       child.parseAxisAndHeader();
       keys(child.component.axes).forEach((channel: SpatialScaleChannel) => {
-        if (this.resolve[channel].axis === 'shared') {
+        if ((this.resolve[channel] as SpatialResolve).axis === 'shared') {
           // If shared/union axis
 
           // Just use the first axes definition for each channel
@@ -152,7 +152,7 @@ export class LayerModel extends Model {
 
       // TODO: correctly implement independent axes
       keys(child.component.legends).forEach((channel: NonspatialScaleChannel) => {
-        if (this.resolve[channel].legend === 'shared') { // if shared/union scale
+        if ((this.resolve[channel] as NonspatialResolve).legend === 'shared') { // if shared/union scale
           // just use the first legend definition for each channel
           if (!legendComponent[channel]) {
             legendComponent[channel] = child.component.legends[channel];

--- a/src/log.ts
+++ b/src/log.ts
@@ -206,6 +206,10 @@ export namespace message {
     return `Scale type "${scaleType}" does not work with mark ${mark}.`;
   }
 
+  export function independentScaleMeansIndependentGuide(channel: Channel) {
+    return `Setting the scale to be independent for ${channel} means we also have to set the guide (axis or legend) to be independent.`;
+  }
+
   export const INVAID_DOMAIN = 'Invalid scale domain';
 
   export const UNABLE_TO_MERGE_DOMAINS = 'Unable to merge domains';

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,0 +1,47 @@
+import {NonspatialScaleChannel, SCALE_CHANNELS, SPATIAL_SCALE_CHANNELS, SpatialScaleChannel, UNIT_SCALE_CHANNELS} from './channel';
+import * as log from './log';
+import {contains} from './util';
+
+export type ResolveMode = 'independent' | 'shared';
+
+export interface SpatialResolve {
+  scale: ResolveMode;
+  axis?: ResolveMode;
+}
+
+export interface NonspatialResolve {
+  scale: ResolveMode;
+  legend?: ResolveMode;
+}
+
+export type Resolve = SpatialResolve | NonspatialResolve;
+
+export function isSpatialResolve(resolve: Resolve): resolve is SpatialResolve {
+  return 'axis' in resolve;
+}
+
+export function isNonspatialResolve(resolve: Resolve): resolve is NonspatialResolve {
+  return 'legend' in resolve;
+}
+
+export type ResolveMapping = {[P in NonspatialScaleChannel]?: NonspatialResolve} | {[P in SpatialScaleChannel]?: SpatialResolve};
+
+export function initLayerResolve(resolve: ResolveMapping): ResolveMapping {
+  UNIT_SCALE_CHANNELS.forEach(channel => {
+    const res: Resolve = resolve[channel] || {scale: 'shared'};
+    const guide = contains(SPATIAL_SCALE_CHANNELS, channel) ? 'axis' : 'legend';
+
+    if (res.scale === 'independent' && (
+      (isSpatialResolve(res) && res.axis === 'shared') ||
+      (isNonspatialResolve(res) && res.legend === 'shared'))) {
+      log.warn(log.message.independentScaleMeansIndependentGuide(channel));
+    }
+
+    resolve[channel] = {
+      scale: res.scale || 'shared',
+      [guide]: res.scale === 'independent' ? 'independent' : (res[guide] || 'shared')
+    };
+  });
+
+  return resolve;
+}

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -16,7 +16,17 @@ export interface NonspatialResolve {
 
 export type Resolve = SpatialResolve | NonspatialResolve;
 
-export type ResolveMapping = {[P in NonspatialScaleChannel]?: NonspatialResolve} & {[P in SpatialScaleChannel]?: SpatialResolve};
+// TODO: replace this with {[P in NonspatialScaleChannel]?: NonspatialResolve} & {[P in SpatialScaleChannel]?: SpatialResolve}; and make sure that the right schema is being generated
+export type ResolveMapping = {
+  // spatial channels
+  x?: SpatialResolve
+  y?: SpatialResolve
+  // non-spatial channels
+  color?: NonspatialResolve
+  opacity?: NonspatialResolve
+  size?: NonspatialResolve
+  shape?: NonspatialResolve
+};
 
 export function initLayerResolve(resolve: ResolveMapping): ResolveMapping {
   const out: ResolveMapping = {};

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -5,43 +5,34 @@ import {contains} from './util';
 export type ResolveMode = 'independent' | 'shared';
 
 export interface SpatialResolve {
-  scale: ResolveMode;
+  scale?: ResolveMode;
   axis?: ResolveMode;
 }
 
 export interface NonspatialResolve {
-  scale: ResolveMode;
+  scale?: ResolveMode;
   legend?: ResolveMode;
 }
 
 export type Resolve = SpatialResolve | NonspatialResolve;
 
-export function isSpatialResolve(resolve: Resolve): resolve is SpatialResolve {
-  return 'axis' in resolve;
-}
-
-export function isNonspatialResolve(resolve: Resolve): resolve is NonspatialResolve {
-  return 'legend' in resolve;
-}
-
-export type ResolveMapping = {[P in NonspatialScaleChannel]?: NonspatialResolve} | {[P in SpatialScaleChannel]?: SpatialResolve};
+export type ResolveMapping = {[P in NonspatialScaleChannel]?: NonspatialResolve} & {[P in SpatialScaleChannel]?: SpatialResolve};
 
 export function initLayerResolve(resolve: ResolveMapping): ResolveMapping {
+  const out: ResolveMapping = {};
   UNIT_SCALE_CHANNELS.forEach(channel => {
     const res: Resolve = resolve[channel] || {scale: 'shared'};
     const guide = contains(SPATIAL_SCALE_CHANNELS, channel) ? 'axis' : 'legend';
 
-    if (res.scale === 'independent' && (
-      (isSpatialResolve(res) && res.axis === 'shared') ||
-      (isNonspatialResolve(res) && res.legend === 'shared'))) {
+    if (res.scale === 'independent' && (res['axis'] === 'shared' || res['legend'] === 'shared')) {
       log.warn(log.message.independentScaleMeansIndependentGuide(channel));
     }
 
-    resolve[channel] = {
+    out[channel] = {
       scale: res.scale || 'shared',
       [guide]: res.scale === 'independent' ? 'independent' : (res[guide] || 'shared')
     };
   });
 
-  return resolve;
+  return out;
 }

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -1,6 +1,6 @@
 import {COLUMN, ROW, X, X2, Y, Y2} from './channel';
-import {CompositeMark} from './compositemark';
 import * as compositeMark from './compositemark';
+import {CompositeMark} from './compositemark';
 import {Config} from './config';
 import {Data} from './data';
 import {channelHasField, Encoding, EncodingWithFacet, isRanged} from './encoding';
@@ -10,6 +10,7 @@ import {Field, FieldDef} from './fielddef';
 import * as log from './log';
 import {AREA, isPrimitiveMark, LINE, Mark, MarkDef} from './mark';
 import {Repeat} from './repeat';
+import {ResolveMapping} from './resolve';
 import {SelectionDef} from './selection';
 import {stack} from './stack';
 import {TopLevelProperties} from './toplevelprops';
@@ -117,6 +118,8 @@ export interface GenericLayerSpec<U extends GenericUnitSpec<any, any>> extends B
    * Unit specs that will be layered.
    */
   layer: (GenericLayerSpec<U> | U)[];
+
+  resolve?: ResolveMapping;
 }
 
 export type LayerSpec = GenericLayerSpec<UnitSpec>;

--- a/test/compile/layer.test.ts
+++ b/test/compile/layer.test.ts
@@ -1,5 +1,6 @@
 import {assert} from 'chai';
 
+import {parseMainAxis} from '../../src/compile/axis/parse';
 import {LayerModel} from '../../src/compile/layer';
 import {LayerSpec} from '../../src/spec';
 import {parseLayerModel} from '../util';
@@ -61,6 +62,50 @@ describe('Layer', function() {
         ],
         sort: true
       });
+    });
+  });
+
+  describe('dual axis chart', () => {
+    const model = parseLayerModel({
+      layer: [{
+        mark: 'point',
+        encoding: {
+          x: {field: 'a', type: 'quantitative'}
+        }
+      },{
+        mark: 'point',
+        encoding: {
+          x: {field: 'b', type: 'quantitative'}
+        }
+      }],
+      resolve: {
+        x: {
+          scale: 'independent'
+        }
+      }
+    });
+
+    assert.equal(model.children.length, 2);
+
+    it('should leave scales in children', () => {
+      model.parseScale();
+
+      assert.equal(model.component.scales['x'], undefined);
+      assert.deepEqual(model.children[0].component.scales['x'].domain, {
+        data: 'layer_0_main',
+        field: 'a'
+      });
+      assert.deepEqual(model.children[1].component.scales['x'].domain, {
+        data: 'layer_1_main',
+        field: 'b'
+      });
+    });
+
+    it('should create second axis on top', () => {
+      model.parseAxisAndHeader();
+
+      assert.equal(model.component.axes['x'].axes.length, 2);
+      assert.equal(model.component.axes['x'].axes[1].orient, 'top');
     });
   });
 });

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -1,0 +1,102 @@
+import {assert} from 'chai';
+import * as log from '../src/log';
+import {initLayerResolve, ResolveMapping} from '../src/resolve';
+
+describe('resolve', () => {
+  describe('initLayerResolve', () => {
+    const defaults: ResolveMapping = {
+      x: {scale: 'shared', axis: 'shared'},
+      y: {scale: 'shared', axis: 'shared'},
+      size: {scale: 'shared', legend: 'shared'},
+      shape: {scale: 'shared', legend: 'shared'},
+      color: {scale: 'shared', legend: 'shared'},
+      opacity: {scale: 'shared', legend: 'shared'}
+    };
+
+    it('should share by default', () => {
+      const actual = initLayerResolve({});
+      assert.deepEqual<ResolveMapping>(actual, defaults);
+    });
+
+    it('should set x axis to independent', () => {
+      const actual = initLayerResolve({x: {
+        axis: 'independent'
+      }});
+
+      assert.deepEqual<ResolveMapping>(actual, {
+        ...defaults,
+        x: {
+          scale: 'shared',
+          axis: 'independent'
+        }
+      });
+    });
+
+    it('should set x axis to independent even if we set scale to shared', () => {
+      const actual = initLayerResolve({x: {
+        scale: 'shared',
+        axis: 'independent'
+      }});
+
+      assert.deepEqual<ResolveMapping>(actual, {
+        ...defaults,
+        x: {
+          scale: 'shared',
+          axis: 'independent'
+        }
+      });
+    });
+
+    it('should set color legend to independent', () => {
+      const actual = initLayerResolve({color: {
+        legend: 'independent'
+      }});
+
+      assert.deepEqual<ResolveMapping>(actual, {
+        ...defaults,
+        color: {
+          scale: 'shared',
+          legend: 'independent'
+        }
+      });
+    });
+
+    it('should force independent axis if scale is independent', () => {
+      log.runLocalLogger((localLogger) => {
+        const actual = initLayerResolve({x: {
+          scale: 'independent',
+          axis: 'shared'
+        }});
+
+        assert.deepEqual<ResolveMapping>(actual, {
+          ...defaults,
+          x: {
+            scale: 'independent',
+            axis: 'independent'
+          }
+        });
+
+        assert.equal(localLogger.warns[0], log.message.independentScaleMeansIndependentGuide('x'));
+      });
+    });
+
+    it('should force independent axis if scale is independent', () => {
+      log.runLocalLogger((localLogger) => {
+        const actual = initLayerResolve({color: {
+          scale: 'independent',
+          legend: 'shared'
+        }});
+
+        assert.deepEqual<ResolveMapping>(actual, {
+          ...defaults,
+          color: {
+            scale: 'independent',
+            legend: 'independent'
+          }
+        });
+
+        assert.equal(localLogger.warns[0], log.message.independentScaleMeansIndependentGuide('color'));
+      });
+    });
+  });
+});


### PR DESCRIPTION
Depends on https://github.com/vega/vega-lite/pull/2318

- Add resolve types
- Add resolve to layer
- Implement dual axis chart support

<img width="547" alt="screen shot 2017-04-29 at 18 26 14" src="https://cloud.githubusercontent.com/assets/589034/25560729/c4acadf6-2d10-11e7-8a99-6aed2fb40018.png">

Example spec

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "width": 460,
  "height": 240,
  "layer": [
    {
      "data": {"url": "data/co2.csv"},
      "mark": "line",
      "encoding": {
        "x": {
          "field": "Year",
          "type": "temporal",
          "timeUnit": "year"
        },
        "y": {
          "field": "Mean",
          "type": "quantitative",
          "scale": {"zero": false},
          "axis": {"title": "CO2 in PPM"}
        }
      }
    },
    {
      "layer": [
        {
          "data": {"values": [{"rule": 0}]},
          "mark": "rule",
          "encoding": {
            "y": {
              "field": "rule",
              "type": "quantitative",
              "axis": {"title": "Mean Global Temperature"}
            },
            "opacity": {"value": 0.4},
            "color": {"value": "black"}
          }
        },
        {
          "data": {"url": "data/temp.csv"},
          "mark": "line",
          "encoding": {
            "x": {
              "field": "Year",
              "type": "temporal",
              "timeUnit": "year"
            },
            "y": {"field": "Value","type": "quantitative"},
            "color": {"value": "firebrick"}
          }
        }
      ]
    }
  ],
  "resolve": {"y": {"scale": "independent"}}
}
```