### PR TITLE
Correct rangeType for text, tooltip and x2/y2.

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -180,11 +180,17 @@ export function rangeType(channel: Channel): RangeType {
     case Y:
     case SIZE:
     case OPACITY:
+    // X2 and Y2 use X and Y scales, so they similarly have continuous range.
+    case X2:
+    case Y2:
       return 'continuous';
 
     case ROW:
     case COLUMN:
     case SHAPE:
+    // TEXT and TOOLTIP have no scale but have discrete output
+    case TEXT:
+    case TOOLTIP:
       return 'discrete';
 
     // Color can be either continuous or discrete, depending on scale type.
@@ -192,12 +198,8 @@ export function rangeType(channel: Channel): RangeType {
       return 'flexible';
 
     // No scale, no range type.
-    case X2:
-    case Y2:
     case DETAIL:
-    case TEXT:
     case ORDER:
-    case TOOLTIP:
       return undefined;
   }
   /* istanbul ignore next: should never reach here. */


### PR DESCRIPTION
This makes `"nominal"` the default `type` for `text` and `tooltip`

Fix #2335

![vega_editor](https://cloud.githubusercontent.com/assets/111269/25596208/ef6a360e-2e7c-11e7-8fac-c3b8069677d5.png)

