### PR TITLE
Fix anchor links in mark documentation

### DIFF
--- a/site/docs/mark.md
+++ b/site/docs/mark.md
@@ -31,7 +31,7 @@ A mark definition object can contains the following values.
 
 The `mark` property in a Vega-Lite specification defines the visualization's mark type.
 
-The supported mark types are [`point`](#point-mark), [`circle`](#circle-and-square-marks), [`square`](#circle-and-square-marks), [`text`](#text), [`tick`](#tick-mark), [`bar`](#bar-mark), [`line`](#line-mark), and [`area`](#area). In general, one mark instance is generated per input data element. However, line and area mark types represent multiple data elements as a contiguous line or shape.
+The supported mark types are [`point`](#point), [`circle`](#circle-and-square), [`square`](#circle-and-square), [`text`](#text), [`tick`](#tick-mark), [`bar`](#bar), [`line`](#line), and [`area`](#area). In general, one mark instance is generated per input data element. However, line and area mark types represent multiple data elements as a contiguous line or shape.
 
 
 <!-- why mark-based approach over chart typology + but we support variety of chart types -->


### PR DESCRIPTION
The anchor links in the mark docs don't work because they all have the `-mark` suffix at the moment.

Thank you for this awesome project! I'm enjoying working with it a lot!
  
