### PR TITLE
[WIP] add utc support when user specify scale type as utc

### DIFF
--- a/src/compile/data/timeunit.ts
+++ b/src/compile/data/timeunit.ts
@@ -29,7 +29,9 @@ export class TimeUnitNode extends DataFlowNode {
     const formula = model.reduceFieldDef((timeUnitComponent: TimeUnitComponent, fieldDef, channel) => {
       const utc = model.scale(channel) && model.scale(channel).type === 'utc';
       if (fieldDef.type === TEMPORAL && fieldDef.timeUnit) {
-        const f = field(fieldDef) + (utc ? '_utc' : '');
+        // const f = (utc ? 'utc' : '') + field(fieldDef);
+        const f = field(fieldDef);
+
         timeUnitComponent[f] = {
           as: f,
           timeUnit: fieldDef.timeUnit,

--- a/src/compile/data/timeunit.ts
+++ b/src/compile/data/timeunit.ts
@@ -13,6 +13,7 @@ export interface TimeUnitComponent {
   as: string;
   timeUnit: TimeUnit;
   field: string;
+  utc: boolean;
 }
 
 export class TimeUnitNode extends DataFlowNode {
@@ -25,13 +26,15 @@ export class TimeUnitNode extends DataFlowNode {
   }
 
   public static make(model: ModelWithField) {
-    const formula = model.reduceFieldDef((timeUnitComponent: TimeUnitComponent, fieldDef) => {
+    const formula = model.reduceFieldDef((timeUnitComponent: TimeUnitComponent, fieldDef, channel) => {
+      const utc = model.scale(channel) && model.scale(channel).type === 'utc';
       if (fieldDef.type === TEMPORAL && fieldDef.timeUnit) {
-        const f = field(fieldDef);
+        const f = field(fieldDef) + (utc ? '_utc' : '');
         timeUnitComponent[f] = {
           as: f,
           timeUnit: fieldDef.timeUnit,
-          field: fieldDef.field
+          field: fieldDef.field,
+          utc: utc
         };
       }
       return timeUnitComponent;
@@ -74,7 +77,7 @@ export class TimeUnitNode extends DataFlowNode {
       return {
         type: 'formula',
         as: c.as,
-        expr: fieldExpr(c.timeUnit, c.field)
+        expr: fieldExpr(c.timeUnit, c.field, c.utc)
       } as VgFormulaTransform;
     });
   }

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -116,8 +116,7 @@ export function expression(model: Model, filter: Filter): string {
     const fieldExpr = filter.timeUnit ?
       // For timeUnit, cast into integer with time() so we can use ===, inrange, indexOf to compare values directly.
         // TODO: We calculate timeUnit on the fly here. Consider if we would like to consolidate this with timeUnit pipeline
-        // TODO: support utc
-      ('time(' + timeUnitFieldExpr(filter.timeUnit, filter.field) + ')') :
+      ('time(' + timeUnitFieldExpr(filter.timeUnit, filter.field, false) + ')') :
       field(filter, {expr: 'datum'});
 
     if (isEqualFilter(filter)) {

--- a/src/timeunit.ts
+++ b/src/timeunit.ts
@@ -164,21 +164,22 @@ export function containsTimeUnit(fullTimeUnit: TimeUnit, timeUnit: TimeUnit) {
 /**
  * Returns Vega expresssion for a given timeUnit and fieldRef
  */
-export function fieldExpr(fullTimeUnit: TimeUnit, field: string): string {
+export function fieldExpr(fullTimeUnit: TimeUnit, field: string, isutc: boolean): string {
   const fieldRef =  `datum[${stringValue(field)}]`;
 
-  function func(timeUnit: TimeUnit) {
+  function func(timeUnit: TimeUnit, utc: boolean) {
+    const prefix: string = utc ? 'utc' : '';
     if (timeUnit === TimeUnit.QUARTER) {
       // quarter starting at 0 (0,3,6,9).
-      return `(quarter(${fieldRef})-1)`;
+      return `(${prefix}quarter(${fieldRef})-1)`;
     } else {
-      return `${timeUnit}(${fieldRef})`;
+      return `${prefix}${timeUnit}(${fieldRef})`;
     }
   }
 
   const d = SINGLE_TIMEUNITS.reduce((_d: DateTimeExpr, tu: TimeUnit) => {
     if (containsTimeUnit(fullTimeUnit, tu)) {
-      _d[tu] = func(tu);
+      _d[tu] = func(tu, isutc);
     }
     return _d;
   }, {});
@@ -186,7 +187,7 @@ export function fieldExpr(fullTimeUnit: TimeUnit, field: string): string {
   if (d.day && keys(d).length > 1) {
     log.warn(log.message.dayReplacedWithDate(fullTimeUnit));
     delete d.day;
-    d.date = func(TimeUnit.DATE);
+    d.date = func(TimeUnit.DATE, isutc);
   }
 
   return dateTimeExpr(d);

--- a/test/timeunit.test.ts
+++ b/test/timeunit.test.ts
@@ -47,7 +47,7 @@ describe('timeUnit', () => {
   describe('fieldExpr', () => {
     it('should return correct field expression for YEARMONTHDATEHOURSMINUTESSECONDS', () => {
       assert.equal(
-        fieldExpr(TimeUnit.YEARMONTHDATEHOURSMINUTESSECONDS, 'x'),
+        fieldExpr(TimeUnit.YEARMONTHDATEHOURSMINUTESSECONDS, 'x', false),
         'datetime(year(datum["x"]), month(datum["x"]), date(datum["x"]), hours(datum["x"]), minutes(datum["x"]), seconds(datum["x"]), 0)'
       );
     });
@@ -56,7 +56,7 @@ describe('timeUnit', () => {
     it('should automatically correct YEARMONTHDAY to be YEARMONTHDATE', () => {
       log.runLocalLogger((localLogger) => {
         assert.equal(
-          fieldExpr('yearmonthday' as any, 'x'),
+          fieldExpr('yearmonthday' as any, 'x', false),
           'datetime(year(datum["x"]), month(datum["x"]), date(datum["x"]), 0, 0, 0, 0)'
         );
         assert.equal(localLogger.warns[0], log.message.dayReplacedWithDate('yearmonthday' as any));
@@ -65,22 +65,34 @@ describe('timeUnit', () => {
 
     it('should return correct field expression for QUARTER', () => {
       assert.equal(
-        fieldExpr(TimeUnit.QUARTER, 'x'),
+        fieldExpr(TimeUnit.QUARTER, 'x', false),
         'datetime(0, (quarter(datum["x"])-1)*3, 1, 0, 0, 0, 0)'
       );
     });
 
     it('should return correct field expression for DAY', () => {
       assert.equal(
-        fieldExpr(TimeUnit.DAY, 'x'),
+        fieldExpr(TimeUnit.DAY, 'x', false),
         'datetime(2006, 0, day(datum["x"])+1, 0, 0, 0, 0)'
       );
     });
 
     it('should return correct field expression for MILLISECONDS', () => {
       assert.equal(
-        fieldExpr(TimeUnit.MILLISECONDS, 'x'),
+        fieldExpr(TimeUnit.MILLISECONDS, 'x', false),
         'datetime(0, 0, 1, 0, 0, 0, milliseconds(datum["x"]))'
+      );
+    });
+
+    it('should return correct field expression with utc for MILLISECONDS', () => {
+      assert.equal(
+        fieldExpr(TimeUnit.DAY, 'x', true),
+        'datetime(2006, 0, utcday(datum["x"])+1, 0, 0, 0, 0)'
+      );
+
+      assert.equal(
+        fieldExpr(TimeUnit.QUARTER, 'x', true),
+        'datetime(0, (utcquarter(datum["x"])-1)*3, 1, 0, 0, 0, 0)'
       );
     });
   });


### PR DESCRIPTION
Fix #446, support UTC input and output

## INPUT
To parse data in local time or UTC time, there are two cases: 
1) By default, user will parse data in local time.
```
{
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "description": "Google's stock price over time.",
  "data": {
    "values": [
      {"date": "10 Oct 2011 22:48:00"},
      {"date": "11 Oct 2022 23:00:00"}
    ],
    "format": {"type": "json"}
  },
  "mark": "point",
  "encoding": {
    "x": {"timeUnit": "date","field": "date","type": "temporal"},
    "y": {"timeUnit": "hours","field": "date","type": "temporal"}
  }
}
```

<img width="266" alt="screen shot 2017-05-02 at 1 47 20 pm" src="https://cloud.githubusercontent.com/assets/11696585/25638650/e9f94644-2f3d-11e7-82a7-bd73a9a27db5.png">


2) To parse it in utc time, we need to have custom `format` with `utc`
```
{
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "description": "Google's stock price over time.",
  "data": {
    "values": [
      {"date": "10 Oct 2011 22:48:00"},
      {"date": "11 Oct 2022 23:00:00"}
    ],
    "format": {"type": "json", "parse": {"date": "utc:'%d %b %Y %H:%M:%S'"}}
  },
  "mark": "point",
  "encoding": {
    "x": {"timeUnit": "date","field": "date","type": "temporal"},
    "y": {"timeUnit": "hours","field": "date","type": "temporal"}
  }
}
```
<img width="251" alt="screen shot 2017-05-02 at 1 50 32 pm" src="https://cloud.githubusercontent.com/assets/11696585/25638762/53f5e5fc-2f3e-11e7-804d-03484f87fe1a.png">


See [vega](https://vega.github.io/vega/docs/data/) for `format`

## Output:
1) User will output local time by default.
```
{
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "description": "Google's stock price over time.",
  "data": {
    "values": [
        {
          "date": "Sun, 01 Jan 2012 23:00:00",
          "price": 150
        },
        {
          "date": "Sun, 02 Jan 2012 00:00:00",
          "price": 100
        },
        {
          "date": "Sun, 02 Jan 2012 01:00:00",
          "price": 170
        },
        {
          "date": "Sun, 02 Jan 2012 02:00:00",
          "price": 165
        },
        {
          "date": "Sun, 02 Jan 2012 03:00:00",
          "price": 200
        }
      ]
  },
  "mark": "line",
  "encoding": {
    "x": {"field": "date", "type": "temporal", "timeUnit": "yearmonthdatehoursminutes"},
    "y": {"field": "price", "type": "quantitative"}
  }
}
```
<img width="261" alt="screen shot 2017-05-02 at 2 55 08 pm" src="https://cloud.githubusercontent.com/assets/11696585/25641135/5b5895c0-2f47-11e7-9303-6d9e9758bf00.png">



2) If user want to output in UTC time, we need to specify scale type as `utc`: `scale: {type: utc, ...}`.

```
{
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "description": "Google's stock price over time.",
  "data": {
    "values": [
        {
          "date": "Sun, 01 Jan 2012 23:00:00",
          "price": 150
        },
        {
          "date": "Sun, 02 Jan 2012 00:00:00",
          "price": 100
        },
        {
          "date": "Sun, 02 Jan 2012 01:00:00",
          "price": 170
        },
        {
          "date": "Sun, 02 Jan 2012 02:00:00",
          "price": 165
        },
        {
          "date": "Sun, 02 Jan 2012 03:00:00",
          "price": 200
        }
      ]
  },
  "mark": "line",
  "encoding": {
    "x": {"field": "date", "type": "temporal", "timeUnit": "yearmonthdatehoursminutes", "scale": {"type": "utc"}},
    "y": {"field": "price", "type": "quantitative"}
  }
}
```

<img width="264" alt="screen shot 2017-05-02 at 2 55 52 pm" src="https://cloud.githubusercontent.com/assets/11696585/25641153/75026d3e-2f47-11e7-9e86-0c96a4f4164e.png">




