### PR TITLE
Bring back the code to let utc timeunit and utc scale not be consistent

### DIFF
--- a/src/compile/mark/init.ts
+++ b/src/compile/mark/init.ts
@@ -1,12 +1,11 @@
 import {Channel} from '../../channel';
 import {Config} from '../../config';
 import {Encoding, isAggregate} from '../../encoding';
-import {FieldDef, isContinuous, isFieldDef, PositionFieldDef} from '../../fielddef';
+import {FieldDef, isContinuous, isFieldDef} from '../../fielddef';
 import * as log from '../../log';
 import {AREA, BAR, CIRCLE, isMarkDef, LINE, Mark, MarkDef, Orient, POINT, RECT, RULE, SQUARE, TEXT, TICK} from '../../mark';
-import {hasDiscreteDomain, Scale, ScaleType} from '../../scale';
+import {hasDiscreteDomain, Scale} from '../../scale';
 import {StackProperties} from '../../stack';
-import {convertToUTC, isUTCTimeUnit} from '../../timeunit';
 import {TEMPORAL} from '../../type';
 import {contains, Dict} from '../../util';
 import {getMarkConfig} from '../common';

--- a/src/compile/scale/init.ts
+++ b/src/compile/scale/init.ts
@@ -7,7 +7,6 @@ import {Mark} from '../../mark';
 import {channelScalePropertyIncompatability, Scale, ScaleConfig, scaleTypeSupportProperty} from '../../scale';
 import * as util from '../../util';
 
-import {TimeUnit} from '../../timeunit';
 import {initDomain} from './domain';
 import rangeMixins from './range';
 import * as rules from './rules';

--- a/src/compile/scale/type.ts
+++ b/src/compile/scale/type.ts
@@ -157,7 +157,7 @@ export function fieldDefMatchScaleType(specifiedType: ScaleType, fieldDef: Field
     if (!fieldDef.timeUnit) {
       return contains([ScaleType.TIME, ScaleType.UTC, undefined], specifiedType);
     } else {
-      return contains([ScaleType.UTC, ScaleType.TIME, undefined], specifiedType) || hasDiscreteDomain(specifiedType);
+      return contains([ScaleType.TIME, ScaleType.UTC, undefined], specifiedType) || hasDiscreteDomain(specifiedType);
     }
   } else if (type === Type.QUANTITATIVE) {
     if (fieldDef.bin) {

--- a/src/compile/scale/type.ts
+++ b/src/compile/scale/type.ts
@@ -3,7 +3,7 @@ import * as log from '../../log';
 import {Channel, hasScale, rangeType, supportScaleType} from '../../channel';
 import {Mark} from '../../mark';
 import {ScaleConfig, ScaleType} from '../../scale';
-import {isDiscreteByDefault, isUTCTimeUnit} from '../../timeunit';
+import {isDiscreteByDefault} from '../../timeunit';
 
 import {field, FieldDef} from '../../fielddef';
 import {hasDiscreteDomain} from '../../scale';
@@ -86,9 +86,6 @@ function defaultType(channel: Channel, fieldDef: FieldDef<string>, mark: Mark,
       if (isDiscreteByDefault(fieldDef.timeUnit)) {
         return discreteToContinuousType(channel, mark, hasTopLevelSize, specifiedRangeStep, scaleConfig);
       }
-      if (fieldDef.timeUnit && isUTCTimeUnit(fieldDef.timeUnit)) {
-        return 'utc';
-      }
       return 'time';
 
     case 'quantitative':
@@ -160,11 +157,7 @@ export function fieldDefMatchScaleType(specifiedType: ScaleType, fieldDef: Field
     if (!fieldDef.timeUnit) {
       return contains([ScaleType.TIME, ScaleType.UTC, undefined], specifiedType);
     } else {
-      if (isUTCTimeUnit(fieldDef.timeUnit)) {
-        return contains([ScaleType.UTC, undefined], specifiedType) || hasDiscreteDomain(specifiedType);
-      } else {
-        return contains([ScaleType.TIME, undefined], specifiedType) || hasDiscreteDomain(specifiedType);
-      }
+      return contains([ScaleType.UTC, ScaleType.TIME, undefined], specifiedType) || hasDiscreteDomain(specifiedType);
     }
   } else if (type === Type.QUANTITATIVE) {
     if (fieldDef.bin) {

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -12,7 +12,7 @@ import * as log from './log';
 import {Scale, ScaleType} from './scale';
 import {SortField, SortOrder} from './sort';
 import {StackOffset} from './stack';
-import {convertToUTC, isDiscreteByDefault, isUTCTimeUnit, TimeUnit} from './timeunit';
+import {isDiscreteByDefault, TimeUnit} from './timeunit';
 import {getFullName, Type} from './type';
 import {isBoolean, isString, stringValue} from './util';
 
@@ -322,16 +322,6 @@ export function normalize(channelDef: ChannelDef<string>, channel: Channel) {
         type: newType
       };
     }
-
-    if (isScaleFieldDef(fieldDef)) {
-      const scaleFieldDef: ScaleFieldDef<Field> = fieldDef;
-      if (scaleFieldDef.scale !== undefined && scaleFieldDef.scale.type === ScaleType.UTC) {
-        if (fieldDef.timeUnit !== undefined && !isUTCTimeUnit(fieldDef.timeUnit)) {
-          fieldDef.timeUnit = convertToUTC(fieldDef.timeUnit);
-        }
-      }
-    }
-
 
     const {compatible, warning} = channelCompatibility(fieldDef, channel);
     if (!compatible) {

--- a/src/timeunit.ts
+++ b/src/timeunit.ts
@@ -334,10 +334,6 @@ export function isDiscreteByDefault(timeUnit: TimeUnit) {
   return false;
 }
 
-export function isUTCTimeUnit(timeUnit: TimeUnit) {
+function isUTCTimeUnit(timeUnit: TimeUnit) {
   return timeUnit.substr(0, 3) === 'utc';
-}
-
-export function convertToUTC(timeUnit: TimeUnit) {
-  return ('utc' + timeUnit) as TimeUnit;
 }

--- a/test/compile/scale/init.test.ts
+++ b/test/compile/scale/init.test.ts
@@ -35,13 +35,5 @@ describe('compile/scale', () => {
       assert.equal(scale.paddingOuter, 0.15);
       assert.isUndefined(scale.padding);
     });
-
-    it('should have "utc" as the default scale type if the timeunit is utc', () => {
-      const scale = initScale(
-        'x', {field: 'a', type: 'temporal', timeUnit: 'utcyear'}, {scale: {bandPaddingInner: 0.3}},
-        'bar', 100, []
-      );
-      assert.equal(scale.type, 'utc');
-    });
   });
 });

--- a/test/compile/scale/type.test.ts
+++ b/test/compile/scale/type.test.ts
@@ -301,14 +301,6 @@ describe('compile/scale', () => {
         );
       });
 
-      it('should return utc scale type if timeunit is utc and specified scale type is not discrete domain', () => {
-        assert.equal(
-          scaleType(ScaleType.LOG, 'x', {type: 'temporal', timeUnit: 'utcyear'}, 'point', undefined, undefined, defaultConfig),
-          ScaleType.UTC
-        );
-      });
-
-
       it('should return default scale type if data type is temporal but specified scale type is time or utc or any discrete type', () => {
         assert.equal(
           scaleType(ScaleType.LINEAR, 'x', {type: 'temporal', timeUnit: 'year'}, 'point', undefined, undefined, defaultConfig),

--- a/test/fielddef.test.ts
+++ b/test/fielddef.test.ts
@@ -46,11 +46,6 @@ describe('fieldDef', () => {
       assert.deepEqual(normalize(fieldDef, 'x'), {field: 'a', type: 'quantitative'});
       assert.equal(localLogger.warns[0], log.message.invalidAggregate('boxplot'));
     }));
-
-    it('should use utc timeunit with utc scale type.',() => {
-      const fieldDef = {field: 'a', type: 'temporal', timeUnit: 'year', scale: {type: 'utc'}};
-      assert.deepEqual(normalize(fieldDef, 'x')['timeUnit'], 'utcyear');
-    });
   });
 
   describe('channelCompatability', () => {


### PR DESCRIPTION
After the discussion with @kanitw, we agree on:

### Input
read input data as utc behavior should remain mostly the same as https://github.com/vega/vega-lite/pull/2345 Only difference is for input time data in ISO format, we will parse the data in utc.

### Output
To have user output in utc, we need to let user specify either one of:
1) utc timeunit when you have input data in local time, or 
2) utc scale type when you have input data in utc time
to have the correct output in utc time. But not **both** of utc timeunit and utc scale type since that will cause a trouble by shifting the output twice in vega.

Fix #2048 
The reason for why the #2048 output is wrong is that the input data is in ISO format and we will parse it in utc time automatically. So we need to be consistent to have data output in utc or in local time as well. So the right spec should be either:
1) utc scale type to let user output in utc

```
{
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "description": "Line chart of Horsepower over time",
  "data": {"url": "data/cars.json"},
  "mark": "bar",
  "encoding": {
    "x": {"field": "Year", "type": "temporal", "scale": {"type": "utc"}},
    "y": {"field": "Horsepower", "type": "quantitative", "aggregate": "mean"}
  }
}

```

<img width="264" alt="screen shot 2017-05-08 at 12 22 57 pm" src="https://cloud.githubusercontent.com/assets/11696585/25821438/e5bab6fc-33e9-11e7-968d-6b8ccdb17545.png">



or 

2) utc timeunit to let user output in localtime

```
{
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "description": "Line chart of Horsepower over time",
  "data": {"url": "data/cars.json"},
  "mark": "bar",
  "encoding": {
    "x": {"field": "Year", "type": "temporal", "timeUnit": "utcyear"},
    "y": {"field": "Horsepower", "type": "quantitative", "aggregate": "mean"}
  }
}
```

<img width="257" alt="screen shot 2017-05-08 at 12 24 31 pm" src="https://cloud.githubusercontent.com/assets/11696585/25821440/ea0db07e-33e9-11e7-93a4-a44b3f81453e.png">


