### PR TITLE
Boxplot Orient

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -49,6 +49,9 @@
                             "$ref": "#/definitions/MarkDef"
                         },
                         {
+                            "$ref": "#/definitions/BoxPlotDef"
+                        },
+                        {
                             "enum": [
                                 "area",
                                 "bar",
@@ -174,10 +177,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/UnitSpec"
+                                "$ref": "#/definitions/GenericUnitSpec<Encoding, AnyMark>"
                             },
                             {
-                                "$ref": "#/definitions/LayerSpec"
+                                "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<Encoding, AnyMark>>"
                             }
                         ]
                     },
@@ -333,13 +336,13 @@
                 "spec": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/UnitSpec"
+                            "$ref": "#/definitions/GenericUnitSpec<Encoding, AnyMark>"
                         },
                         {
-                            "$ref": "#/definitions/LayerSpec"
+                            "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<Encoding, AnyMark>>"
                         },
                         {
-                            "$ref": "#/definitions/RepeatSpec"
+                            "$ref": "#/definitions/GenericRepeatSpec<GenericUnitSpec<Encoding, AnyMark>>"
                         }
                     ]
                 },
@@ -435,13 +438,13 @@
                 "spec": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/UnitSpec"
+                            "$ref": "#/definitions/GenericUnitSpec<Encoding, AnyMark>"
                         },
                         {
-                            "$ref": "#/definitions/LayerSpec"
+                            "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<Encoding, AnyMark>>"
                         },
                         {
-                            "$ref": "#/definitions/RepeatSpec"
+                            "$ref": "#/definitions/GenericRepeatSpec<GenericUnitSpec<Encoding, AnyMark>>"
                         }
                     ]
                 },
@@ -549,13 +552,13 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/UnitSpec"
+                                "$ref": "#/definitions/GenericUnitSpec<Encoding, AnyMark>"
                             },
                             {
-                                "$ref": "#/definitions/LayerSpec"
+                                "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<Encoding, AnyMark>>"
                             },
                             {
-                                "$ref": "#/definitions/RepeatSpec"
+                                "$ref": "#/definitions/GenericRepeatSpec<GenericUnitSpec<Encoding, AnyMark>>"
                             }
                         ]
                     },
@@ -605,13 +608,13 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/UnitSpec"
+                                "$ref": "#/definitions/GenericUnitSpec<Encoding, AnyMark>"
                             },
                             {
-                                "$ref": "#/definitions/LayerSpec"
+                                "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<Encoding, AnyMark>>"
                             },
                             {
-                                "$ref": "#/definitions/RepeatSpec"
+                                "$ref": "#/definitions/GenericRepeatSpec<GenericUnitSpec<Encoding, AnyMark>>"
                             }
                         ]
                     },
@@ -1634,6 +1637,25 @@
                     "type": "number"
                 }
             },
+            "type": "object"
+        },
+        "BoxPlotDef": {
+            "additionalProperties": false,
+            "properties": {
+                "orient": {
+                    "$ref": "#/definitions/Orient"
+                },
+                "type": {
+                    "enum": [
+                        "box-plot"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "orient",
+                "type"
+            ],
             "type": "object"
         },
         "CalculateTransform": {
@@ -2721,7 +2743,7 @@
             ],
             "type": "string"
         },
-        "LayerSpec": {
+        "GenericLayerSpec<GenericUnitSpec<Encoding, AnyMark>>": {
             "additionalProperties": false,
             "properties": {
                 "data": {
@@ -2751,10 +2773,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/UnitSpec"
+                                "$ref": "#/definitions/GenericUnitSpec<Encoding, AnyMark>"
                             },
                             {
-                                "$ref": "#/definitions/LayerSpec"
+                                "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<Encoding, AnyMark>>"
                             }
                         ]
                     },
@@ -2812,7 +2834,7 @@
             ],
             "type": "object"
         },
-        "RepeatSpec": {
+        "GenericRepeatSpec<GenericUnitSpec<Encoding, AnyMark>>": {
             "additionalProperties": false,
             "properties": {
                 "data": {
@@ -2843,13 +2865,13 @@
                 "spec": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/UnitSpec"
+                            "$ref": "#/definitions/GenericUnitSpec<Encoding, AnyMark>"
                         },
                         {
-                            "$ref": "#/definitions/LayerSpec"
+                            "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<Encoding, AnyMark>>"
                         },
                         {
-                            "$ref": "#/definitions/RepeatSpec"
+                            "$ref": "#/definitions/GenericRepeatSpec<GenericUnitSpec<Encoding, AnyMark>>"
                         }
                     ]
                 },
@@ -2874,7 +2896,7 @@
             ],
             "type": "object"
         },
-        "UnitSpec": {
+        "GenericUnitSpec<Encoding, AnyMark>": {
             "additionalProperties": false,
             "properties": {
                 "data": {
@@ -2907,6 +2929,9 @@
                     "anyOf": [
                         {
                             "$ref": "#/definitions/MarkDef"
+                        },
+                        {
+                            "$ref": "#/definitions/BoxPlotDef"
                         },
                         {
                             "enum": [

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -177,10 +177,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/GenericUnitSpec<Encoding, AnyMark>"
+                                "$ref": "#/definitions/UnitSpec"
                             },
                             {
-                                "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<Encoding, AnyMark>>"
+                                "$ref": "#/definitions/LayerSpec"
                             }
                         ]
                     },
@@ -336,13 +336,13 @@
                 "spec": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/GenericUnitSpec<Encoding, AnyMark>"
+                            "$ref": "#/definitions/UnitSpec"
                         },
                         {
-                            "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<Encoding, AnyMark>>"
+                            "$ref": "#/definitions/LayerSpec"
                         },
                         {
-                            "$ref": "#/definitions/GenericRepeatSpec<GenericUnitSpec<Encoding, AnyMark>>"
+                            "$ref": "#/definitions/RepeatSpec"
                         }
                     ]
                 },
@@ -438,13 +438,13 @@
                 "spec": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/GenericUnitSpec<Encoding, AnyMark>"
+                            "$ref": "#/definitions/UnitSpec"
                         },
                         {
-                            "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<Encoding, AnyMark>>"
+                            "$ref": "#/definitions/LayerSpec"
                         },
                         {
-                            "$ref": "#/definitions/GenericRepeatSpec<GenericUnitSpec<Encoding, AnyMark>>"
+                            "$ref": "#/definitions/RepeatSpec"
                         }
                     ]
                 },
@@ -552,13 +552,13 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/GenericUnitSpec<Encoding, AnyMark>"
+                                "$ref": "#/definitions/UnitSpec"
                             },
                             {
-                                "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<Encoding, AnyMark>>"
+                                "$ref": "#/definitions/LayerSpec"
                             },
                             {
-                                "$ref": "#/definitions/GenericRepeatSpec<GenericUnitSpec<Encoding, AnyMark>>"
+                                "$ref": "#/definitions/RepeatSpec"
                             }
                         ]
                     },
@@ -608,13 +608,13 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/GenericUnitSpec<Encoding, AnyMark>"
+                                "$ref": "#/definitions/UnitSpec"
                             },
                             {
-                                "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<Encoding, AnyMark>>"
+                                "$ref": "#/definitions/LayerSpec"
                             },
                             {
-                                "$ref": "#/definitions/GenericRepeatSpec<GenericUnitSpec<Encoding, AnyMark>>"
+                                "$ref": "#/definitions/RepeatSpec"
                             }
                         ]
                     },
@@ -2743,7 +2743,7 @@
             ],
             "type": "string"
         },
-        "GenericLayerSpec<GenericUnitSpec<Encoding, AnyMark>>": {
+        "LayerSpec": {
             "additionalProperties": false,
             "properties": {
                 "data": {
@@ -2773,10 +2773,10 @@
                     "items": {
                         "anyOf": [
                             {
-                                "$ref": "#/definitions/GenericUnitSpec<Encoding, AnyMark>"
+                                "$ref": "#/definitions/UnitSpec"
                             },
                             {
-                                "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<Encoding, AnyMark>>"
+                                "$ref": "#/definitions/LayerSpec"
                             }
                         ]
                     },
@@ -2834,7 +2834,7 @@
             ],
             "type": "object"
         },
-        "GenericRepeatSpec<GenericUnitSpec<Encoding, AnyMark>>": {
+        "RepeatSpec": {
             "additionalProperties": false,
             "properties": {
                 "data": {
@@ -2865,13 +2865,13 @@
                 "spec": {
                     "anyOf": [
                         {
-                            "$ref": "#/definitions/GenericUnitSpec<Encoding, AnyMark>"
+                            "$ref": "#/definitions/UnitSpec"
                         },
                         {
-                            "$ref": "#/definitions/GenericLayerSpec<GenericUnitSpec<Encoding, AnyMark>>"
+                            "$ref": "#/definitions/LayerSpec"
                         },
                         {
-                            "$ref": "#/definitions/GenericRepeatSpec<GenericUnitSpec<Encoding, AnyMark>>"
+                            "$ref": "#/definitions/RepeatSpec"
                         }
                     ]
                 },
@@ -2896,7 +2896,7 @@
             ],
             "type": "object"
         },
-        "GenericUnitSpec<Encoding, AnyMark>": {
+        "UnitSpec": {
             "additionalProperties": false,
             "properties": {
                 "data": {

--- a/scripts/rename-schema.sh
+++ b/scripts/rename-schema.sh
@@ -1,5 +1,5 @@
-perl -pi -e s,'GenericLayerSpec<.*..\.','LayerSpec',g build/vega-lite-schema.json
-perl -pi -e s,'GenericRepeatSpec<.*..\.','RepeatSpec',g build/vega-lite-schema.json
-perl -pi -e s,'GenericUnitSpec<Encoding<.*..\.','UnitSpec',g build/vega-lite-schema.json
-perl -pi -e s,'GenericUnitSpec<EncodingWithFacet<.*..\.','FacetedUnitSpec',g build/vega-lite-schema.json
+perl -pi -e s,'GenericLayerSpec<.*>','LayerSpec',g build/vega-lite-schema.json
+perl -pi -e s,'GenericRepeatSpec<.*>','RepeatSpec',g build/vega-lite-schema.json
+perl -pi -e s,'GenericUnitSpec<EncodingWithFacet<.*>','FacetedUnitSpec',g build/vega-lite-schema.json
+perl -pi -e s,'GenericUnitSpec<Encoding<.*>','UnitSpec',g build/vega-lite-schema.json
 perl -pi -e s,'<Field>',,g build/vega-lite-schema.json

--- a/src/compile/mark/init.ts
+++ b/src/compile/mark/init.ts
@@ -3,12 +3,13 @@ import {Config} from '../../config';
 import {Encoding, isAggregate} from '../../encoding';
 import {FieldDef, isContinuous, isFieldDef} from '../../fielddef';
 import * as log from '../../log';
-import {AREA, BAR, CIRCLE, isMarkDef, LINE, Mark, MarkDef, Orient, POINT, RECT, RULE, SQUARE, TEXT, TICK} from '../../mark';
+import {AREA, BAR, CIRCLE, isMarkDef, LINE, Mark, MarkDef, POINT, RECT, RULE, SQUARE, TEXT, TICK} from '../../mark';
 import {hasDiscreteDomain, Scale} from '../../scale';
 import {StackProperties} from '../../stack';
 import {TEMPORAL} from '../../type';
 import {contains, Dict} from '../../util';
 import {getMarkConfig} from '../common';
+import {Orient} from './../../vega.schema';
 
 export function initMarkDef(mark: Mark | MarkDef, encoding: Encoding<string>, scale: Dict<Scale>, config: Config): MarkDef {
   const markDef = isMarkDef(mark) ? {...mark} : {type: mark};

--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -30,15 +30,6 @@ export function normalizeBoxPlot(spec: GenericUnitSpec<Encoding<Field>, BOXPLOT 
 
   if (encoding.x && encoding.y) {
     // 2D
-    if (isContinuous(encoding.x) && isContinuous(encoding.y)) {
-      const xEncChannel = encoding.x as FieldDef<Field>;
-      const yEncChannel = encoding.y as FieldDef<Field>;
-      if (xEncChannel.aggregate === BOXPLOT && yEncChannel.aggregate === BOXPLOT) {
-        throw new Error('Both x and y cannot have aggregate');
-      }
-    } else if (isDiscrete(encoding.x) && isDiscrete(encoding.y)) {
-      throw new Error('Both x and y cannot be discrete');
-    }
 
     const orient: Orient = box2DOrient(spec);
     const params = box2DParams(spec, orient);
@@ -154,6 +145,16 @@ export function box2DOrient(spec: GenericUnitSpec<Encoding<Field>, BOXPLOT | Box
   const xEncChannel = encoding.x as FieldDef<Field>;
   const yEncChannel = encoding.y as FieldDef<Field>;
   let resultOrient: Orient;
+
+  if (isContinuous(encoding.x) && isContinuous(encoding.y)) {
+    const xEncChannel = encoding.x as FieldDef<Field>;
+    const yEncChannel = encoding.y as FieldDef<Field>;
+    if (xEncChannel.aggregate === BOXPLOT && yEncChannel.aggregate === BOXPLOT) {
+      throw new Error('Both x and y cannot have aggregate');
+    }
+  } else if (isDiscrete(encoding.x) && isDiscrete(encoding.y)) {
+    throw new Error('Both x and y cannot be discrete');
+  }
 
   if (isDiscrete(encoding.x) && isContinuous(encoding.y)) {
     resultOrient = 'vertical';

--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -13,6 +13,10 @@ export interface BoxPlotDef {
   orient: Orient;
 }
 
+export function isBoxPlotDef(object: BOXPLOT | BoxPlotDef): object is BoxPlotDef {
+  return !!object['type'];
+}
+
 export interface BoxPlotConfig extends MarkConfig {
   /** Size of the box and mid tick of a box plot */
   size?: number;
@@ -159,7 +163,7 @@ export function box2DOrient(spec: GenericUnitSpec<Encoding<Field>, BOXPLOT | Box
       } else if (xEncChannel.aggregate === BOXPLOT && yEncChannel.aggregate === BOXPLOT) {
         throw new Error('Both x and y cannot have aggregate');
       } else {
-        if (instanceofBoxPlotDef(mark)) {
+        if (isBoxPlotDef(mark)) {
           if (mark && mark.orient) {
             resultOrient = mark.orient;
           } else {
@@ -178,9 +182,6 @@ export function box2DOrient(spec: GenericUnitSpec<Encoding<Field>, BOXPLOT | Box
   return resultOrient;
 }
 
-export function instanceofBoxPlotDef(object: any): object is BoxPlotDef {
-  return typeof object !== 'string' && 'type' in object && 'orient' in object;
-}
 
 export function box2DParams(spec: GenericUnitSpec<Encoding<Field>, BOXPLOT | BoxPlotDef>, orient: Orient) {
   const {mark: mark, encoding: encoding, ...outerSpec} = spec;

--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -1,21 +1,25 @@
 import {Config} from '../config';
-import {Field} from '../fielddef';
 import {Encoding} from './../encoding';
-import {isContinuous, isDiscrete, PositionFieldDef} from './../fielddef';
-import {MarkConfig} from './../mark';
+import {Field, FieldDef, isContinuous, isDiscrete, PositionFieldDef} from './../fielddef';
+import {MarkConfig, MarkDef} from './../mark';
 import {GenericUnitSpec, LayerSpec} from './../spec';
+import {Orient} from './../vega.schema';
 
 export const BOXPLOT: 'box-plot' = 'box-plot';
 export type BOXPLOT = typeof BOXPLOT;
 
+export interface BoxPlotDef {
+  type: BOXPLOT;
+  orient: Orient;
+}
 
 export interface BoxPlotConfig extends MarkConfig {
   /** Size of the box and mid tick of a box plot */
   size?: number;
 }
 
-export function normalizeBoxPlot(spec: GenericUnitSpec<Encoding<Field>, BOXPLOT>, config: Config): LayerSpec {
-  const {mark: _m, encoding: encoding, ...outerSpec} = spec;
+export function normalizeBoxPlot(spec: GenericUnitSpec<Encoding<Field>, BOXPLOT | BoxPlotDef>, config: Config): LayerSpec {
+  const {mark: mark, encoding: encoding, ...outerSpec} = spec;
   const {x: _x, y: _y, ...nonPositionEncoding} = encoding;
   const {size: size, ...nonPositionEncodingWithoutSize} = nonPositionEncoding;
   const {color: _color, ...nonPositionEncodingWithoutColorSize} = nonPositionEncodingWithoutSize;
@@ -26,23 +30,23 @@ export function normalizeBoxPlot(spec: GenericUnitSpec<Encoding<Field>, BOXPLOT>
 
   if (encoding.x && encoding.y) {
     // 2D
-    if (isDiscrete(encoding.x) && isContinuous(encoding.y)) {
-      // vertical
-      discreteAxis = 'x';
-      continuousAxis = 'y';
-      continuousAxisChannelDef = encoding.y;
-
-      discreteAxisFieldDef = encoding.x;
-    } else if (isDiscrete(encoding.y) && isContinuous(encoding.x)) {
-      // horizontal
-      discreteAxis = 'y';
-      continuousAxis = 'x';
-      continuousAxisChannelDef = encoding.x;
-
-      discreteAxisFieldDef = encoding.y;
-    } else {
-      throw new Error('Need one continuous and one discrete axis for 2D boxplots');
+    if (isContinuous(encoding.x) && isContinuous(encoding.y)) {
+      const xEncChannel = encoding.x as FieldDef<Field>;
+      const yEncChannel = encoding.y as FieldDef<Field>;
+      if (xEncChannel.aggregate === BOXPLOT && yEncChannel.aggregate === BOXPLOT) {
+        throw new Error('Both x and y cannot have aggregate');
+      }
+    } else if (isDiscrete(encoding.x) && isDiscrete(encoding.y)) {
+      throw new Error('Both x and y cannot be discrete');
     }
+
+    const orient: Orient = box2DOrient(spec);
+    const params = box2DParams(spec, orient);
+    discreteAxisFieldDef = params.discreteAxisFieldDef;
+    continuousAxisChannelDef = params.continuousAxisChannelDef;
+    discreteAxis = params.discreteAxis;
+    continuousAxis = params.continuousAxis;
+
   } else if (encoding.x && isContinuous(encoding.x) && encoding.y === undefined) {
     // 1D horizontal
     continuousAxis = 'x';
@@ -145,3 +149,71 @@ export function normalizeBoxPlot(spec: GenericUnitSpec<Encoding<Field>, BOXPLOT>
   };
 }
 
+export function box2DOrient(spec: GenericUnitSpec<Encoding<Field>, BOXPLOT | BoxPlotDef>): Orient {
+  const {mark: mark, encoding: encoding, ...outerSpec} = spec;
+  const xEncChannel = encoding.x as FieldDef<Field>;
+  const yEncChannel = encoding.y as FieldDef<Field>;
+  let resultOrient: Orient;
+
+  if (isDiscrete(encoding.x) && isContinuous(encoding.y)) {
+    resultOrient = 'vertical';
+  } else if (isDiscrete(encoding.y) && isContinuous(encoding.x)) {
+    resultOrient = 'horizontal';
+  } else {
+    if (isContinuous(encoding.x) && isContinuous(encoding.y)) {
+      if (xEncChannel.aggregate === undefined && yEncChannel.aggregate === BOXPLOT) {
+        resultOrient = 'vertical';
+      } else if (yEncChannel.aggregate === undefined && xEncChannel.aggregate === BOXPLOT) {
+        resultOrient = 'horizontal';
+      } else if (xEncChannel.aggregate === BOXPLOT && yEncChannel.aggregate === BOXPLOT) {
+        return undefined; // invalid spec
+      } else {
+        const markChannel = mark as BoxPlotDef;
+        if (markChannel && markChannel.orient) {
+          resultOrient = markChannel.orient;
+        } else {
+          // default orientation = vertical
+          resultOrient = 'vertical';
+        }
+      }
+    } else {
+      resultOrient = undefined; // 2 discrete axes
+    }
+  }
+
+  return resultOrient;
+}
+
+export function box2DParams(spec: GenericUnitSpec<Encoding<Field>, BOXPLOT | BoxPlotDef>, orient: Orient) {
+  const {mark: mark, encoding: encoding, ...outerSpec} = spec;
+
+  let discreteAxisFieldDef: PositionFieldDef<Field>, continuousAxisChannelDef: PositionFieldDef<Field>;
+  let discreteAxis, continuousAxis;
+
+  if (orient === 'vertical') {
+    discreteAxis = 'x';
+    continuousAxis = 'y';
+    continuousAxisChannelDef = encoding.y;
+    discreteAxisFieldDef = encoding.x;
+  } else {
+    discreteAxis = 'y';
+    continuousAxis = 'x';
+    continuousAxisChannelDef = encoding.x;
+    discreteAxisFieldDef = encoding.y;
+  }
+
+  if (continuousAxisChannelDef && continuousAxisChannelDef.aggregate) {
+    const {aggregate: aggregate, ...continuousAxisWithoutAggregate} = continuousAxisChannelDef;
+    if (aggregate !== BOXPLOT) {
+      throw new Error('Continuous axis should not be aggregated');
+    }
+    continuousAxisChannelDef = continuousAxisWithoutAggregate;
+  }
+
+  return {
+    discreteAxisFieldDef: discreteAxisFieldDef,
+    continuousAxisChannelDef: continuousAxisChannelDef,
+    discreteAxis: discreteAxis,
+    continuousAxis: continuousAxis
+  };
+}

--- a/src/compositemark/index.ts
+++ b/src/compositemark/index.ts
@@ -1,7 +1,7 @@
 import {Config} from './../config';
-import {isMarkDef, MarkDef} from './../mark';
+import {AnyMark, isMarkDef, Mark, MarkDef} from './../mark';
 import {GenericUnitSpec, LayerSpec} from './../spec';
-import {BOXPLOT, normalizeBoxPlot} from './boxplot';
+import {BOXPLOT, BoxPlotDef, normalizeBoxPlot} from './boxplot';
 import {ERRORBAR, normalizeErrorBar} from './errorbar';
 
 export {BoxPlotConfig} from './boxplot';
@@ -21,6 +21,9 @@ export function remove(mark: string) {
 }
 
 export type CompositeMark = BOXPLOT | ERRORBAR;
+
+export type CompositeMarkDef = BoxPlotDef;
+
 export type CompositeAggregate = BOXPLOT;
 
 add(BOXPLOT, normalizeBoxPlot);
@@ -31,7 +34,7 @@ add(ERRORBAR, normalizeErrorBar);
  */
 export function normalize(
     // This GenericUnitSpec has any as Encoding because unit specs with composite mark can have additional encoding channels.
-    spec: GenericUnitSpec<any, string | MarkDef>,
+    spec: GenericUnitSpec<any, AnyMark>,
     config: Config
   ): LayerSpec {
 

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -1,6 +1,6 @@
+import {CompositeMark, CompositeMarkDef} from './compositemark/index';
 import {toSet} from './util';
 import {Interpolate, Orient, VgMarkConfig} from './vega.schema';
-export {Orient} from './vega.schema';
 
 export namespace Mark {
   export const AREA: 'area' = 'area';
@@ -93,13 +93,15 @@ export interface MarkDef {
   tension?: number;
 }
 
-export function isMarkDef(mark: string | MarkDef): mark is MarkDef {
+export type AnyMark = CompositeMark | CompositeMarkDef | Mark | MarkDef;
+
+export function isMarkDef(mark: AnyMark): mark is (MarkDef | CompositeMarkDef) {
   return mark['type'];
 }
 
 const PRIMITIVE_MARK_INDEX = toSet(PRIMITIVE_MARKS);
 
-export function isPrimitiveMark(mark: string | MarkDef): mark is Mark {
+export function isPrimitiveMark(mark: CompositeMark | CompositeMarkDef | Mark | MarkDef): mark is Mark {
   const markType = isMarkDef(mark) ? mark.type : mark;
   return markType in PRIMITIVE_MARK_INDEX;
 }

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -8,7 +8,7 @@ import * as vlEncoding from './encoding';
 import {Facet} from './facet';
 import {Field, FieldDef} from './fielddef';
 import * as log from './log';
-import {AREA, isPrimitiveMark, LINE, Mark, MarkDef} from './mark';
+import {AnyMark, AREA, isPrimitiveMark, LINE, Mark, MarkDef} from './mark';
 import {Repeat} from './repeat';
 import {ResolveMapping} from './resolve';
 import {SelectionDef} from './selection';
@@ -106,12 +106,12 @@ export type UnitSpec = GenericUnitSpec<Encoding<Field>, Mark | MarkDef>;
 /**
  * Unit spec that can contain composite mark
  */
-export type CompositeUnitSpec = GenericUnitSpec<Encoding<Field>, CompositeMark | Mark | MarkDef>;
+export type CompositeUnitSpec = GenericUnitSpec<Encoding<Field>, AnyMark>;
 
 /**
  * Unit spec that can contain composite mark and row or column channels.
  */
-export type FacetedCompositeUnitSpec = GenericUnitSpec<EncodingWithFacet<Field>, CompositeMark | Mark | MarkDef>;
+export type FacetedCompositeUnitSpec = GenericUnitSpec<EncodingWithFacet<Field>, AnyMark>;
 
 export interface GenericLayerSpec<U extends GenericUnitSpec<any, any>> extends BaseSpec, UnitSize {
   /**
@@ -309,12 +309,12 @@ function normalizeFacetedUnit(spec: FacetedCompositeUnitSpec, config: Config): F
   };
 }
 
-function isNonFacetUnitSpecWithPrimitiveMark(spec: GenericUnitSpec<Encoding<Field>, string | MarkDef>):
+function isNonFacetUnitSpecWithPrimitiveMark(spec: GenericUnitSpec<Encoding<Field>, AnyMark>):
   spec is GenericUnitSpec<Encoding<Field>, Mark> {
     return isPrimitiveMark(spec.mark);
 }
 
-function normalizeNonFacetUnit(spec: GenericUnitSpec<Encoding<Field>, string | MarkDef>, config: Config) {
+function normalizeNonFacetUnit(spec: GenericUnitSpec<Encoding<Field>, AnyMark>, config: Config) {
   if (isNonFacetUnitSpecWithPrimitiveMark(spec)) {
     // TODO: thoroughly test
     if (isRanged(spec.encoding)) {

--- a/test/compositemark.test.ts
+++ b/test/compositemark.test.ts
@@ -236,7 +236,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           "color": {"value" : "skyblue"}
         }
       }, defaultConfig);
-    }, Error, 'Continuous axis should not be aggregate');
+    }, Error, 'Continuous axis should not have customized aggregation function min');
   });
 
   it("should produce an error if continuous axis has aggregate property 2D", () => {
@@ -257,7 +257,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           "color": {"value" : "skyblue"}
         }
       }, defaultConfig);
-    }, Error, 'Continuous axis should not be aggregate');
+    }, Error, 'Continuous axis should not have customized aggregation function min');
   });
 
   it("should produce an error if build 1D boxplot with a discrete axis", () => {

--- a/test/compositemark.test.ts
+++ b/test/compositemark.test.ts
@@ -3,7 +3,7 @@
 import {assert} from 'chai';
 import {Encoding} from '../src/encoding';
 import {Field} from '../src/fielddef';
-import {MarkDef} from '../src/mark';
+import {Mark, MarkDef} from '../src/mark';
 import {GenericSpec, GenericUnitSpec, normalize} from '../src/spec';
 import {Config, defaultConfig} from './../src/config';
 
@@ -99,15 +99,16 @@ describe("normalizeErrorBar", () => {
  });
 
 describe("normalizeBox", () => {
-  it("should produce an error if both axes are continuous", () => {
+  it("should produce an error if both axes have aggregate boxplot", () => {
     assert.throws(() => {
       normalize({
         "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
         "data": {"url": "data/population.json"},
         mark: "box-plot",
         encoding: {
-          "x": {"field": "people","type": "quantitative"},
+          "x": {"aggregate": "box-plot", "field": "people","type": "quantitative"},
           "y": {
+            "aggregate": "box-plot",
             "field": "people",
             "type": "quantitative",
             "axis": {"title": "population"}
@@ -116,10 +117,129 @@ describe("normalizeBox", () => {
           "color": {"value" : "skyblue"}
         }
       }, defaultConfig);
-    }, Error, 'Need one continuous and one discrete axis for 2D boxplots');
+    }, Error, 'Both x and y cannot have aggregate');
   });
 
-  it("should produce an error if continuous axis has aggregate property", () => {
+it("should produce correct layered specs for vertical boxplot with two quantitative axes and use default orientation", () => {
+     assert.deepEqual<GenericSpec<GenericUnitSpec<Encoding<Field>, string | MarkDef>>>(normalize({
+        "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
+        "data": {"url": "data/population.json"},
+        mark: "box-plot",
+        encoding: {
+          "x": {"field": "age","type": "quantitative"},
+          "y": {
+            "field": "people",
+            "type": "quantitative",
+            "axis": {"title": "population"}
+          },
+          "size": {"value": 5},
+          "color": {"value" : "skyblue"}
+        }
+      }, defaultConfig), {
+        "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
+        "data": {"url": "data/population.json"},
+        "layer": [
+          {
+            mark: {
+              type: 'rule',
+              role: 'boxWhisker'
+            },
+            "encoding": {
+              "x": {"field": "age","type": "quantitative"},
+              "y": {
+                "aggregate": "min",
+                "field": "people",
+                "type": "quantitative",
+                "axis": {"title": "population"}
+              },
+              "y2": {
+                "aggregate": "q1",
+                "field": "people",
+                "type": "quantitative"
+              }
+            }
+          },
+          {
+            mark: {
+              type: 'rule',
+              role: 'boxWhisker'
+            },
+            "encoding": {
+              "x": {"field": "age","type": "quantitative"},
+              "y": {
+                "aggregate": "q3",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "y2": {
+                "aggregate": "max",
+                "field": "people",
+                "type": "quantitative"
+              }
+            }
+          },
+          {
+            mark: {
+              type: 'bar',
+              role: 'box'
+            },
+            "encoding": {
+              "x": {"field": "age","type": "quantitative"},
+              "y": {
+                "aggregate": "q1",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "y2": {
+                "aggregate": "q3",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "size": {"value": 5},
+              "color": {"value" : "skyblue"}
+            }
+          },
+          {
+            mark: {
+              type: 'tick',
+              role: 'boxMid'
+            },
+            "encoding": {
+              "x": {"field": "age","type": "quantitative"},
+              "y": {
+                "aggregate": "median",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "color": {"value" : "white"},
+              "size": {"value": 5}
+            }
+          }
+        ]
+      });
+  });
+
+  it("should produce an error if continuous axis has aggregate property 1D", () => {
+    assert.throws(() => {
+      normalize({
+        "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
+        "data": {"url": "data/population.json"},
+        mark: "box-plot",
+        encoding: {
+          "y": {
+            "aggregate": "min",
+            "field": "people",
+            "type": "quantitative",
+            "axis": {"title": "population"}
+          },
+          "size": {"value": 5},
+          "color": {"value" : "skyblue"}
+        }
+      }, defaultConfig);
+    }, Error, 'Continuous axis should not be aggregate');
+  });
+
+  it("should produce an error if continuous axis has aggregate property 2D", () => {
     assert.throws(() => {
       normalize({
         "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
@@ -170,7 +290,411 @@ describe("normalizeBox", () => {
           "color": {"value" : "skyblue"}
         }
       }, defaultConfig);
-    }, Error, 'Need one continuous and one discrete axis');
+    }, Error, 'Both x and y cannot be discrete');
+  });
+
+  it("should produce correct layered specs for vertical boxplot with two quantitative axes and specify orientation with orient", () => {
+    assert.deepEqual<GenericSpec<GenericUnitSpec<Encoding<Field>, Mark | MarkDef>>>(normalize({
+        "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
+        "data": {"url": "data/population.json"},
+        mark: {
+          type: "box-plot",
+          orient: "vertical"
+        },
+        encoding: {
+          "x": {"field": "age","type": "quantitative"},
+          "y": {
+            "field": "people",
+            "type": "quantitative",
+            "axis": {"title": "population"}
+          },
+          "size": {"value": 5},
+          "color": {"value" : "skyblue"}
+        }
+      }, defaultConfig), {
+        "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
+        "data": {"url": "data/population.json"},
+        "layer": [
+          {
+            mark: {
+              type: 'rule',
+              role: 'boxWhisker'
+            },
+            "encoding": {
+              "x": {"field": "age","type": "quantitative"},
+              "y": {
+                "aggregate": "min",
+                "field": "people",
+                "type": "quantitative",
+                "axis": {"title": "population"}
+              },
+              "y2": {
+                "aggregate": "q1",
+                "field": "people",
+                "type": "quantitative"
+              }
+            }
+          },
+          {
+            mark: {
+              type: 'rule',
+              role: 'boxWhisker'
+            },
+            "encoding": {
+              "x": {"field": "age","type": "quantitative"},
+              "y": {
+                "aggregate": "q3",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "y2": {
+                "aggregate": "max",
+                "field": "people",
+                "type": "quantitative"
+              }
+            }
+          },
+          {
+            mark: {
+              type: 'bar',
+              role: 'box'
+            },
+            "encoding": {
+              "x": {"field": "age","type": "quantitative"},
+              "y": {
+                "aggregate": "q1",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "y2": {
+                "aggregate": "q3",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "size": {"value": 5},
+              "color": {"value" : "skyblue"}
+            }
+          },
+          {
+            mark: {
+              type: 'tick',
+              role: 'boxMid'
+            },
+            "encoding": {
+              "x": {"field": "age","type": "quantitative"},
+              "y": {
+                "aggregate": "median",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "color": {"value" : "white"},
+              "size": {"value": 5}
+            }
+          }
+        ]
+      });
+  });
+
+  it("should produce correct layered specs for horizontal boxplot with two quantitative axes and specify orientation with orient", () => {
+     assert.deepEqual<GenericSpec<GenericUnitSpec<Encoding<Field>, Mark | MarkDef>>>(normalize({
+        "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
+        "data": {"url": "data/population.json"},
+        mark: {
+          type: "box-plot",
+          orient: "horizontal"
+        },
+        encoding: {
+          "y": {"field": "age","type": "quantitative"},
+          "x": {
+            "field": "people",
+            "type": "quantitative",
+            "axis": {"title": "population"}
+          },
+          "size": {"value": 5},
+          "color": {"value" : "skyblue"}
+        }
+      }, defaultConfig), {
+        "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
+        "data": {"url": "data/population.json"},
+        "layer": [
+          {
+            mark: {
+              type: 'rule',
+              role: 'boxWhisker'
+            },
+            "encoding": {
+              "y": {"field": "age","type": "quantitative"},
+              "x": {
+                "aggregate": "min",
+                "field": "people",
+                "type": "quantitative",
+                "axis": {"title": "population"}
+              },
+              "x2": {
+                "aggregate": "q1",
+                "field": "people",
+                "type": "quantitative"
+              }
+            }
+          },
+          {
+            mark: {
+              type: 'rule',
+              role: 'boxWhisker'
+            },
+            "encoding": {
+              "y": {"field": "age","type": "quantitative"},
+              "x": {
+                "aggregate": "q3",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "x2": {
+                "aggregate": "max",
+                "field": "people",
+                "type": "quantitative"
+              }
+            }
+          },
+          {
+            mark: {
+              type: 'bar',
+              role: 'box'
+            },
+            "encoding": {
+              "y": {"field": "age","type": "quantitative"},
+              "x": {
+                "aggregate": "q1",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "x2": {
+                "aggregate": "q3",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "size": {"value": 5},
+              "color": {"value" : "skyblue"}
+            }
+          },
+          {
+            mark: {
+              type: 'tick',
+              role: 'boxMid'
+            },
+            "encoding": {
+              "y": {"field": "age","type": "quantitative"},
+              "x": {
+                "aggregate": "median",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "size": {"value": 5},
+              "color": {"value" : "white"}
+            }
+          }
+        ]
+      });
+  });
+
+  it("should produce correct layered specs for vertical boxplot with two quantitative axes and specify orientation with aggregate", () => {
+     assert.deepEqual<GenericSpec<GenericUnitSpec<Encoding<Field>, string | MarkDef>>>(normalize({
+        "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
+        "data": {"url": "data/population.json"},
+        mark: "box-plot",
+        encoding: {
+          "x": {"field": "age","type": "quantitative"},
+          "y": {
+            "field": "people",
+            "type": "quantitative",
+            "aggregate": "box-plot",
+            "axis": {"title": "population"}
+          },
+          "size": {"value": 5},
+          "color": {"value" : "skyblue"}
+        }
+      }, defaultConfig), {
+        "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
+        "data": {"url": "data/population.json"},
+        "layer": [
+          {
+            mark: {
+              type: 'rule',
+              role: 'boxWhisker'
+            },
+            "encoding": {
+              "x": {"field": "age","type": "quantitative"},
+              "y": {
+                "aggregate": "min",
+                "field": "people",
+                "type": "quantitative",
+                "axis": {"title": "population"}
+              },
+              "y2": {
+                "aggregate": "q1",
+                "field": "people",
+                "type": "quantitative"
+              }
+            }
+          },
+          {
+            mark: {
+              type: 'rule',
+              role: 'boxWhisker'
+            },
+            "encoding": {
+              "x": {"field": "age","type": "quantitative"},
+              "y": {
+                "aggregate": "q3",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "y2": {
+                "aggregate": "max",
+                "field": "people",
+                "type": "quantitative"
+              }
+            }
+          },
+          {
+            mark: {
+              type: 'bar',
+              role: 'box'
+            },
+            "encoding": {
+              "x": {"field": "age","type": "quantitative"},
+              "y": {
+                "aggregate": "q1",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "y2": {
+                "aggregate": "q3",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "size": {"value": 5},
+              "color": {"value" : "skyblue"}
+            }
+          },
+          {
+            mark: {
+              type: 'tick',
+              role: 'boxMid'
+            },
+            "encoding": {
+              "x": {"field": "age","type": "quantitative"},
+              "y": {
+                "aggregate": "median",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "color": {"value" : "white"},
+              "size": {"value": 5}
+            }
+          }
+        ]
+      });
+  });
+
+  it("should produce correct layered specs for horizontal boxplot with two quantitative axes and specify orientation with aggregate", () => {
+     assert.deepEqual<GenericSpec<GenericUnitSpec<Encoding<Field>, string | MarkDef>>>(normalize({
+        "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
+        "data": {"url": "data/population.json"},
+        mark: "box-plot",
+        encoding: {
+          "y": {"field": "age","type": "quantitative"},
+          "x": {
+            "field": "people",
+            "type": "quantitative",
+            "aggregate": "box-plot",
+            "axis": {"title": "population"}
+          },
+          "size": {"value": 5},
+          "color": {"value" : "skyblue"}
+        }
+      }, defaultConfig), {
+        "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
+        "data": {"url": "data/population.json"},
+        "layer": [
+          {
+            mark: {
+              type: 'rule',
+              role: 'boxWhisker'
+            },
+            "encoding": {
+              "y": {"field": "age","type": "quantitative"},
+              "x": {
+                "aggregate": "min",
+                "field": "people",
+                "type": "quantitative",
+                "axis": {"title": "population"}
+              },
+              "x2": {
+                "aggregate": "q1",
+                "field": "people",
+                "type": "quantitative"
+              }
+            }
+          },
+          {
+            mark: {
+              type: 'rule',
+              role: 'boxWhisker'
+            },
+            "encoding": {
+              "y": {"field": "age","type": "quantitative"},
+              "x": {
+                "aggregate": "q3",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "x2": {
+                "aggregate": "max",
+                "field": "people",
+                "type": "quantitative"
+              }
+            }
+          },
+          {
+            mark: {
+              type: 'bar',
+              role: 'box'
+            },
+            "encoding": {
+              "y": {"field": "age","type": "quantitative"},
+              "x": {
+                "aggregate": "q1",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "x2": {
+                "aggregate": "q3",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "size": {"value": 5},
+              "color": {"value" : "skyblue"}
+            }
+          },
+          {
+            mark: {
+              type: 'tick',
+              role: 'boxMid'
+            },
+            "encoding": {
+              "y": {"field": "age","type": "quantitative"},
+              "x": {
+                "aggregate": "median",
+                "field": "people",
+                "type": "quantitative"
+              },
+              "size": {"value": 5},
+              "color": {"value" : "white"}
+            }
+          }
+        ]
+      });
   });
 
   it("should produce correct layered specs for vertical boxplot with min and max", () => {


### PR DESCRIPTION
Allow the use of aggregate and or orient to determine box plot orientation.

Refers to issue: #2303 

This is the updated version of the boxplot pr in a new branch and pr because of weird merging in the #2313 pr.