### PR TITLE
Break apart pixel and data signals for interval selections

### DIFF
--- a/examples/specs/interactive_splom.vl.json
+++ b/examples/specs/interactive_splom.vl.json
@@ -10,14 +10,15 @@
     "selection": {
       "brush": {
         "type": "interval", "resolve": "union",
-        "encodings": ["x"],
         "on": "[mousedown[event.shiftKey], mouseup] > mousemove",
-        "translate": "[mousedown[event.shiftKey], mouseup] > mousemove"
+        "translate": "[mousedown[event.shiftKey], mouseup] > mousemove",
+        "zoom": "wheel[event.shiftKey]"
       },
       "grid": {
         "type": "interval", "resolve": "global",
         "bind": "scales",
-        "translate": "[mousedown[!event.shiftKey], mouseup] > mousemove"
+        "translate": "[mousedown[!event.shiftKey], mouseup] > mousemove",
+        "zoom": "wheel[!event.shiftKey]"
       }
     },
     "encoding": {

--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -51,7 +51,7 @@
             "type": "group",
             "signals": [
                 {
-                    "name": "brush_Horsepower",
+                    "name": "brush_x",
                     "value": [],
                     "on": [
                         {
@@ -59,10 +59,10 @@
                                 "source": "scope",
                                 "type": "mousedown",
                                 "filter": [
-                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                 ]
                             },
-                            "update": "invert(\"x\", [x(unit), x(unit)])"
+                            "update": "[x(unit), x(unit)]"
                         },
                         {
                             "events": {
@@ -74,7 +74,7 @@
                                         "source": "scope",
                                         "type": "mousedown",
                                         "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
                                     {
@@ -83,111 +83,102 @@
                                     }
                                 ]
                             },
-                            "update": "[brush_Horsepower[0], invert(\"x\", clamp(x(unit), 0, width))]"
+                            "update": "[brush_x[0], clamp(x(unit), 0, width)]"
+                        },
+                        {
+                            "events": {
+                                "scale": "x"
+                            },
+                            "update": "!isArray(brush_Horsepower) ? brush_x : [scale(\"x\", brush_Horsepower[0]), scale(\"x\", brush_Horsepower[1])]"
                         },
                         {
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.x + (brush_Horsepower[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_Horsepower[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_Horsepower",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "brush_x"
+                            },
+                            "update": "invert(\"x\", brush_x)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_y",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
+                                ]
+                            },
+                            "update": "[y(unit), y(unit)]"
+                        },
+                        {
+                            "events": {
+                                "source": "window",
+                                "type": "mousemove",
+                                "consume": true,
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
+                                        ]
+                                    },
+                                    {
+                                        "source": "window",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "[brush_y[0], clamp(y(unit), 0, height)]"
+                        },
+                        {
+                            "events": {
+                                "scale": "y"
+                            },
+                            "update": "!isArray(brush_Miles_per_Gallon) ? brush_y : [scale(\"y\", brush_Miles_per_Gallon[0]), scale(\"y\", brush_Miles_per_Gallon[1])]"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_translate_delta"
+                            },
+                            "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_zoom_delta"
+                            },
+                            "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
                         }
                     ]
                 },
                 {
                     "name": "brush_Miles_per_Gallon",
-                    "value": [],
                     "on": [
                         {
                             "events": {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                ]
+                                "signal": "brush_y"
                             },
-                            "update": "invert(\"y\", [y(unit), y(unit)])"
-                        },
-                        {
-                            "events": {
-                                "source": "window",
-                                "type": "mousemove",
-                                "consume": true,
-                                "between": [
-                                    {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
-                                    },
-                                    {
-                                        "source": "window",
-                                        "type": "mouseup"
-                                    }
-                                ]
-                            },
-                            "update": "[brush_Miles_per_Gallon[0], invert(\"y\", clamp(y(unit), 0, height))]"
-                        },
-                        {
-                            "events": {
-                                "signal": "brush_translate_delta"
-                            },
-                            "update": "clampRange([brush_translate_anchor.extent_y[0] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height, brush_translate_anchor.extent_y[1] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
-                        },
-                        {
-                            "events": {
-                                "signal": "brush_zoom_delta"
-                            },
-                            "update": "clampRange([brush_zoom_anchor.y + (brush_Miles_per_Gallon[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_Miles_per_Gallon[1] - brush_zoom_anchor.y) * brush_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
-                        }
-                    ]
-                },
-                {
-                    "name": "brush_size",
-                    "value": [],
-                    "on": [
-                        {
-                            "events": {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                ]
-                            },
-                            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                        },
-                        {
-                            "events": {
-                                "source": "window",
-                                "type": "mousemove",
-                                "consume": true,
-                                "between": [
-                                    {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
-                                    },
-                                    {
-                                        "source": "window",
-                                        "type": "mouseup"
-                                    }
-                                ]
-                            },
-                            "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                        },
-                        {
-                            "events": {
-                                "signal": "brush_zoom_delta"
-                            },
-                            "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                            "update": "invert(\"y\", brush_y)"
                         }
                     ]
                 },
@@ -207,7 +198,7 @@
                                     "markname": "brush_brush"
                                 }
                             ],
-                            "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_Horsepower), extent_y: slice(brush_Miles_per_Gallon), }"
+                            "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x), extent_y: slice(brush_y)}"
                         }
                     ]
                 },
@@ -249,7 +240,7 @@
                                     "markname": "brush_brush"
                                 }
                             ],
-                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                            "update": "{x: x(unit), y: y(unit)}"
                         }
                     ]
                 },
@@ -321,18 +312,7 @@
                             "x": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[0]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "x2": [
-                                {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[1]"
+                                    "signal": "brush_x[0]"
                                 },
                                 {
                                     "value": 0
@@ -341,8 +321,16 @@
                             "y": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[0]"
+                                    "signal": "brush_y[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "signal": "brush_x[1]"
                                 },
                                 {
                                     "value": 0
@@ -351,8 +339,7 @@
                             "y2": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[1]"
+                                    "signal": "brush_y[1]"
                                 },
                                 {
                                     "value": 0
@@ -413,18 +400,7 @@
                             "x": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[0]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "x2": [
-                                {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[1]"
+                                    "signal": "brush_x[0]"
                                 },
                                 {
                                     "value": 0
@@ -433,8 +409,16 @@
                             "y": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[0]"
+                                    "signal": "brush_y[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "signal": "brush_x[1]"
                                 },
                                 {
                                     "value": 0
@@ -443,8 +427,7 @@
                             "y2": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[1]"
+                                    "signal": "brush_y[1]"
                                 },
                                 {
                                     "value": 0

--- a/examples/vg-specs/concat_selections.vg.json
+++ b/examples/vg-specs/concat_selections.vg.json
@@ -124,7 +124,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_Miles_per_Gallon",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -132,11 +132,10 @@
                                         "source": "scope",
                                         "type": "mousedown",
                                         "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"concat_0_x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -148,8 +147,7 @@
                                                 "source": "scope",
                                                 "type": "mousedown",
                                                 "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -158,115 +156,102 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_Miles_per_Gallon[0], invert(\"concat_0_x\", clamp(x(unit), 0, concat_0_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, concat_0_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "concat_0_x"
+                                    },
+                                    "update": "!isArray(brush_Miles_per_Gallon) ? brush_x : [scale(\"concat_0_x\", brush_Miles_per_Gallon[0]), scale(\"concat_0_x\", brush_Miles_per_Gallon[1])]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"concat_0_x\", 0), invert(\"concat_0_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_Miles_per_Gallon[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_Miles_per_Gallon[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"concat_0_x\", 0), invert(\"concat_0_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "brush_Miles_per_Gallon",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "brush_x"
+                                    },
+                                    "update": "invert(\"concat_0_x\", brush_x)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "brush_y",
+                            "value": [],
+                            "on": [
+                                {
+                                    "events": {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
+                                        ]
+                                    },
+                                    "update": "[y(unit), y(unit)]"
+                                },
+                                {
+                                    "events": {
+                                        "source": "window",
+                                        "type": "mousemove",
+                                        "consume": true,
+                                        "between": [
+                                            {
+                                                "source": "scope",
+                                                "type": "mousedown",
+                                                "filter": [
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
+                                                ]
+                                            },
+                                            {
+                                                "source": "window",
+                                                "type": "mouseup"
+                                            }
+                                        ]
+                                    },
+                                    "update": "[brush_y[0], clamp(y(unit), 0, concat_0_height)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "concat_0_y"
+                                    },
+                                    "update": "!isArray(brush_Horsepower) ? brush_y : [scale(\"concat_0_y\", brush_Horsepower[0]), scale(\"concat_0_y\", brush_Horsepower[1])]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "brush_translate_delta"
+                                    },
+                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "brush_zoom_delta"
+                                    },
+                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
                                 }
                             ]
                         },
                         {
                             "name": "brush_Horsepower",
-                            "value": [],
                             "on": [
                                 {
                                     "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
+                                        "signal": "brush_y"
                                     },
-                                    "update": "invert(\"concat_0_y\", [y(unit), y(unit)])"
-                                },
-                                {
-                                    "events": {
-                                        "source": "window",
-                                        "type": "mousemove",
-                                        "consume": true,
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "window",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "[brush_Horsepower[0], invert(\"concat_0_y\", clamp(y(unit), 0, concat_0_height))]"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_translate_delta"
-                                    },
-                                    "update": "clampRange([brush_translate_anchor.extent_y[0] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height, brush_translate_anchor.extent_y[1] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height], invert(\"concat_0_y\", unit.height), invert(\"concat_0_y\", 0))"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_zoom_delta"
-                                    },
-                                    "update": "clampRange([brush_zoom_anchor.y + (brush_Horsepower[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_Horsepower[1] - brush_zoom_anchor.y) * brush_zoom_delta], invert(\"concat_0_y\", unit.height), invert(\"concat_0_y\", 0))"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "brush_size",
-                            "value": [],
-                            "on": [
-                                {
-                                    "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
-                                    },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                                },
-                                {
-                                    "events": {
-                                        "source": "window",
-                                        "type": "mousemove",
-                                        "consume": true,
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "window",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_zoom_delta"
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "invert(\"concat_0_y\", brush_y)"
                                 }
                             ]
                         },
@@ -286,7 +271,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_Miles_per_Gallon), extent_y: slice(brush_Horsepower), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x), extent_y: slice(brush_y)}"
                                 }
                             ]
                         },
@@ -328,7 +313,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"concat_0_x\", x(unit)), y: invert(\"concat_0_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -387,18 +372,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -407,8 +381,16 @@
                                     "y": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_y",
-                                            "signal": "brush[1].extent[0]"
+                                            "signal": "brush_y[0]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0
@@ -417,8 +399,7 @@
                                     "y2": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_y",
-                                            "signal": "brush[1].extent[1]"
+                                            "signal": "brush_y[1]"
                                         },
                                         {
                                             "value": 0
@@ -472,18 +453,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -492,8 +462,16 @@
                                     "y": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_y",
-                                            "signal": "brush[1].extent[0]"
+                                            "signal": "brush_y[0]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0
@@ -502,8 +480,7 @@
                                     "y2": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_y",
-                                            "signal": "brush[1].extent[1]"
+                                            "signal": "brush_y[1]"
                                         },
                                         {
                                             "value": 0
@@ -610,7 +587,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
+                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
                                 },
                                 {
                                     "events": {
@@ -628,7 +605,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
                                 },
                                 {
                                     "events": {
@@ -654,7 +631,7 @@
                                             "type": "mousedown"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"concat_1_x\"), extent_y: domain(\"concat_1_y\"), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: domain(\"concat_1_x\"), extent_y: domain(\"concat_1_y\")}"
                                 }
                             ]
                         },

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -266,7 +266,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_X",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -275,11 +275,10 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -291,8 +290,7 @@
                                                 "type": "mousedown",
                                                 "filter": [
                                                     "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -301,65 +299,36 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_X[0], invert(\"x\", clamp(x(unit), 0, child_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, child_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "x"
+                                    },
+                                    "update": "!isArray(brush_X) ? brush_x : [scale(\"x\", brush_X[0]), scale(\"x\", brush_X[1])]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_X[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_X[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
-                            "value": [],
+                            "name": "brush_X",
                             "on": [
                                 {
                                     "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
+                                        "signal": "brush_x"
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                                },
-                                {
-                                    "events": {
-                                        "source": "scope",
-                                        "type": "mousemove",
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "scope",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_zoom_delta"
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "invert(\"x\", brush_x)"
                                 }
                             ]
                         },
@@ -382,7 +351,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_X), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x)}"
                                 }
                             ]
                         },
@@ -426,7 +395,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -475,7 +444,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
+                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
                                 },
                                 {
                                     "events": {
@@ -493,7 +462,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
                                 },
                                 {
                                     "events": {
@@ -522,7 +491,7 @@
                                             ]
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: domain(\"x\"), extent_y: domain(\"y\")}"
                                 }
                             ]
                         },
@@ -646,15 +615,13 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "x",
-                                        "signal": "brush[0].extent[1]"
+                                        "signal": "brush_x[0]"
                                     },
                                     "y": {
                                         "value": 0
+                                    },
+                                    "x2": {
+                                        "signal": "brush_x[1]"
                                     },
                                     "y2": {
                                         "field": {
@@ -763,15 +730,13 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "x",
-                                        "signal": "brush[0].extent[1]"
+                                        "signal": "brush_x[0]"
                                     },
                                     "y": {
                                         "value": 0
+                                    },
+                                    "x2": {
+                                        "signal": "brush_x[1]"
                                     },
                                     "y2": {
                                         "field": {

--- a/examples/vg-specs/interactive_splom.vg.json
+++ b/examples/vg-specs/interactive_splom.vg.json
@@ -178,7 +178,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_Horsepower",
+                            "name": "brush_y",
                             "value": [],
                             "on": [
                                 {
@@ -187,11 +187,10 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"child_Horsepower_Horsepower_x\", [x(unit), x(unit)])"
+                                    "update": "[y(unit), y(unit)]"
                                 },
                                 {
                                     "events": {
@@ -203,8 +202,7 @@
                                                 "type": "mousedown",
                                                 "filter": [
                                                     "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -213,71 +211,42 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_Horsepower[0], invert(\"child_Horsepower_Horsepower_x\", clamp(x(unit), 0, child_Horsepower_Horsepower_width))]"
+                                    "update": "[brush_y[0], clamp(y(unit), 0, child_Horsepower_Horsepower_height)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_Horsepower_Horsepower_y"
+                                    },
+                                    "update": "!isArray(brush_Horsepower) ? brush_y : [scale(\"child_Horsepower_Horsepower_y\", brush_Horsepower[0]), scale(\"child_Horsepower_Horsepower_y\", brush_Horsepower[1])]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"child_Horsepower_Horsepower_x\", 0), invert(\"child_Horsepower_Horsepower_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_Horsepower[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_Horsepower[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"child_Horsepower_Horsepower_x\", 0), invert(\"child_Horsepower_Horsepower_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
-                            "value": [],
+                            "name": "brush_Horsepower",
                             "on": [
                                 {
                                     "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
+                                        "signal": "brush_y"
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                                },
-                                {
-                                    "events": {
-                                        "source": "scope",
-                                        "type": "mousemove",
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "scope",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_zoom_delta"
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "invert(\"child_Horsepower_Horsepower_y\", brush_y)"
                                 }
                             ]
                         },
                         {
                             "name": "brush",
-                            "update": "[{encoding: \"x\", field: \"Horsepower\", extent: brush_Horsepower}]"
+                            "update": "[{encoding: \"y\", field: \"Horsepower\", extent: brush_Horsepower}]"
                         },
                         {
                             "name": "brush_translate_anchor",
@@ -294,7 +263,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_Horsepower), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_y: slice(brush_y)}"
                                 }
                             ]
                         },
@@ -335,10 +304,13 @@
                                         {
                                             "source": "scope",
                                             "type": "wheel",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"child_Horsepower_Horsepower_x\", x(unit)), y: invert(\"child_Horsepower_Horsepower_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -350,6 +322,9 @@
                                         {
                                             "source": "scope",
                                             "type": "wheel",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
                                             "markname": "brush_brush"
                                         }
                                     ],
@@ -387,7 +362,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
                                 },
                                 {
                                     "events": {
@@ -416,7 +391,7 @@
                                             ]
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_y: domain(\"child_Horsepower_Horsepower_y\"), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_y: domain(\"child_Horsepower_Horsepower_y\")}"
                                 }
                             ]
                         },
@@ -455,7 +430,10 @@
                                     "events": [
                                         {
                                             "source": "scope",
-                                            "type": "wheel"
+                                            "type": "wheel",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
                                         }
                                     ],
                                     "update": "{x: invert(\"child_Horsepower_Horsepower_x\", x(unit)), y: invert(\"child_Horsepower_Horsepower_y\", y(unit))}"
@@ -469,7 +447,10 @@
                                     "events": [
                                         {
                                             "source": "scope",
-                                            "type": "wheel"
+                                            "type": "wheel",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
                                         }
                                     ],
                                     "force": true,
@@ -514,20 +495,18 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "child_Horsepower_Horsepower_x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "child_Horsepower_Horsepower_x",
-                                        "signal": "brush[0].extent[1]"
-                                    },
-                                    "y": {
                                         "value": 0
                                     },
-                                    "y2": {
+                                    "y": {
+                                        "signal": "brush_y[0]"
+                                    },
+                                    "x2": {
                                         "field": {
-                                            "group": "height"
+                                            "group": "width"
                                         }
+                                    },
+                                    "y2": {
+                                        "signal": "brush_y[1]"
                                     }
                                 }
                             },
@@ -584,20 +563,18 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "child_Horsepower_Horsepower_x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "child_Horsepower_Horsepower_x",
-                                        "signal": "brush[0].extent[1]"
-                                    },
-                                    "y": {
                                         "value": 0
                                     },
-                                    "y2": {
+                                    "y": {
+                                        "signal": "brush_y[0]"
+                                    },
+                                    "x2": {
                                         "field": {
-                                            "group": "height"
+                                            "group": "width"
                                         }
+                                    },
+                                    "y2": {
+                                        "signal": "brush_y[1]"
                                     }
                                 }
                             },
@@ -698,7 +675,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_Horsepower",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -707,11 +684,10 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"child_Horsepower_Miles_per_Gallon_x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -723,8 +699,7 @@
                                                 "type": "mousedown",
                                                 "filter": [
                                                     "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -733,24 +708,41 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_Horsepower[0], invert(\"child_Horsepower_Miles_per_Gallon_x\", clamp(x(unit), 0, child_Horsepower_Miles_per_Gallon_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, child_Horsepower_Miles_per_Gallon_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_Horsepower_Miles_per_Gallon_x"
+                                    },
+                                    "update": "!isArray(brush_Horsepower) ? brush_x : [scale(\"child_Horsepower_Miles_per_Gallon_x\", brush_Horsepower[0]), scale(\"child_Horsepower_Miles_per_Gallon_x\", brush_Horsepower[1])]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"child_Horsepower_Miles_per_Gallon_x\", 0), invert(\"child_Horsepower_Miles_per_Gallon_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_Horsepower[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_Horsepower[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"child_Horsepower_Miles_per_Gallon_x\", 0), invert(\"child_Horsepower_Miles_per_Gallon_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
+                            "name": "brush_Horsepower",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "brush_x"
+                                    },
+                                    "update": "invert(\"child_Horsepower_Miles_per_Gallon_x\", brush_x)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "brush_y",
                             "value": [],
                             "on": [
                                 {
@@ -759,11 +751,10 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
+                                    "update": "[y(unit), y(unit)]"
                                 },
                                 {
                                     "events": {
@@ -775,8 +766,7 @@
                                                 "type": "mousedown",
                                                 "filter": [
                                                     "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -785,19 +775,42 @@
                                             }
                                         ]
                                     },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
+                                    "update": "[brush_y[0], clamp(y(unit), 0, child_Horsepower_Miles_per_Gallon_height)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_Horsepower_Miles_per_Gallon_y"
+                                    },
+                                    "update": "!isArray(brush_Miles_per_Gallon) ? brush_y : [scale(\"child_Horsepower_Miles_per_Gallon_y\", brush_Miles_per_Gallon[0]), scale(\"child_Horsepower_Miles_per_Gallon_y\", brush_Miles_per_Gallon[1])]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "brush_translate_delta"
+                                    },
+                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "brush_Miles_per_Gallon",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "brush_y"
+                                    },
+                                    "update": "invert(\"child_Horsepower_Miles_per_Gallon_y\", brush_y)"
                                 }
                             ]
                         },
                         {
                             "name": "brush",
-                            "update": "[{encoding: \"x\", field: \"Horsepower\", extent: brush_Horsepower}]"
+                            "update": "[{encoding: \"x\", field: \"Horsepower\", extent: brush_Horsepower}, {encoding: \"y\", field: \"Miles_per_Gallon\", extent: brush_Miles_per_Gallon}]"
                         },
                         {
                             "name": "brush_translate_anchor",
@@ -814,7 +827,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_Horsepower), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x), extent_y: slice(brush_y)}"
                                 }
                             ]
                         },
@@ -855,10 +868,13 @@
                                         {
                                             "source": "scope",
                                             "type": "wheel",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"child_Horsepower_Miles_per_Gallon_x\", x(unit)), y: invert(\"child_Horsepower_Miles_per_Gallon_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -870,6 +886,9 @@
                                         {
                                             "source": "scope",
                                             "type": "wheel",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
                                             "markname": "brush_brush"
                                         }
                                     ],
@@ -907,7 +926,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
+                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
                                 },
                                 {
                                     "events": {
@@ -925,7 +944,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
                                 },
                                 {
                                     "events": {
@@ -954,7 +973,7 @@
                                             ]
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"child_Horsepower_Miles_per_Gallon_x\"), extent_y: domain(\"child_Horsepower_Miles_per_Gallon_y\"), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: domain(\"child_Horsepower_Miles_per_Gallon_x\"), extent_y: domain(\"child_Horsepower_Miles_per_Gallon_y\")}"
                                 }
                             ]
                         },
@@ -993,7 +1012,10 @@
                                     "events": [
                                         {
                                             "source": "scope",
-                                            "type": "wheel"
+                                            "type": "wheel",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
                                         }
                                     ],
                                     "update": "{x: invert(\"child_Horsepower_Miles_per_Gallon_x\", x(unit)), y: invert(\"child_Horsepower_Miles_per_Gallon_y\", y(unit))}"
@@ -1007,7 +1029,10 @@
                                     "events": [
                                         {
                                             "source": "scope",
-                                            "type": "wheel"
+                                            "type": "wheel",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
                                         }
                                     ],
                                     "force": true,
@@ -1052,20 +1077,16 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "child_Horsepower_Miles_per_Gallon_x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "child_Horsepower_Miles_per_Gallon_x",
-                                        "signal": "brush[0].extent[1]"
+                                        "signal": "brush_x[0]"
                                     },
                                     "y": {
-                                        "value": 0
+                                        "signal": "brush_y[0]"
+                                    },
+                                    "x2": {
+                                        "signal": "brush_x[1]"
                                     },
                                     "y2": {
-                                        "field": {
-                                            "group": "height"
-                                        }
+                                        "signal": "brush_y[1]"
                                     }
                                 }
                             },
@@ -1122,20 +1143,16 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "child_Horsepower_Miles_per_Gallon_x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "child_Horsepower_Miles_per_Gallon_x",
-                                        "signal": "brush[0].extent[1]"
+                                        "signal": "brush_x[0]"
                                     },
                                     "y": {
-                                        "value": 0
+                                        "signal": "brush_y[0]"
+                                    },
+                                    "x2": {
+                                        "signal": "brush_x[1]"
                                     },
                                     "y2": {
-                                        "field": {
-                                            "group": "height"
-                                        }
+                                        "signal": "brush_y[1]"
                                     }
                                 }
                             },
@@ -1239,7 +1256,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_Acceleration",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -1248,11 +1265,10 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"child_Acceleration_Horsepower_x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -1264,8 +1280,7 @@
                                                 "type": "mousedown",
                                                 "filter": [
                                                     "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -1274,24 +1289,41 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_Acceleration[0], invert(\"child_Acceleration_Horsepower_x\", clamp(x(unit), 0, child_Acceleration_Horsepower_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, child_Acceleration_Horsepower_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_Acceleration_Horsepower_x"
+                                    },
+                                    "update": "!isArray(brush_Acceleration) ? brush_x : [scale(\"child_Acceleration_Horsepower_x\", brush_Acceleration[0]), scale(\"child_Acceleration_Horsepower_x\", brush_Acceleration[1])]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"child_Acceleration_Horsepower_x\", 0), invert(\"child_Acceleration_Horsepower_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_Acceleration[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_Acceleration[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"child_Acceleration_Horsepower_x\", 0), invert(\"child_Acceleration_Horsepower_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
+                            "name": "brush_Acceleration",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "brush_x"
+                                    },
+                                    "update": "invert(\"child_Acceleration_Horsepower_x\", brush_x)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "brush_y",
                             "value": [],
                             "on": [
                                 {
@@ -1300,11 +1332,10 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
+                                    "update": "[y(unit), y(unit)]"
                                 },
                                 {
                                     "events": {
@@ -1316,8 +1347,7 @@
                                                 "type": "mousedown",
                                                 "filter": [
                                                     "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -1326,19 +1356,42 @@
                                             }
                                         ]
                                     },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
+                                    "update": "[brush_y[0], clamp(y(unit), 0, child_Acceleration_Horsepower_height)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_Acceleration_Horsepower_y"
+                                    },
+                                    "update": "!isArray(brush_Horsepower) ? brush_y : [scale(\"child_Acceleration_Horsepower_y\", brush_Horsepower[0]), scale(\"child_Acceleration_Horsepower_y\", brush_Horsepower[1])]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "brush_translate_delta"
+                                    },
+                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "brush_Horsepower",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "brush_y"
+                                    },
+                                    "update": "invert(\"child_Acceleration_Horsepower_y\", brush_y)"
                                 }
                             ]
                         },
                         {
                             "name": "brush",
-                            "update": "[{encoding: \"x\", field: \"Acceleration\", extent: brush_Acceleration}]"
+                            "update": "[{encoding: \"x\", field: \"Acceleration\", extent: brush_Acceleration}, {encoding: \"y\", field: \"Horsepower\", extent: brush_Horsepower}]"
                         },
                         {
                             "name": "brush_translate_anchor",
@@ -1355,7 +1408,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_Acceleration), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x), extent_y: slice(brush_y)}"
                                 }
                             ]
                         },
@@ -1396,10 +1449,13 @@
                                         {
                                             "source": "scope",
                                             "type": "wheel",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"child_Acceleration_Horsepower_x\", x(unit)), y: invert(\"child_Acceleration_Horsepower_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -1411,6 +1467,9 @@
                                         {
                                             "source": "scope",
                                             "type": "wheel",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
                                             "markname": "brush_brush"
                                         }
                                     ],
@@ -1448,7 +1507,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
+                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
                                 },
                                 {
                                     "events": {
@@ -1466,7 +1525,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
                                 },
                                 {
                                     "events": {
@@ -1495,7 +1554,7 @@
                                             ]
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"child_Acceleration_Horsepower_x\"), extent_y: domain(\"child_Acceleration_Horsepower_y\"), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: domain(\"child_Acceleration_Horsepower_x\"), extent_y: domain(\"child_Acceleration_Horsepower_y\")}"
                                 }
                             ]
                         },
@@ -1534,7 +1593,10 @@
                                     "events": [
                                         {
                                             "source": "scope",
-                                            "type": "wheel"
+                                            "type": "wheel",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
                                         }
                                     ],
                                     "update": "{x: invert(\"child_Acceleration_Horsepower_x\", x(unit)), y: invert(\"child_Acceleration_Horsepower_y\", y(unit))}"
@@ -1548,7 +1610,10 @@
                                     "events": [
                                         {
                                             "source": "scope",
-                                            "type": "wheel"
+                                            "type": "wheel",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
                                         }
                                     ],
                                     "force": true,
@@ -1593,20 +1658,16 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "child_Acceleration_Horsepower_x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "child_Acceleration_Horsepower_x",
-                                        "signal": "brush[0].extent[1]"
+                                        "signal": "brush_x[0]"
                                     },
                                     "y": {
-                                        "value": 0
+                                        "signal": "brush_y[0]"
+                                    },
+                                    "x2": {
+                                        "signal": "brush_x[1]"
                                     },
                                     "y2": {
-                                        "field": {
-                                            "group": "height"
-                                        }
+                                        "signal": "brush_y[1]"
                                     }
                                 }
                             },
@@ -1663,20 +1724,16 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "child_Acceleration_Horsepower_x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "child_Acceleration_Horsepower_x",
-                                        "signal": "brush[0].extent[1]"
+                                        "signal": "brush_x[0]"
                                     },
                                     "y": {
-                                        "value": 0
+                                        "signal": "brush_y[0]"
+                                    },
+                                    "x2": {
+                                        "signal": "brush_x[1]"
                                     },
                                     "y2": {
-                                        "field": {
-                                            "group": "height"
-                                        }
+                                        "signal": "brush_y[1]"
                                     }
                                 }
                             },
@@ -1780,7 +1837,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_Acceleration",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -1789,11 +1846,10 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"child_Acceleration_Miles_per_Gallon_x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -1805,8 +1861,7 @@
                                                 "type": "mousedown",
                                                 "filter": [
                                                     "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -1815,24 +1870,41 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_Acceleration[0], invert(\"child_Acceleration_Miles_per_Gallon_x\", clamp(x(unit), 0, child_Acceleration_Miles_per_Gallon_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, child_Acceleration_Miles_per_Gallon_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_Acceleration_Miles_per_Gallon_x"
+                                    },
+                                    "update": "!isArray(brush_Acceleration) ? brush_x : [scale(\"child_Acceleration_Miles_per_Gallon_x\", brush_Acceleration[0]), scale(\"child_Acceleration_Miles_per_Gallon_x\", brush_Acceleration[1])]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"child_Acceleration_Miles_per_Gallon_x\", 0), invert(\"child_Acceleration_Miles_per_Gallon_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_Acceleration[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_Acceleration[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"child_Acceleration_Miles_per_Gallon_x\", 0), invert(\"child_Acceleration_Miles_per_Gallon_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
+                            "name": "brush_Acceleration",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "brush_x"
+                                    },
+                                    "update": "invert(\"child_Acceleration_Miles_per_Gallon_x\", brush_x)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "brush_y",
                             "value": [],
                             "on": [
                                 {
@@ -1841,11 +1913,10 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
+                                    "update": "[y(unit), y(unit)]"
                                 },
                                 {
                                     "events": {
@@ -1857,8 +1928,7 @@
                                                 "type": "mousedown",
                                                 "filter": [
                                                     "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -1867,19 +1937,42 @@
                                             }
                                         ]
                                     },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
+                                    "update": "[brush_y[0], clamp(y(unit), 0, child_Acceleration_Miles_per_Gallon_height)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_Acceleration_Miles_per_Gallon_y"
+                                    },
+                                    "update": "!isArray(brush_Miles_per_Gallon) ? brush_y : [scale(\"child_Acceleration_Miles_per_Gallon_y\", brush_Miles_per_Gallon[0]), scale(\"child_Acceleration_Miles_per_Gallon_y\", brush_Miles_per_Gallon[1])]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "brush_translate_delta"
+                                    },
+                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "brush_Miles_per_Gallon",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "brush_y"
+                                    },
+                                    "update": "invert(\"child_Acceleration_Miles_per_Gallon_y\", brush_y)"
                                 }
                             ]
                         },
                         {
                             "name": "brush",
-                            "update": "[{encoding: \"x\", field: \"Acceleration\", extent: brush_Acceleration}]"
+                            "update": "[{encoding: \"x\", field: \"Acceleration\", extent: brush_Acceleration}, {encoding: \"y\", field: \"Miles_per_Gallon\", extent: brush_Miles_per_Gallon}]"
                         },
                         {
                             "name": "brush_translate_anchor",
@@ -1896,7 +1989,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_Acceleration), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x), extent_y: slice(brush_y)}"
                                 }
                             ]
                         },
@@ -1937,10 +2030,13 @@
                                         {
                                             "source": "scope",
                                             "type": "wheel",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"child_Acceleration_Miles_per_Gallon_x\", x(unit)), y: invert(\"child_Acceleration_Miles_per_Gallon_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -1952,6 +2048,9 @@
                                         {
                                             "source": "scope",
                                             "type": "wheel",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
                                             "markname": "brush_brush"
                                         }
                                     ],
@@ -1989,7 +2088,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
+                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
                                 },
                                 {
                                     "events": {
@@ -2007,7 +2106,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
                                 },
                                 {
                                     "events": {
@@ -2036,7 +2135,7 @@
                                             ]
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"child_Acceleration_Miles_per_Gallon_x\"), extent_y: domain(\"child_Acceleration_Miles_per_Gallon_y\"), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: domain(\"child_Acceleration_Miles_per_Gallon_x\"), extent_y: domain(\"child_Acceleration_Miles_per_Gallon_y\")}"
                                 }
                             ]
                         },
@@ -2075,7 +2174,10 @@
                                     "events": [
                                         {
                                             "source": "scope",
-                                            "type": "wheel"
+                                            "type": "wheel",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
                                         }
                                     ],
                                     "update": "{x: invert(\"child_Acceleration_Miles_per_Gallon_x\", x(unit)), y: invert(\"child_Acceleration_Miles_per_Gallon_y\", y(unit))}"
@@ -2089,7 +2191,10 @@
                                     "events": [
                                         {
                                             "source": "scope",
-                                            "type": "wheel"
+                                            "type": "wheel",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
                                         }
                                     ],
                                     "force": true,
@@ -2134,20 +2239,16 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "child_Acceleration_Miles_per_Gallon_x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "child_Acceleration_Miles_per_Gallon_x",
-                                        "signal": "brush[0].extent[1]"
+                                        "signal": "brush_x[0]"
                                     },
                                     "y": {
-                                        "value": 0
+                                        "signal": "brush_y[0]"
+                                    },
+                                    "x2": {
+                                        "signal": "brush_x[1]"
                                     },
                                     "y2": {
-                                        "field": {
-                                            "group": "height"
-                                        }
+                                        "signal": "brush_y[1]"
                                     }
                                 }
                             },
@@ -2204,20 +2305,16 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "child_Acceleration_Miles_per_Gallon_x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "child_Acceleration_Miles_per_Gallon_x",
-                                        "signal": "brush[0].extent[1]"
+                                        "signal": "brush_x[0]"
                                     },
                                     "y": {
-                                        "value": 0
+                                        "signal": "brush_y[0]"
+                                    },
+                                    "x2": {
+                                        "signal": "brush_x[1]"
                                     },
                                     "y2": {
-                                        "field": {
-                                            "group": "height"
-                                        }
+                                        "signal": "brush_y[1]"
                                     }
                                 }
                             },

--- a/examples/vg-specs/layered_crossfilter.vg.json
+++ b/examples/vg-specs/layered_crossfilter.vg.json
@@ -447,7 +447,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_distance",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -455,11 +455,10 @@
                                         "source": "scope",
                                         "type": "mousedown",
                                         "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"child_distance_x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -471,8 +470,7 @@
                                                 "source": "scope",
                                                 "type": "mousedown",
                                                 "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -481,64 +479,36 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_distance[0], invert(\"child_distance_x\", clamp(x(unit), 0, child_distance_layer_0_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, child_distance_layer_0_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_distance_x"
+                                    },
+                                    "update": "[]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"child_distance_x\", 0), invert(\"child_distance_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_distance[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_distance[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"child_distance_x\", 0), invert(\"child_distance_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
-                            "value": [],
+                            "name": "brush_distance",
                             "on": [
                                 {
                                     "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
+                                        "signal": "brush_x"
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                                },
-                                {
-                                    "events": {
-                                        "source": "window",
-                                        "type": "mousemove",
-                                        "consume": true,
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "window",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_zoom_delta"
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "invert(\"child_distance_x\", brush_x)"
                                 }
                             ]
                         },
@@ -558,7 +528,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_distance), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x)}"
                                 }
                             ]
                         },
@@ -600,7 +570,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"child_distance_x\", x(unit)), y: invert(\"child_distance_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -659,18 +629,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_distance_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_distance_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -680,6 +639,15 @@
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
                                             "value": 0
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0
@@ -782,18 +750,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_distance_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_distance_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -803,6 +760,15 @@
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
                                             "value": 0
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0
@@ -932,7 +898,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_delay",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -940,11 +906,10 @@
                                         "source": "scope",
                                         "type": "mousedown",
                                         "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"child_delay_x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -956,8 +921,7 @@
                                                 "source": "scope",
                                                 "type": "mousedown",
                                                 "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -966,64 +930,36 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_delay[0], invert(\"child_delay_x\", clamp(x(unit), 0, child_delay_layer_0_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, child_delay_layer_0_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_delay_x"
+                                    },
+                                    "update": "[]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"child_delay_x\", 0), invert(\"child_delay_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_delay[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_delay[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"child_delay_x\", 0), invert(\"child_delay_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
-                            "value": [],
+                            "name": "brush_delay",
                             "on": [
                                 {
                                     "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
+                                        "signal": "brush_x"
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                                },
-                                {
-                                    "events": {
-                                        "source": "window",
-                                        "type": "mousemove",
-                                        "consume": true,
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "window",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_zoom_delta"
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "invert(\"child_delay_x\", brush_x)"
                                 }
                             ]
                         },
@@ -1043,7 +979,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_delay), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x)}"
                                 }
                             ]
                         },
@@ -1085,7 +1021,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"child_delay_x\", x(unit)), y: invert(\"child_delay_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -1144,18 +1080,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_delay_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_delay_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -1165,6 +1090,15 @@
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
                                             "value": 0
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0
@@ -1267,18 +1201,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_delay_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_delay_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -1288,6 +1211,15 @@
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
                                             "value": 0
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0
@@ -1417,7 +1349,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_time",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -1425,11 +1357,10 @@
                                         "source": "scope",
                                         "type": "mousedown",
                                         "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"child_time_x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -1441,8 +1372,7 @@
                                                 "source": "scope",
                                                 "type": "mousedown",
                                                 "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -1451,64 +1381,36 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_time[0], invert(\"child_time_x\", clamp(x(unit), 0, child_time_layer_0_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, child_time_layer_0_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_time_x"
+                                    },
+                                    "update": "[]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"child_time_x\", 0), invert(\"child_time_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_time[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_time[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"child_time_x\", 0), invert(\"child_time_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
-                            "value": [],
+                            "name": "brush_time",
                             "on": [
                                 {
                                     "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
+                                        "signal": "brush_x"
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                                },
-                                {
-                                    "events": {
-                                        "source": "window",
-                                        "type": "mousemove",
-                                        "consume": true,
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "window",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_zoom_delta"
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "invert(\"child_time_x\", brush_x)"
                                 }
                             ]
                         },
@@ -1528,7 +1430,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_time), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x)}"
                                 }
                             ]
                         },
@@ -1570,7 +1472,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"child_time_x\", x(unit)), y: invert(\"child_time_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -1629,18 +1531,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_time_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_time_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -1650,6 +1541,15 @@
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
                                             "value": 0
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0
@@ -1752,18 +1652,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_time_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_time_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -1773,6 +1662,15 @@
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
                                             "value": 0
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -140,7 +140,7 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
+                            "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
                         },
                         {
                             "events": {
@@ -158,7 +158,7 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                            "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
                         },
                         {
                             "events": {
@@ -187,7 +187,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
+                            "update": "{x: x(unit), y: y(unit), extent_x: domain(\"x\"), extent_y: domain(\"y\")}"
                         }
                     ]
                 },
@@ -297,7 +297,7 @@
                     ]
                 },
                 {
-                    "name": "brush_Horsepower",
+                    "name": "brush_x",
                     "value": [],
                     "on": [
                         {
@@ -306,10 +306,10 @@
                                 "type": "mousedown",
                                 "filter": [
                                     "event.shiftKey",
-                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                 ]
                             },
-                            "update": "invert(\"x\", [x(unit), x(unit)])"
+                            "update": "[x(unit), x(unit)]"
                         },
                         {
                             "events": {
@@ -321,7 +321,7 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
                                     {
@@ -330,113 +330,103 @@
                                     }
                                 ]
                             },
-                            "update": "[brush_Horsepower[0], invert(\"x\", clamp(x(unit), 0, layer_1_width))]"
+                            "update": "[brush_x[0], clamp(x(unit), 0, layer_1_width)]"
+                        },
+                        {
+                            "events": {
+                                "scale": "x"
+                            },
+                            "update": "!isArray(brush_Horsepower) ? brush_x : [scale(\"x\", brush_Horsepower[0]), scale(\"x\", brush_Horsepower[1])]"
                         },
                         {
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.x + (brush_Horsepower[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_Horsepower[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_Horsepower",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "brush_x"
+                            },
+                            "update": "invert(\"x\", brush_x)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_y",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "event.shiftKey",
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
+                                ]
+                            },
+                            "update": "[y(unit), y(unit)]"
+                        },
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousemove",
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "event.shiftKey",
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
+                                        ]
+                                    },
+                                    {
+                                        "source": "scope",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "[brush_y[0], clamp(y(unit), 0, layer_1_height)]"
+                        },
+                        {
+                            "events": {
+                                "scale": "y"
+                            },
+                            "update": "!isArray(brush_Miles_per_Gallon) ? brush_y : [scale(\"y\", brush_Miles_per_Gallon[0]), scale(\"y\", brush_Miles_per_Gallon[1])]"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_translate_delta"
+                            },
+                            "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_zoom_delta"
+                            },
+                            "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
                         }
                     ]
                 },
                 {
                     "name": "brush_Miles_per_Gallon",
-                    "value": [],
                     "on": [
                         {
                             "events": {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "event.shiftKey",
-                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                ]
+                                "signal": "brush_y"
                             },
-                            "update": "invert(\"y\", [y(unit), y(unit)])"
-                        },
-                        {
-                            "events": {
-                                "source": "scope",
-                                "type": "mousemove",
-                                "between": [
-                                    {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
-                                    },
-                                    {
-                                        "source": "scope",
-                                        "type": "mouseup"
-                                    }
-                                ]
-                            },
-                            "update": "[brush_Miles_per_Gallon[0], invert(\"y\", clamp(y(unit), 0, layer_1_height))]"
-                        },
-                        {
-                            "events": {
-                                "signal": "brush_translate_delta"
-                            },
-                            "update": "clampRange([brush_translate_anchor.extent_y[0] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height, brush_translate_anchor.extent_y[1] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
-                        },
-                        {
-                            "events": {
-                                "signal": "brush_zoom_delta"
-                            },
-                            "update": "clampRange([brush_zoom_anchor.y + (brush_Miles_per_Gallon[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_Miles_per_Gallon[1] - brush_zoom_anchor.y) * brush_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
-                        }
-                    ]
-                },
-                {
-                    "name": "brush_size",
-                    "value": [],
-                    "on": [
-                        {
-                            "events": {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "event.shiftKey",
-                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                ]
-                            },
-                            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                        },
-                        {
-                            "events": {
-                                "source": "scope",
-                                "type": "mousemove",
-                                "between": [
-                                    {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
-                                    },
-                                    {
-                                        "source": "scope",
-                                        "type": "mouseup"
-                                    }
-                                ]
-                            },
-                            "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                        },
-                        {
-                            "events": {
-                                "signal": "brush_zoom_delta"
-                            },
-                            "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                            "update": "invert(\"y\", brush_y)"
                         }
                     ]
                 },
@@ -459,7 +449,7 @@
                                     "markname": "brush_brush"
                                 }
                             ],
-                            "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_Horsepower), extent_y: slice(brush_Miles_per_Gallon), }"
+                            "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x), extent_y: slice(brush_y)}"
                         }
                     ]
                 },
@@ -503,7 +493,7 @@
                                     "markname": "brush_brush"
                                 }
                             ],
-                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                            "update": "{x: x(unit), y: y(unit)}"
                         }
                     ]
                 },
@@ -575,18 +565,7 @@
                             "x": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[0]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "x2": [
-                                {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[1]"
+                                    "signal": "brush_x[0]"
                                 },
                                 {
                                     "value": 0
@@ -595,8 +574,16 @@
                             "y": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[0]"
+                                    "signal": "brush_y[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "signal": "brush_x[1]"
                                 },
                                 {
                                     "value": 0
@@ -605,8 +592,7 @@
                             "y2": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[1]"
+                                    "signal": "brush_y[1]"
                                 },
                                 {
                                     "value": 0
@@ -718,18 +704,7 @@
                             "x": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[0]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "x2": [
-                                {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[1]"
+                                    "signal": "brush_x[0]"
                                 },
                                 {
                                     "value": 0
@@ -738,8 +713,16 @@
                             "y": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[0]"
+                                    "signal": "brush_y[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "signal": "brush_x[1]"
                                 },
                                 {
                                     "value": 0
@@ -748,8 +731,7 @@
                             "y2": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[1]"
+                                    "signal": "brush_y[1]"
                                 },
                                 {
                                     "value": 0

--- a/examples/vg-specs/overview_detail.vg.json
+++ b/examples/vg-specs/overview_detail.vg.json
@@ -129,7 +129,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_date",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -137,11 +137,10 @@
                                         "source": "scope",
                                         "type": "mousedown",
                                         "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"concat_0_x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -153,8 +152,7 @@
                                                 "source": "scope",
                                                 "type": "mousedown",
                                                 "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -163,64 +161,36 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_date[0], invert(\"concat_0_x\", clamp(x(unit), 0, concat_0_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, concat_0_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "concat_0_x"
+                                    },
+                                    "update": "!isArray(brush_date) ? brush_x : [scale(\"concat_0_x\", brush_date[0]), scale(\"concat_0_x\", brush_date[1])]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"concat_0_x\", 0), invert(\"concat_0_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_date[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_date[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"concat_0_x\", 0), invert(\"concat_0_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
-                            "value": [],
+                            "name": "brush_date",
                             "on": [
                                 {
                                     "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
+                                        "signal": "brush_x"
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                                },
-                                {
-                                    "events": {
-                                        "source": "window",
-                                        "type": "mousemove",
-                                        "consume": true,
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "window",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_zoom_delta"
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "invert(\"concat_0_x\", brush_x)"
                                 }
                             ]
                         },
@@ -240,7 +210,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_date), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x)}"
                                 }
                             ]
                         },
@@ -282,7 +252,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"concat_0_x\", x(unit)), y: invert(\"concat_0_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -341,18 +311,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -362,6 +321,15 @@
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
                                             "value": 0
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0
@@ -426,18 +394,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -447,6 +404,15 @@
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
                                             "value": 0
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0

--- a/examples/vg-specs/panzoom_scatter.vg.json
+++ b/examples/vg-specs/panzoom_scatter.vg.json
@@ -63,7 +63,7 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
+                            "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
                         },
                         {
                             "events": {
@@ -81,7 +81,7 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                            "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
                         },
                         {
                             "events": {
@@ -107,7 +107,7 @@
                                     "type": "mousedown"
                                 }
                             ],
-                            "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
+                            "update": "{x: x(unit), y: y(unit), extent_x: domain(\"x\"), extent_y: domain(\"y\")}"
                         }
                     ]
                 },

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -2,6 +2,7 @@ import {Channel, X, Y} from '../../channel';
 import {warn} from '../../log';
 import {hasContinuousDomain, isBinScale} from '../../scale';
 import {extend, keys, stringValue} from '../../util';
+import {VgEventStream} from '../../vega.schema';
 import {UnitModel} from '../unit';
 import {channelSignalName, ProjectComponent, SelectionCompiler, SelectionComponent, STORE, TUPLE} from './selection';
 import scales from './transforms/scales';
@@ -18,7 +19,7 @@ const interval:SelectionCompiler = {
 
     if (selCmpt.translate && !(scales.has(selCmpt))) {
       const filterExpr = `!event.item || event.item.mark.name !== ${stringValue(name + BRUSH)}`;
-      events(selCmpt, function(_: any[], evt: any) {
+      events(selCmpt, function(_: any[], evt: VgEventStream) {
         const filters = evt.between[0].filter || (evt.between[0].filter = []);
         if (filters.indexOf(filterExpr) < 0) {
           filters.push(filterExpr);
@@ -138,7 +139,7 @@ function channelSignals(model: UnitModel, selCmpt: SelectionComponent, channel: 
       size  = model.getSizeSignalRef(channel === X ? 'width' : 'height').signal,
       coord = `${channel}(unit)`;
 
-  const on = events(selCmpt, function(def: any[], evt: any) {
+  const on = events(selCmpt, function(def: any[], evt: VgEventStream) {
     return def.concat(
       {events: evt.between[0], update: `[${coord}, ${coord}]`},           // Brush Start
       {events: evt, update: `[${vname}[0], clamp(${coord}, 0, ${size})]`} // Brush End
@@ -165,7 +166,7 @@ function channelSignals(model: UnitModel, selCmpt: SelectionComponent, channel: 
 }
 
 function events(selCmpt: SelectionComponent, cb: Function) {
-  return selCmpt.events.reduce(function(on: any[], evt: any) {
+  return selCmpt.events.reduce(function(on: any[], evt: VgEventStream) {
     if (!evt.between) {
       warn(`${evt} is not an ordered event stream for interval selections`);
       return on;

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -64,10 +64,10 @@ const interval:SelectionCompiler = {
     }
 
     const update = {
-      x: extend({}, xi !== null ? {signal: `${name}_x[0]`} : {value: 0}),
-      y: extend({}, yi !== null ? {signal: `${name}_y[0]`} : {value: 0}),
-      x2: extend({}, xi !== null ? {signal: `${name}_x[1]`} : {field: {group: 'width'}}),
-      y2: extend({}, yi !== null ? {signal: `${name}_y[1]`} : {field: {group: 'height'}})
+      x: xi !== null ? {signal: `${name}_x[0]`} : {value: 0},
+      y: yi !== null ? {signal: `${name}_y[0]`} : {value: 0},
+      x2: xi !== null ? {signal: `${name}_x[1]`} : {field: {group: 'width'}},
+      y2: yi !== null ? {signal: `${name}_y[1]`} : {field: {group: 'height'}}
     };
 
     // If the selection is resolved to global, only a single interval is in
@@ -125,6 +125,9 @@ export function projections(selCmpt: SelectionComponent) {
   return {x, xi, y, yi};
 }
 
+/**
+ * Returns the visual and data signals for an interval selection.
+ */
 function channelSignals(model: UnitModel, selCmpt: SelectionComponent, channel: Channel): any {
   const vname = channelSignalName(selCmpt, channel, 'visual'),
       dname = channelSignalName(selCmpt, channel, 'data'),

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -250,8 +250,8 @@ export function invert(model: UnitModel, selCmpt: SelectionComponent, channel: C
   return selCmpt.domain === 'data' ? `invert(${scale}, ${expr})` : expr;
 }
 
-export function channelSignalName(selCmpt: SelectionComponent, channel: Channel) {
-  return selCmpt.name + '_' + selCmpt.fields[channel];
+export function channelSignalName(selCmpt: SelectionComponent, channel: Channel, range: 'visual' | 'data') {
+  return selCmpt.name + '_' + (range === 'visual' ? channel : selCmpt.fields[channel]);
 }
 
 function clipMarks(marks: any[]): any[] {

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -245,11 +245,6 @@ function compiler(type: SelectionTypes): SelectionCompiler {
   return null;
 }
 
-export function invert(model: UnitModel, selCmpt: SelectionComponent, channel: Channel, expr: string) {
-  const scale = stringValue(model.scaleName(channel));
-  return selCmpt.domain === 'data' ? `invert(${scale}, ${expr})` : expr;
-}
-
 export function channelSignalName(selCmpt: SelectionComponent, channel: Channel, range: 'visual' | 'data') {
   return selCmpt.name + '_' + (range === 'visual' ? channel : selCmpt.fields[channel]);
 }

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -3,7 +3,7 @@ import {Channel} from '../../channel';
 import {SelectionDomain as SelectionScaleDomain} from '../../scale';
 import {SelectionDef, SelectionDomain, SelectionResolutions, SelectionTypes} from '../../selection';
 import {Dict, extend, isString, stringValue} from '../../util';
-import {VgBinding, VgData} from '../../vega.schema';
+import {VgBinding, VgData, VgEventStream} from '../../vega.schema';
 import {LayerModel} from '../layer';
 import {Model} from '../model';
 import {UnitModel} from '../unit';
@@ -21,7 +21,7 @@ export interface SelectionComponent {
   name: string;
   type: SelectionTypes;
   domain: SelectionDomain;
-  events: any;
+  events: VgEventStream;
   // predicate?: string;
   bind?: 'scales' | VgBinding | {[key: string]: VgBinding};
   resolve: SelectionResolutions;

--- a/src/compile/selection/transforms/scales.ts
+++ b/src/compile/selection/transforms/scales.ts
@@ -3,7 +3,6 @@ import {warn} from '../../../log';
 import {hasContinuousDomain} from '../../../scale';
 import {stringValue} from '../../../util';
 import {UnitModel} from '../../unit';
-import {SIZE as INTERVAL_SIZE} from '../interval';
 import {channelSignalName, MODIFY, TUPLE} from '../selection';
 import {TransformCompiler} from './transforms';
 
@@ -27,30 +26,29 @@ const scaleBindings:TransformCompiler = {
         return;
       }
 
-      scale.domainRaw = {signal: channelSignalName(selCmpt, channel)};
+      scale.domainRaw = {signal: channelSignalName(selCmpt, channel, 'data')};
       bound.push(channel);
     });
   },
 
   topLevelSignals: function(model, selCmpt, signals) {
     const channels = selCmpt.scales.filter((channel) => {
-      return !(signals.filter((s) => s.name === channelSignalName(selCmpt, channel)).length);
+      return !(signals.filter((s) => s.name === channelSignalName(selCmpt, channel, 'data')).length);
     });
 
     return signals.concat(channels.map((channel) => {
-      return {name: channelSignalName(selCmpt, channel)};
+      return {name: channelSignalName(selCmpt, channel, 'data')};
     }));
   },
 
   signals: function(model, selCmpt, signals) {
     const name = selCmpt.name;
     signals = signals.filter(function(s) {
-      return s.name !== name + INTERVAL_SIZE &&
-        s.name !== name + TUPLE && s.name !== MODIFY;
+      return s.name !== name + TUPLE && s.name !== MODIFY;
     });
 
     selCmpt.scales.forEach(function(channel) {
-      const signal = signals.filter((s) => s.name === channelSignalName(selCmpt, channel))[0];
+      const signal = signals.filter((s) => s.name === channelSignalName(selCmpt, channel, 'data'))[0];
       signal.push = 'outer';
       delete signal.value;
       delete signal.update;

--- a/src/compile/selection/transforms/scales.ts
+++ b/src/compile/selection/transforms/scales.ts
@@ -1,6 +1,6 @@
 import {Channel} from '../../../channel';
 import {warn} from '../../../log';
-import {hasContinuousDomain} from '../../../scale';
+import {hasContinuousDomain, isBinScale} from '../../../scale';
 import {stringValue} from '../../../util';
 import {UnitModel} from '../../unit';
 import {channelSignalName, MODIFY, TUPLE} from '../selection';
@@ -21,8 +21,8 @@ const scaleBindings:TransformCompiler = {
       const channel = p.encoding;
       const scale = model.getComponent('scales', channel);
 
-      if (!scale || !hasContinuousDomain(scale.type)) {
-        warn('Scale bindings are currently only supported for scales with continuous domains.');
+      if (!scale || !hasContinuousDomain(scale.type) || isBinScale(scale.type)) {
+        warn('Scale bindings are currently only supported for scales with unbinned, continuous domains.');
         return;
       }
 

--- a/src/compile/selection/transforms/translate.ts
+++ b/src/compile/selection/transforms/translate.ts
@@ -78,8 +78,8 @@ function onDelta(model: UnitModel, selCmpt: SelectionComponent, channel: Channel
       delta  = name + DELTA,
       sign = getSign(selCmpt, channel),
       offset = sign + (hasScales ?
-        `span(${anchor}.extent_${channel}) * ${delta}.${channel} / unit.${size}` :
-        `${delta}.${channel}`),
+        ` span(${anchor}.extent_${channel}) * ${delta}.${channel} / unit.${size}` :
+        ` ${delta}.${channel}`),
       extent = `${anchor}.extent_${channel}`,
       range = `[${extent}[0] ${offset}, ${extent}[1] ${offset}]`;
 

--- a/src/compile/selection/transforms/translate.ts
+++ b/src/compile/selection/transforms/translate.ts
@@ -1,7 +1,7 @@
 import {selector as parseSelector} from 'vega-event-selector';
 import {Channel, X, Y} from '../../../channel';
 import {stringValue} from '../../../util';
-import {BRUSH as INTERVAL_BRUSH, projections as intervalProjections, SIZE as INTERVAL_SIZE} from '../interval';
+import {BRUSH as INTERVAL_BRUSH, projections as intervalProjections} from '../interval';
 import {channelSignalName, SelectionComponent} from '../selection';
 import {UnitModel} from './../../unit';
 import {default as scalesCompiler, domain} from './scales';
@@ -17,13 +17,12 @@ const translate:TransformCompiler = {
 
   signals: function(model, selCmpt, signals) {
     const name = selCmpt.name,
-        scales = scalesCompiler.has(selCmpt),
-        size = scales ? 'unit' : name + INTERVAL_SIZE,
+        hasScales = scalesCompiler.has(selCmpt),
         anchor = name + ANCHOR,
         {x, y} = intervalProjections(selCmpt);
     let events = parseSelector(selCmpt.translate, 'scope');
 
-    if (!scales) {
+    if (!hasScales) {
       events = events.map((e) => (e.between[0].markname = name + INTERVAL_BRUSH, e));
     }
 
@@ -32,13 +31,11 @@ const translate:TransformCompiler = {
       value: {},
       on: [{
         events: events.map((e) => e.between[0]),
-        update: '{x: x(unit), y: y(unit), ' +
-          `width: ${size}.width, height: ${size}.height` +
-
-          (x !== null ? ', extent_x: ' + (scales ? domain(model, X) :
+        update: '{x: x(unit), y: y(unit)' +
+          (x !== null ? ', extent_x: ' + (hasScales ? domain(model, X) :
               `slice(${channelSignalName(selCmpt, 'x', 'visual')})`) : '') +
 
-          (y !== null ? ', extent_y: ' + (scales ? domain(model, Y) :
+          (y !== null ? ', extent_y: ' + (hasScales ? domain(model, Y) :
               `slice(${channelSignalName(selCmpt, 'y', 'visual')})`) : '') + '}'
       }]
     }, {
@@ -64,17 +61,30 @@ const translate:TransformCompiler = {
 
 export {translate as default};
 
+function getSign(selCmpt: SelectionComponent, channel: Channel) {
+  if (scalesCompiler.has(selCmpt)) {
+    return channel === Y ? '+' : '-';
+  }
+  return '+';
+}
+
 function onDelta(model: UnitModel, selCmpt: SelectionComponent, channel: Channel, size: 'width' | 'height', signals: any[]) {
   const name = selCmpt.name,
-      signal:any = signals.filter((s:any) => s.name === channelSignalName(selCmpt, channel, 'visual'))[0],
+      hasScales = scalesCompiler.has(selCmpt),
+      signal:any = signals.filter((s:any) => {
+        return s.name === channelSignalName(selCmpt, channel, hasScales ? 'data' : 'visual');
+      })[0],
       anchor = name + ANCHOR,
       delta  = name + DELTA,
+      sign = getSign(selCmpt, channel),
+      offset = sign + (hasScales ?
+        `span(${anchor}.extent_${channel}) * ${delta}.${channel} / unit.${size}` :
+        `${delta}.${channel}`),
       extent = `${anchor}.extent_${channel}`,
-      range = `[${extent}[0] + ${delta}.${channel}, ` +
-        `${extent}[1] + ${delta}.${channel}]`;
+      range = `[${extent}[0] ${offset}, ${extent}[1] ${offset}]`;
 
   signal.on.push({
     events: {signal: delta},
-    update: scalesCompiler.has(selCmpt) ? range : `clampRange(${range}, 0, unit.${size})`
+    update: hasScales ? range : `clampRange(${range}, 0, unit.${size})`
   });
 }

--- a/src/compile/selection/transforms/zoom.ts
+++ b/src/compile/selection/transforms/zoom.ts
@@ -18,9 +18,7 @@ const zoom:TransformCompiler = {
   signals: function(model, selCmpt, signals) {
     const name = selCmpt.name,
         delta = name + DELTA,
-        {x, y} = intervalProjections(selCmpt),
-        sx = stringValue(model.scaleName(X)),
-        sy = stringValue(model.scaleName(Y));
+        {x, y} = intervalProjections(selCmpt);
 
     let events = parseSelector(selCmpt.zoom, 'scope');
 
@@ -32,7 +30,7 @@ const zoom:TransformCompiler = {
       name: name + ANCHOR,
       on: [{
         events: events,
-        update: `{x: invert(${sx}, x(unit)), y: invert(${sy}, y(unit))}`
+        update: `{x: x(unit), y: y(unit)}`
       }]
     }, {
       name: delta,
@@ -70,19 +68,17 @@ export {zoom as default};
 
 function onDelta(model: UnitModel, selCmpt: SelectionComponent, channel: Channel, size: 'width' | 'height', signals: any[]) {
   const name = selCmpt.name,
-      signal:any = signals.filter((s:any) => s.name === channelSignalName(selCmpt, channel))[0],
+      signal:any = signals.filter((s:any) => s.name === channelSignalName(selCmpt, channel, 'visual'))[0],
       scales = scalesCompiler.has(selCmpt),
       base = scales ? domain(model, channel) : signal.name,
       anchor = `${name}${ANCHOR}.${channel}`,
       delta  = name + DELTA,
       scale  = stringValue(model.scaleName(channel)),
       range  = `[${anchor} + (${base}[0] - ${anchor}) * ${delta}, ` +
-        `${anchor} + (${base}[1] - ${anchor}) * ${delta}]`,
-      lo = `invert(${scale}` + (channel === X ? ', 0' : `, unit.${size}`) + ')',
-      hi = `invert(${scale}` + (channel === X ? `, unit.${size}` : ', 0') + ')';
+        `${anchor} + (${base}[1] - ${anchor}) * ${delta}]`;
 
   signal.on.push({
     events: {signal: delta},
-    update: scales ? range : `clampRange(${range}, ${lo}, ${hi})`
+    update: scales ? range : `clampRange(${range}, 0, unit.${size})`
   });
 }

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -38,6 +38,8 @@ export type VgSignalRef = {
   signal: string
 };
 
+export type VgEventStream = any;
+
 // TODO: add type of value (Make it VgValueRef<T> {value?:T ...})
 export type VgValueRef = {
   value?: number | string | boolean,

--- a/test/compile/selection/interval.test.ts
+++ b/test/compile/selection/interval.test.ts
@@ -40,118 +40,105 @@ describe('Interval Selections', function() {
     it('builds projection signals', function() {
       const oneSg = interval.signals(model, selCmpts['one']);
       assert.includeDeepMembers(oneSg, [{
-        "name": "one_Horsepower",
+        "name": "one_x",
         "value": [],
         "on": [
           {
             "events": parseSelector('mousedown', 'scope')[0],
-            "update": "invert(\"x\", [x(unit), x(unit)])"
+            "update": "[x(unit), x(unit)]"
           },
           {
             "events": parseSelector('[mousedown, window:mouseup] > window:mousemove!', 'scope')[0],
-            "update": "[one_Horsepower[0], invert(\"x\", clamp(x(unit), 0, width))]"
+            "update": "[one_x[0], clamp(x(unit), 0, width)]"
+          },
+          {
+            "events": {"scale": "x"},
+            "update": "!isArray(one_Horsepower) ? one_x : [scale(\"x\", one_Horsepower[0]), scale(\"x\", one_Horsepower[1])]"
           }
         ]
+      }, {
+        "name": "one_Horsepower",
+        "on": [{
+          "events": {"signal": "one_x"},
+          "update": "invert(\"x\", one_x)"
+        }]
       }]);
 
       const twoSg = interval.signals(model, selCmpts['two']);
       assert.includeDeepMembers(twoSg, [{
         "name": "two_Miles_per_Gallon",
-        "on": [],
-        "value": []
+        "on": []
       }]);
 
       const threeSg = interval.signals(model, selCmpts['three']);
       assert.includeDeepMembers(threeSg, [
         {
-          "name": "three_Horsepower",
+          "name": "three_x",
           "value": [],
           "on": [
             {
               "events": parseSelector('mousedown', 'scope')[0],
-              "update": "invert(\"x\", [x(unit), x(unit)])"
+              "update": "[x(unit), x(unit)]"
             },
             {
               "events": parseSelector('[mousedown, mouseup] > mousemove', 'scope')[0],
-              "update": "[three_Horsepower[0], invert(\"x\", clamp(x(unit), 0, width))]"
+              "update": "[three_x[0], clamp(x(unit), 0, width)]"
             },
             {
               "events": parseSelector('keydown', 'scope')[0],
-              "update": "invert(\"x\", [x(unit), x(unit)])"
+              "update": "[x(unit), x(unit)]"
             },
             {
               "events": parseSelector('[keydown, keyup] > keypress', 'scope')[0],
-              "update": "[three_Horsepower[0], invert(\"x\", clamp(x(unit), 0, width))]"
+              "update": "[three_x[0], clamp(x(unit), 0, width)]"
+            },
+            {
+              "events": {"scale": "x"},
+              "update": "!isArray(three_Horsepower) ? three_x : [scale(\"x\", three_Horsepower[0]), scale(\"x\", three_Horsepower[1])]"
+            }
+          ]
+        },
+        {
+          "name": "three_Horsepower",
+          "on": [{
+            "events": {"signal": "three_x"},
+            "update": "invert(\"x\", three_x)"
+          }]
+        },
+        {
+          "name": "three_y",
+          "value": [],
+          "on": [
+            {
+              "events": parseSelector('mousedown', 'scope')[0],
+              "update": "[y(unit), y(unit)]"
+            },
+            {
+              "events": parseSelector('[mousedown, mouseup] > mousemove', 'scope')[0],
+              "update": "[three_y[0], clamp(y(unit), 0, height)]"
+            },
+            {
+              "events": parseSelector('keydown', 'scope')[0],
+              "update": "[y(unit), y(unit)]"
+            },
+            {
+              "events": parseSelector('[keydown, keyup] > keypress', 'scope')[0],
+              "update": "[three_y[0], clamp(y(unit), 0, height)]"
+            },
+            {
+              "events": {"scale": "y"},
+              "update": "!isArray(three_Miles_per_Gallon) ? three_y : [scale(\"y\", three_Miles_per_Gallon[0]), scale(\"y\", three_Miles_per_Gallon[1])]"
             }
           ]
         },
         {
           "name": "three_Miles_per_Gallon",
-          "value": [],
-          "on": [
-            {
-              "events": parseSelector('mousedown', 'scope')[0],
-              "update": "invert(\"y\", [y(unit), y(unit)])"
-            },
-            {
-              "events": parseSelector('[mousedown, mouseup] > mousemove', 'scope')[0],
-              "update": "[three_Miles_per_Gallon[0], invert(\"y\", clamp(y(unit), 0, height))]"
-            },
-            {
-              "events": parseSelector('keydown', 'scope')[0],
-              "update": "invert(\"y\", [y(unit), y(unit)])"
-            },
-            {
-              "events": parseSelector('[keydown, keyup] > keypress', 'scope')[0],
-              "update": "[three_Miles_per_Gallon[0], invert(\"y\", clamp(y(unit), 0, height))]"
-            }
-          ]
+          "on": [{
+            "events": {"signal": "three_y"},
+            "update": "invert(\"y\", three_y)"
+          }]
         }
       ]);
-    });
-
-    it('builds size signals', function() {
-      const oneSg = interval.signals(model, selCmpts['one']);
-      assert.includeDeepMembers(oneSg, [{
-        "name": "one_size",
-        "value": [],
-        "on": [
-          {
-            "events": parseSelector('mousedown', 'scope')[0],
-            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-          },
-          {
-            "events": parseSelector('[mousedown, window:mouseup] > window:mousemove!', 'scope')[0],
-            "update": "{x: one_size.x, y: one_size.y, width: abs(x(unit) - one_size.x), height: abs(y(unit) - one_size.y)}"
-          }
-        ]
-      }]);
-
-      // Skip twoSg because bindScales should remove the size.
-
-      const threeSg = interval.signals(model, selCmpts['three']);
-      assert.includeDeepMembers(threeSg, [{
-        "name": "three_size",
-        "value": [],
-        "on": [
-          {
-            "events": parseSelector('mousedown', 'scope')[0],
-            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-          },
-          {
-            "events": parseSelector('[mousedown, mouseup] > mousemove', 'scope')[0],
-            "update": "{x: three_size.x, y: three_size.y, width: abs(x(unit) - three_size.x), height: abs(y(unit) - three_size.y)}"
-          },
-          {
-            "events": parseSelector('keydown', 'scope')[0],
-            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-          },
-          {
-            "events": parseSelector('[keydown, keyup] > keypress', 'scope')[0],
-            "update": "{x: three_size.x, y: three_size.y, width: abs(x(unit) - three_size.x), height: abs(y(unit) - three_size.y)}"
-          }
-        ]
-      }]);
     });
 
     it('builds trigger signals', function() {
@@ -279,32 +266,40 @@ describe('Interval Selections', function() {
             "x": [
               {
                 "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
-                "scale": "x",
-                "signal": "one[0].extent[0]"
+                "signal": "one_x[0]"
               },
-              {"value": 0}
-            ],
-            "x2": [
               {
-                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
-                "scale": "x",
-                "signal": "one[0].extent[1]"
-              },
-              {"value": 0}
+                "value": 0
+              }
             ],
             "y": [
               {
                 "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
                 "value": 0
               },
-              {"value": 0}
+              {
+                "value": 0
+              }
+            ],
+            "x2": [
+              {
+                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "signal": "one_x[1]"
+              },
+              {
+                "value": 0
+              }
             ],
             "y2": [
               {
                 "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
-                "field": {"group": "height"}
+                "field": {
+                  "group": "height"
+                }
               },
-              {"value": 0}
+              {
+                "value": 0
+              }
             ]
           }
         }
@@ -322,32 +317,40 @@ describe('Interval Selections', function() {
             "x": [
               {
                 "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
-                "scale": "x",
-                "signal": "one[0].extent[0]"
+                "signal": "one_x[0]"
               },
-              {"value": 0}
-            ],
-            "x2": [
               {
-                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
-                "scale": "x",
-                "signal": "one[0].extent[1]"
-              },
-              {"value": 0}
+                "value": 0
+              }
             ],
             "y": [
               {
                 "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
                 "value": 0
               },
-              {"value": 0}
+              {
+                "value": 0
+              }
+            ],
+            "x2": [
+              {
+                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "signal": "one_x[1]"
+              },
+              {
+                "value": 0
+              }
             ],
             "y2": [
               {
                 "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
-                "field": {"group": "height"}
+                "field": {
+                  "group": "height"
+                }
               },
-              {"value": 0}
+              {
+                "value": 0
+              }
             ]
           }
         }
@@ -367,20 +370,16 @@ describe('Interval Selections', function() {
           },
           "update": {
             "x": {
-              "scale": "x",
-              "signal": "three[0].extent[0]"
-            },
-            "x2": {
-              "scale": "x",
-              "signal": "three[0].extent[1]"
+              "signal": "three_x[0]"
             },
             "y": {
-              "scale": "y",
-              "signal": "three[1].extent[0]"
+              "signal": "three_y[0]"
+            },
+            "x2": {
+              "signal": "three_x[1]"
             },
             "y2": {
-              "scale": "y",
-              "signal": "three[1].extent[1]"
+              "signal": "three_y[1]"
             }
           }
         }
@@ -396,20 +395,16 @@ describe('Interval Selections', function() {
           },
           "update": {
             "x": {
-              "scale": "x",
-              "signal": "three[0].extent[0]"
-            },
-            "x2": {
-              "scale": "x",
-              "signal": "three[0].extent[1]"
+              "signal": "three_x[0]"
             },
             "y": {
-              "scale": "y",
-              "signal": "three[1].extent[0]"
+              "signal": "three_y[0]"
+            },
+            "x2": {
+              "signal": "three_x[1]"
             },
             "y2": {
-              "scale": "y",
-              "signal": "three[1].extent[1]"
+              "signal": "three_y[1]"
             }
           }
         }

--- a/test/compile/selection/layers.test.ts
+++ b/test/compile/selection/layers.test.ts
@@ -120,18 +120,7 @@ describe('Layered Selections', function() {
             "x": [
               {
                 "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                "scale": "x",
-                "signal": "brush[0].extent[0]"
-              },
-              {
-                "value": 0
-              }
-            ],
-            "x2": [
-              {
-                "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                "scale": "x",
-                "signal": "brush[0].extent[1]"
+                "signal": "brush_x[0]"
               },
               {
                 "value": 0
@@ -140,8 +129,16 @@ describe('Layered Selections', function() {
             "y": [
               {
                 "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                "scale": "y",
-                "signal": "brush[1].extent[0]"
+                "signal": "brush_y[0]"
+              },
+              {
+                "value": 0
+              }
+            ],
+            "x2": [
+              {
+                "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                "signal": "brush_x[1]"
               },
               {
                 "value": 0
@@ -150,8 +147,7 @@ describe('Layered Selections', function() {
             "y2": [
               {
                 "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                "scale": "y",
-                "signal": "brush[1].extent[1]"
+                "signal": "brush_y[1]"
               },
               {
                 "value": 0
@@ -176,18 +172,7 @@ describe('Layered Selections', function() {
             "x": [
               {
                 "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                "scale": "x",
-                "signal": "brush[0].extent[0]"
-              },
-              {
-                "value": 0
-              }
-            ],
-            "x2": [
-              {
-                "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                "scale": "x",
-                "signal": "brush[0].extent[1]"
+                "signal": "brush_x[0]"
               },
               {
                 "value": 0
@@ -196,8 +181,16 @@ describe('Layered Selections', function() {
             "y": [
               {
                 "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                "scale": "y",
-                "signal": "brush[1].extent[0]"
+                "signal": "brush_y[0]"
+              },
+              {
+                "value": 0
+              }
+            ],
+            "x2": [
+              {
+                "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                "signal": "brush_x[1]"
               },
               {
                 "value": 0
@@ -206,8 +199,7 @@ describe('Layered Selections', function() {
             "y2": [
               {
                 "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                "scale": "y",
-                "signal": "brush[1].extent[1]"
+                "signal": "brush_y[1]"
               },
               {
                 "value": 0

--- a/test/compile/selection/translate.test.ts
+++ b/test/compile/selection/translate.test.ts
@@ -62,7 +62,7 @@ describe('Translate Selection Transform', function() {
         "on": [
           {
             "events": parseSelector('@four_brush:mousedown', 'scope'),
-            "update": "{x: x(unit), y: y(unit), width: four_size.width, height: four_size.height, extent_x: slice(four_Horsepower), extent_y: slice(four_Miles_per_Gallon), }"
+            "update": "{x: x(unit), y: y(unit), extent_x: slice(four_x), extent_y: slice(four_y)}"
           }
         ]
       },
@@ -78,17 +78,17 @@ describe('Translate Selection Transform', function() {
       }
     ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_Horsepower')[0].on, [
+    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_x')[0].on, [
       {
         "events": {"signal": "four_translate_delta"},
-        "update": "clampRange([four_translate_anchor.extent_x[0] + abs(span(four_translate_anchor.extent_x)) * four_translate_delta.x / four_translate_anchor.width, four_translate_anchor.extent_x[1] + abs(span(four_translate_anchor.extent_x)) * four_translate_delta.x / four_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+        "update": "clampRange([four_translate_anchor.extent_x[0] + four_translate_delta.x, four_translate_anchor.extent_x[1] + four_translate_delta.x], 0, unit.width)"
       }
     ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_Miles_per_Gallon')[0].on, [
+    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_y')[0].on, [
       {
         "events": {"signal": "four_translate_delta"},
-        "update": "clampRange([four_translate_anchor.extent_y[0] - abs(span(four_translate_anchor.extent_y)) * four_translate_delta.y / four_translate_anchor.height, four_translate_anchor.extent_y[1] - abs(span(four_translate_anchor.extent_y)) * four_translate_delta.y / four_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
+        "update": "clampRange([four_translate_anchor.extent_y[0] + four_translate_delta.y, four_translate_anchor.extent_y[1] + four_translate_delta.y], 0, unit.height)"
       }
     ]);
   });
@@ -96,7 +96,6 @@ describe('Translate Selection Transform', function() {
   it('builds signals for custom events', function() {
     model.component.selection = {five: selCmpts['five']};
     const signals = selection.assembleUnitSelectionSignals(model, []);
-
     assert.includeDeepMembers(signals, [
       {
         "name": "five_translate_anchor",
@@ -104,7 +103,7 @@ describe('Translate Selection Transform', function() {
         "on": [
           {
             "events": parseSelector('@five_brush:mousedown, @five_brush:keydown', 'scope'),
-            "update": "{x: x(unit), y: y(unit), width: five_size.width, height: five_size.height, extent_x: slice(five_Horsepower), extent_y: slice(five_Miles_per_Gallon), }"
+            "update": "{x: x(unit), y: y(unit), extent_x: slice(five_x), extent_y: slice(five_y)}"
           }
         ]
       },
@@ -120,17 +119,17 @@ describe('Translate Selection Transform', function() {
       }
     ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_Horsepower')[0].on, [
+    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_x')[0].on, [
       {
         "events": {"signal": "five_translate_delta"},
-        "update": "clampRange([five_translate_anchor.extent_x[0] + abs(span(five_translate_anchor.extent_x)) * five_translate_delta.x / five_translate_anchor.width, five_translate_anchor.extent_x[1] + abs(span(five_translate_anchor.extent_x)) * five_translate_delta.x / five_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+        "update": "clampRange([five_translate_anchor.extent_x[0] + five_translate_delta.x, five_translate_anchor.extent_x[1] + five_translate_delta.x], 0, unit.width)"
       }
     ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_Miles_per_Gallon')[0].on, [
+    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_y')[0].on, [
       {
         "events": {"signal": "five_translate_delta"},
-        "update": "clampRange([five_translate_anchor.extent_y[0] - abs(span(five_translate_anchor.extent_y)) * five_translate_delta.y / five_translate_anchor.height, five_translate_anchor.extent_y[1] - abs(span(five_translate_anchor.extent_y)) * five_translate_delta.y / five_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
+        "update": "clampRange([five_translate_anchor.extent_y[0] + five_translate_delta.y, five_translate_anchor.extent_y[1] + five_translate_delta.y], 0, unit.height)"
       }
     ]);
   });
@@ -145,7 +144,7 @@ describe('Translate Selection Transform', function() {
         "on": [
           {
             "events": parseSelector('mousedown', 'scope'),
-            "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
+            "update": "{x: x(unit), y: y(unit), extent_x: domain(\"x\"), extent_y: domain(\"y\")}"
           }
         ]
       },
@@ -164,14 +163,14 @@ describe('Translate Selection Transform', function() {
     assert.includeDeepMembers(signals.filter((s) => s.name === 'six_Horsepower')[0].on, [
       {
         "events": {"signal": "six_translate_delta"},
-        "update": "[six_translate_anchor.extent_x[0] - abs(span(six_translate_anchor.extent_x)) * six_translate_delta.x / six_translate_anchor.width, six_translate_anchor.extent_x[1] - abs(span(six_translate_anchor.extent_x)) * six_translate_delta.x / six_translate_anchor.width]"
+        "update": "[six_translate_anchor.extent_x[0] - span(six_translate_anchor.extent_x) * six_translate_delta.x / unit.width, six_translate_anchor.extent_x[1] - span(six_translate_anchor.extent_x) * six_translate_delta.x / unit.width]"
       }
     ]);
 
     assert.includeDeepMembers(signals.filter((s) => s.name === 'six_Miles_per_Gallon')[0].on, [
       {
         "events": {"signal": "six_translate_delta"},
-        "update": "[six_translate_anchor.extent_y[0] + abs(span(six_translate_anchor.extent_y)) * six_translate_delta.y / six_translate_anchor.height, six_translate_anchor.extent_y[1] + abs(span(six_translate_anchor.extent_y)) * six_translate_delta.y / six_translate_anchor.height]"
+        "update": "[six_translate_anchor.extent_y[0] + span(six_translate_anchor.extent_y) * six_translate_delta.y / unit.height, six_translate_anchor.extent_y[1] + span(six_translate_anchor.extent_y) * six_translate_delta.y / unit.height]"
       }
     ]);
   });

--- a/test/compile/selection/zoom.test.ts
+++ b/test/compile/selection/zoom.test.ts
@@ -61,7 +61,7 @@ describe('Zoom Selection Transform', function() {
         "on": [
           {
             "events": parseSelector('@four_brush:wheel', 'scope'),
-            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+            "update": "{x: x(unit), y: y(unit)}"
           }
         ]
       },
@@ -77,24 +77,17 @@ describe('Zoom Selection Transform', function() {
       }
     ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_Horsepower')[0].on, [
+    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_x')[0].on, [
       {
         "events": {"signal": "four_zoom_delta"},
-        "update": "clampRange([four_zoom_anchor.x + (four_Horsepower[0] - four_zoom_anchor.x) * four_zoom_delta, four_zoom_anchor.x + (four_Horsepower[1] - four_zoom_anchor.x) * four_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+        "update": "clampRange([four_zoom_anchor.x + (four_x[0] - four_zoom_anchor.x) * four_zoom_delta, four_zoom_anchor.x + (four_x[1] - four_zoom_anchor.x) * four_zoom_delta], 0, unit.width)"
       }
     ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_Miles_per_Gallon')[0].on, [
+    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_y')[0].on, [
       {
         "events": {"signal": "four_zoom_delta"},
-        "update": "clampRange([four_zoom_anchor.y + (four_Miles_per_Gallon[0] - four_zoom_anchor.y) * four_zoom_delta, four_zoom_anchor.y + (four_Miles_per_Gallon[1] - four_zoom_anchor.y) * four_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
-      }
-    ]);
-
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_size')[0].on, [
-      {
-        "events": {"signal": "four_zoom_delta"},
-        "update": "{x: four_size.x, y: four_size.y, width: four_size.width * four_zoom_delta , height: four_size.height * four_zoom_delta}"
+        "update": "clampRange([four_zoom_anchor.y + (four_y[0] - four_zoom_anchor.y) * four_zoom_delta, four_zoom_anchor.y + (four_y[1] - four_zoom_anchor.y) * four_zoom_delta], 0, unit.height)"
       }
     ]);
   });
@@ -108,7 +101,7 @@ describe('Zoom Selection Transform', function() {
         "on": [
           {
             "events": parseSelector('@five_brush:wheel, @five_brush:pinch', 'scope'),
-            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+            "update": "{x: x(unit), y: y(unit)}"
           }
         ]
       },
@@ -124,24 +117,17 @@ describe('Zoom Selection Transform', function() {
       }
     ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_Horsepower')[0].on, [
+    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_x')[0].on, [
       {
         "events": {"signal": "five_zoom_delta"},
-        "update": "clampRange([five_zoom_anchor.x + (five_Horsepower[0] - five_zoom_anchor.x) * five_zoom_delta, five_zoom_anchor.x + (five_Horsepower[1] - five_zoom_anchor.x) * five_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+        "update": "clampRange([five_zoom_anchor.x + (five_x[0] - five_zoom_anchor.x) * five_zoom_delta, five_zoom_anchor.x + (five_x[1] - five_zoom_anchor.x) * five_zoom_delta], 0, unit.width)"
       }
     ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_Miles_per_Gallon')[0].on, [
+    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_y')[0].on, [
       {
         "events": {"signal": "five_zoom_delta"},
-        "update": "clampRange([five_zoom_anchor.y + (five_Miles_per_Gallon[0] - five_zoom_anchor.y) * five_zoom_delta, five_zoom_anchor.y + (five_Miles_per_Gallon[1] - five_zoom_anchor.y) * five_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
-      }
-    ]);
-
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_size')[0].on, [
-      {
-        "events": {"signal": "five_zoom_delta"},
-        "update": "{x: five_size.x, y: five_size.y, width: five_size.width * five_zoom_delta , height: five_size.height * five_zoom_delta}"
+        "update": "clampRange([five_zoom_anchor.y + (five_y[0] - five_zoom_anchor.y) * five_zoom_delta, five_zoom_anchor.y + (five_y[1] - five_zoom_anchor.y) * five_zoom_delta], 0, unit.height)"
       }
     ]);
   });


### PR DESCRIPTION
~~Please merge after #2376.~~  Done

This PR should address the issues with interval selections identified in ~~#2148~~, ~~#2284~~, ~~#2288~~, and ~~#2315~~ (once vega/vega-parser#32 is merged). Interval selections now generate separate signals in pixel and data space. 

![crossfiltering](https://cloud.githubusercontent.com/assets/42262/26133426/cb527e08-3a5b-11e7-8a5b-90ac7ebbe23a.gif)

![overviewdetail](https://cloud.githubusercontent.com/assets/42262/26133433/cfab642e-3a5b-11e7-8966-df6ed58d7911.gif)

One todo remains before this PR can be reviewed: unbound intervals (i.e., brushes) do not yet update when bound intervals (i.e., panning & zooming) are modified. This results in the behaviour shown here whereby points do not recolour when panning/zooming the grid: 

![interactivesplom](https://cloud.githubusercontent.com/assets/42262/26133462/09c039be-3a5c-11e7-9a99-b68a8038cb47.gif)
