### PR TITLE
groupby => groupBy

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -4958,7 +4958,7 @@
         "SummarizeTransform": {
             "additionalProperties": false,
             "properties": {
-                "groupby": {
+                "groupBy": {
                     "description": "Array of fields we will be useing for group by",
                     "items": {
                         "type": "string"
@@ -4974,7 +4974,6 @@
                 }
             },
             "required": [
-                "groupby",
                 "summarize"
             ],
             "type": "object"

--- a/examples/specs/layered_box_plot.vl.json
+++ b/examples/specs/layered_box_plot.vl.json
@@ -31,7 +31,7 @@
           "as": "people_median"
         }
       ],
-      "groupby": ["age"]
+      "groupBy": ["age"]
     }
   ],
   "layer": [

--- a/src/compile/data/aggregate.ts
+++ b/src/compile/data/aggregate.ts
@@ -117,7 +117,7 @@ export class AggregateNode extends DataFlowNode {
       }
     }
 
-    for(const s of t.groupby) {
+    for(const s of t.groupBy) {
       dims[s] = true;
     }
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -71,7 +71,7 @@ export interface SummarizeTransform {
   /**
    * Array of fields we will be useing for group by
    */
-  groupby: string[];
+  groupBy?: string[];
 }
 
 export interface Summarize {

--- a/test/compile/data/aggregate.test.ts
+++ b/test/compile/data/aggregate.test.ts
@@ -133,7 +133,8 @@ describe('compile/data/summary', function () {
           {aggregate: 'mean', field: 'Displacement', as: 'Displacement_mean'},
           {aggregate: 'sum', field: 'Acceleration', as: 'Acceleration_sum'}
         ],
-        groupby: ['Displacement_mean', 'Acceleration_sum']};
+        groupBy: ['Displacement_mean', 'Acceleration_sum']
+      };
 
       const model = parseUnitModel({
         mark: "point",
@@ -158,7 +159,7 @@ describe('compile/data/summary', function () {
         {aggregate: 'mean', field: 'Displacement', as: 'Displacement_mean'},
         {aggregate: 'max', field: 'Displacement', as: 'Displacement_max'},
         {aggregate: 'sum', field: 'Acceleration', as: 'Acceleration_sum'}],
-        groupby: ['Displacement_mean', 'Acceleration_sum']};
+        groupBy: ['Displacement_mean', 'Acceleration_sum']};
 
       const model = parseUnitModel({
         mark: "point",

--- a/test/compile/data/transform.test.ts
+++ b/test/compile/data/transform.test.ts
@@ -42,7 +42,16 @@ describe('compile/data/transform', () => {
       const model = parseUnitModel({
         data: {values: []},
         mark: 'point',
-        transform: [{bin: true, field: 'field', as: 'a'}, {summarize: [{aggregate: 'count', field: 'f', as: 'b'}, {aggregate: 'sum', field: 'f', as: 'c'}], groupby: ['field']}],
+        transform: [
+          {bin: true, field: 'field', as: 'a'},
+          {
+            summarize: [
+              {aggregate: 'count', field: 'f', as: 'b'},
+              {aggregate: 'sum', field: 'f', as: 'c'}
+            ],
+            groupBy: ['field']
+          }
+        ],
         encoding: {
           x: {field: 'a', type: 'temporal', timeUnit: 'month'}
         }


### PR DESCRIPTION
For groupBy case, I strongly think that this should have camel case for consistency with *most* of the rest of the language.  

(If I had notice that it's not camel case in the original PR, I wouldn't have merged it.)