### PR TITLE
Create parse nodes together with the filter nodes and do not move the…

### DIFF
--- a/examples/vg-specs/lookup.vg.json
+++ b/examples/vg-specs/lookup.vg.json
@@ -14,10 +14,7 @@
             "name": "source_0",
             "url": "data/lookup_groups.csv",
             "format": {
-                "type": "csv",
-                "parse": {
-                    "age": "number"
-                }
+                "type": "csv"
             },
             "transform": [
                 {
@@ -31,6 +28,11 @@
                         "age",
                         "height"
                     ]
+                },
+                {
+                    "type": "formula",
+                    "expr": "toNumber(datum[\"age\"])",
+                    "as": "age"
                 },
                 {
                     "type": "filter",

--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -45,11 +45,11 @@ Description of the dataflow (http://asciiflow.com/):
      +---+----+
          |
          v
-       Parse
-         |
-         v
      Transforms
 (Filter, Compute, ...)
+         |
+         v
+       Parse
          |
          v
      Null Filter
@@ -100,12 +100,6 @@ export function parseData(model: Model): DataComponent {
   // the current head of the tree that we are appending to
   let head = root;
 
-  const parse = ParseNode.make(model);
-  if (parse) {
-    parse.parent = root;
-    head = parse;
-  }
-
   // HACK: This is equivalent for merging bin extent for union scale.
   // FIXME(https://github.com/vega/vega-lite/issues/2270): Correctly merge extent / bin node for shared bin scale
   const parentIsLayer = model.parent && (model.parent instanceof LayerModel);
@@ -123,6 +117,12 @@ export function parseData(model: Model): DataComponent {
     const {first, last} = parseTransformArray(model);
     first.parent = head;
     head = last;
+  }
+
+  const parse = ParseNode.make(model);
+  if (parse) {
+    parse.parent = head;
+    head = parse;
   }
 
   if (model instanceof ModelWithField) {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -22,7 +22,7 @@ export const DEFAULT_REQUIRED_CHANNEL_MAP: RequiredChannelMap = {
 
 export interface SupportedChannelMap {
   [mark: string]: {
-    [channel: string]: number
+    [channel: string]: boolean
   };
 }
 

--- a/test/compile/data/formatparse.test.ts
+++ b/test/compile/data/formatparse.test.ts
@@ -30,27 +30,6 @@ describe('compile/data/formatparse', () => {
       });
     });
 
-    it('should return a correct parse for filtered fields', () => {
-      const model = parseUnitModel({
-        "data": {"url": "a.json"},
-        "transform": [
-          {"filter": {"field": "a", "equal": {year: 2000}}},
-          {"filter": {"field": "b", "oneOf": ["a", "b"]}},
-          {"filter": {"field": "c", "range": [{year: 2000}, {year: 2001}]}},
-          {"filter": {"field": "d", "range": [1,2]}}
-        ],
-        "mark": "point",
-        encoding: {}
-      });
-
-      assert.deepEqual(parse(model), {
-        a: 'date',
-        b: 'string',
-        c: 'date',
-        d: 'number'
-      });
-    });
-
     it('should return a correct customized parse.', () => {
       const model = parseUnitModel({
         "data": {"url": "a.json", "format": {"parse": {"c": "number", "d": "date"}}},

--- a/typings/vega-util.d.ts
+++ b/typings/vega-util.d.ts
@@ -26,6 +26,6 @@ declare module 'vega-util' {
   export function isString(a: any): a is string;
   export function isNumber(a: any): a is number;
 
-  export function toSet<T>(array: T[]): {[T: string]: 1}
+  export function toSet<T>(array: T[]): {[T: string]: boolean}
   export function stringValue(a: any): string;
 }


### PR DESCRIPTION
… parse nodes through lookup nodes if the lookup node creates fields that the format parse node needs.

This is necessary because we don't know whether a parse should go into the primary or secondary source of a lookup. This PR resolves this issue by moving parse after transforms but parse gets pushed through transforms if possible. 

Supercedes https://github.com/vega/vega-lite/pull/2420
