### PR TITLE
Revert "Ignore scale.domain when binned. Fixes #2422"

### DIFF
--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -65,16 +65,12 @@ function parseSingleChannelDomain(scale: Scale, model: UnitModel, channel:Channe
   const fieldDef = model.fieldDef(channel);
 
   if (scale.domain && scale.domain !== 'unaggregated' && !isSelectionDomain(scale.domain)) { // explicit value
-    if (fieldDef.bin) {
-      log.warn(log.message.conflictedDomain(channel));
-    } else {
-      if (isDateTime(scale.domain[0])) {
-        return (scale.domain as DateTime[]).map((dt) => {
-          return {signal: dateTimeExpr(dt, true)};
-        });
-      }
-      return scale.domain;
+    if (isDateTime(scale.domain[0])) {
+      return (scale.domain as DateTime[]).map((dt) => {
+        return {signal: dateTimeExpr(dt, true)};
+      });
     }
+    return scale.domain;
   }
 
   const stack = model.stack;

--- a/src/log.ts
+++ b/src/log.ts
@@ -212,10 +212,6 @@ export namespace message {
     return `Setting the scale to be independent for ${channel} means we also have to set the guide (axis or legend) to be independent.`;
   }
 
-  export function conflictedDomain(channel: Channel) {
-    return `${channel}-scale's "domain" is ignored as it is binned.`;
-  }
-
   export const INVAID_DOMAIN = 'Invalid scale domain';
 
   export const UNABLE_TO_MERGE_DOMAINS = 'Unable to merge domains';

--- a/test/compile/scale/domain.test.ts
+++ b/test/compile/scale/domain.test.ts
@@ -159,26 +159,6 @@ describe('compile/scale', () => {
         assert.deepEqual(_domain, [0, 200]);
       });
 
-      it('should ignore the custom domain when binned', log.wrap((localLogger) => {
-        const model = parseUnitModel({
-          mark: "point",
-          encoding: {
-            y: {
-              field: 'origin',
-              type: 'quantitative',
-              scale: {domain: [0,200]},
-              bin: {maxbins: 15}
-            }
-          }
-        });
-        const _domain = parseDomain(model,'y');
-
-        assert.deepEqual(_domain, {
-          signal: 'sequence(bin_maxbins_15_origin_bins.start, bin_maxbins_15_origin_bins.stop + bin_maxbins_15_origin_bins.step, bin_maxbins_15_origin_bins.step)'
-        });
-        assert.equal(localLogger.warns[0], log.message.conflictedDomain("y"));
-      }));
-
       it('should return the aggregated domain if we do not overrride it', function() {
         const model = parseUnitModel({
           mark: "point",


### PR DESCRIPTION
@domoritz @yhoonkim 
As discussed [here](https://github.com/vega/vega-lite/pull/2428#issuecomment-304756108), 
I wonder if we should revert #2428.

Shouldn't `scale.domain` be allowed for binned field and instead `extent` is also automatically set to be the same as `domain`?  
