### PR TITLE
Identify units via model names in selection stores

### DIFF
--- a/examples/specs/interactive_splom.vl.json
+++ b/examples/specs/interactive_splom.vl.json
@@ -10,14 +10,15 @@
     "selection": {
       "brush": {
         "type": "interval", "resolve": "union",
-        "encodings": ["x"],
         "on": "[mousedown[event.shiftKey], mouseup] > mousemove",
-        "translate": "[mousedown[event.shiftKey], mouseup] > mousemove"
+        "translate": "[mousedown[event.shiftKey], mouseup] > mousemove",
+        "zoom": "wheel[event.shiftKey]"
       },
       "grid": {
         "type": "interval", "resolve": "global",
         "bind": "scales",
-        "translate": "[mousedown[!event.shiftKey], mouseup] > mousemove"
+        "translate": "[mousedown[!event.shiftKey], mouseup] > mousemove",
+        "zoom": "wheel[!event.shiftKey]"
       }
     },
     "encoding": {

--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -95,13 +95,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
+                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, width)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, width)"
                         }
                     ]
                 },
@@ -161,13 +161,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
+                            "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, height)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
+                            "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, height)"
                         }
                     ]
                 },
@@ -267,7 +267,7 @@
                             "events": {
                                 "signal": "brush"
                             },
-                            "update": "{unit: unit.datum && unit.datum._id, intervals: brush}"
+                            "update": "{unit: \"\", intervals: brush}"
                         }
                     ]
                 },
@@ -311,7 +311,7 @@
                         "update": {
                             "x": [
                                 {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"\"",
                                     "signal": "brush_x[0]"
                                 },
                                 {
@@ -320,7 +320,7 @@
                             ],
                             "y": [
                                 {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"\"",
                                     "signal": "brush_y[0]"
                                 },
                                 {
@@ -329,7 +329,7 @@
                             ],
                             "x2": [
                                 {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"\"",
                                     "signal": "brush_x[1]"
                                 },
                                 {
@@ -338,7 +338,7 @@
                             ],
                             "y2": [
                                 {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"\"",
                                     "signal": "brush_y[1]"
                                 },
                                 {
@@ -367,7 +367,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "!vlInterval(\"brush_store\", parent._id, datum, \"union\", \"all\")",
+                                    "test": "!vlInterval(\"brush_store\", \"\", datum, \"union\", \"all\")",
                                     "value": "grey"
                                 },
                                 {
@@ -399,7 +399,7 @@
                         "update": {
                             "x": [
                                 {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"\"",
                                     "signal": "brush_x[0]"
                                 },
                                 {
@@ -408,7 +408,7 @@
                             ],
                             "y": [
                                 {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"\"",
                                     "signal": "brush_y[0]"
                                 },
                                 {
@@ -417,7 +417,7 @@
                             ],
                             "x2": [
                                 {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"\"",
                                     "signal": "brush_x[1]"
                                 },
                                 {
@@ -426,7 +426,7 @@
                             ],
                             "y2": [
                                 {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"\"",
                                     "signal": "brush_y[1]"
                                 },
                                 {

--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -51,7 +51,7 @@
             "type": "group",
             "signals": [
                 {
-                    "name": "brush_Horsepower",
+                    "name": "brush_x",
                     "value": [],
                     "on": [
                         {
@@ -59,10 +59,10 @@
                                 "source": "scope",
                                 "type": "mousedown",
                                 "filter": [
-                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                 ]
                             },
-                            "update": "invert(\"x\", [x(unit), x(unit)])"
+                            "update": "[x(unit), x(unit)]"
                         },
                         {
                             "events": {
@@ -74,7 +74,7 @@
                                         "source": "scope",
                                         "type": "mousedown",
                                         "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
                                     {
@@ -83,111 +83,102 @@
                                     }
                                 ]
                             },
-                            "update": "[brush_Horsepower[0], invert(\"x\", clamp(x(unit), 0, width))]"
+                            "update": "[brush_x[0], clamp(x(unit), 0, width)]"
+                        },
+                        {
+                            "events": {
+                                "scale": "x"
+                            },
+                            "update": "!isArray(brush_Horsepower) ? brush_x : [scale(\"x\", brush_Horsepower[0]), scale(\"x\", brush_Horsepower[1])]"
                         },
                         {
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.x + (brush_Horsepower[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_Horsepower[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_Horsepower",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "brush_x"
+                            },
+                            "update": "invert(\"x\", brush_x)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_y",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
+                                ]
+                            },
+                            "update": "[y(unit), y(unit)]"
+                        },
+                        {
+                            "events": {
+                                "source": "window",
+                                "type": "mousemove",
+                                "consume": true,
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
+                                        ]
+                                    },
+                                    {
+                                        "source": "window",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "[brush_y[0], clamp(y(unit), 0, height)]"
+                        },
+                        {
+                            "events": {
+                                "scale": "y"
+                            },
+                            "update": "!isArray(brush_Miles_per_Gallon) ? brush_y : [scale(\"y\", brush_Miles_per_Gallon[0]), scale(\"y\", brush_Miles_per_Gallon[1])]"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_translate_delta"
+                            },
+                            "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_zoom_delta"
+                            },
+                            "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
                         }
                     ]
                 },
                 {
                     "name": "brush_Miles_per_Gallon",
-                    "value": [],
                     "on": [
                         {
                             "events": {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                ]
+                                "signal": "brush_y"
                             },
-                            "update": "invert(\"y\", [y(unit), y(unit)])"
-                        },
-                        {
-                            "events": {
-                                "source": "window",
-                                "type": "mousemove",
-                                "consume": true,
-                                "between": [
-                                    {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
-                                    },
-                                    {
-                                        "source": "window",
-                                        "type": "mouseup"
-                                    }
-                                ]
-                            },
-                            "update": "[brush_Miles_per_Gallon[0], invert(\"y\", clamp(y(unit), 0, height))]"
-                        },
-                        {
-                            "events": {
-                                "signal": "brush_translate_delta"
-                            },
-                            "update": "clampRange([brush_translate_anchor.extent_y[0] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height, brush_translate_anchor.extent_y[1] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
-                        },
-                        {
-                            "events": {
-                                "signal": "brush_zoom_delta"
-                            },
-                            "update": "clampRange([brush_zoom_anchor.y + (brush_Miles_per_Gallon[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_Miles_per_Gallon[1] - brush_zoom_anchor.y) * brush_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
-                        }
-                    ]
-                },
-                {
-                    "name": "brush_size",
-                    "value": [],
-                    "on": [
-                        {
-                            "events": {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                ]
-                            },
-                            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                        },
-                        {
-                            "events": {
-                                "source": "window",
-                                "type": "mousemove",
-                                "consume": true,
-                                "between": [
-                                    {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
-                                    },
-                                    {
-                                        "source": "window",
-                                        "type": "mouseup"
-                                    }
-                                ]
-                            },
-                            "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                        },
-                        {
-                            "events": {
-                                "signal": "brush_zoom_delta"
-                            },
-                            "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                            "update": "invert(\"y\", brush_y)"
                         }
                     ]
                 },
@@ -207,7 +198,7 @@
                                     "markname": "brush_brush"
                                 }
                             ],
-                            "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_Horsepower), extent_y: slice(brush_Miles_per_Gallon), }"
+                            "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x), extent_y: slice(brush_y)}"
                         }
                     ]
                 },
@@ -249,7 +240,7 @@
                                     "markname": "brush_brush"
                                 }
                             ],
-                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                            "update": "{x: x(unit), y: y(unit)}"
                         }
                     ]
                 },
@@ -321,18 +312,7 @@
                             "x": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[0]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "x2": [
-                                {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[1]"
+                                    "signal": "brush_x[0]"
                                 },
                                 {
                                     "value": 0
@@ -341,8 +321,16 @@
                             "y": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[0]"
+                                    "signal": "brush_y[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "signal": "brush_x[1]"
                                 },
                                 {
                                     "value": 0
@@ -351,8 +339,7 @@
                             "y2": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[1]"
+                                    "signal": "brush_y[1]"
                                 },
                                 {
                                     "value": 0
@@ -413,18 +400,7 @@
                             "x": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[0]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "x2": [
-                                {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[1]"
+                                    "signal": "brush_x[0]"
                                 },
                                 {
                                     "value": 0
@@ -433,8 +409,16 @@
                             "y": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[0]"
+                                    "signal": "brush_y[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "signal": "brush_x[1]"
                                 },
                                 {
                                     "value": 0
@@ -443,8 +427,7 @@
                             "y2": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[1]"
+                                    "signal": "brush_y[1]"
                                 },
                                 {
                                     "value": 0

--- a/examples/vg-specs/concat_selections.vg.json
+++ b/examples/vg-specs/concat_selections.vg.json
@@ -124,7 +124,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_Miles_per_Gallon",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -132,11 +132,10 @@
                                         "source": "scope",
                                         "type": "mousedown",
                                         "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"concat_0_x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -148,8 +147,7 @@
                                                 "source": "scope",
                                                 "type": "mousedown",
                                                 "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -158,115 +156,102 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_Miles_per_Gallon[0], invert(\"concat_0_x\", clamp(x(unit), 0, concat_0_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, concat_0_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "concat_0_x"
+                                    },
+                                    "update": "!isArray(brush_Miles_per_Gallon) ? brush_x : [scale(\"concat_0_x\", brush_Miles_per_Gallon[0]), scale(\"concat_0_x\", brush_Miles_per_Gallon[1])]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"concat_0_x\", 0), invert(\"concat_0_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_Miles_per_Gallon[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_Miles_per_Gallon[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"concat_0_x\", 0), invert(\"concat_0_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "brush_Miles_per_Gallon",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "brush_x"
+                                    },
+                                    "update": "invert(\"concat_0_x\", brush_x)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "brush_y",
+                            "value": [],
+                            "on": [
+                                {
+                                    "events": {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
+                                        ]
+                                    },
+                                    "update": "[y(unit), y(unit)]"
+                                },
+                                {
+                                    "events": {
+                                        "source": "window",
+                                        "type": "mousemove",
+                                        "consume": true,
+                                        "between": [
+                                            {
+                                                "source": "scope",
+                                                "type": "mousedown",
+                                                "filter": [
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
+                                                ]
+                                            },
+                                            {
+                                                "source": "window",
+                                                "type": "mouseup"
+                                            }
+                                        ]
+                                    },
+                                    "update": "[brush_y[0], clamp(y(unit), 0, concat_0_height)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "concat_0_y"
+                                    },
+                                    "update": "!isArray(brush_Horsepower) ? brush_y : [scale(\"concat_0_y\", brush_Horsepower[0]), scale(\"concat_0_y\", brush_Horsepower[1])]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "brush_translate_delta"
+                                    },
+                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "brush_zoom_delta"
+                                    },
+                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
                                 }
                             ]
                         },
                         {
                             "name": "brush_Horsepower",
-                            "value": [],
                             "on": [
                                 {
                                     "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
+                                        "signal": "brush_y"
                                     },
-                                    "update": "invert(\"concat_0_y\", [y(unit), y(unit)])"
-                                },
-                                {
-                                    "events": {
-                                        "source": "window",
-                                        "type": "mousemove",
-                                        "consume": true,
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "window",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "[brush_Horsepower[0], invert(\"concat_0_y\", clamp(y(unit), 0, concat_0_height))]"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_translate_delta"
-                                    },
-                                    "update": "clampRange([brush_translate_anchor.extent_y[0] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height, brush_translate_anchor.extent_y[1] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height], invert(\"concat_0_y\", unit.height), invert(\"concat_0_y\", 0))"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_zoom_delta"
-                                    },
-                                    "update": "clampRange([brush_zoom_anchor.y + (brush_Horsepower[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_Horsepower[1] - brush_zoom_anchor.y) * brush_zoom_delta], invert(\"concat_0_y\", unit.height), invert(\"concat_0_y\", 0))"
-                                }
-                            ]
-                        },
-                        {
-                            "name": "brush_size",
-                            "value": [],
-                            "on": [
-                                {
-                                    "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
-                                    },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                                },
-                                {
-                                    "events": {
-                                        "source": "window",
-                                        "type": "mousemove",
-                                        "consume": true,
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "window",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_zoom_delta"
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "invert(\"concat_0_y\", brush_y)"
                                 }
                             ]
                         },
@@ -286,7 +271,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_Miles_per_Gallon), extent_y: slice(brush_Horsepower), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x), extent_y: slice(brush_y)}"
                                 }
                             ]
                         },
@@ -328,7 +313,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"concat_0_x\", x(unit)), y: invert(\"concat_0_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -387,18 +372,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -407,8 +381,16 @@
                                     "y": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_y",
-                                            "signal": "brush[1].extent[0]"
+                                            "signal": "brush_y[0]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0
@@ -417,8 +399,7 @@
                                     "y2": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_y",
-                                            "signal": "brush[1].extent[1]"
+                                            "signal": "brush_y[1]"
                                         },
                                         {
                                             "value": 0
@@ -472,18 +453,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -492,8 +462,16 @@
                                     "y": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_y",
-                                            "signal": "brush[1].extent[0]"
+                                            "signal": "brush_y[0]"
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0
@@ -502,8 +480,7 @@
                                     "y2": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_y",
-                                            "signal": "brush[1].extent[1]"
+                                            "signal": "brush_y[1]"
                                         },
                                         {
                                             "value": 0
@@ -610,7 +587,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
+                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
                                 },
                                 {
                                     "events": {
@@ -628,7 +605,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
                                 },
                                 {
                                     "events": {
@@ -654,7 +631,7 @@
                                             "type": "mousedown"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"concat_1_x\"), extent_y: domain(\"concat_1_y\"), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: domain(\"concat_1_x\"), extent_y: domain(\"concat_1_y\")}"
                                 }
                             ]
                         },

--- a/examples/vg-specs/concat_selections.vg.json
+++ b/examples/vg-specs/concat_selections.vg.json
@@ -168,13 +168,13 @@
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, concat_0_width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, concat_0_width)"
                                 }
                             ]
                         },
@@ -234,13 +234,13 @@
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
+                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, concat_0_height)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
+                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, concat_0_height)"
                                 }
                             ]
                         },
@@ -340,7 +340,7 @@
                                     "events": {
                                         "signal": "brush"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: brush}"
+                                    "update": "{unit: \"concat_0_\", intervals: brush}"
                                 }
                             ]
                         },
@@ -371,7 +371,7 @@
                                 "update": {
                                     "x": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
                                             "signal": "brush_x[0]"
                                         },
                                         {
@@ -380,7 +380,7 @@
                                     ],
                                     "y": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
                                             "signal": "brush_y[0]"
                                         },
                                         {
@@ -389,7 +389,7 @@
                                     ],
                                     "x2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
                                             "signal": "brush_x[1]"
                                         },
                                         {
@@ -398,7 +398,7 @@
                                     ],
                                     "y2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
                                             "signal": "brush_y[1]"
                                         },
                                         {
@@ -452,7 +452,7 @@
                                 "update": {
                                     "x": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
                                             "signal": "brush_x[0]"
                                         },
                                         {
@@ -461,7 +461,7 @@
                                     ],
                                     "y": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
                                             "signal": "brush_y[0]"
                                         },
                                         {
@@ -470,7 +470,7 @@
                                     ],
                                     "x2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
                                             "signal": "brush_x[1]"
                                         },
                                         {
@@ -479,7 +479,7 @@
                                     ],
                                     "y2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
                                             "signal": "brush_y[1]"
                                         },
                                         {
@@ -587,7 +587,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
+                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / concat_1_width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / concat_1_width]"
                                 },
                                 {
                                     "events": {
@@ -605,7 +605,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / concat_1_height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / concat_1_height]"
                                 },
                                 {
                                     "events": {
@@ -697,7 +697,7 @@
                                     "events": {
                                         "signal": "grid"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: grid}"
+                                    "update": "{unit: \"concat_1_\", intervals: grid}"
                                 }
                             ]
                         },
@@ -733,7 +733,7 @@
                                     },
                                     "stroke": [
                                         {
-                                            "test": "vlInterval(\"brush_store\", parent._id, datum, \"union\", \"all\")",
+                                            "test": "vlInterval(\"brush_store\", \"concat_1_\", datum, \"union\", \"all\")",
                                             "value": "steelblue"
                                         },
                                         {

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -266,7 +266,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_X",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -275,11 +275,10 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -291,8 +290,7 @@
                                                 "type": "mousedown",
                                                 "filter": [
                                                     "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -301,65 +299,36 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_X[0], invert(\"x\", clamp(x(unit), 0, child_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, child_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "x"
+                                    },
+                                    "update": "!isArray(brush_X) ? brush_x : [scale(\"x\", brush_X[0]), scale(\"x\", brush_X[1])]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_X[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_X[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
-                            "value": [],
+                            "name": "brush_X",
                             "on": [
                                 {
                                     "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
+                                        "signal": "brush_x"
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                                },
-                                {
-                                    "events": {
-                                        "source": "scope",
-                                        "type": "mousemove",
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "scope",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_zoom_delta"
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "invert(\"x\", brush_x)"
                                 }
                             ]
                         },
@@ -382,7 +351,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_X), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x)}"
                                 }
                             ]
                         },
@@ -426,7 +395,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -475,7 +444,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
+                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
                                 },
                                 {
                                     "events": {
@@ -493,7 +462,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
                                 },
                                 {
                                     "events": {
@@ -522,7 +491,7 @@
                                             ]
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: domain(\"x\"), extent_y: domain(\"y\")}"
                                 }
                             ]
                         },
@@ -646,15 +615,13 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "x",
-                                        "signal": "brush[0].extent[1]"
+                                        "signal": "brush_x[0]"
                                     },
                                     "y": {
                                         "value": 0
+                                    },
+                                    "x2": {
+                                        "signal": "brush_x[1]"
                                     },
                                     "y2": {
                                         "field": {
@@ -763,15 +730,13 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "x",
-                                        "signal": "brush[0].extent[1]"
+                                        "signal": "brush_x[0]"
                                     },
                                     "y": {
                                         "value": 0
+                                    },
+                                    "x2": {
+                                        "signal": "brush_x[1]"
                                     },
                                     "y2": {
                                         "field": {

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -311,13 +311,13 @@
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, child_width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, child_width)"
                                 }
                             ]
                         },
@@ -422,7 +422,7 @@
                                     "events": {
                                         "signal": "brush"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: brush}"
+                                    "update": "{unit: \"child_\", intervals: brush}"
                                 }
                             ]
                         },
@@ -433,7 +433,7 @@
                                     "events": {
                                         "signal": "brush"
                                     },
-                                    "update": "modify(\"brush_store\", brush_tuple, {unit: brush_tuple.unit})"
+                                    "update": "modify(\"brush_store\", brush_tuple, {unit: \"child_\"})"
                                 }
                             ]
                         },
@@ -444,7 +444,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
+                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / child_width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / child_width]"
                                 },
                                 {
                                     "events": {
@@ -462,7 +462,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_height]"
                                 },
                                 {
                                     "events": {
@@ -559,7 +559,7 @@
                                     "events": {
                                         "signal": "grid"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: grid}"
+                                    "update": "{unit: \"child_\", intervals: grid}"
                                 }
                             ]
                         },
@@ -585,7 +585,7 @@
                                     "events": {
                                         "signal": "xenc"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, encodings: xenc.encodings, fields: xenc.fields, values: xenc.values, X: xenc.values[0]}"
+                                    "update": "{unit: \"child_\", encodings: xenc.encodings, fields: xenc.fields, values: xenc.values, X: xenc.values[0]}"
                                 }
                             ]
                         },
@@ -651,7 +651,7 @@
                                     },
                                     "fill": [
                                         {
-                                            "test": "vlPoint(\"xenc_store\", parent._id, datum, \"union\", \"all\")",
+                                            "test": "vlPoint(\"xenc_store\", \"child_\", datum, \"union\", \"all\")",
                                             "value": "red"
                                         },
                                         {
@@ -660,7 +660,7 @@
                                     ],
                                     "size": [
                                         {
-                                            "test": "vlInterval(\"brush_store\", parent._id, datum, \"intersect\", \"all\")",
+                                            "test": "vlInterval(\"brush_store\", \"child_\", datum, \"intersect\", \"all\")",
                                             "value": 250
                                         },
                                         {

--- a/examples/vg-specs/interactive_splom.vg.json
+++ b/examples/vg-specs/interactive_splom.vg.json
@@ -223,13 +223,13 @@
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
+                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, child_Horsepower_Horsepower_height)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
+                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, child_Horsepower_Horsepower_height)"
                                 }
                             ]
                         },
@@ -340,7 +340,7 @@
                                     "events": {
                                         "signal": "brush"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: brush}"
+                                    "update": "{unit: \"child_Horsepower_Horsepower_\", intervals: brush}"
                                 }
                             ]
                         },
@@ -351,7 +351,7 @@
                                     "events": {
                                         "signal": "brush"
                                     },
-                                    "update": "modify(\"brush_store\", brush_tuple, {unit: brush_tuple.unit})"
+                                    "update": "modify(\"brush_store\", brush_tuple, {unit: \"child_Horsepower_Horsepower_\"})"
                                 }
                             ]
                         },
@@ -362,7 +362,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_Horsepower_Horsepower_height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_Horsepower_Horsepower_height]"
                                 },
                                 {
                                     "events": {
@@ -465,7 +465,7 @@
                                     "events": {
                                         "signal": "grid"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: grid}"
+                                    "update": "{unit: \"child_Horsepower_Horsepower_\", intervals: grid}"
                                 }
                             ]
                         },
@@ -531,7 +531,7 @@
                                     },
                                     "stroke": [
                                         {
-                                            "test": "!vlInterval(\"brush_store\", parent._id, datum, \"union\", \"all\")",
+                                            "test": "!vlInterval(\"brush_store\", \"child_Horsepower_Horsepower_\", datum, \"union\", \"all\")",
                                             "value": "grey"
                                         },
                                         {
@@ -720,13 +720,13 @@
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, child_Horsepower_Miles_per_Gallon_width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, child_Horsepower_Miles_per_Gallon_width)"
                                 }
                             ]
                         },
@@ -787,13 +787,13 @@
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
+                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, child_Horsepower_Miles_per_Gallon_height)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
+                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, child_Horsepower_Miles_per_Gallon_height)"
                                 }
                             ]
                         },
@@ -904,7 +904,7 @@
                                     "events": {
                                         "signal": "brush"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: brush}"
+                                    "update": "{unit: \"child_Horsepower_Miles_per_Gallon_\", intervals: brush}"
                                 }
                             ]
                         },
@@ -915,7 +915,7 @@
                                     "events": {
                                         "signal": "brush"
                                     },
-                                    "update": "modify(\"brush_store\", brush_tuple, {unit: brush_tuple.unit})"
+                                    "update": "modify(\"brush_store\", brush_tuple, {unit: \"child_Horsepower_Miles_per_Gallon_\"})"
                                 }
                             ]
                         },
@@ -926,7 +926,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
+                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / child_Horsepower_Miles_per_Gallon_width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / child_Horsepower_Miles_per_Gallon_width]"
                                 },
                                 {
                                     "events": {
@@ -944,7 +944,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_Horsepower_Miles_per_Gallon_height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_Horsepower_Miles_per_Gallon_height]"
                                 },
                                 {
                                     "events": {
@@ -1047,7 +1047,7 @@
                                     "events": {
                                         "signal": "grid"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: grid}"
+                                    "update": "{unit: \"child_Horsepower_Miles_per_Gallon_\", intervals: grid}"
                                 }
                             ]
                         },
@@ -1111,7 +1111,7 @@
                                     },
                                     "stroke": [
                                         {
-                                            "test": "!vlInterval(\"brush_store\", parent._id, datum, \"union\", \"all\")",
+                                            "test": "!vlInterval(\"brush_store\", \"child_Horsepower_Miles_per_Gallon_\", datum, \"union\", \"all\")",
                                             "value": "grey"
                                         },
                                         {
@@ -1301,13 +1301,13 @@
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, child_Acceleration_Horsepower_width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, child_Acceleration_Horsepower_width)"
                                 }
                             ]
                         },
@@ -1368,13 +1368,13 @@
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
+                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, child_Acceleration_Horsepower_height)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
+                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, child_Acceleration_Horsepower_height)"
                                 }
                             ]
                         },
@@ -1485,7 +1485,7 @@
                                     "events": {
                                         "signal": "brush"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: brush}"
+                                    "update": "{unit: \"child_Acceleration_Horsepower_\", intervals: brush}"
                                 }
                             ]
                         },
@@ -1496,7 +1496,7 @@
                                     "events": {
                                         "signal": "brush"
                                     },
-                                    "update": "modify(\"brush_store\", brush_tuple, {unit: brush_tuple.unit})"
+                                    "update": "modify(\"brush_store\", brush_tuple, {unit: \"child_Acceleration_Horsepower_\"})"
                                 }
                             ]
                         },
@@ -1507,7 +1507,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
+                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / child_Acceleration_Horsepower_width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / child_Acceleration_Horsepower_width]"
                                 },
                                 {
                                     "events": {
@@ -1525,7 +1525,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_Acceleration_Horsepower_height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_Acceleration_Horsepower_height]"
                                 },
                                 {
                                     "events": {
@@ -1628,7 +1628,7 @@
                                     "events": {
                                         "signal": "grid"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: grid}"
+                                    "update": "{unit: \"child_Acceleration_Horsepower_\", intervals: grid}"
                                 }
                             ]
                         },
@@ -1692,7 +1692,7 @@
                                     },
                                     "stroke": [
                                         {
-                                            "test": "!vlInterval(\"brush_store\", parent._id, datum, \"union\", \"all\")",
+                                            "test": "!vlInterval(\"brush_store\", \"child_Acceleration_Horsepower_\", datum, \"union\", \"all\")",
                                             "value": "grey"
                                         },
                                         {
@@ -1882,13 +1882,13 @@
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, child_Acceleration_Miles_per_Gallon_width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, child_Acceleration_Miles_per_Gallon_width)"
                                 }
                             ]
                         },
@@ -1949,13 +1949,13 @@
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
+                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, child_Acceleration_Miles_per_Gallon_height)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
+                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, child_Acceleration_Miles_per_Gallon_height)"
                                 }
                             ]
                         },
@@ -2066,7 +2066,7 @@
                                     "events": {
                                         "signal": "brush"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: brush}"
+                                    "update": "{unit: \"child_Acceleration_Miles_per_Gallon_\", intervals: brush}"
                                 }
                             ]
                         },
@@ -2077,7 +2077,7 @@
                                     "events": {
                                         "signal": "brush"
                                     },
-                                    "update": "modify(\"brush_store\", brush_tuple, {unit: brush_tuple.unit})"
+                                    "update": "modify(\"brush_store\", brush_tuple, {unit: \"child_Acceleration_Miles_per_Gallon_\"})"
                                 }
                             ]
                         },
@@ -2088,7 +2088,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
+                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / child_Acceleration_Miles_per_Gallon_width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / child_Acceleration_Miles_per_Gallon_width]"
                                 },
                                 {
                                     "events": {
@@ -2106,7 +2106,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_Acceleration_Miles_per_Gallon_height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_Acceleration_Miles_per_Gallon_height]"
                                 },
                                 {
                                     "events": {
@@ -2209,7 +2209,7 @@
                                     "events": {
                                         "signal": "grid"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: grid}"
+                                    "update": "{unit: \"child_Acceleration_Miles_per_Gallon_\", intervals: grid}"
                                 }
                             ]
                         },
@@ -2273,7 +2273,7 @@
                                     },
                                     "stroke": [
                                         {
-                                            "test": "!vlInterval(\"brush_store\", parent._id, datum, \"union\", \"all\")",
+                                            "test": "!vlInterval(\"brush_store\", \"child_Acceleration_Miles_per_Gallon_\", datum, \"union\", \"all\")",
                                             "value": "grey"
                                         },
                                         {

--- a/examples/vg-specs/interactive_splom.vg.json
+++ b/examples/vg-specs/interactive_splom.vg.json
@@ -178,7 +178,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_Horsepower",
+                            "name": "brush_y",
                             "value": [],
                             "on": [
                                 {
@@ -187,11 +187,10 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"child_Horsepower_Horsepower_x\", [x(unit), x(unit)])"
+                                    "update": "[y(unit), y(unit)]"
                                 },
                                 {
                                     "events": {
@@ -203,8 +202,7 @@
                                                 "type": "mousedown",
                                                 "filter": [
                                                     "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -213,71 +211,42 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_Horsepower[0], invert(\"child_Horsepower_Horsepower_x\", clamp(x(unit), 0, child_Horsepower_Horsepower_width))]"
+                                    "update": "[brush_y[0], clamp(y(unit), 0, child_Horsepower_Horsepower_height)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_Horsepower_Horsepower_y"
+                                    },
+                                    "update": "!isArray(brush_Horsepower) ? brush_y : [scale(\"child_Horsepower_Horsepower_y\", brush_Horsepower[0]), scale(\"child_Horsepower_Horsepower_y\", brush_Horsepower[1])]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"child_Horsepower_Horsepower_x\", 0), invert(\"child_Horsepower_Horsepower_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_Horsepower[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_Horsepower[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"child_Horsepower_Horsepower_x\", 0), invert(\"child_Horsepower_Horsepower_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
-                            "value": [],
+                            "name": "brush_Horsepower",
                             "on": [
                                 {
                                     "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
+                                        "signal": "brush_y"
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                                },
-                                {
-                                    "events": {
-                                        "source": "scope",
-                                        "type": "mousemove",
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "scope",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_zoom_delta"
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "invert(\"child_Horsepower_Horsepower_y\", brush_y)"
                                 }
                             ]
                         },
                         {
                             "name": "brush",
-                            "update": "[{encoding: \"x\", field: \"Horsepower\", extent: brush_Horsepower}]"
+                            "update": "[{encoding: \"y\", field: \"Horsepower\", extent: brush_Horsepower}]"
                         },
                         {
                             "name": "brush_translate_anchor",
@@ -294,7 +263,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_Horsepower), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_y: slice(brush_y)}"
                                 }
                             ]
                         },
@@ -335,10 +304,13 @@
                                         {
                                             "source": "scope",
                                             "type": "wheel",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"child_Horsepower_Horsepower_x\", x(unit)), y: invert(\"child_Horsepower_Horsepower_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -350,6 +322,9 @@
                                         {
                                             "source": "scope",
                                             "type": "wheel",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
                                             "markname": "brush_brush"
                                         }
                                     ],
@@ -387,7 +362,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
                                 },
                                 {
                                     "events": {
@@ -416,7 +391,7 @@
                                             ]
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_y: domain(\"child_Horsepower_Horsepower_y\"), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_y: domain(\"child_Horsepower_Horsepower_y\")}"
                                 }
                             ]
                         },
@@ -455,7 +430,10 @@
                                     "events": [
                                         {
                                             "source": "scope",
-                                            "type": "wheel"
+                                            "type": "wheel",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
                                         }
                                     ],
                                     "update": "{x: invert(\"child_Horsepower_Horsepower_x\", x(unit)), y: invert(\"child_Horsepower_Horsepower_y\", y(unit))}"
@@ -469,7 +447,10 @@
                                     "events": [
                                         {
                                             "source": "scope",
-                                            "type": "wheel"
+                                            "type": "wheel",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
                                         }
                                     ],
                                     "force": true,
@@ -514,20 +495,18 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "child_Horsepower_Horsepower_x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "child_Horsepower_Horsepower_x",
-                                        "signal": "brush[0].extent[1]"
-                                    },
-                                    "y": {
                                         "value": 0
                                     },
-                                    "y2": {
+                                    "y": {
+                                        "signal": "brush_y[0]"
+                                    },
+                                    "x2": {
                                         "field": {
-                                            "group": "height"
+                                            "group": "width"
                                         }
+                                    },
+                                    "y2": {
+                                        "signal": "brush_y[1]"
                                     }
                                 }
                             },
@@ -584,20 +563,18 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "child_Horsepower_Horsepower_x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "child_Horsepower_Horsepower_x",
-                                        "signal": "brush[0].extent[1]"
-                                    },
-                                    "y": {
                                         "value": 0
                                     },
-                                    "y2": {
+                                    "y": {
+                                        "signal": "brush_y[0]"
+                                    },
+                                    "x2": {
                                         "field": {
-                                            "group": "height"
+                                            "group": "width"
                                         }
+                                    },
+                                    "y2": {
+                                        "signal": "brush_y[1]"
                                     }
                                 }
                             },
@@ -698,7 +675,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_Horsepower",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -707,11 +684,10 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"child_Horsepower_Miles_per_Gallon_x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -723,8 +699,7 @@
                                                 "type": "mousedown",
                                                 "filter": [
                                                     "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -733,24 +708,41 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_Horsepower[0], invert(\"child_Horsepower_Miles_per_Gallon_x\", clamp(x(unit), 0, child_Horsepower_Miles_per_Gallon_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, child_Horsepower_Miles_per_Gallon_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_Horsepower_Miles_per_Gallon_x"
+                                    },
+                                    "update": "!isArray(brush_Horsepower) ? brush_x : [scale(\"child_Horsepower_Miles_per_Gallon_x\", brush_Horsepower[0]), scale(\"child_Horsepower_Miles_per_Gallon_x\", brush_Horsepower[1])]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"child_Horsepower_Miles_per_Gallon_x\", 0), invert(\"child_Horsepower_Miles_per_Gallon_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_Horsepower[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_Horsepower[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"child_Horsepower_Miles_per_Gallon_x\", 0), invert(\"child_Horsepower_Miles_per_Gallon_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
+                            "name": "brush_Horsepower",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "brush_x"
+                                    },
+                                    "update": "invert(\"child_Horsepower_Miles_per_Gallon_x\", brush_x)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "brush_y",
                             "value": [],
                             "on": [
                                 {
@@ -759,11 +751,10 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
+                                    "update": "[y(unit), y(unit)]"
                                 },
                                 {
                                     "events": {
@@ -775,8 +766,7 @@
                                                 "type": "mousedown",
                                                 "filter": [
                                                     "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -785,19 +775,42 @@
                                             }
                                         ]
                                     },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
+                                    "update": "[brush_y[0], clamp(y(unit), 0, child_Horsepower_Miles_per_Gallon_height)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_Horsepower_Miles_per_Gallon_y"
+                                    },
+                                    "update": "!isArray(brush_Miles_per_Gallon) ? brush_y : [scale(\"child_Horsepower_Miles_per_Gallon_y\", brush_Miles_per_Gallon[0]), scale(\"child_Horsepower_Miles_per_Gallon_y\", brush_Miles_per_Gallon[1])]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "brush_translate_delta"
+                                    },
+                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "brush_Miles_per_Gallon",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "brush_y"
+                                    },
+                                    "update": "invert(\"child_Horsepower_Miles_per_Gallon_y\", brush_y)"
                                 }
                             ]
                         },
                         {
                             "name": "brush",
-                            "update": "[{encoding: \"x\", field: \"Horsepower\", extent: brush_Horsepower}]"
+                            "update": "[{encoding: \"x\", field: \"Horsepower\", extent: brush_Horsepower}, {encoding: \"y\", field: \"Miles_per_Gallon\", extent: brush_Miles_per_Gallon}]"
                         },
                         {
                             "name": "brush_translate_anchor",
@@ -814,7 +827,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_Horsepower), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x), extent_y: slice(brush_y)}"
                                 }
                             ]
                         },
@@ -855,10 +868,13 @@
                                         {
                                             "source": "scope",
                                             "type": "wheel",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"child_Horsepower_Miles_per_Gallon_x\", x(unit)), y: invert(\"child_Horsepower_Miles_per_Gallon_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -870,6 +886,9 @@
                                         {
                                             "source": "scope",
                                             "type": "wheel",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
                                             "markname": "brush_brush"
                                         }
                                     ],
@@ -907,7 +926,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
+                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
                                 },
                                 {
                                     "events": {
@@ -925,7 +944,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
                                 },
                                 {
                                     "events": {
@@ -954,7 +973,7 @@
                                             ]
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"child_Horsepower_Miles_per_Gallon_x\"), extent_y: domain(\"child_Horsepower_Miles_per_Gallon_y\"), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: domain(\"child_Horsepower_Miles_per_Gallon_x\"), extent_y: domain(\"child_Horsepower_Miles_per_Gallon_y\")}"
                                 }
                             ]
                         },
@@ -993,7 +1012,10 @@
                                     "events": [
                                         {
                                             "source": "scope",
-                                            "type": "wheel"
+                                            "type": "wheel",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
                                         }
                                     ],
                                     "update": "{x: invert(\"child_Horsepower_Miles_per_Gallon_x\", x(unit)), y: invert(\"child_Horsepower_Miles_per_Gallon_y\", y(unit))}"
@@ -1007,7 +1029,10 @@
                                     "events": [
                                         {
                                             "source": "scope",
-                                            "type": "wheel"
+                                            "type": "wheel",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
                                         }
                                     ],
                                     "force": true,
@@ -1052,20 +1077,16 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "child_Horsepower_Miles_per_Gallon_x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "child_Horsepower_Miles_per_Gallon_x",
-                                        "signal": "brush[0].extent[1]"
+                                        "signal": "brush_x[0]"
                                     },
                                     "y": {
-                                        "value": 0
+                                        "signal": "brush_y[0]"
+                                    },
+                                    "x2": {
+                                        "signal": "brush_x[1]"
                                     },
                                     "y2": {
-                                        "field": {
-                                            "group": "height"
-                                        }
+                                        "signal": "brush_y[1]"
                                     }
                                 }
                             },
@@ -1122,20 +1143,16 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "child_Horsepower_Miles_per_Gallon_x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "child_Horsepower_Miles_per_Gallon_x",
-                                        "signal": "brush[0].extent[1]"
+                                        "signal": "brush_x[0]"
                                     },
                                     "y": {
-                                        "value": 0
+                                        "signal": "brush_y[0]"
+                                    },
+                                    "x2": {
+                                        "signal": "brush_x[1]"
                                     },
                                     "y2": {
-                                        "field": {
-                                            "group": "height"
-                                        }
+                                        "signal": "brush_y[1]"
                                     }
                                 }
                             },
@@ -1239,7 +1256,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_Acceleration",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -1248,11 +1265,10 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"child_Acceleration_Horsepower_x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -1264,8 +1280,7 @@
                                                 "type": "mousedown",
                                                 "filter": [
                                                     "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -1274,24 +1289,41 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_Acceleration[0], invert(\"child_Acceleration_Horsepower_x\", clamp(x(unit), 0, child_Acceleration_Horsepower_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, child_Acceleration_Horsepower_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_Acceleration_Horsepower_x"
+                                    },
+                                    "update": "!isArray(brush_Acceleration) ? brush_x : [scale(\"child_Acceleration_Horsepower_x\", brush_Acceleration[0]), scale(\"child_Acceleration_Horsepower_x\", brush_Acceleration[1])]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"child_Acceleration_Horsepower_x\", 0), invert(\"child_Acceleration_Horsepower_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_Acceleration[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_Acceleration[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"child_Acceleration_Horsepower_x\", 0), invert(\"child_Acceleration_Horsepower_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
+                            "name": "brush_Acceleration",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "brush_x"
+                                    },
+                                    "update": "invert(\"child_Acceleration_Horsepower_x\", brush_x)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "brush_y",
                             "value": [],
                             "on": [
                                 {
@@ -1300,11 +1332,10 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
+                                    "update": "[y(unit), y(unit)]"
                                 },
                                 {
                                     "events": {
@@ -1316,8 +1347,7 @@
                                                 "type": "mousedown",
                                                 "filter": [
                                                     "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -1326,19 +1356,42 @@
                                             }
                                         ]
                                     },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
+                                    "update": "[brush_y[0], clamp(y(unit), 0, child_Acceleration_Horsepower_height)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_Acceleration_Horsepower_y"
+                                    },
+                                    "update": "!isArray(brush_Horsepower) ? brush_y : [scale(\"child_Acceleration_Horsepower_y\", brush_Horsepower[0]), scale(\"child_Acceleration_Horsepower_y\", brush_Horsepower[1])]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "brush_translate_delta"
+                                    },
+                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "brush_Horsepower",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "brush_y"
+                                    },
+                                    "update": "invert(\"child_Acceleration_Horsepower_y\", brush_y)"
                                 }
                             ]
                         },
                         {
                             "name": "brush",
-                            "update": "[{encoding: \"x\", field: \"Acceleration\", extent: brush_Acceleration}]"
+                            "update": "[{encoding: \"x\", field: \"Acceleration\", extent: brush_Acceleration}, {encoding: \"y\", field: \"Horsepower\", extent: brush_Horsepower}]"
                         },
                         {
                             "name": "brush_translate_anchor",
@@ -1355,7 +1408,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_Acceleration), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x), extent_y: slice(brush_y)}"
                                 }
                             ]
                         },
@@ -1396,10 +1449,13 @@
                                         {
                                             "source": "scope",
                                             "type": "wheel",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"child_Acceleration_Horsepower_x\", x(unit)), y: invert(\"child_Acceleration_Horsepower_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -1411,6 +1467,9 @@
                                         {
                                             "source": "scope",
                                             "type": "wheel",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
                                             "markname": "brush_brush"
                                         }
                                     ],
@@ -1448,7 +1507,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
+                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
                                 },
                                 {
                                     "events": {
@@ -1466,7 +1525,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
                                 },
                                 {
                                     "events": {
@@ -1495,7 +1554,7 @@
                                             ]
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"child_Acceleration_Horsepower_x\"), extent_y: domain(\"child_Acceleration_Horsepower_y\"), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: domain(\"child_Acceleration_Horsepower_x\"), extent_y: domain(\"child_Acceleration_Horsepower_y\")}"
                                 }
                             ]
                         },
@@ -1534,7 +1593,10 @@
                                     "events": [
                                         {
                                             "source": "scope",
-                                            "type": "wheel"
+                                            "type": "wheel",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
                                         }
                                     ],
                                     "update": "{x: invert(\"child_Acceleration_Horsepower_x\", x(unit)), y: invert(\"child_Acceleration_Horsepower_y\", y(unit))}"
@@ -1548,7 +1610,10 @@
                                     "events": [
                                         {
                                             "source": "scope",
-                                            "type": "wheel"
+                                            "type": "wheel",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
                                         }
                                     ],
                                     "force": true,
@@ -1593,20 +1658,16 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "child_Acceleration_Horsepower_x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "child_Acceleration_Horsepower_x",
-                                        "signal": "brush[0].extent[1]"
+                                        "signal": "brush_x[0]"
                                     },
                                     "y": {
-                                        "value": 0
+                                        "signal": "brush_y[0]"
+                                    },
+                                    "x2": {
+                                        "signal": "brush_x[1]"
                                     },
                                     "y2": {
-                                        "field": {
-                                            "group": "height"
-                                        }
+                                        "signal": "brush_y[1]"
                                     }
                                 }
                             },
@@ -1663,20 +1724,16 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "child_Acceleration_Horsepower_x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "child_Acceleration_Horsepower_x",
-                                        "signal": "brush[0].extent[1]"
+                                        "signal": "brush_x[0]"
                                     },
                                     "y": {
-                                        "value": 0
+                                        "signal": "brush_y[0]"
+                                    },
+                                    "x2": {
+                                        "signal": "brush_x[1]"
                                     },
                                     "y2": {
-                                        "field": {
-                                            "group": "height"
-                                        }
+                                        "signal": "brush_y[1]"
                                     }
                                 }
                             },
@@ -1780,7 +1837,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_Acceleration",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -1789,11 +1846,10 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"child_Acceleration_Miles_per_Gallon_x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -1805,8 +1861,7 @@
                                                 "type": "mousedown",
                                                 "filter": [
                                                     "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -1815,24 +1870,41 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_Acceleration[0], invert(\"child_Acceleration_Miles_per_Gallon_x\", clamp(x(unit), 0, child_Acceleration_Miles_per_Gallon_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, child_Acceleration_Miles_per_Gallon_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_Acceleration_Miles_per_Gallon_x"
+                                    },
+                                    "update": "!isArray(brush_Acceleration) ? brush_x : [scale(\"child_Acceleration_Miles_per_Gallon_x\", brush_Acceleration[0]), scale(\"child_Acceleration_Miles_per_Gallon_x\", brush_Acceleration[1])]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"child_Acceleration_Miles_per_Gallon_x\", 0), invert(\"child_Acceleration_Miles_per_Gallon_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_Acceleration[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_Acceleration[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"child_Acceleration_Miles_per_Gallon_x\", 0), invert(\"child_Acceleration_Miles_per_Gallon_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
+                            "name": "brush_Acceleration",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "brush_x"
+                                    },
+                                    "update": "invert(\"child_Acceleration_Miles_per_Gallon_x\", brush_x)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "brush_y",
                             "value": [],
                             "on": [
                                 {
@@ -1841,11 +1913,10 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
+                                    "update": "[y(unit), y(unit)]"
                                 },
                                 {
                                     "events": {
@@ -1857,8 +1928,7 @@
                                                 "type": "mousedown",
                                                 "filter": [
                                                     "event.shiftKey",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -1867,19 +1937,42 @@
                                             }
                                         ]
                                     },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
+                                    "update": "[brush_y[0], clamp(y(unit), 0, child_Acceleration_Miles_per_Gallon_height)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_Acceleration_Miles_per_Gallon_y"
+                                    },
+                                    "update": "!isArray(brush_Miles_per_Gallon) ? brush_y : [scale(\"child_Acceleration_Miles_per_Gallon_y\", brush_Miles_per_Gallon[0]), scale(\"child_Acceleration_Miles_per_Gallon_y\", brush_Miles_per_Gallon[1])]"
+                                },
+                                {
+                                    "events": {
+                                        "signal": "brush_translate_delta"
+                                    },
+                                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
+                                }
+                            ]
+                        },
+                        {
+                            "name": "brush_Miles_per_Gallon",
+                            "on": [
+                                {
+                                    "events": {
+                                        "signal": "brush_y"
+                                    },
+                                    "update": "invert(\"child_Acceleration_Miles_per_Gallon_y\", brush_y)"
                                 }
                             ]
                         },
                         {
                             "name": "brush",
-                            "update": "[{encoding: \"x\", field: \"Acceleration\", extent: brush_Acceleration}]"
+                            "update": "[{encoding: \"x\", field: \"Acceleration\", extent: brush_Acceleration}, {encoding: \"y\", field: \"Miles_per_Gallon\", extent: brush_Miles_per_Gallon}]"
                         },
                         {
                             "name": "brush_translate_anchor",
@@ -1896,7 +1989,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_Acceleration), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x), extent_y: slice(brush_y)}"
                                 }
                             ]
                         },
@@ -1937,10 +2030,13 @@
                                         {
                                             "source": "scope",
                                             "type": "wheel",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"child_Acceleration_Miles_per_Gallon_x\", x(unit)), y: invert(\"child_Acceleration_Miles_per_Gallon_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -1952,6 +2048,9 @@
                                         {
                                             "source": "scope",
                                             "type": "wheel",
+                                            "filter": [
+                                                "event.shiftKey"
+                                            ],
                                             "markname": "brush_brush"
                                         }
                                     ],
@@ -1989,7 +2088,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
+                                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
                                 },
                                 {
                                     "events": {
@@ -2007,7 +2106,7 @@
                                     "events": {
                                         "signal": "grid_translate_delta"
                                     },
-                                    "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
                                 },
                                 {
                                     "events": {
@@ -2036,7 +2135,7 @@
                                             ]
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"child_Acceleration_Miles_per_Gallon_x\"), extent_y: domain(\"child_Acceleration_Miles_per_Gallon_y\"), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: domain(\"child_Acceleration_Miles_per_Gallon_x\"), extent_y: domain(\"child_Acceleration_Miles_per_Gallon_y\")}"
                                 }
                             ]
                         },
@@ -2075,7 +2174,10 @@
                                     "events": [
                                         {
                                             "source": "scope",
-                                            "type": "wheel"
+                                            "type": "wheel",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
                                         }
                                     ],
                                     "update": "{x: invert(\"child_Acceleration_Miles_per_Gallon_x\", x(unit)), y: invert(\"child_Acceleration_Miles_per_Gallon_y\", y(unit))}"
@@ -2089,7 +2191,10 @@
                                     "events": [
                                         {
                                             "source": "scope",
-                                            "type": "wheel"
+                                            "type": "wheel",
+                                            "filter": [
+                                                "!event.shiftKey"
+                                            ]
                                         }
                                     ],
                                     "force": true,
@@ -2134,20 +2239,16 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "child_Acceleration_Miles_per_Gallon_x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "child_Acceleration_Miles_per_Gallon_x",
-                                        "signal": "brush[0].extent[1]"
+                                        "signal": "brush_x[0]"
                                     },
                                     "y": {
-                                        "value": 0
+                                        "signal": "brush_y[0]"
+                                    },
+                                    "x2": {
+                                        "signal": "brush_x[1]"
                                     },
                                     "y2": {
-                                        "field": {
-                                            "group": "height"
-                                        }
+                                        "signal": "brush_y[1]"
                                     }
                                 }
                             },
@@ -2204,20 +2305,16 @@
                                 },
                                 "update": {
                                     "x": {
-                                        "scale": "child_Acceleration_Miles_per_Gallon_x",
-                                        "signal": "brush[0].extent[0]"
-                                    },
-                                    "x2": {
-                                        "scale": "child_Acceleration_Miles_per_Gallon_x",
-                                        "signal": "brush[0].extent[1]"
+                                        "signal": "brush_x[0]"
                                     },
                                     "y": {
-                                        "value": 0
+                                        "signal": "brush_y[0]"
+                                    },
+                                    "x2": {
+                                        "signal": "brush_x[1]"
                                     },
                                     "y2": {
-                                        "field": {
-                                            "group": "height"
-                                        }
+                                        "signal": "brush_y[1]"
                                     }
                                 }
                             },

--- a/examples/vg-specs/layered_crossfilter.vg.json
+++ b/examples/vg-specs/layered_crossfilter.vg.json
@@ -447,7 +447,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_distance",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -455,11 +455,10 @@
                                         "source": "scope",
                                         "type": "mousedown",
                                         "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"child_distance_x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -471,8 +470,7 @@
                                                 "source": "scope",
                                                 "type": "mousedown",
                                                 "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -481,64 +479,36 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_distance[0], invert(\"child_distance_x\", clamp(x(unit), 0, child_distance_layer_0_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, child_distance_layer_0_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_distance_x"
+                                    },
+                                    "update": "[]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"child_distance_x\", 0), invert(\"child_distance_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_distance[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_distance[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"child_distance_x\", 0), invert(\"child_distance_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
-                            "value": [],
+                            "name": "brush_distance",
                             "on": [
                                 {
                                     "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
+                                        "signal": "brush_x"
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                                },
-                                {
-                                    "events": {
-                                        "source": "window",
-                                        "type": "mousemove",
-                                        "consume": true,
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "window",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_zoom_delta"
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "invert(\"child_distance_x\", brush_x)"
                                 }
                             ]
                         },
@@ -558,7 +528,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_distance), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x)}"
                                 }
                             ]
                         },
@@ -600,7 +570,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"child_distance_x\", x(unit)), y: invert(\"child_distance_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -659,18 +629,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_distance_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_distance_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -680,6 +639,15 @@
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
                                             "value": 0
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0
@@ -782,18 +750,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_distance_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_distance_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -803,6 +760,15 @@
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
                                             "value": 0
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0
@@ -932,7 +898,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_delay",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -940,11 +906,10 @@
                                         "source": "scope",
                                         "type": "mousedown",
                                         "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"child_delay_x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -956,8 +921,7 @@
                                                 "source": "scope",
                                                 "type": "mousedown",
                                                 "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -966,64 +930,36 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_delay[0], invert(\"child_delay_x\", clamp(x(unit), 0, child_delay_layer_0_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, child_delay_layer_0_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_delay_x"
+                                    },
+                                    "update": "[]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"child_delay_x\", 0), invert(\"child_delay_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_delay[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_delay[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"child_delay_x\", 0), invert(\"child_delay_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
-                            "value": [],
+                            "name": "brush_delay",
                             "on": [
                                 {
                                     "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
+                                        "signal": "brush_x"
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                                },
-                                {
-                                    "events": {
-                                        "source": "window",
-                                        "type": "mousemove",
-                                        "consume": true,
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "window",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_zoom_delta"
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "invert(\"child_delay_x\", brush_x)"
                                 }
                             ]
                         },
@@ -1043,7 +979,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_delay), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x)}"
                                 }
                             ]
                         },
@@ -1085,7 +1021,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"child_delay_x\", x(unit)), y: invert(\"child_delay_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -1144,18 +1080,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_delay_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_delay_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -1165,6 +1090,15 @@
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
                                             "value": 0
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0
@@ -1267,18 +1201,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_delay_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_delay_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -1288,6 +1211,15 @@
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
                                             "value": 0
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0
@@ -1417,7 +1349,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_time",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -1425,11 +1357,10 @@
                                         "source": "scope",
                                         "type": "mousedown",
                                         "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"child_time_x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -1441,8 +1372,7 @@
                                                 "source": "scope",
                                                 "type": "mousedown",
                                                 "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -1451,64 +1381,36 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_time[0], invert(\"child_time_x\", clamp(x(unit), 0, child_time_layer_0_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, child_time_layer_0_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "child_time_x"
+                                    },
+                                    "update": "[]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"child_time_x\", 0), invert(\"child_time_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_time[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_time[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"child_time_x\", 0), invert(\"child_time_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
-                            "value": [],
+                            "name": "brush_time",
                             "on": [
                                 {
                                     "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
+                                        "signal": "brush_x"
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                                },
-                                {
-                                    "events": {
-                                        "source": "window",
-                                        "type": "mousemove",
-                                        "consume": true,
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "window",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_zoom_delta"
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "invert(\"child_time_x\", brush_x)"
                                 }
                             ]
                         },
@@ -1528,7 +1430,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_time), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x)}"
                                 }
                             ]
                         },
@@ -1570,7 +1472,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"child_time_x\", x(unit)), y: invert(\"child_time_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -1629,18 +1531,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_time_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_time_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -1650,6 +1541,15 @@
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
                                             "value": 0
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0
@@ -1752,18 +1652,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_time_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "child_time_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -1773,6 +1662,15 @@
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
                                             "value": 0
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0

--- a/examples/vg-specs/layered_crossfilter.vg.json
+++ b/examples/vg-specs/layered_crossfilter.vg.json
@@ -101,7 +101,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "vlInterval(\"brush_store\", null, datum, \"union\", \"all\")"
+                    "expr": "vlInterval(\"brush_store\", \"child_distance_layer_1_\", datum, \"union\", \"all\")"
                 },
                 {
                     "type": "filter",
@@ -203,7 +203,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "vlInterval(\"brush_store\", null, datum, \"union\", \"all\")"
+                    "expr": "vlInterval(\"brush_store\", \"child_delay_layer_1_\", datum, \"union\", \"all\")"
                 },
                 {
                     "type": "filter",
@@ -305,7 +305,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "vlInterval(\"brush_store\", null, datum, \"union\", \"all\")"
+                    "expr": "vlInterval(\"brush_store\", \"child_time_layer_1_\", datum, \"union\", \"all\")"
                 },
                 {
                     "type": "filter",
@@ -491,13 +491,13 @@
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, child_distance_layer_0_width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, child_distance_layer_0_width)"
                                 }
                             ]
                         },
@@ -597,7 +597,7 @@
                                     "events": {
                                         "signal": "brush"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: brush}"
+                                    "update": "{unit: \"child_distance_layer_0_\", intervals: brush}"
                                 }
                             ]
                         },
@@ -628,7 +628,7 @@
                                 "update": {
                                     "x": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_distance_layer_0_\"",
                                             "signal": "brush_x[0]"
                                         },
                                         {
@@ -637,7 +637,7 @@
                                     ],
                                     "y": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_distance_layer_0_\"",
                                             "value": 0
                                         },
                                         {
@@ -646,7 +646,7 @@
                                     ],
                                     "x2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_distance_layer_0_\"",
                                             "signal": "brush_x[1]"
                                         },
                                         {
@@ -655,7 +655,7 @@
                                     ],
                                     "y2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_distance_layer_0_\"",
                                             "field": {
                                                 "group": "height"
                                             }
@@ -749,7 +749,7 @@
                                 "update": {
                                     "x": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_distance_layer_0_\"",
                                             "signal": "brush_x[0]"
                                         },
                                         {
@@ -758,7 +758,7 @@
                                     ],
                                     "y": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_distance_layer_0_\"",
                                             "value": 0
                                         },
                                         {
@@ -767,7 +767,7 @@
                                     ],
                                     "x2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_distance_layer_0_\"",
                                             "signal": "brush_x[1]"
                                         },
                                         {
@@ -776,7 +776,7 @@
                                     ],
                                     "y2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_distance_layer_0_\"",
                                             "field": {
                                                 "group": "height"
                                             }
@@ -942,13 +942,13 @@
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, child_delay_layer_0_width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, child_delay_layer_0_width)"
                                 }
                             ]
                         },
@@ -1048,7 +1048,7 @@
                                     "events": {
                                         "signal": "brush"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: brush}"
+                                    "update": "{unit: \"child_delay_layer_0_\", intervals: brush}"
                                 }
                             ]
                         },
@@ -1079,7 +1079,7 @@
                                 "update": {
                                     "x": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_delay_layer_0_\"",
                                             "signal": "brush_x[0]"
                                         },
                                         {
@@ -1088,7 +1088,7 @@
                                     ],
                                     "y": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_delay_layer_0_\"",
                                             "value": 0
                                         },
                                         {
@@ -1097,7 +1097,7 @@
                                     ],
                                     "x2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_delay_layer_0_\"",
                                             "signal": "brush_x[1]"
                                         },
                                         {
@@ -1106,7 +1106,7 @@
                                     ],
                                     "y2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_delay_layer_0_\"",
                                             "field": {
                                                 "group": "height"
                                             }
@@ -1200,7 +1200,7 @@
                                 "update": {
                                     "x": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_delay_layer_0_\"",
                                             "signal": "brush_x[0]"
                                         },
                                         {
@@ -1209,7 +1209,7 @@
                                     ],
                                     "y": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_delay_layer_0_\"",
                                             "value": 0
                                         },
                                         {
@@ -1218,7 +1218,7 @@
                                     ],
                                     "x2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_delay_layer_0_\"",
                                             "signal": "brush_x[1]"
                                         },
                                         {
@@ -1227,7 +1227,7 @@
                                     ],
                                     "y2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_delay_layer_0_\"",
                                             "field": {
                                                 "group": "height"
                                             }
@@ -1393,13 +1393,13 @@
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, child_time_layer_0_width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, child_time_layer_0_width)"
                                 }
                             ]
                         },
@@ -1499,7 +1499,7 @@
                                     "events": {
                                         "signal": "brush"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: brush}"
+                                    "update": "{unit: \"child_time_layer_0_\", intervals: brush}"
                                 }
                             ]
                         },
@@ -1530,7 +1530,7 @@
                                 "update": {
                                     "x": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_time_layer_0_\"",
                                             "signal": "brush_x[0]"
                                         },
                                         {
@@ -1539,7 +1539,7 @@
                                     ],
                                     "y": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_time_layer_0_\"",
                                             "value": 0
                                         },
                                         {
@@ -1548,7 +1548,7 @@
                                     ],
                                     "x2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_time_layer_0_\"",
                                             "signal": "brush_x[1]"
                                         },
                                         {
@@ -1557,7 +1557,7 @@
                                     ],
                                     "y2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_time_layer_0_\"",
                                             "field": {
                                                 "group": "height"
                                             }
@@ -1651,7 +1651,7 @@
                                 "update": {
                                     "x": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_time_layer_0_\"",
                                             "signal": "brush_x[0]"
                                         },
                                         {
@@ -1660,7 +1660,7 @@
                                     ],
                                     "y": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_time_layer_0_\"",
                                             "value": 0
                                         },
                                         {
@@ -1669,7 +1669,7 @@
                                     ],
                                     "x2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_time_layer_0_\"",
                                             "signal": "brush_x[1]"
                                         },
                                         {
@@ -1678,7 +1678,7 @@
                                     ],
                                     "y2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"child_time_layer_0_\"",
                                             "field": {
                                                 "group": "height"
                                             }

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -140,7 +140,7 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
+                            "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
                         },
                         {
                             "events": {
@@ -158,7 +158,7 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                            "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
                         },
                         {
                             "events": {
@@ -187,7 +187,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
+                            "update": "{x: x(unit), y: y(unit), extent_x: domain(\"x\"), extent_y: domain(\"y\")}"
                         }
                     ]
                 },
@@ -297,7 +297,7 @@
                     ]
                 },
                 {
-                    "name": "brush_Horsepower",
+                    "name": "brush_x",
                     "value": [],
                     "on": [
                         {
@@ -306,10 +306,10 @@
                                 "type": "mousedown",
                                 "filter": [
                                     "event.shiftKey",
-                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                 ]
                             },
-                            "update": "invert(\"x\", [x(unit), x(unit)])"
+                            "update": "[x(unit), x(unit)]"
                         },
                         {
                             "events": {
@@ -321,7 +321,7 @@
                                         "type": "mousedown",
                                         "filter": [
                                             "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
                                     {
@@ -330,113 +330,103 @@
                                     }
                                 ]
                             },
-                            "update": "[brush_Horsepower[0], invert(\"x\", clamp(x(unit), 0, layer_1_width))]"
+                            "update": "[brush_x[0], clamp(x(unit), 0, layer_1_width)]"
+                        },
+                        {
+                            "events": {
+                                "scale": "x"
+                            },
+                            "update": "!isArray(brush_Horsepower) ? brush_x : [scale(\"x\", brush_Horsepower[0]), scale(\"x\", brush_Horsepower[1])]"
                         },
                         {
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.x + (brush_Horsepower[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_Horsepower[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_Horsepower",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "brush_x"
+                            },
+                            "update": "invert(\"x\", brush_x)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_y",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "event.shiftKey",
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
+                                ]
+                            },
+                            "update": "[y(unit), y(unit)]"
+                        },
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousemove",
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "event.shiftKey",
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
+                                        ]
+                                    },
+                                    {
+                                        "source": "scope",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "[brush_y[0], clamp(y(unit), 0, layer_1_height)]"
+                        },
+                        {
+                            "events": {
+                                "scale": "y"
+                            },
+                            "update": "!isArray(brush_Miles_per_Gallon) ? brush_y : [scale(\"y\", brush_Miles_per_Gallon[0]), scale(\"y\", brush_Miles_per_Gallon[1])]"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_translate_delta"
+                            },
+                            "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_zoom_delta"
+                            },
+                            "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
                         }
                     ]
                 },
                 {
                     "name": "brush_Miles_per_Gallon",
-                    "value": [],
                     "on": [
                         {
                             "events": {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "event.shiftKey",
-                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                ]
+                                "signal": "brush_y"
                             },
-                            "update": "invert(\"y\", [y(unit), y(unit)])"
-                        },
-                        {
-                            "events": {
-                                "source": "scope",
-                                "type": "mousemove",
-                                "between": [
-                                    {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
-                                    },
-                                    {
-                                        "source": "scope",
-                                        "type": "mouseup"
-                                    }
-                                ]
-                            },
-                            "update": "[brush_Miles_per_Gallon[0], invert(\"y\", clamp(y(unit), 0, layer_1_height))]"
-                        },
-                        {
-                            "events": {
-                                "signal": "brush_translate_delta"
-                            },
-                            "update": "clampRange([brush_translate_anchor.extent_y[0] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height, brush_translate_anchor.extent_y[1] - abs(span(brush_translate_anchor.extent_y)) * brush_translate_delta.y / brush_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
-                        },
-                        {
-                            "events": {
-                                "signal": "brush_zoom_delta"
-                            },
-                            "update": "clampRange([brush_zoom_anchor.y + (brush_Miles_per_Gallon[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_Miles_per_Gallon[1] - brush_zoom_anchor.y) * brush_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
-                        }
-                    ]
-                },
-                {
-                    "name": "brush_size",
-                    "value": [],
-                    "on": [
-                        {
-                            "events": {
-                                "source": "scope",
-                                "type": "mousedown",
-                                "filter": [
-                                    "event.shiftKey",
-                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                ]
-                            },
-                            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                        },
-                        {
-                            "events": {
-                                "source": "scope",
-                                "type": "mousemove",
-                                "between": [
-                                    {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "event.shiftKey",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
-                                    },
-                                    {
-                                        "source": "scope",
-                                        "type": "mouseup"
-                                    }
-                                ]
-                            },
-                            "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                        },
-                        {
-                            "events": {
-                                "signal": "brush_zoom_delta"
-                            },
-                            "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                            "update": "invert(\"y\", brush_y)"
                         }
                     ]
                 },
@@ -459,7 +449,7 @@
                                     "markname": "brush_brush"
                                 }
                             ],
-                            "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_Horsepower), extent_y: slice(brush_Miles_per_Gallon), }"
+                            "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x), extent_y: slice(brush_y)}"
                         }
                     ]
                 },
@@ -503,7 +493,7 @@
                                     "markname": "brush_brush"
                                 }
                             ],
-                            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                            "update": "{x: x(unit), y: y(unit)}"
                         }
                     ]
                 },
@@ -575,18 +565,7 @@
                             "x": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[0]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "x2": [
-                                {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[1]"
+                                    "signal": "brush_x[0]"
                                 },
                                 {
                                     "value": 0
@@ -595,8 +574,16 @@
                             "y": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[0]"
+                                    "signal": "brush_y[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "signal": "brush_x[1]"
                                 },
                                 {
                                     "value": 0
@@ -605,8 +592,7 @@
                             "y2": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[1]"
+                                    "signal": "brush_y[1]"
                                 },
                                 {
                                     "value": 0
@@ -718,18 +704,7 @@
                             "x": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[0]"
-                                },
-                                {
-                                    "value": 0
-                                }
-                            ],
-                            "x2": [
-                                {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "x",
-                                    "signal": "brush[0].extent[1]"
+                                    "signal": "brush_x[0]"
                                 },
                                 {
                                     "value": 0
@@ -738,8 +713,16 @@
                             "y": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[0]"
+                                    "signal": "brush_y[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "signal": "brush_x[1]"
                                 },
                                 {
                                     "value": 0
@@ -748,8 +731,7 @@
                             "y2": [
                                 {
                                     "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                    "scale": "y",
-                                    "signal": "brush[1].extent[1]"
+                                    "signal": "brush_y[1]"
                                 },
                                 {
                                     "value": 0

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -140,7 +140,7 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
+                            "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / layer_0_width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / layer_0_width]"
                         },
                         {
                             "events": {
@@ -158,7 +158,7 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
+                            "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / layer_0_height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / layer_0_height]"
                         },
                         {
                             "events": {
@@ -255,7 +255,7 @@
                             "events": {
                                 "signal": "grid"
                             },
-                            "update": "{unit: unit.datum && unit.datum._id, intervals: grid}"
+                            "update": "{unit: \"layer_0_\", intervals: grid}"
                         }
                     ]
                 },
@@ -281,7 +281,7 @@
                             "events": {
                                 "signal": "cyl"
                             },
-                            "update": "{unit: unit.datum && unit.datum._id, encodings: cyl.encodings, fields: cyl.fields, values: cyl.values, Cylinders: cyl.values[0]}"
+                            "update": "{unit: \"layer_0_\", encodings: cyl.encodings, fields: cyl.fields, values: cyl.values, Cylinders: cyl.values[0]}"
                         }
                     ]
                 },
@@ -342,13 +342,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
+                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, layer_1_width)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, layer_1_width)"
                         }
                     ]
                 },
@@ -409,13 +409,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, unit.height)"
+                            "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, layer_1_height)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, unit.height)"
+                            "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, layer_1_height)"
                         }
                     ]
                 },
@@ -520,7 +520,7 @@
                             "events": {
                                 "signal": "brush"
                             },
-                            "update": "{unit: unit.datum && unit.datum._id, intervals: brush}"
+                            "update": "{unit: \"layer_1_\", intervals: brush}"
                         }
                     ]
                 },
@@ -564,7 +564,7 @@
                         "update": {
                             "x": [
                                 {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_1_\"",
                                     "signal": "brush_x[0]"
                                 },
                                 {
@@ -573,7 +573,7 @@
                             ],
                             "y": [
                                 {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_1_\"",
                                     "signal": "brush_y[0]"
                                 },
                                 {
@@ -582,7 +582,7 @@
                             ],
                             "x2": [
                                 {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_1_\"",
                                     "signal": "brush_x[1]"
                                 },
                                 {
@@ -591,7 +591,7 @@
                             ],
                             "y2": [
                                 {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_1_\"",
                                     "signal": "brush_y[1]"
                                 },
                                 {
@@ -621,7 +621,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", parent._id, datum, \"union\", \"all\")",
+                                    "test": "vlInterval(\"brush_store\", \"layer_0_\", datum, \"union\", \"all\")",
                                     "value": "grey"
                                 },
                                 {
@@ -661,7 +661,7 @@
                             },
                             "fill": [
                                 {
-                                    "test": "!vlInterval(\"brush_store\", parent._id, datum, \"union\", \"all\")",
+                                    "test": "!vlInterval(\"brush_store\", \"layer_1_\", datum, \"union\", \"all\")",
                                     "value": "grey"
                                 },
                                 {
@@ -671,7 +671,7 @@
                             ],
                             "size": [
                                 {
-                                    "test": "vlPoint(\"cyl_store\", parent._id, datum, \"union\", \"all\")",
+                                    "test": "vlPoint(\"cyl_store\", \"layer_1_\", datum, \"union\", \"all\")",
                                     "value": 150
                                 },
                                 {
@@ -703,7 +703,7 @@
                         "update": {
                             "x": [
                                 {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_1_\"",
                                     "signal": "brush_x[0]"
                                 },
                                 {
@@ -712,7 +712,7 @@
                             ],
                             "y": [
                                 {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_1_\"",
                                     "signal": "brush_y[0]"
                                 },
                                 {
@@ -721,7 +721,7 @@
                             ],
                             "x2": [
                                 {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_1_\"",
                                     "signal": "brush_x[1]"
                                 },
                                 {
@@ -730,7 +730,7 @@
                             ],
                             "y2": [
                                 {
-                                    "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_1_\"",
                                     "signal": "brush_y[1]"
                                 },
                                 {

--- a/examples/vg-specs/overview_detail.vg.json
+++ b/examples/vg-specs/overview_detail.vg.json
@@ -129,7 +129,7 @@
                     },
                     "signals": [
                         {
-                            "name": "brush_date",
+                            "name": "brush_x",
                             "value": [],
                             "on": [
                                 {
@@ -137,11 +137,10 @@
                                         "source": "scope",
                                         "type": "mousedown",
                                         "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
                                         ]
                                     },
-                                    "update": "invert(\"concat_0_x\", [x(unit), x(unit)])"
+                                    "update": "[x(unit), x(unit)]"
                                 },
                                 {
                                     "events": {
@@ -153,8 +152,7 @@
                                                 "source": "scope",
                                                 "type": "mousedown",
                                                 "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
+                                                    "!event.item || event.item.mark.name !== \"brush_brush\""
                                                 ]
                                             },
                                             {
@@ -163,64 +161,36 @@
                                             }
                                         ]
                                     },
-                                    "update": "[brush_date[0], invert(\"concat_0_x\", clamp(x(unit), 0, concat_0_width))]"
+                                    "update": "[brush_x[0], clamp(x(unit), 0, concat_0_width)]"
+                                },
+                                {
+                                    "events": {
+                                        "scale": "concat_0_x"
+                                    },
+                                    "update": "!isArray(brush_date) ? brush_x : [scale(\"concat_0_x\", brush_date[0]), scale(\"concat_0_x\", brush_date[1])]"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width, brush_translate_anchor.extent_x[1] + abs(span(brush_translate_anchor.extent_x)) * brush_translate_delta.x / brush_translate_anchor.width], invert(\"concat_0_x\", 0), invert(\"concat_0_x\", unit.width))"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_date[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_date[1] - brush_zoom_anchor.x) * brush_zoom_delta], invert(\"concat_0_x\", 0), invert(\"concat_0_x\", unit.width))"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
                                 }
                             ]
                         },
                         {
-                            "name": "brush_size",
-                            "value": [],
+                            "name": "brush_date",
                             "on": [
                                 {
                                     "events": {
-                                        "source": "scope",
-                                        "type": "mousedown",
-                                        "filter": [
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                            "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                        ]
+                                        "signal": "brush_x"
                                     },
-                                    "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-                                },
-                                {
-                                    "events": {
-                                        "source": "window",
-                                        "type": "mousemove",
-                                        "consume": true,
-                                        "between": [
-                                            {
-                                                "source": "scope",
-                                                "type": "mousedown",
-                                                "filter": [
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")",
-                                                    "!event.item || (event.item && event.item.mark.name !== \"brush_brush\")"
-                                                ]
-                                            },
-                                            {
-                                                "source": "window",
-                                                "type": "mouseup"
-                                            }
-                                        ]
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: abs(x(unit) - brush_size.x), height: abs(y(unit) - brush_size.y)}"
-                                },
-                                {
-                                    "events": {
-                                        "signal": "brush_zoom_delta"
-                                    },
-                                    "update": "{x: brush_size.x, y: brush_size.y, width: brush_size.width * brush_zoom_delta , height: brush_size.height * brush_zoom_delta}"
+                                    "update": "invert(\"concat_0_x\", brush_x)"
                                 }
                             ]
                         },
@@ -240,7 +210,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: x(unit), y: y(unit), width: brush_size.width, height: brush_size.height, extent_x: slice(brush_date), }"
+                                    "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x)}"
                                 }
                             ]
                         },
@@ -282,7 +252,7 @@
                                             "markname": "brush_brush"
                                         }
                                     ],
-                                    "update": "{x: invert(\"concat_0_x\", x(unit)), y: invert(\"concat_0_y\", y(unit))}"
+                                    "update": "{x: x(unit), y: y(unit)}"
                                 }
                             ]
                         },
@@ -341,18 +311,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -362,6 +321,15 @@
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
                                             "value": 0
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0
@@ -426,18 +394,7 @@
                                     "x": [
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_x",
-                                            "signal": "brush[0].extent[0]"
-                                        },
-                                        {
-                                            "value": 0
-                                        }
-                                    ],
-                                    "x2": [
-                                        {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                                            "scale": "concat_0_x",
-                                            "signal": "brush[0].extent[1]"
+                                            "signal": "brush_x[0]"
                                         },
                                         {
                                             "value": 0
@@ -447,6 +404,15 @@
                                         {
                                             "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
                                             "value": 0
+                                        },
+                                        {
+                                            "value": 0
+                                        }
+                                    ],
+                                    "x2": [
+                                        {
+                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "signal": "brush_x[1]"
                                         },
                                         {
                                             "value": 0

--- a/examples/vg-specs/overview_detail.vg.json
+++ b/examples/vg-specs/overview_detail.vg.json
@@ -173,13 +173,13 @@
                                     "events": {
                                         "signal": "brush_translate_delta"
                                     },
-                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, unit.width)"
+                                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, concat_0_width)"
                                 },
                                 {
                                     "events": {
                                         "signal": "brush_zoom_delta"
                                     },
-                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, unit.width)"
+                                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, concat_0_width)"
                                 }
                             ]
                         },
@@ -279,7 +279,7 @@
                                     "events": {
                                         "signal": "brush"
                                     },
-                                    "update": "{unit: unit.datum && unit.datum._id, intervals: brush}"
+                                    "update": "{unit: \"concat_0_\", intervals: brush}"
                                 }
                             ]
                         },
@@ -310,7 +310,7 @@
                                 "update": {
                                     "x": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
                                             "signal": "brush_x[0]"
                                         },
                                         {
@@ -319,7 +319,7 @@
                                     ],
                                     "y": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
                                             "value": 0
                                         },
                                         {
@@ -328,7 +328,7 @@
                                     ],
                                     "x2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
                                             "signal": "brush_x[1]"
                                         },
                                         {
@@ -337,7 +337,7 @@
                                     ],
                                     "y2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
                                             "field": {
                                                 "group": "height"
                                             }
@@ -393,7 +393,7 @@
                                 "update": {
                                     "x": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
                                             "signal": "brush_x[0]"
                                         },
                                         {
@@ -402,7 +402,7 @@
                                     ],
                                     "y": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
                                             "value": 0
                                         },
                                         {
@@ -411,7 +411,7 @@
                                     ],
                                     "x2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
                                             "signal": "brush_x[1]"
                                         },
                                         {
@@ -420,7 +420,7 @@
                                     ],
                                     "y2": [
                                         {
-                                            "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                                            "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
                                             "field": {
                                                 "group": "height"
                                             }

--- a/examples/vg-specs/paintbrush.vg.json
+++ b/examples/vg-specs/paintbrush.vg.json
@@ -87,7 +87,7 @@
                             "events": {
                                 "signal": "paintbrush"
                             },
-                            "update": "{unit: unit.datum && unit.datum._id, encodings: paintbrush.encodings, fields: paintbrush.fields, values: paintbrush.values}"
+                            "update": "{unit: \"\", encodings: paintbrush.encodings, fields: paintbrush.fields, values: paintbrush.values}"
                         }
                     ]
                 },
@@ -142,7 +142,7 @@
                             },
                             "size": [
                                 {
-                                    "test": "vlPoint(\"paintbrush_store\", parent._id, datum, \"union\", \"all\")",
+                                    "test": "vlPoint(\"paintbrush_store\", \"\", datum, \"union\", \"all\")",
                                     "value": 300
                                 },
                                 {

--- a/examples/vg-specs/panzoom_scatter.vg.json
+++ b/examples/vg-specs/panzoom_scatter.vg.json
@@ -63,7 +63,7 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
+                            "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / width]"
                         },
                         {
                             "events": {
@@ -81,7 +81,7 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
+                            "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / height]"
                         },
                         {
                             "events": {
@@ -173,7 +173,7 @@
                             "events": {
                                 "signal": "grid"
                             },
-                            "update": "{unit: unit.datum && unit.datum._id, intervals: grid}"
+                            "update": "{unit: \"\", intervals: grid}"
                         }
                     ]
                 },

--- a/examples/vg-specs/panzoom_scatter.vg.json
+++ b/examples/vg-specs/panzoom_scatter.vg.json
@@ -63,7 +63,7 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_x[0] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width, grid_translate_anchor.extent_x[1] - abs(span(grid_translate_anchor.extent_x)) * grid_translate_delta.x / grid_translate_anchor.width]"
+                            "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / unit.width]"
                         },
                         {
                             "events": {
@@ -81,7 +81,7 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_y[0] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height, grid_translate_anchor.extent_y[1] + abs(span(grid_translate_anchor.extent_y)) * grid_translate_delta.y / grid_translate_anchor.height]"
+                            "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / unit.height]"
                         },
                         {
                             "events": {
@@ -107,7 +107,7 @@
                                     "type": "mousedown"
                                 }
                             ],
-                            "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
+                            "update": "{x: x(unit), y: y(unit), extent_x: domain(\"x\"), extent_y: domain(\"y\")}"
                         }
                     ]
                 },

--- a/examples/vg-specs/query_widgets.vg.json
+++ b/examples/vg-specs/query_widgets.vg.json
@@ -112,7 +112,7 @@
                             "events": {
                                 "signal": "CylYr"
                             },
-                            "update": "{unit: unit.datum && unit.datum._id, encodings: CylYr.encodings, fields: CylYr.fields, values: CylYr.values, Cylinders: CylYr.values[0], Year: CylYr.values[1]}"
+                            "update": "{unit: \"\", encodings: CylYr.encodings, fields: CylYr.fields, values: CylYr.values, Cylinders: CylYr.values[0], Year: CylYr.values[1]}"
                         }
                     ]
                 },
@@ -161,7 +161,7 @@
                             },
                             "fill": [
                                 {
-                                    "test": "!vlPoint(\"CylYr_store\", parent._id, datum, \"union\", \"all\")",
+                                    "test": "!vlPoint(\"CylYr_store\", \"\", datum, \"union\", \"all\")",
                                     "value": "grey"
                                 },
                                 {

--- a/src/compile/mark/mixins.ts
+++ b/src/compile/mark/mixins.ts
@@ -81,7 +81,7 @@ function selectionTest(model: UnitModel, selectionName: string) {
     name = negate ? selectionName.slice(1) : selectionName,
     selection = model.getComponent('selection', name);
   return (negate ? '!' : '') +
-    predicate(selection.name, selection.type, selection.resolve);
+    predicate(model, selection.name, selection.type, selection.resolve);
 }
 
 export function text(model: UnitModel, vgChannel: 'text' | 'tooltip' = 'text') {

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -49,7 +49,7 @@ const interval:SelectionCompiler = {
   modifyExpr: function(model, selCmpt) {
     const tpl = selCmpt.name + TUPLE;
     return tpl + ', ' +
-      (selCmpt.resolve === 'global' ? 'true' : `{unit: ${tpl}.unit}`);
+      (selCmpt.resolve === 'global' ? 'true' : `{unit: ${stringValue(model.getName(''))}}`);
   },
 
   marks: function(model, selCmpt, marks) {
@@ -77,7 +77,7 @@ const interval:SelectionCompiler = {
     if (selCmpt.resolve === 'global') {
       keys(update).forEach(function(key) {
         update[key] = [{
-          test: `${store}.length && ${tpl} && ${tpl}.unit === ${store}[0].unit`,
+          test: `${store}.length && ${store}[0].unit === ${stringValue(model.getName(''))}`,
           ...update[key]
         }, {value: 0}];
       });

--- a/src/compile/selection/multi.ts
+++ b/src/compile/selection/multi.ts
@@ -28,7 +28,7 @@ const multi:SelectionCompiler = {
   modifyExpr: function(model, selCmpt) {
     const tpl = selCmpt.name + TUPLE;
     return tpl + ', ' +
-      (selCmpt.resolve === 'global' ? 'null' : `{unit: ${tpl}.unit}`);
+      (selCmpt.resolve === 'global' ? 'null' : `{unit: ${stringValue(model.getName(''))}}`);
   }
 };
 

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -250,8 +250,8 @@ export function invert(model: UnitModel, selCmpt: SelectionComponent, channel: C
   return selCmpt.domain === 'data' ? `invert(${scale}, ${expr})` : expr;
 }
 
-export function channelSignalName(selCmpt: SelectionComponent, channel: Channel) {
-  return selCmpt.name + '_' + selCmpt.fields[channel];
+export function channelSignalName(selCmpt: SelectionComponent, channel: Channel, range: 'visual' | 'data') {
+  return selCmpt.name + '_' + (range === 'visual' ? channel : selCmpt.fields[channel]);
 }
 
 function clipMarks(marks: any[]): any[] {

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -245,11 +245,6 @@ function compiler(type: SelectionTypes): SelectionCompiler {
   return null;
 }
 
-export function invert(model: UnitModel, selCmpt: SelectionComponent, channel: Channel, expr: string) {
-  const scale = stringValue(model.scaleName(channel));
-  return selCmpt.domain === 'data' ? `invert(${scale}, ${expr})` : expr;
-}
-
 export function channelSignalName(selCmpt: SelectionComponent, channel: Channel, range: 'visual' | 'data') {
   return selCmpt.name + '_' + (range === 'visual' ? channel : selCmpt.fields[channel]);
 }

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -115,7 +115,7 @@ export function assembleUnitSelectionSignals(model: UnitModel, signals: any[]) {
       name: name + TUPLE,
       on: [{
         events: {signal: name},
-        update: `{unit: unit.datum && unit.datum._id, ${tupleExpr}}`
+        update: `{unit: ${stringValue(model.getName(''))}, ${tupleExpr}}`
       }]
     }, {
       name: name + MODIFY,
@@ -212,13 +212,11 @@ const PREDICATES_OPS = {
   intersect_others: '"intersect", "others"'
 };
 
-// TODO: How to better differentiate unit than parent._id?
-export function predicate(name: string, type: SelectionTypes, resolve?: string, datum?: string, parent?: string): string {
+export function predicate(model: Model, name: string, type: SelectionTypes, resolve?: string, datum?: string): string {
   const store = stringValue(name + STORE),
         op = PREDICATES_OPS[resolve || 'global'];
   datum = datum || 'datum';
-  parent = parent === null ? null : 'parent._id';
-  return compiler(type).predicate + `(${store}, ${parent}, ${datum}, ${op})`;
+  return compiler(type).predicate + `(${store}, ${stringValue(model.getName(''))}, ${datum}, ${op})`;
 }
 
 // Utility functions

--- a/src/compile/selection/single.ts
+++ b/src/compile/selection/single.ts
@@ -27,7 +27,7 @@ const single:SelectionCompiler = {
   modifyExpr: function(model, selCmpt) {
     const tpl = selCmpt.name + TUPLE;
     return tpl + ', ' +
-      (selCmpt.resolve === 'global' ? 'true' : `{unit: ${tpl}.unit}`);
+      (selCmpt.resolve === 'global' ? 'true' : `{unit: ${stringValue(model.getName(''))}}`);
   }
 };
 

--- a/src/compile/selection/transforms/scales.ts
+++ b/src/compile/selection/transforms/scales.ts
@@ -3,7 +3,6 @@ import {warn} from '../../../log';
 import {hasContinuousDomain} from '../../../scale';
 import {stringValue} from '../../../util';
 import {UnitModel} from '../../unit';
-import {SIZE as INTERVAL_SIZE} from '../interval';
 import {channelSignalName, MODIFY, TUPLE} from '../selection';
 import {TransformCompiler} from './transforms';
 
@@ -27,30 +26,29 @@ const scaleBindings:TransformCompiler = {
         return;
       }
 
-      scale.domainRaw = {signal: channelSignalName(selCmpt, channel)};
+      scale.domainRaw = {signal: channelSignalName(selCmpt, channel, 'data')};
       bound.push(channel);
     });
   },
 
   topLevelSignals: function(model, selCmpt, signals) {
     const channels = selCmpt.scales.filter((channel) => {
-      return !(signals.filter((s) => s.name === channelSignalName(selCmpt, channel)).length);
+      return !(signals.filter((s) => s.name === channelSignalName(selCmpt, channel, 'data')).length);
     });
 
     return signals.concat(channels.map((channel) => {
-      return {name: channelSignalName(selCmpt, channel)};
+      return {name: channelSignalName(selCmpt, channel, 'data')};
     }));
   },
 
   signals: function(model, selCmpt, signals) {
     const name = selCmpt.name;
     signals = signals.filter(function(s) {
-      return s.name !== name + INTERVAL_SIZE &&
-        s.name !== name + TUPLE && s.name !== MODIFY;
+      return s.name !== name + TUPLE && s.name !== MODIFY;
     });
 
     selCmpt.scales.forEach(function(channel) {
-      const signal = signals.filter((s) => s.name === channelSignalName(selCmpt, channel))[0];
+      const signal = signals.filter((s) => s.name === channelSignalName(selCmpt, channel, 'data'))[0];
       signal.push = 'outer';
       delete signal.value;
       delete signal.update;

--- a/src/compile/selection/transforms/scales.ts
+++ b/src/compile/selection/transforms/scales.ts
@@ -1,6 +1,6 @@
 import {Channel} from '../../../channel';
 import {warn} from '../../../log';
-import {hasContinuousDomain} from '../../../scale';
+import {hasContinuousDomain, isBinScale} from '../../../scale';
 import {stringValue} from '../../../util';
 import {UnitModel} from '../../unit';
 import {channelSignalName, MODIFY, TUPLE} from '../selection';
@@ -21,8 +21,8 @@ const scaleBindings:TransformCompiler = {
       const channel = p.encoding;
       const scale = model.getComponent('scales', channel);
 
-      if (!scale || !hasContinuousDomain(scale.type)) {
-        warn('Scale bindings are currently only supported for scales with continuous domains.');
+      if (!scale || !hasContinuousDomain(scale.type) || isBinScale(scale.type)) {
+        warn('Scale bindings are currently only supported for scales with unbinned, continuous domains.');
         return;
       }
 

--- a/src/compile/selection/transforms/toggle.ts
+++ b/src/compile/selection/transforms/toggle.ts
@@ -1,6 +1,6 @@
+import {stringValue} from '../../../util';
 import {TUPLE} from '../selection';
 import {TransformCompiler} from './transforms';
-import {stringValue} from '../../../util';
 
 const TOGGLE = '_toggle';
 

--- a/src/compile/selection/transforms/toggle.ts
+++ b/src/compile/selection/transforms/toggle.ts
@@ -1,5 +1,6 @@
 import {TUPLE} from '../selection';
 import {TransformCompiler} from './transforms';
+import {stringValue} from '../../../util';
 
 const TOGGLE = '_toggle';
 
@@ -23,7 +24,7 @@ const toggle:TransformCompiler = {
     return `${signal} ? null : ${tpl}, ` +
       (selCmpt.resolve === 'global' ?
         `${signal} ? null : true, ` :
-        `${signal} ? null : {unit: ${tpl}.unit}, `) +
+        `${signal} ? null : {unit: ${stringValue(model.getName(''))}}, `) +
       `${signal} ? ${tpl} : null`;
   }
 };

--- a/src/compile/selection/transforms/translate.ts
+++ b/src/compile/selection/transforms/translate.ts
@@ -78,8 +78,8 @@ function onDelta(model: UnitModel, selCmpt: SelectionComponent, channel: Channel
       delta  = name + DELTA,
       sign = getSign(selCmpt, channel),
       offset = sign + (hasScales ?
-        `span(${anchor}.extent_${channel}) * ${delta}.${channel} / unit.${size}` :
-        `${delta}.${channel}`),
+        ` span(${anchor}.extent_${channel}) * ${delta}.${channel} / unit.${size}` :
+        ` ${delta}.${channel}`),
       extent = `${anchor}.extent_${channel}`,
       range = `[${extent}[0] ${offset}, ${extent}[1] ${offset}]`;
 

--- a/src/compile/selection/transforms/translate.ts
+++ b/src/compile/selection/transforms/translate.ts
@@ -1,7 +1,7 @@
 import {selector as parseSelector} from 'vega-event-selector';
 import {Channel, X, Y} from '../../../channel';
 import {stringValue} from '../../../util';
-import {BRUSH as INTERVAL_BRUSH, projections as intervalProjections, SIZE as INTERVAL_SIZE} from '../interval';
+import {BRUSH as INTERVAL_BRUSH, projections as intervalProjections} from '../interval';
 import {channelSignalName, SelectionComponent} from '../selection';
 import {UnitModel} from './../../unit';
 import {default as scalesCompiler, domain} from './scales';
@@ -17,13 +17,12 @@ const translate:TransformCompiler = {
 
   signals: function(model, selCmpt, signals) {
     const name = selCmpt.name,
-        scales = scalesCompiler.has(selCmpt),
-        size = scales ? 'unit' : name + INTERVAL_SIZE,
+        hasScales = scalesCompiler.has(selCmpt),
         anchor = name + ANCHOR,
         {x, y} = intervalProjections(selCmpt);
     let events = parseSelector(selCmpt.translate, 'scope');
 
-    if (!scales) {
+    if (!hasScales) {
       events = events.map((e) => (e.between[0].markname = name + INTERVAL_BRUSH, e));
     }
 
@@ -32,13 +31,11 @@ const translate:TransformCompiler = {
       value: {},
       on: [{
         events: events.map((e) => e.between[0]),
-        update: '{x: x(unit), y: y(unit), ' +
-          `width: ${size}.width, height: ${size}.height` +
-
-          (x !== null ? ', extent_x: ' + (scales ? domain(model, X) :
+        update: '{x: x(unit), y: y(unit)' +
+          (x !== null ? ', extent_x: ' + (hasScales ? domain(model, X) :
               `slice(${channelSignalName(selCmpt, 'x', 'visual')})`) : '') +
 
-          (y !== null ? ', extent_y: ' + (scales ? domain(model, Y) :
+          (y !== null ? ', extent_y: ' + (hasScales ? domain(model, Y) :
               `slice(${channelSignalName(selCmpt, 'y', 'visual')})`) : '') + '}'
       }]
     }, {
@@ -64,17 +61,30 @@ const translate:TransformCompiler = {
 
 export {translate as default};
 
+function getSign(selCmpt: SelectionComponent, channel: Channel) {
+  if (scalesCompiler.has(selCmpt)) {
+    return channel === Y ? '+' : '-';
+  }
+  return '+';
+}
+
 function onDelta(model: UnitModel, selCmpt: SelectionComponent, channel: Channel, size: 'width' | 'height', signals: any[]) {
   const name = selCmpt.name,
-      signal:any = signals.filter((s:any) => s.name === channelSignalName(selCmpt, channel, 'visual'))[0],
+      hasScales = scalesCompiler.has(selCmpt),
+      signal:any = signals.filter((s:any) => {
+        return s.name === channelSignalName(selCmpt, channel, hasScales ? 'data' : 'visual');
+      })[0],
       anchor = name + ANCHOR,
       delta  = name + DELTA,
+      sign = getSign(selCmpt, channel),
+      offset = sign + (hasScales ?
+        `span(${anchor}.extent_${channel}) * ${delta}.${channel} / unit.${size}` :
+        `${delta}.${channel}`),
       extent = `${anchor}.extent_${channel}`,
-      range = `[${extent}[0] + ${delta}.${channel}, ` +
-        `${extent}[1] + ${delta}.${channel}]`;
+      range = `[${extent}[0] ${offset}, ${extent}[1] ${offset}]`;
 
   signal.on.push({
     events: {signal: delta},
-    update: scalesCompiler.has(selCmpt) ? range : `clampRange(${range}, 0, unit.${size})`
+    update: hasScales ? range : `clampRange(${range}, 0, unit.${size})`
   });
 }

--- a/src/compile/selection/transforms/translate.ts
+++ b/src/compile/selection/transforms/translate.ts
@@ -74,17 +74,18 @@ function onDelta(model: UnitModel, selCmpt: SelectionComponent, channel: Channel
       signal:any = signals.filter((s:any) => {
         return s.name === channelSignalName(selCmpt, channel, hasScales ? 'data' : 'visual');
       })[0],
+      sizeSg = model.getSizeSignalRef(size).signal,
       anchor = name + ANCHOR,
       delta  = name + DELTA,
       sign = getSign(selCmpt, channel),
       offset = sign + (hasScales ?
-        ` span(${anchor}.extent_${channel}) * ${delta}.${channel} / unit.${size}` :
+        ` span(${anchor}.extent_${channel}) * ${delta}.${channel} / ${sizeSg}` :
         ` ${delta}.${channel}`),
       extent = `${anchor}.extent_${channel}`,
       range = `[${extent}[0] ${offset}, ${extent}[1] ${offset}]`;
 
   signal.on.push({
     events: {signal: delta},
-    update: hasScales ? range : `clampRange(${range}, 0, unit.${size})`
+    update: hasScales ? range : `clampRange(${range}, 0, ${sizeSg})`
   });
 }

--- a/src/compile/selection/transforms/zoom.ts
+++ b/src/compile/selection/transforms/zoom.ts
@@ -18,9 +18,7 @@ const zoom:TransformCompiler = {
   signals: function(model, selCmpt, signals) {
     const name = selCmpt.name,
         delta = name + DELTA,
-        {x, y} = intervalProjections(selCmpt),
-        sx = stringValue(model.scaleName(X)),
-        sy = stringValue(model.scaleName(Y));
+        {x, y} = intervalProjections(selCmpt);
 
     let events = parseSelector(selCmpt.zoom, 'scope');
 
@@ -32,7 +30,7 @@ const zoom:TransformCompiler = {
       name: name + ANCHOR,
       on: [{
         events: events,
-        update: `{x: invert(${sx}, x(unit)), y: invert(${sy}, y(unit))}`
+        update: `{x: x(unit), y: y(unit)}`
       }]
     }, {
       name: delta,
@@ -70,19 +68,17 @@ export {zoom as default};
 
 function onDelta(model: UnitModel, selCmpt: SelectionComponent, channel: Channel, size: 'width' | 'height', signals: any[]) {
   const name = selCmpt.name,
-      signal:any = signals.filter((s:any) => s.name === channelSignalName(selCmpt, channel))[0],
+      signal:any = signals.filter((s:any) => s.name === channelSignalName(selCmpt, channel, 'visual'))[0],
       scales = scalesCompiler.has(selCmpt),
       base = scales ? domain(model, channel) : signal.name,
       anchor = `${name}${ANCHOR}.${channel}`,
       delta  = name + DELTA,
       scale  = stringValue(model.scaleName(channel)),
       range  = `[${anchor} + (${base}[0] - ${anchor}) * ${delta}, ` +
-        `${anchor} + (${base}[1] - ${anchor}) * ${delta}]`,
-      lo = `invert(${scale}` + (channel === X ? ', 0' : `, unit.${size}`) + ')',
-      hi = `invert(${scale}` + (channel === X ? `, unit.${size}` : ', 0') + ')';
+        `${anchor} + (${base}[1] - ${anchor}) * ${delta}]`;
 
   signal.on.push({
     events: {signal: delta},
-    update: scales ? range : `clampRange(${range}, ${lo}, ${hi})`
+    update: scales ? range : `clampRange(${range}, 0, unit.${size})`
   });
 }

--- a/src/compile/selection/transforms/zoom.ts
+++ b/src/compile/selection/transforms/zoom.ts
@@ -66,6 +66,7 @@ function onDelta(model: UnitModel, selCmpt: SelectionComponent, channel: Channel
       signal:any = signals.filter((s:any) => {
         return s.name === channelSignalName(selCmpt, channel, hasScales ? 'data' : 'visual');
       })[0],
+      sizeSg = model.getSizeSignalRef(size).signal,
       base = hasScales ? domain(model, channel) : signal.name,
       anchor = `${name}${ANCHOR}.${channel}`,
       delta  = name + DELTA,
@@ -75,6 +76,6 @@ function onDelta(model: UnitModel, selCmpt: SelectionComponent, channel: Channel
 
   signal.on.push({
     events: {signal: delta},
-    update: hasScales ? range : `clampRange(${range}, 0, unit.${size})`
+    update: hasScales ? range : `clampRange(${range}, 0, ${sizeSg})`
   });
 }

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -111,7 +111,7 @@ export function expression(model: Model, filter: Filter): string {
     return filter;
   } else if (isSelectionFilter(filter)) {
     const selection = model.getComponent('selection', filter.selection);
-    return predicate(filter.selection, selection.type, selection.resolve, null, null);
+    return predicate(model, filter.selection, selection.type, selection.resolve, null);
   } else { // Filter Object
     const fieldExpr = filter.timeUnit ?
       // For timeUnit, cast into integer with time() so we can use ===, inrange, indexOf to compare values directly.

--- a/test/compile/selection/interval.test.ts
+++ b/test/compile/selection/interval.test.ts
@@ -40,118 +40,105 @@ describe('Interval Selections', function() {
     it('builds projection signals', function() {
       const oneSg = interval.signals(model, selCmpts['one']);
       assert.includeDeepMembers(oneSg, [{
-        "name": "one_Horsepower",
+        "name": "one_x",
         "value": [],
         "on": [
           {
             "events": parseSelector('mousedown', 'scope')[0],
-            "update": "invert(\"x\", [x(unit), x(unit)])"
+            "update": "[x(unit), x(unit)]"
           },
           {
             "events": parseSelector('[mousedown, window:mouseup] > window:mousemove!', 'scope')[0],
-            "update": "[one_Horsepower[0], invert(\"x\", clamp(x(unit), 0, width))]"
+            "update": "[one_x[0], clamp(x(unit), 0, width)]"
+          },
+          {
+            "events": {"scale": "x"},
+            "update": "!isArray(one_Horsepower) ? one_x : [scale(\"x\", one_Horsepower[0]), scale(\"x\", one_Horsepower[1])]"
           }
         ]
+      }, {
+        "name": "one_Horsepower",
+        "on": [{
+          "events": {"signal": "one_x"},
+          "update": "invert(\"x\", one_x)"
+        }]
       }]);
 
       const twoSg = interval.signals(model, selCmpts['two']);
       assert.includeDeepMembers(twoSg, [{
         "name": "two_Miles_per_Gallon",
-        "on": [],
-        "value": []
+        "on": []
       }]);
 
       const threeSg = interval.signals(model, selCmpts['three']);
       assert.includeDeepMembers(threeSg, [
         {
-          "name": "three_Horsepower",
+          "name": "three_x",
           "value": [],
           "on": [
             {
               "events": parseSelector('mousedown', 'scope')[0],
-              "update": "invert(\"x\", [x(unit), x(unit)])"
+              "update": "[x(unit), x(unit)]"
             },
             {
               "events": parseSelector('[mousedown, mouseup] > mousemove', 'scope')[0],
-              "update": "[three_Horsepower[0], invert(\"x\", clamp(x(unit), 0, width))]"
+              "update": "[three_x[0], clamp(x(unit), 0, width)]"
             },
             {
               "events": parseSelector('keydown', 'scope')[0],
-              "update": "invert(\"x\", [x(unit), x(unit)])"
+              "update": "[x(unit), x(unit)]"
             },
             {
               "events": parseSelector('[keydown, keyup] > keypress', 'scope')[0],
-              "update": "[three_Horsepower[0], invert(\"x\", clamp(x(unit), 0, width))]"
+              "update": "[three_x[0], clamp(x(unit), 0, width)]"
+            },
+            {
+              "events": {"scale": "x"},
+              "update": "!isArray(three_Horsepower) ? three_x : [scale(\"x\", three_Horsepower[0]), scale(\"x\", three_Horsepower[1])]"
+            }
+          ]
+        },
+        {
+          "name": "three_Horsepower",
+          "on": [{
+            "events": {"signal": "three_x"},
+            "update": "invert(\"x\", three_x)"
+          }]
+        },
+        {
+          "name": "three_y",
+          "value": [],
+          "on": [
+            {
+              "events": parseSelector('mousedown', 'scope')[0],
+              "update": "[y(unit), y(unit)]"
+            },
+            {
+              "events": parseSelector('[mousedown, mouseup] > mousemove', 'scope')[0],
+              "update": "[three_y[0], clamp(y(unit), 0, height)]"
+            },
+            {
+              "events": parseSelector('keydown', 'scope')[0],
+              "update": "[y(unit), y(unit)]"
+            },
+            {
+              "events": parseSelector('[keydown, keyup] > keypress', 'scope')[0],
+              "update": "[three_y[0], clamp(y(unit), 0, height)]"
+            },
+            {
+              "events": {"scale": "y"},
+              "update": "!isArray(three_Miles_per_Gallon) ? three_y : [scale(\"y\", three_Miles_per_Gallon[0]), scale(\"y\", three_Miles_per_Gallon[1])]"
             }
           ]
         },
         {
           "name": "three_Miles_per_Gallon",
-          "value": [],
-          "on": [
-            {
-              "events": parseSelector('mousedown', 'scope')[0],
-              "update": "invert(\"y\", [y(unit), y(unit)])"
-            },
-            {
-              "events": parseSelector('[mousedown, mouseup] > mousemove', 'scope')[0],
-              "update": "[three_Miles_per_Gallon[0], invert(\"y\", clamp(y(unit), 0, height))]"
-            },
-            {
-              "events": parseSelector('keydown', 'scope')[0],
-              "update": "invert(\"y\", [y(unit), y(unit)])"
-            },
-            {
-              "events": parseSelector('[keydown, keyup] > keypress', 'scope')[0],
-              "update": "[three_Miles_per_Gallon[0], invert(\"y\", clamp(y(unit), 0, height))]"
-            }
-          ]
+          "on": [{
+            "events": {"signal": "three_y"},
+            "update": "invert(\"y\", three_y)"
+          }]
         }
       ]);
-    });
-
-    it('builds size signals', function() {
-      const oneSg = interval.signals(model, selCmpts['one']);
-      assert.includeDeepMembers(oneSg, [{
-        "name": "one_size",
-        "value": [],
-        "on": [
-          {
-            "events": parseSelector('mousedown', 'scope')[0],
-            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-          },
-          {
-            "events": parseSelector('[mousedown, window:mouseup] > window:mousemove!', 'scope')[0],
-            "update": "{x: one_size.x, y: one_size.y, width: abs(x(unit) - one_size.x), height: abs(y(unit) - one_size.y)}"
-          }
-        ]
-      }]);
-
-      // Skip twoSg because bindScales should remove the size.
-
-      const threeSg = interval.signals(model, selCmpts['three']);
-      assert.includeDeepMembers(threeSg, [{
-        "name": "three_size",
-        "value": [],
-        "on": [
-          {
-            "events": parseSelector('mousedown', 'scope')[0],
-            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-          },
-          {
-            "events": parseSelector('[mousedown, mouseup] > mousemove', 'scope')[0],
-            "update": "{x: three_size.x, y: three_size.y, width: abs(x(unit) - three_size.x), height: abs(y(unit) - three_size.y)}"
-          },
-          {
-            "events": parseSelector('keydown', 'scope')[0],
-            "update": "{x: x(unit), y: y(unit), width: 0, height: 0}"
-          },
-          {
-            "events": parseSelector('[keydown, keyup] > keypress', 'scope')[0],
-            "update": "{x: three_size.x, y: three_size.y, width: abs(x(unit) - three_size.x), height: abs(y(unit) - three_size.y)}"
-          }
-        ]
-      }]);
     });
 
     it('builds trigger signals', function() {
@@ -279,32 +266,40 @@ describe('Interval Selections', function() {
             "x": [
               {
                 "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
-                "scale": "x",
-                "signal": "one[0].extent[0]"
+                "signal": "one_x[0]"
               },
-              {"value": 0}
-            ],
-            "x2": [
               {
-                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
-                "scale": "x",
-                "signal": "one[0].extent[1]"
-              },
-              {"value": 0}
+                "value": 0
+              }
             ],
             "y": [
               {
                 "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
                 "value": 0
               },
-              {"value": 0}
+              {
+                "value": 0
+              }
+            ],
+            "x2": [
+              {
+                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "signal": "one_x[1]"
+              },
+              {
+                "value": 0
+              }
             ],
             "y2": [
               {
                 "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
-                "field": {"group": "height"}
+                "field": {
+                  "group": "height"
+                }
               },
-              {"value": 0}
+              {
+                "value": 0
+              }
             ]
           }
         }
@@ -322,32 +317,40 @@ describe('Interval Selections', function() {
             "x": [
               {
                 "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
-                "scale": "x",
-                "signal": "one[0].extent[0]"
+                "signal": "one_x[0]"
               },
-              {"value": 0}
-            ],
-            "x2": [
               {
-                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
-                "scale": "x",
-                "signal": "one[0].extent[1]"
-              },
-              {"value": 0}
+                "value": 0
+              }
             ],
             "y": [
               {
                 "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
                 "value": 0
               },
-              {"value": 0}
+              {
+                "value": 0
+              }
+            ],
+            "x2": [
+              {
+                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "signal": "one_x[1]"
+              },
+              {
+                "value": 0
+              }
             ],
             "y2": [
               {
                 "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
-                "field": {"group": "height"}
+                "field": {
+                  "group": "height"
+                }
               },
-              {"value": 0}
+              {
+                "value": 0
+              }
             ]
           }
         }
@@ -367,20 +370,16 @@ describe('Interval Selections', function() {
           },
           "update": {
             "x": {
-              "scale": "x",
-              "signal": "three[0].extent[0]"
-            },
-            "x2": {
-              "scale": "x",
-              "signal": "three[0].extent[1]"
+              "signal": "three_x[0]"
             },
             "y": {
-              "scale": "y",
-              "signal": "three[1].extent[0]"
+              "signal": "three_y[0]"
+            },
+            "x2": {
+              "signal": "three_x[1]"
             },
             "y2": {
-              "scale": "y",
-              "signal": "three[1].extent[1]"
+              "signal": "three_y[1]"
             }
           }
         }
@@ -396,20 +395,16 @@ describe('Interval Selections', function() {
           },
           "update": {
             "x": {
-              "scale": "x",
-              "signal": "three[0].extent[0]"
-            },
-            "x2": {
-              "scale": "x",
-              "signal": "three[0].extent[1]"
+              "signal": "three_x[0]"
             },
             "y": {
-              "scale": "y",
-              "signal": "three[1].extent[0]"
+              "signal": "three_y[0]"
+            },
+            "x2": {
+              "signal": "three_x[1]"
             },
             "y2": {
-              "scale": "y",
-              "signal": "three[1].extent[1]"
+              "signal": "three_y[1]"
             }
           }
         }

--- a/test/compile/selection/interval.test.ts
+++ b/test/compile/selection/interval.test.ts
@@ -185,7 +185,7 @@ describe('Interval Selections', function() {
         "on": [
           {
             "events": {"signal": "one"},
-            "update": `{unit: unit.datum && unit.datum._id, ${oneExpr}}`
+            "update": `{unit: \"\", ${oneExpr}}`
           }
         ]
       },
@@ -194,7 +194,7 @@ describe('Interval Selections', function() {
         "on": [
           {
             "events": {"signal": "two"},
-            "update": `{unit: unit.datum && unit.datum._id, ${twoExpr}}`
+            "update": `{unit: \"\", ${twoExpr}}`
           }
         ]
       },
@@ -203,7 +203,7 @@ describe('Interval Selections', function() {
         "on": [
           {
             "events": {"signal": "three"},
-            "update": `{unit: unit.datum && unit.datum._id, ${threeExpr}}`
+            "update": `{unit: \"\", ${threeExpr}}`
           }
         ]
       }
@@ -218,7 +218,7 @@ describe('Interval Selections', function() {
     assert.equal(twoExpr, 'two_tuple, true');
 
     const threeExpr = interval.modifyExpr(model, selCmpts['three']);
-    assert.equal(threeExpr, 'three_tuple, {unit: three_tuple.unit}');
+    assert.equal(threeExpr, 'three_tuple, {unit: \"\"}');
 
     const signals = selection.assembleUnitSelectionSignals(model, []);
     assert.includeDeepMembers(signals, [
@@ -265,7 +265,7 @@ describe('Interval Selections', function() {
           "update": {
             "x": [
               {
-                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "test": "data(\"one_store\").length && data(\"one_store\")[0].unit === \"\"",
                 "signal": "one_x[0]"
               },
               {
@@ -274,7 +274,7 @@ describe('Interval Selections', function() {
             ],
             "y": [
               {
-                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "test": "data(\"one_store\").length && data(\"one_store\")[0].unit === \"\"",
                 "value": 0
               },
               {
@@ -283,7 +283,7 @@ describe('Interval Selections', function() {
             ],
             "x2": [
               {
-                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "test": "data(\"one_store\").length && data(\"one_store\")[0].unit === \"\"",
                 "signal": "one_x[1]"
               },
               {
@@ -292,7 +292,7 @@ describe('Interval Selections', function() {
             ],
             "y2": [
               {
-                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "test": "data(\"one_store\").length && data(\"one_store\")[0].unit === \"\"",
                 "field": {
                   "group": "height"
                 }
@@ -316,7 +316,7 @@ describe('Interval Selections', function() {
           "update": {
             "x": [
               {
-                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "test": "data(\"one_store\").length && data(\"one_store\")[0].unit === \"\"",
                 "signal": "one_x[0]"
               },
               {
@@ -325,7 +325,7 @@ describe('Interval Selections', function() {
             ],
             "y": [
               {
-                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "test": "data(\"one_store\").length && data(\"one_store\")[0].unit === \"\"",
                 "value": 0
               },
               {
@@ -334,7 +334,7 @@ describe('Interval Selections', function() {
             ],
             "x2": [
               {
-                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "test": "data(\"one_store\").length && data(\"one_store\")[0].unit === \"\"",
                 "signal": "one_x[1]"
               },
               {
@@ -343,7 +343,7 @@ describe('Interval Selections', function() {
             ],
             "y2": [
               {
-                "test": "data(\"one_store\").length && one_tuple && one_tuple.unit === data(\"one_store\")[0].unit",
+                "test": "data(\"one_store\").length && data(\"one_store\")[0].unit === \"\"",
                 "field": {
                   "group": "height"
                 }

--- a/test/compile/selection/layers.test.ts
+++ b/test/compile/selection/layers.test.ts
@@ -120,18 +120,7 @@ describe('Layered Selections', function() {
             "x": [
               {
                 "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                "scale": "x",
-                "signal": "brush[0].extent[0]"
-              },
-              {
-                "value": 0
-              }
-            ],
-            "x2": [
-              {
-                "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                "scale": "x",
-                "signal": "brush[0].extent[1]"
+                "signal": "brush_x[0]"
               },
               {
                 "value": 0
@@ -140,8 +129,16 @@ describe('Layered Selections', function() {
             "y": [
               {
                 "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                "scale": "y",
-                "signal": "brush[1].extent[0]"
+                "signal": "brush_y[0]"
+              },
+              {
+                "value": 0
+              }
+            ],
+            "x2": [
+              {
+                "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                "signal": "brush_x[1]"
               },
               {
                 "value": 0
@@ -150,8 +147,7 @@ describe('Layered Selections', function() {
             "y2": [
               {
                 "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                "scale": "y",
-                "signal": "brush[1].extent[1]"
+                "signal": "brush_y[1]"
               },
               {
                 "value": 0
@@ -176,18 +172,7 @@ describe('Layered Selections', function() {
             "x": [
               {
                 "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                "scale": "x",
-                "signal": "brush[0].extent[0]"
-              },
-              {
-                "value": 0
-              }
-            ],
-            "x2": [
-              {
-                "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                "scale": "x",
-                "signal": "brush[0].extent[1]"
+                "signal": "brush_x[0]"
               },
               {
                 "value": 0
@@ -196,8 +181,16 @@ describe('Layered Selections', function() {
             "y": [
               {
                 "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                "scale": "y",
-                "signal": "brush[1].extent[0]"
+                "signal": "brush_y[0]"
+              },
+              {
+                "value": 0
+              }
+            ],
+            "x2": [
+              {
+                "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                "signal": "brush_x[1]"
               },
               {
                 "value": 0
@@ -206,8 +199,7 @@ describe('Layered Selections', function() {
             "y2": [
               {
                 "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
-                "scale": "y",
-                "signal": "brush[1].extent[1]"
+                "signal": "brush_y[1]"
               },
               {
                 "value": 0

--- a/test/compile/selection/layers.test.ts
+++ b/test/compile/selection/layers.test.ts
@@ -119,7 +119,7 @@ describe('Layered Selections', function() {
           "update": {
             "x": [
               {
-                "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_0_\"",
                 "signal": "brush_x[0]"
               },
               {
@@ -128,7 +128,7 @@ describe('Layered Selections', function() {
             ],
             "y": [
               {
-                "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_0_\"",
                 "signal": "brush_y[0]"
               },
               {
@@ -137,7 +137,7 @@ describe('Layered Selections', function() {
             ],
             "x2": [
               {
-                "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_0_\"",
                 "signal": "brush_x[1]"
               },
               {
@@ -146,7 +146,7 @@ describe('Layered Selections', function() {
             ],
             "y2": [
               {
-                "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_0_\"",
                 "signal": "brush_y[1]"
               },
               {
@@ -171,7 +171,7 @@ describe('Layered Selections', function() {
           "update": {
             "x": [
               {
-                "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_0_\"",
                 "signal": "brush_x[0]"
               },
               {
@@ -180,7 +180,7 @@ describe('Layered Selections', function() {
             ],
             "y": [
               {
-                "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_0_\"",
                 "signal": "brush_y[0]"
               },
               {
@@ -189,7 +189,7 @@ describe('Layered Selections', function() {
             ],
             "x2": [
               {
-                "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_0_\"",
                 "signal": "brush_x[1]"
               },
               {
@@ -198,7 +198,7 @@ describe('Layered Selections', function() {
             ],
             "y2": [
               {
-                "test": "data(\"brush_store\").length && brush_tuple && brush_tuple.unit === data(\"brush_store\")[0].unit",
+                "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"layer_0_\"",
                 "signal": "brush_y[1]"
               },
               {

--- a/test/compile/selection/multi.test.ts
+++ b/test/compile/selection/multi.test.ts
@@ -62,7 +62,7 @@ describe('Multi Selection', function() {
         "on": [
           {
             "events": {"signal": "one"},
-            "update": `{unit: unit.datum && unit.datum._id, ${oneExpr}}`
+            "update": `{unit: \"\", ${oneExpr}}`
           }
         ]
       },
@@ -71,7 +71,7 @@ describe('Multi Selection', function() {
         "on": [
           {
             "events": {"signal": "two"},
-            "update": `{unit: unit.datum && unit.datum._id, ${twoExpr}}`
+            "update": `{unit: \"\", ${twoExpr}}`
           }
         ]
       }

--- a/test/compile/selection/predicate.test.ts
+++ b/test/compile/selection/predicate.test.ts
@@ -41,14 +41,14 @@ describe('Selection Predicate', function() {
     const single = getModel({type: 'single'});
     assert.deepEqual(nonPosition('color', single), {
       color: [
-        {test: "!vlPoint(\"one_store\", parent._id, datum, \"union\", \"all\")", value: "grey"},
+        {test: "!vlPoint(\"one_store\", \"\", datum, \"union\", \"all\")", value: "grey"},
         {scale: "color", field: "Cylinders"}
       ]
     });
 
     assert.deepEqual(nonPosition('opacity', single), {
       opacity: [
-        {test: "vlPoint(\"one_store\", parent._id, datum, \"union\", \"all\")", value: 0.5},
+        {test: "vlPoint(\"one_store\", \"\", datum, \"union\", \"all\")", value: 0.5},
         {scale: "opacity", field: "Origin"}
       ]
     });
@@ -56,14 +56,14 @@ describe('Selection Predicate', function() {
     const multi = getModel({type: 'multi'});
     assert.deepEqual(nonPosition('color', multi), {
       color: [
-        {test: "!vlPoint(\"one_store\", parent._id, datum, \"union\", \"all\")", value: "grey"},
+        {test: "!vlPoint(\"one_store\", \"\", datum, \"union\", \"all\")", value: "grey"},
         {scale: "color", field: "Cylinders"}
       ]
     });
 
     assert.deepEqual(nonPosition('opacity', multi), {
       opacity: [
-        {test: "vlPoint(\"one_store\", parent._id, datum, \"union\", \"all\")", value: 0.5},
+        {test: "vlPoint(\"one_store\", \"\", datum, \"union\", \"all\")", value: 0.5},
         {scale: "opacity", field: "Origin"}
       ]
     });
@@ -71,14 +71,14 @@ describe('Selection Predicate', function() {
     const interval = getModel({type: 'interval'});
     assert.deepEqual(nonPosition('color', interval), {
       color: [
-        {test: "!vlInterval(\"one_store\", parent._id, datum, \"union\", \"all\")", value: "grey"},
+        {test: "!vlInterval(\"one_store\", \"\", datum, \"union\", \"all\")", value: "grey"},
         {scale: "color", field: "Cylinders"}
       ]
     });
 
     assert.deepEqual(nonPosition('opacity', interval), {
       opacity: [
-        {test: "vlInterval(\"one_store\", parent._id, datum, \"union\", \"all\")", value: 0.5},
+        {test: "vlInterval(\"one_store\", \"\", datum, \"union\", \"all\")", value: 0.5},
         {scale: "opacity", field: "Origin"}
       ]
     });

--- a/test/compile/selection/single.test.ts
+++ b/test/compile/selection/single.test.ts
@@ -62,7 +62,7 @@ describe('Single Selection', function() {
         "on": [
           {
             "events": {"signal": "one"},
-            "update": `{unit: unit.datum && unit.datum._id, ${oneExpr}}`
+            "update": `{unit: \"\", ${oneExpr}}`
           }
         ]
       },
@@ -71,7 +71,7 @@ describe('Single Selection', function() {
         "on": [
           {
             "events": {"signal": "two"},
-            "update": `{unit: unit.datum && unit.datum._id, ${twoExpr}}`
+            "update": `{unit: \"\", ${twoExpr}}`
           }
         ]
       }

--- a/test/compile/selection/toggle.test.ts
+++ b/test/compile/selection/toggle.test.ts
@@ -53,7 +53,7 @@ describe('Toggle Selection Transform', function() {
     assert.equal(oneExpr, 'one_toggle ? null : one_tuple, one_toggle ? null : true, one_toggle ? one_tuple : null');
 
     const twoExpr = toggle.modifyExpr(model, selCmpts['two'], '');
-    assert.equal(twoExpr, 'two_toggle ? null : two_tuple, two_toggle ? null : {unit: two_tuple.unit}, two_toggle ? two_tuple : null');
+    assert.equal(twoExpr, 'two_toggle ? null : two_tuple, two_toggle ? null : {unit: \"\"}, two_toggle ? two_tuple : null');
 
     const signals = selection.assembleUnitSelectionSignals(model, []);
     assert.includeDeepMembers(signals, [

--- a/test/compile/selection/translate.test.ts
+++ b/test/compile/selection/translate.test.ts
@@ -62,7 +62,7 @@ describe('Translate Selection Transform', function() {
         "on": [
           {
             "events": parseSelector('@four_brush:mousedown', 'scope'),
-            "update": "{x: x(unit), y: y(unit), width: four_size.width, height: four_size.height, extent_x: slice(four_Horsepower), extent_y: slice(four_Miles_per_Gallon), }"
+            "update": "{x: x(unit), y: y(unit), extent_x: slice(four_x), extent_y: slice(four_y)}"
           }
         ]
       },
@@ -78,17 +78,17 @@ describe('Translate Selection Transform', function() {
       }
     ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_Horsepower')[0].on, [
+    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_x')[0].on, [
       {
         "events": {"signal": "four_translate_delta"},
-        "update": "clampRange([four_translate_anchor.extent_x[0] + abs(span(four_translate_anchor.extent_x)) * four_translate_delta.x / four_translate_anchor.width, four_translate_anchor.extent_x[1] + abs(span(four_translate_anchor.extent_x)) * four_translate_delta.x / four_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+        "update": "clampRange([four_translate_anchor.extent_x[0] + four_translate_delta.x, four_translate_anchor.extent_x[1] + four_translate_delta.x], 0, unit.width)"
       }
     ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_Miles_per_Gallon')[0].on, [
+    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_y')[0].on, [
       {
         "events": {"signal": "four_translate_delta"},
-        "update": "clampRange([four_translate_anchor.extent_y[0] - abs(span(four_translate_anchor.extent_y)) * four_translate_delta.y / four_translate_anchor.height, four_translate_anchor.extent_y[1] - abs(span(four_translate_anchor.extent_y)) * four_translate_delta.y / four_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
+        "update": "clampRange([four_translate_anchor.extent_y[0] + four_translate_delta.y, four_translate_anchor.extent_y[1] + four_translate_delta.y], 0, unit.height)"
       }
     ]);
   });
@@ -96,7 +96,6 @@ describe('Translate Selection Transform', function() {
   it('builds signals for custom events', function() {
     model.component.selection = {five: selCmpts['five']};
     const signals = selection.assembleUnitSelectionSignals(model, []);
-
     assert.includeDeepMembers(signals, [
       {
         "name": "five_translate_anchor",
@@ -104,7 +103,7 @@ describe('Translate Selection Transform', function() {
         "on": [
           {
             "events": parseSelector('@five_brush:mousedown, @five_brush:keydown', 'scope'),
-            "update": "{x: x(unit), y: y(unit), width: five_size.width, height: five_size.height, extent_x: slice(five_Horsepower), extent_y: slice(five_Miles_per_Gallon), }"
+            "update": "{x: x(unit), y: y(unit), extent_x: slice(five_x), extent_y: slice(five_y)}"
           }
         ]
       },
@@ -120,17 +119,17 @@ describe('Translate Selection Transform', function() {
       }
     ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_Horsepower')[0].on, [
+    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_x')[0].on, [
       {
         "events": {"signal": "five_translate_delta"},
-        "update": "clampRange([five_translate_anchor.extent_x[0] + abs(span(five_translate_anchor.extent_x)) * five_translate_delta.x / five_translate_anchor.width, five_translate_anchor.extent_x[1] + abs(span(five_translate_anchor.extent_x)) * five_translate_delta.x / five_translate_anchor.width], invert(\"x\", 0), invert(\"x\", unit.width))"
+        "update": "clampRange([five_translate_anchor.extent_x[0] + five_translate_delta.x, five_translate_anchor.extent_x[1] + five_translate_delta.x], 0, unit.width)"
       }
     ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_Miles_per_Gallon')[0].on, [
+    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_y')[0].on, [
       {
         "events": {"signal": "five_translate_delta"},
-        "update": "clampRange([five_translate_anchor.extent_y[0] - abs(span(five_translate_anchor.extent_y)) * five_translate_delta.y / five_translate_anchor.height, five_translate_anchor.extent_y[1] - abs(span(five_translate_anchor.extent_y)) * five_translate_delta.y / five_translate_anchor.height], invert(\"y\", unit.height), invert(\"y\", 0))"
+        "update": "clampRange([five_translate_anchor.extent_y[0] + five_translate_delta.y, five_translate_anchor.extent_y[1] + five_translate_delta.y], 0, unit.height)"
       }
     ]);
   });
@@ -145,7 +144,7 @@ describe('Translate Selection Transform', function() {
         "on": [
           {
             "events": parseSelector('mousedown', 'scope'),
-            "update": "{x: x(unit), y: y(unit), width: unit.width, height: unit.height, extent_x: domain(\"x\"), extent_y: domain(\"y\"), }"
+            "update": "{x: x(unit), y: y(unit), extent_x: domain(\"x\"), extent_y: domain(\"y\")}"
           }
         ]
       },
@@ -164,14 +163,14 @@ describe('Translate Selection Transform', function() {
     assert.includeDeepMembers(signals.filter((s) => s.name === 'six_Horsepower')[0].on, [
       {
         "events": {"signal": "six_translate_delta"},
-        "update": "[six_translate_anchor.extent_x[0] - abs(span(six_translate_anchor.extent_x)) * six_translate_delta.x / six_translate_anchor.width, six_translate_anchor.extent_x[1] - abs(span(six_translate_anchor.extent_x)) * six_translate_delta.x / six_translate_anchor.width]"
+        "update": "[six_translate_anchor.extent_x[0] - span(six_translate_anchor.extent_x) * six_translate_delta.x / unit.width, six_translate_anchor.extent_x[1] - span(six_translate_anchor.extent_x) * six_translate_delta.x / unit.width]"
       }
     ]);
 
     assert.includeDeepMembers(signals.filter((s) => s.name === 'six_Miles_per_Gallon')[0].on, [
       {
         "events": {"signal": "six_translate_delta"},
-        "update": "[six_translate_anchor.extent_y[0] + abs(span(six_translate_anchor.extent_y)) * six_translate_delta.y / six_translate_anchor.height, six_translate_anchor.extent_y[1] + abs(span(six_translate_anchor.extent_y)) * six_translate_delta.y / six_translate_anchor.height]"
+        "update": "[six_translate_anchor.extent_y[0] + span(six_translate_anchor.extent_y) * six_translate_delta.y / unit.height, six_translate_anchor.extent_y[1] + span(six_translate_anchor.extent_y) * six_translate_delta.y / unit.height]"
       }
     ]);
   });

--- a/test/compile/selection/translate.test.ts
+++ b/test/compile/selection/translate.test.ts
@@ -81,14 +81,14 @@ describe('Translate Selection Transform', function() {
     assert.includeDeepMembers(signals.filter((s) => s.name === 'four_x')[0].on, [
       {
         "events": {"signal": "four_translate_delta"},
-        "update": "clampRange([four_translate_anchor.extent_x[0] + four_translate_delta.x, four_translate_anchor.extent_x[1] + four_translate_delta.x], 0, unit.width)"
+        "update": "clampRange([four_translate_anchor.extent_x[0] + four_translate_delta.x, four_translate_anchor.extent_x[1] + four_translate_delta.x], 0, width)"
       }
     ]);
 
     assert.includeDeepMembers(signals.filter((s) => s.name === 'four_y')[0].on, [
       {
         "events": {"signal": "four_translate_delta"},
-        "update": "clampRange([four_translate_anchor.extent_y[0] + four_translate_delta.y, four_translate_anchor.extent_y[1] + four_translate_delta.y], 0, unit.height)"
+        "update": "clampRange([four_translate_anchor.extent_y[0] + four_translate_delta.y, four_translate_anchor.extent_y[1] + four_translate_delta.y], 0, height)"
       }
     ]);
   });
@@ -122,14 +122,14 @@ describe('Translate Selection Transform', function() {
     assert.includeDeepMembers(signals.filter((s) => s.name === 'five_x')[0].on, [
       {
         "events": {"signal": "five_translate_delta"},
-        "update": "clampRange([five_translate_anchor.extent_x[0] + five_translate_delta.x, five_translate_anchor.extent_x[1] + five_translate_delta.x], 0, unit.width)"
+        "update": "clampRange([five_translate_anchor.extent_x[0] + five_translate_delta.x, five_translate_anchor.extent_x[1] + five_translate_delta.x], 0, width)"
       }
     ]);
 
     assert.includeDeepMembers(signals.filter((s) => s.name === 'five_y')[0].on, [
       {
         "events": {"signal": "five_translate_delta"},
-        "update": "clampRange([five_translate_anchor.extent_y[0] + five_translate_delta.y, five_translate_anchor.extent_y[1] + five_translate_delta.y], 0, unit.height)"
+        "update": "clampRange([five_translate_anchor.extent_y[0] + five_translate_delta.y, five_translate_anchor.extent_y[1] + five_translate_delta.y], 0, height)"
       }
     ]);
   });
@@ -163,14 +163,14 @@ describe('Translate Selection Transform', function() {
     assert.includeDeepMembers(signals.filter((s) => s.name === 'six_Horsepower')[0].on, [
       {
         "events": {"signal": "six_translate_delta"},
-        "update": "[six_translate_anchor.extent_x[0] - span(six_translate_anchor.extent_x) * six_translate_delta.x / unit.width, six_translate_anchor.extent_x[1] - span(six_translate_anchor.extent_x) * six_translate_delta.x / unit.width]"
+        "update": "[six_translate_anchor.extent_x[0] - span(six_translate_anchor.extent_x) * six_translate_delta.x / width, six_translate_anchor.extent_x[1] - span(six_translate_anchor.extent_x) * six_translate_delta.x / width]"
       }
     ]);
 
     assert.includeDeepMembers(signals.filter((s) => s.name === 'six_Miles_per_Gallon')[0].on, [
       {
         "events": {"signal": "six_translate_delta"},
-        "update": "[six_translate_anchor.extent_y[0] + span(six_translate_anchor.extent_y) * six_translate_delta.y / unit.height, six_translate_anchor.extent_y[1] + span(six_translate_anchor.extent_y) * six_translate_delta.y / unit.height]"
+        "update": "[six_translate_anchor.extent_y[0] + span(six_translate_anchor.extent_y) * six_translate_delta.y / height, six_translate_anchor.extent_y[1] + span(six_translate_anchor.extent_y) * six_translate_delta.y / height]"
       }
     ]);
   });

--- a/test/compile/selection/zoom.test.ts
+++ b/test/compile/selection/zoom.test.ts
@@ -61,7 +61,7 @@ describe('Zoom Selection Transform', function() {
         "on": [
           {
             "events": parseSelector('@four_brush:wheel', 'scope'),
-            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+            "update": "{x: x(unit), y: y(unit)}"
           }
         ]
       },
@@ -77,24 +77,17 @@ describe('Zoom Selection Transform', function() {
       }
     ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_Horsepower')[0].on, [
+    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_x')[0].on, [
       {
         "events": {"signal": "four_zoom_delta"},
-        "update": "clampRange([four_zoom_anchor.x + (four_Horsepower[0] - four_zoom_anchor.x) * four_zoom_delta, four_zoom_anchor.x + (four_Horsepower[1] - four_zoom_anchor.x) * four_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+        "update": "clampRange([four_zoom_anchor.x + (four_x[0] - four_zoom_anchor.x) * four_zoom_delta, four_zoom_anchor.x + (four_x[1] - four_zoom_anchor.x) * four_zoom_delta], 0, unit.width)"
       }
     ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_Miles_per_Gallon')[0].on, [
+    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_y')[0].on, [
       {
         "events": {"signal": "four_zoom_delta"},
-        "update": "clampRange([four_zoom_anchor.y + (four_Miles_per_Gallon[0] - four_zoom_anchor.y) * four_zoom_delta, four_zoom_anchor.y + (four_Miles_per_Gallon[1] - four_zoom_anchor.y) * four_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
-      }
-    ]);
-
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_size')[0].on, [
-      {
-        "events": {"signal": "four_zoom_delta"},
-        "update": "{x: four_size.x, y: four_size.y, width: four_size.width * four_zoom_delta , height: four_size.height * four_zoom_delta}"
+        "update": "clampRange([four_zoom_anchor.y + (four_y[0] - four_zoom_anchor.y) * four_zoom_delta, four_zoom_anchor.y + (four_y[1] - four_zoom_anchor.y) * four_zoom_delta], 0, unit.height)"
       }
     ]);
   });
@@ -108,7 +101,7 @@ describe('Zoom Selection Transform', function() {
         "on": [
           {
             "events": parseSelector('@five_brush:wheel, @five_brush:pinch', 'scope'),
-            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+            "update": "{x: x(unit), y: y(unit)}"
           }
         ]
       },
@@ -124,24 +117,17 @@ describe('Zoom Selection Transform', function() {
       }
     ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_Horsepower')[0].on, [
+    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_x')[0].on, [
       {
         "events": {"signal": "five_zoom_delta"},
-        "update": "clampRange([five_zoom_anchor.x + (five_Horsepower[0] - five_zoom_anchor.x) * five_zoom_delta, five_zoom_anchor.x + (five_Horsepower[1] - five_zoom_anchor.x) * five_zoom_delta], invert(\"x\", 0), invert(\"x\", unit.width))"
+        "update": "clampRange([five_zoom_anchor.x + (five_x[0] - five_zoom_anchor.x) * five_zoom_delta, five_zoom_anchor.x + (five_x[1] - five_zoom_anchor.x) * five_zoom_delta], 0, unit.width)"
       }
     ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_Miles_per_Gallon')[0].on, [
+    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_y')[0].on, [
       {
         "events": {"signal": "five_zoom_delta"},
-        "update": "clampRange([five_zoom_anchor.y + (five_Miles_per_Gallon[0] - five_zoom_anchor.y) * five_zoom_delta, five_zoom_anchor.y + (five_Miles_per_Gallon[1] - five_zoom_anchor.y) * five_zoom_delta], invert(\"y\", unit.height), invert(\"y\", 0))"
-      }
-    ]);
-
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_size')[0].on, [
-      {
-        "events": {"signal": "five_zoom_delta"},
-        "update": "{x: five_size.x, y: five_size.y, width: five_size.width * five_zoom_delta , height: five_size.height * five_zoom_delta}"
+        "update": "clampRange([five_zoom_anchor.y + (five_y[0] - five_zoom_anchor.y) * five_zoom_delta, five_zoom_anchor.y + (five_y[1] - five_zoom_anchor.y) * five_zoom_delta], 0, unit.height)"
       }
     ]);
   });

--- a/test/compile/selection/zoom.test.ts
+++ b/test/compile/selection/zoom.test.ts
@@ -80,14 +80,14 @@ describe('Zoom Selection Transform', function() {
     assert.includeDeepMembers(signals.filter((s) => s.name === 'four_x')[0].on, [
       {
         "events": {"signal": "four_zoom_delta"},
-        "update": "clampRange([four_zoom_anchor.x + (four_x[0] - four_zoom_anchor.x) * four_zoom_delta, four_zoom_anchor.x + (four_x[1] - four_zoom_anchor.x) * four_zoom_delta], 0, unit.width)"
+        "update": "clampRange([four_zoom_anchor.x + (four_x[0] - four_zoom_anchor.x) * four_zoom_delta, four_zoom_anchor.x + (four_x[1] - four_zoom_anchor.x) * four_zoom_delta], 0, width)"
       }
     ]);
 
     assert.includeDeepMembers(signals.filter((s) => s.name === 'four_y')[0].on, [
       {
         "events": {"signal": "four_zoom_delta"},
-        "update": "clampRange([four_zoom_anchor.y + (four_y[0] - four_zoom_anchor.y) * four_zoom_delta, four_zoom_anchor.y + (four_y[1] - four_zoom_anchor.y) * four_zoom_delta], 0, unit.height)"
+        "update": "clampRange([four_zoom_anchor.y + (four_y[0] - four_zoom_anchor.y) * four_zoom_delta, four_zoom_anchor.y + (four_y[1] - four_zoom_anchor.y) * four_zoom_delta], 0, height)"
       }
     ]);
   });
@@ -120,14 +120,14 @@ describe('Zoom Selection Transform', function() {
     assert.includeDeepMembers(signals.filter((s) => s.name === 'five_x')[0].on, [
       {
         "events": {"signal": "five_zoom_delta"},
-        "update": "clampRange([five_zoom_anchor.x + (five_x[0] - five_zoom_anchor.x) * five_zoom_delta, five_zoom_anchor.x + (five_x[1] - five_zoom_anchor.x) * five_zoom_delta], 0, unit.width)"
+        "update": "clampRange([five_zoom_anchor.x + (five_x[0] - five_zoom_anchor.x) * five_zoom_delta, five_zoom_anchor.x + (five_x[1] - five_zoom_anchor.x) * five_zoom_delta], 0, width)"
       }
     ]);
 
     assert.includeDeepMembers(signals.filter((s) => s.name === 'five_y')[0].on, [
       {
         "events": {"signal": "five_zoom_delta"},
-        "update": "clampRange([five_zoom_anchor.y + (five_y[0] - five_zoom_anchor.y) * five_zoom_delta, five_zoom_anchor.y + (five_y[1] - five_zoom_anchor.y) * five_zoom_delta], 0, unit.height)"
+        "update": "clampRange([five_zoom_anchor.y + (five_y[0] - five_zoom_anchor.y) * five_zoom_delta, five_zoom_anchor.y + (five_y[1] - five_zoom_anchor.y) * five_zoom_delta], 0, height)"
       }
     ]);
   });


### PR DESCRIPTION
Please merge after #2377.

Towards #2221, this PR eliminates the use of `_id` to identify which unit a selection occurs in. Instead, we use `model.getName`. 