### PR TITLE
Fixes for selections over binned/timeUnit fields

### DIFF
--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -585,7 +585,7 @@
                                     "events": {
                                         "signal": "xenc"
                                     },
-                                    "update": "{unit: \"child_\", encodings: xenc.encodings, fields: xenc.fields, values: xenc.values, X: xenc.values[0]}"
+                                    "update": "{unit: \"child_\", encodings: xenc.encodings, fields: xenc.fields, values: xenc.values, bins: xenc.bins, X: xenc.values[0]}"
                                 }
                             ]
                         },

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -281,7 +281,7 @@
                             "events": {
                                 "signal": "cyl"
                             },
-                            "update": "{unit: \"layer_0_\", encodings: cyl.encodings, fields: cyl.fields, values: cyl.values, Cylinders: cyl.values[0]}"
+                            "update": "{unit: \"layer_0_\", encodings: cyl.encodings, fields: cyl.fields, values: cyl.values, bins: cyl.bins, Cylinders: cyl.values[0]}"
                         }
                     ]
                 },

--- a/examples/vg-specs/paintbrush.vg.json
+++ b/examples/vg-specs/paintbrush.vg.json
@@ -87,7 +87,7 @@
                             "events": {
                                 "signal": "paintbrush"
                             },
-                            "update": "{unit: \"\", encodings: paintbrush.encodings, fields: paintbrush.fields, values: paintbrush.values}"
+                            "update": "{unit: \"\", encodings: paintbrush.encodings, fields: paintbrush.fields, values: paintbrush.values, bins: paintbrush.bins}"
                         }
                     ]
                 },

--- a/examples/vg-specs/query_widgets.vg.json
+++ b/examples/vg-specs/query_widgets.vg.json
@@ -112,7 +112,7 @@
                             "events": {
                                 "signal": "CylYr"
                             },
-                            "update": "{unit: \"\", encodings: CylYr.encodings, fields: CylYr.fields, values: CylYr.values, Cylinders: CylYr.values[0], Year: CylYr.values[1]}"
+                            "update": "{unit: \"\", encodings: CylYr.encodings, fields: CylYr.fields, values: CylYr.values, bins: CylYr.bins, Cylinders: CylYr.values[0], Year: CylYr.values[1]}"
                         }
                     ]
                 },

--- a/src/compile/selection/multi.ts
+++ b/src/compile/selection/multi.ts
@@ -1,4 +1,4 @@
-import {stringValue} from '../../util';
+import {keys, stringValue} from '../../util';
 import {SelectionCompiler, TUPLE} from './selection';
 
 const multi:SelectionCompiler = {
@@ -7,22 +7,33 @@ const multi:SelectionCompiler = {
   signals: function(model, selCmpt) {
     const proj = selCmpt.project,
         datum  = '(item().isVoronoi ? datum.datum : datum)',
-        encodings = proj.map((p) => stringValue(p.encoding)).join(', '),
+        bins = {},
+        encodings = proj.map((p) => stringValue(p.encoding)).filter((e) => e).join(', '),
         fields = proj.map((p) => stringValue(p.field)).join(', '),
-        values = proj.map((p) => `${datum}[${stringValue(p.field)}]`).join(', ');
+        values = proj.map((p) => {
+          const channel = p.encoding;
+          // Binned fields should capture extents, for a range test against the raw field.
+          return model.fieldDef(channel).bin ? (bins[p.field] = 1,
+            `[${datum}[${stringValue(model.field(channel, {binSuffix: 'start'}))}], ` +
+               `${datum}[${stringValue(model.field(channel, {binSuffix: 'end'}))}]]`) :
+            `${datum}[${stringValue(p.field)}]`;
+        }).join(', ');
+
     return [{
       name: selCmpt.name,
       value: {},
       on: [{
         events: selCmpt.events,
-        update: `{encodings: [${encodings}], fields: [${fields}], values: [${values}]}`
+        update: `{encodings: [${encodings}], fields: [${fields}], values: [${values}]` +
+          (keys(bins).length ? `, bins: ${JSON.stringify(bins)}}` : '}')
       }]
     }];
   },
 
   tupleExpr: function(model, selCmpt) {
     const name = selCmpt.name;
-    return `encodings: ${name}.encodings, fields: ${name}.fields, values: ${name}.values`;
+    return `encodings: ${name}.encodings, fields: ${name}.fields, ` +
+      `values: ${name}.values, bins: ${name}.bins`;
   },
 
   modifyExpr: function(model, selCmpt) {

--- a/src/compile/selection/single.ts
+++ b/src/compile/selection/single.ts
@@ -18,7 +18,7 @@ const single:SelectionCompiler = {
   tupleExpr: function(model, selCmpt) {
     const name = selCmpt.name, values = `${name}.values`;
     return `encodings: ${name}.encodings, fields: ${name}.fields, ` +
-      `values: ${values}, ` +
+      `values: ${values}, bins: ${name}.bins, ` +
       selCmpt.project.map(function(p, i) {
         return `${p.field}: ${values}[${i}]`;
       }).join(', ');

--- a/src/compile/selection/transforms/project.ts
+++ b/src/compile/selection/transforms/project.ts
@@ -10,8 +10,15 @@ const project:TransformCompiler = {
   parse: function(model, selDef, selCmpt) {
     let fields = {};
     // TODO: find a possible channel mapping for these fields.
-    (selDef.fields || []).forEach((f) => fields[f] = null);
-    (selDef.encodings || []).forEach((c: Channel) => fields[model.fieldDef(c).field] = c);
+    (selDef.fields || []).forEach((field) => fields[field] = null);
+    (selDef.encodings || []).forEach((channel: Channel) => {
+      const fieldDef = model.fieldDef(channel);
+      if (fieldDef.timeUnit) {
+        fields[model.field(channel)] = channel;
+      } else {
+        fields[fieldDef.field] = channel;
+      }
+    });
 
     const projection = selCmpt.project || (selCmpt.project = []);
     for (const field in fields) {

--- a/test/compile/selection/multi.test.ts
+++ b/test/compile/selection/multi.test.ts
@@ -10,7 +10,7 @@ describe('Multi Selection', function() {
     "mark": "circle",
     "encoding": {
       "x": {"field": "Horsepower","type": "quantitative"},
-      "y": {"field": "Miles_per_Gallon","type": "quantitative"},
+      "y": {"field": "Miles_per_Gallon","type": "quantitative", "bin": true},
       "color": {"field": "Origin", "type": "N"}
     }
   });
@@ -40,7 +40,7 @@ describe('Multi Selection', function() {
       value: {},
       on: [{
         events: selCmpts['two'].events,
-        update: "{encodings: [\"y\", \"color\"], fields: [\"Miles_per_Gallon\", \"Origin\"], values: [(item().isVoronoi ? datum.datum : datum)[\"Miles_per_Gallon\"], (item().isVoronoi ? datum.datum : datum)[\"Origin\"]]}"
+        "update": "{encodings: [\"y\", \"color\"], fields: [\"Miles_per_Gallon\", \"Origin\"], values: [[(item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_start\"], (item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_end\"]], (item().isVoronoi ? datum.datum : datum)[\"Origin\"]], bins: {\"Miles_per_Gallon\":1}}"
       }]
     }]);
 
@@ -50,10 +50,10 @@ describe('Multi Selection', function() {
 
   it('builds tuple signals', function() {
     const oneExpr = multi.tupleExpr(model, selCmpts['one']);
-    assert.equal(oneExpr, 'encodings: one.encodings, fields: one.fields, values: one.values');
+    assert.equal(oneExpr, 'encodings: one.encodings, fields: one.fields, values: one.values, bins: one.bins');
 
     const twoExpr = multi.tupleExpr(model, selCmpts['two']);
-    assert.equal(twoExpr, 'encodings: two.encodings, fields: two.fields, values: two.values');
+    assert.equal(twoExpr, 'encodings: two.encodings, fields: two.fields, values: two.values, bins: two.bins');
 
     const signals = selection.assembleUnitSelectionSignals(model, []);
     assert.includeDeepMembers(signals, [

--- a/test/compile/selection/single.test.ts
+++ b/test/compile/selection/single.test.ts
@@ -10,7 +10,7 @@ describe('Single Selection', function() {
     "mark": "circle",
     "encoding": {
       "x": {"field": "Horsepower","type": "quantitative"},
-      "y": {"field": "Miles_per_Gallon","type": "quantitative"},
+      "y": {"field": "Miles_per_Gallon","type": "quantitative", "bin": true},
       "color": {"field": "Origin", "type": "N"}
     }
   });
@@ -40,7 +40,7 @@ describe('Single Selection', function() {
       value: {},
       on: [{
         events: selCmpts['two'].events,
-        update: "{encodings: [\"y\", \"color\"], fields: [\"Miles_per_Gallon\", \"Origin\"], values: [(item().isVoronoi ? datum.datum : datum)[\"Miles_per_Gallon\"], (item().isVoronoi ? datum.datum : datum)[\"Origin\"]]}"
+        "update": "{encodings: [\"y\", \"color\"], fields: [\"Miles_per_Gallon\", \"Origin\"], values: [[(item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_start\"], (item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_end\"]], (item().isVoronoi ? datum.datum : datum)[\"Origin\"]], bins: {\"Miles_per_Gallon\":1}}"
       }]
     }]);
 
@@ -50,10 +50,10 @@ describe('Single Selection', function() {
 
   it('builds tuple signals', function() {
     const oneExpr = single.tupleExpr(model, selCmpts['one']);
-    assert.equal(oneExpr, 'encodings: one.encodings, fields: one.fields, values: one.values, _id: one.values[0]');
+    assert.equal(oneExpr, 'encodings: one.encodings, fields: one.fields, values: one.values, bins: one.bins, _id: one.values[0]');
 
     const twoExpr = single.tupleExpr(model, selCmpts['two']);
-    assert.equal(twoExpr, 'encodings: two.encodings, fields: two.fields, values: two.values, Miles_per_Gallon: two.values[0], Origin: two.values[1]');
+    assert.equal(twoExpr, 'encodings: two.encodings, fields: two.fields, values: two.values, bins: two.bins, Miles_per_Gallon: two.values[0], Origin: two.values[1]');
 
     const signals = selection.assembleUnitSelectionSignals(model, []);
     assert.includeDeepMembers(signals, [


### PR DESCRIPTION
Please merge after #2441. 

This PR includes two fixes when using selections across multiview displays:
* For binned fields, point selections store the bin extents which is tested by the corresponding predicate function (vega/vega-parser#35). Fixes #2320.
* For timeUnit fields, the selection is constructed using the derived (not raw field). This assumes we're able to resolve #2448 accordingly. 