### PR TITLE
Only add a scale listener if appropriate, rather than producing an empty array

### DIFF
--- a/examples/vg-specs/layered_crossfilter.vg.json
+++ b/examples/vg-specs/layered_crossfilter.vg.json
@@ -483,12 +483,6 @@
                                 },
                                 {
                                     "events": {
-                                        "scale": "child_distance_x"
-                                    },
-                                    "update": "[]"
-                                },
-                                {
-                                    "events": {
                                         "signal": "brush_translate_delta"
                                     },
                                     "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, child_distance_layer_0_width)"
@@ -934,12 +928,6 @@
                                 },
                                 {
                                     "events": {
-                                        "scale": "child_delay_x"
-                                    },
-                                    "update": "[]"
-                                },
-                                {
-                                    "events": {
                                         "signal": "brush_translate_delta"
                                     },
                                     "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, child_delay_layer_0_width)"
@@ -1382,12 +1370,6 @@
                                         ]
                                     },
                                     "update": "[brush_x[0], clamp(x(unit), 0, child_time_layer_0_width)]"
-                                },
-                                {
-                                    "events": {
-                                        "scale": "child_time_x"
-                                    },
-                                    "update": "[]"
                                 },
                                 {
                                     "events": {

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -149,13 +149,13 @@ function channelSignals(model: UnitModel, selCmpt: SelectionComponent, channel: 
   // React to pan/zooms of continuous scales. Non-continuous scales
   // (bin-linear, band, point) cannot be pan/zoomed and any other changes
   // to their domains (e.g., filtering) should clear the brushes.
-  on.push({
-    events: {scale: scaleName},
-    update: hasContinuousDomain(scaleType) && !isBinScale(scaleType) ?
-      `!isArray(${dname}) ? ${vname} : ` +
-        `[scale(${scaleStr}, ${dname}[0]), scale(${scaleStr}, ${dname}[1])]` :
-      `[]`
-  });
+  if (hasContinuousDomain(scaleType) && !isBinScale(scaleType)) {
+    on.push({
+      events: {scale: scaleName},
+      update: `!isArray(${dname}) ? ${vname} : ` +
+          `[scale(${scaleStr}, ${dname}[0]), scale(${scaleStr}, ${dname}[1])]`
+    });
+  }
 
   return hasScales ? [{name: dname, on: []}] : [{
     name: vname, value: [], on: on


### PR DESCRIPTION
Fixes #2457.