### PR TITLE
Use ordinal scale for discrete timeUnit

### DIFF
--- a/examples/vg-specs/line_quarter_legend.vg.json
+++ b/examples/vg-specs/line_quarter_legend.vg.json
@@ -170,14 +170,13 @@
         },
         {
             "name": "color",
-            "type": "sequential",
+            "type": "ordinal",
             "domain": {
                 "data": "source_0",
-                "field": "quarter_date"
+                "field": "quarter_date",
+                "sort": true
             },
-            "range": "ramp",
-            "nice": false,
-            "zero": false
+            "range": "ordinal"
         }
     ],
     "axes": [

--- a/src/compile/scale/type.ts
+++ b/src/compile/scale/type.ts
@@ -75,8 +75,11 @@ function defaultType(channel: Channel, fieldDef: FieldDef<string>, mark: Mark,
 
     case 'temporal':
       if (channel === 'color') {
-        // Always use `sequential` as the default color scale for continuous data
-        // since it supports both array range and scheme range.
+        if (isDiscreteByDefault(fieldDef.timeUnit)) {
+          // For discrete timeUnit, use ordinal scale so that legend produces correct value.
+          // (See https://github.com/vega/vega-lite/issues/2045.)
+          return 'ordinal';
+        }
         return 'sequential';
       } else if (rangeType(channel) === 'discrete') {
         log.warn(log.message.discreteChannelCannotEncode(channel, 'temporal'));

--- a/test/compile/scale/type.test.ts
+++ b/test/compile/scale/type.test.ts
@@ -190,6 +190,14 @@ describe('compile/scale', () => {
         );
       });
 
+
+      it('should return ordinal scale for temporal color field with discrete timeUnit by default.', () => {
+        assert.equal(
+          scaleType(undefined, 'color', {timeUnit: 'quarter', type: 'temporal'}, 'point', undefined, undefined, defaultConfig),
+          ScaleType.ORDINAL
+        );
+      });
+
       it('should return ordinal for temporal field and throw a warning.', log.wrap((localLogger) => {
         assert.deepEqual(
           scaleType(undefined, 'shape', {type: 'temporal', timeUnit: 'yearmonth'}, 'point', undefined, undefined, defaultConfig),


### PR DESCRIPTION
Fix #2045

  
