### PR TITLE
Layer query_widgets example to better highlight occluded points.

### DIFF
--- a/examples/specs/query_widgets.vl.json
+++ b/examples/specs/query_widgets.vl.json
@@ -2,25 +2,34 @@
   "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
   "description": "Drag the sliders to highlight points.",
   "data": {"url": "data/cars.json"},
-  "transform": [{
-    "calculate": "year(datum.Year)", "as": "Year"
-  }],
-  "selection": {
-    "CylYr": {
-      "type": "single", "fields": ["Cylinders", "Year"],
-      "bind": {
-        "Cylinders": {"input": "range", "min": 3, "max": 8, "step": 1},
-        "Year": {"input": "range", "min": 1969, "max": 1981, "step": 1}
+  "transform": [{"calculate": "year(datum.Year)", "as": "Year"}],
+  "layer": [{
+    "selection": {
+      "CylYr": {
+        "type": "single", "fields": ["Cylinders", "Year"],
+        "bind": {
+          "Cylinders": {"input": "range", "min": 3, "max": 8, "step": 1},
+          "Year": {"input": "range", "min": 1969, "max": 1981, "step": 1}
+        }
+      }
+    },
+    "mark": "circle",
+    "encoding": {
+      "x": {"field": "Horsepower", "type": "quantitative"},
+      "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
+      "color": {
+        "field": "Origin", "type": "nominal",
+        "condition": {"selection": "!CylYr", "value": "grey"}
       }
     }
-  },
-  "mark": "circle",
-  "encoding": {
-    "x": {"field": "Horsepower", "type": "quantitative"},
-    "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
-    "color": {
-      "condition": {"selection": "!CylYr", "value": "grey"},
-      "field": "Origin", "type": "nominal"
+  }, {
+    "transform": [{"filter": {"selection": "CylYr"}}],
+    "mark": "circle",
+    "encoding": {
+      "x": {"field": "Horsepower", "type": "quantitative"},
+      "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
+      "color": {"field": "Origin", "type": "nominal"},
+      "size": {"value": 100}
     }
-  }
+  }]
 }

--- a/examples/vg-specs/query_widgets.vg.json
+++ b/examples/vg-specs/query_widgets.vg.json
@@ -18,17 +18,53 @@
             "name": "source_0",
             "url": "data/cars.json",
             "format": {
-                "type": "json",
-                "parse": {
-                    "Horsepower": "number",
-                    "Miles_per_Gallon": "number"
-                }
+                "type": "json"
             },
             "transform": [
                 {
                     "type": "formula",
                     "expr": "year(datum.Year)",
                     "as": "Year"
+                }
+            ]
+        },
+        {
+            "name": "data_0",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "formula",
+                    "expr": "toNumber(datum[\"Horsepower\"])",
+                    "as": "Horsepower"
+                },
+                {
+                    "type": "formula",
+                    "expr": "toNumber(datum[\"Miles_per_Gallon\"])",
+                    "as": "Miles_per_Gallon"
+                },
+                {
+                    "type": "filter",
+                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
+                }
+            ]
+        },
+        {
+            "name": "data_1",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "formula",
+                    "expr": "toNumber(datum[\"Horsepower\"])",
+                    "as": "Horsepower"
+                },
+                {
+                    "type": "formula",
+                    "expr": "toNumber(datum[\"Miles_per_Gallon\"])",
+                    "as": "Miles_per_Gallon"
+                },
+                {
+                    "type": "filter",
+                    "expr": "vlPoint(\"CylYr_store\", \"layer_1_\", datum, \"union\", \"all\")"
                 },
                 {
                     "type": "filter",
@@ -40,10 +76,26 @@
     "signals": [
         {
             "name": "width",
-            "update": "200"
+            "update": "max(layer_0_width, layer_1_width)"
         },
         {
             "name": "height",
+            "update": "max(layer_0_height, layer_1_height)"
+        },
+        {
+            "name": "layer_0_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_0_height",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_width",
+            "update": "200"
+        },
+        {
+            "name": "layer_1_height",
             "update": "200"
         },
         {
@@ -120,11 +172,11 @@
     ],
     "marks": [
         {
-            "name": "marks",
+            "name": "layer_0_marks",
             "type": "symbol",
             "role": "circle",
             "from": {
-                "data": "source_0"
+                "data": "data_0"
             },
             "encode": {
                 "update": {
@@ -138,7 +190,7 @@
                     },
                     "fill": [
                         {
-                            "test": "!vlPoint(\"CylYr_store\", \"\", datum, \"union\", \"all\")",
+                            "test": "!vlPoint(\"CylYr_store\", \"layer_0_\", datum, \"union\", \"all\")",
                             "value": "grey"
                         },
                         {
@@ -153,7 +205,42 @@
                         "value": 0.7
                     }
                 }
-            }
+            },
+            "clip": true
+        },
+        {
+            "name": "layer_1_marks",
+            "type": "symbol",
+            "role": "circle",
+            "from": {
+                "data": "data_1"
+            },
+            "encode": {
+                "update": {
+                    "x": {
+                        "scale": "x",
+                        "field": "Horsepower"
+                    },
+                    "y": {
+                        "scale": "y",
+                        "field": "Miles_per_Gallon"
+                    },
+                    "fill": {
+                        "scale": "color",
+                        "field": "Origin"
+                    },
+                    "size": {
+                        "value": 100
+                    },
+                    "shape": {
+                        "value": "circle"
+                    },
+                    "opacity": {
+                        "value": 0.7
+                    }
+                }
+            },
+            "clip": true
         }
     ],
     "scales": [
@@ -161,8 +248,17 @@
             "name": "x",
             "type": "linear",
             "domain": {
-                "data": "source_0",
-                "field": "Horsepower"
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "Horsepower"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "Horsepower"
+                    }
+                ],
+                "sort": true
             },
             "range": [
                 0,
@@ -176,8 +272,17 @@
             "name": "y",
             "type": "linear",
             "domain": {
-                "data": "source_0",
-                "field": "Miles_per_Gallon"
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "Miles_per_Gallon"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "Miles_per_Gallon"
+                    }
+                ],
+                "sort": true
             },
             "range": [
                 200,
@@ -191,8 +296,16 @@
             "name": "color",
             "type": "ordinal",
             "domain": {
-                "data": "source_0",
-                "field": "Origin",
+                "fields": [
+                    {
+                        "data": "data_0",
+                        "field": "Origin"
+                    },
+                    {
+                        "data": "data_1",
+                        "field": "Origin"
+                    }
+                ],
                 "sort": true
             },
             "range": "category"


### PR DESCRIPTION
![query_widgets](https://user-images.githubusercontent.com/42262/26858412-e4b1350c-4ae5-11e7-83ab-b565b10e3240.gif)

The odd color scale/legend behaviour is being tracked in vega/vega-scale#4.