### PR TITLE
Use `model.getScaleComponent()` instead of `model.scale()`

### DIFF
--- a/examples/vg-specs/box-plot_minmax_2D_horizontal.vg.json
+++ b/examples/vg-specs/box-plot_minmax_2D_horizontal.vg.json
@@ -266,8 +266,7 @@
                     },
                     "yc": {
                         "scale": "y",
-                        "field": "age",
-                        "band": 0.5
+                        "field": "age"
                     },
                     "height": {
                         "value": 5

--- a/examples/vg-specs/box-plot_minmax_2D_vertical.vg.json
+++ b/examples/vg-specs/box-plot_minmax_2D_vertical.vg.json
@@ -258,8 +258,7 @@
                 "update": {
                     "xc": {
                         "scale": "x",
-                        "field": "age",
-                        "band": 0.5
+                        "field": "age"
                     },
                     "width": {
                         "value": 5

--- a/examples/vg-specs/layer_bar_dual_axis.vg.json
+++ b/examples/vg-specs/layer_bar_dual_axis.vg.json
@@ -174,7 +174,8 @@
                 "update": {
                     "x": {
                         "scale": "x",
-                        "field": "month_date"
+                        "field": "month_date",
+                        "band": 0.5
                     },
                     "y": {
                         "scale": "layer_1_y",

--- a/examples/vg-specs/layer_bar_dual_axis_minmax.vg.json
+++ b/examples/vg-specs/layer_bar_dual_axis_minmax.vg.json
@@ -238,7 +238,8 @@
                 "update": {
                     "x": {
                         "scale": "x",
-                        "field": "month_date"
+                        "field": "month_date",
+                        "band": 0.5
                     },
                     "y": {
                         "scale": "layer_1_y",
@@ -261,7 +262,8 @@
                 "update": {
                     "x": {
                         "scale": "x",
-                        "field": "month_date"
+                        "field": "month_date",
+                        "band": 0.5
                     },
                     "y": {
                         "scale": "layer_1_y",

--- a/examples/vg-specs/layer_bar_line.vg.json
+++ b/examples/vg-specs/layer_bar_line.vg.json
@@ -161,7 +161,8 @@
                 "update": {
                     "x": {
                         "scale": "x",
-                        "field": "a"
+                        "field": "a",
+                        "band": 0.5
                     },
                     "y": {
                         "scale": "y",

--- a/examples/vg-specs/layer_bar_line_union.vg.json
+++ b/examples/vg-specs/layer_bar_line_union.vg.json
@@ -170,7 +170,8 @@
                 "update": {
                     "x": {
                         "scale": "x",
-                        "field": "b"
+                        "field": "b",
+                        "band": 0.5
                     },
                     "y": {
                         "scale": "y",

--- a/examples/vg-specs/layer_box_plot_circle.vg.json
+++ b/examples/vg-specs/layer_box_plot_circle.vg.json
@@ -297,8 +297,7 @@
                     },
                     "yc": {
                         "scale": "y",
-                        "field": "age",
-                        "band": 0.5
+                        "field": "age"
                     },
                     "height": {
                         "value": 14

--- a/examples/vg-specs/layered_box_plot.vg.json
+++ b/examples/vg-specs/layered_box_plot.vg.json
@@ -241,8 +241,7 @@
                     },
                     "yc": {
                         "scale": "y",
-                        "field": "age",
-                        "band": 0.5
+                        "field": "age"
                     },
                     "height": {
                         "value": 5

--- a/src/compile/axis/encode.ts
+++ b/src/compile/axis/encode.ts
@@ -14,7 +14,7 @@ export function labels(model: UnitModel, channel: Channel, labelsSpec: any, def:
 
   // Text
   if (fieldDef.type === TEMPORAL) {
-    const isUTCScale = model.scale(channel).type === ScaleType.UTC;
+    const isUTCScale = model.getScaleComponent(channel).type === ScaleType.UTC;
     labelsSpec = extend({
       text: {
         signal: timeFormatExpression('datum.value', fieldDef.timeUnit, axis.format, config.axis.shortTimeLabels, config.timeFormat, isUTCScale)

--- a/src/compile/axis/rules.ts
+++ b/src/compile/axis/rules.ts
@@ -45,7 +45,7 @@ export function grid(model: UnitModel, channel: Channel, isGridAxis: boolean) {
 export function gridScale(model: UnitModel, channel: Channel, isGridAxis: boolean) {
   if (isGridAxis) {
     const gridChannel: Channel = channel === 'x' ? 'y' : 'x';
-    if (model.scale(gridChannel)) {
+    if (model.getScaleComponent(gridChannel)) {
       return model.scaleName(gridChannel);
     }
   }

--- a/src/compile/data/aggregate.ts
+++ b/src/compile/data/aggregate.ts
@@ -84,8 +84,7 @@ export class AggregateNode extends DataFlowNode {
           meas[fieldDef.field][fieldDef.aggregate] = field(fieldDef);
 
           // add min/max so we can use their union as unaggregated domain
-          const scale = model.scale(channel);
-          if (scale && scale.domain === 'unaggregated') {
+          if (model.scaleDomain(channel) === 'unaggregated') {
             meas[fieldDef.field]['min'] = field(fieldDef, {aggregate: 'min'});
             meas[fieldDef.field]['max'] = field(fieldDef, {aggregate: 'max'});
           }

--- a/src/compile/data/nonpositivefilter.ts
+++ b/src/compile/data/nonpositivefilter.ts
@@ -19,7 +19,7 @@ export class NonPositiveFilterNode extends DataFlowNode {
 
   public static make(model: UnitModel) {
     const filter = model.channels().reduce(function(nonPositiveComponent, channel) {
-      const scale = model.scale(channel);
+      const scale = model.getScaleComponent(channel);
       if (!scale || !model.field(channel)) {
         // don't set anything
         return nonPositiveComponent;

--- a/src/compile/data/stack.ts
+++ b/src/compile/data/stack.ts
@@ -13,7 +13,7 @@ function getStackByFields(model: UnitModel): string[] {
     const channel = by.channel;
     const fieldDef = by.fieldDef;
 
-    const scale = model.scale(channel);
+    const scale = model.getScaleComponent(channel);
     const _field = field(fieldDef, {
       binSuffix: scale && hasDiscreteDomain(scale.type) ? 'range' : 'start'
     });

--- a/src/compile/layout/index.ts
+++ b/src/compile/layout/index.ts
@@ -33,6 +33,8 @@ export function assembleLayoutUnitSignals(model: UnitModel): VgSignal[] {
 
 export function unitSizeExpr(model: UnitModel, sizeType: 'width' | 'height'): string {
   const channel = sizeType==='width' ? 'x' : 'y';
+
+  // TODO: remove this once rangeStep is a part of scale component
   const scale = model.scale(channel);
   if (scale) {
     if (hasDiscreteDomain(scale.type) && scale.rangeStep) {

--- a/src/compile/legend/encode.ts
+++ b/src/compile/legend/encode.ts
@@ -77,7 +77,7 @@ export function labels(fieldDef: FieldDef<string>, labelsSpec: any, model: UnitM
   let labels:any = {};
 
   if (fieldDef.type === TEMPORAL) {
-    const isUTCScale = model.scale(channel).type === ScaleType.UTC;
+    const isUTCScale = model.getScaleComponent(channel).type === ScaleType.UTC;
     labelsSpec = extend({
       text: {
         signal: timeFormatExpression('datum.value', fieldDef.timeUnit, legend.format, config.legend.shortTimeLabels, config.timeFormat, isUTCScale)

--- a/src/compile/legend/parse.ts
+++ b/src/compile/legend/parse.ts
@@ -75,7 +75,7 @@ function getSpecifiedOrDefaultValue(property: keyof VgLegend, specifiedLegend: L
     case 'values':
       return rules.values(specifiedLegend);
     case 'type':
-      return rules.type(specifiedLegend, fieldDef.type, channel, model.scale(channel).type);
+      return rules.type(specifiedLegend, fieldDef.type, channel, model.getScaleComponent(channel).type);
   }
 
   // Otherwise, return specified property.

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -35,7 +35,7 @@ function x(model: UnitModel, stack: StackProperties): VgEncodeEntry {
 
   const xDef = model.encoding.x;
   const xScaleName = model.scaleName(X);
-  const xScale = model.scale(X);
+  const xScale = model.getScaleComponent(X);
   // x, x2, and width -- we must specify two of these in all conditions
   if (orient === 'horizontal') {
     return {
@@ -54,6 +54,7 @@ function x(model: UnitModel, stack: StackProperties): VgEncodeEntry {
 
     return mixins.centeredBandPosition('x', model,
       {...ref.midX(width, config)},
+      // TODO: replace model.scale(X) with model.getScaleComponent once rangeStep is a part of scale component
       defaultSizeRef(xScaleName, model.scale(X), config)
     );
   }
@@ -66,7 +67,7 @@ function y(model: UnitModel, stack: StackProperties) {
 
   const yDef = encoding.y;
   const yScaleName = model.scaleName(Y);
-  const yScale = model.scale(Y);
+  const yScale = model.getScaleComponent(Y);
   // y, y2 & height -- we must specify two of these in all conditions
   if (orient === 'vertical') {
     return {
@@ -81,6 +82,7 @@ function y(model: UnitModel, stack: StackProperties) {
         return mixins.bandPosition('y', model);
       }
     }
+    // TODO: replace model.scale(X) with model.getScaleComponent once rangeStep is a part of scale component
     return mixins.centeredBandPosition('y', model, ref.midY(height, config), defaultSizeRef(yScaleName, model.scale(Y), config));
   }
 }

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -125,8 +125,8 @@ function detailFields(model: UnitModel): string[] {
 }
 
 function clip(model: UnitModel) {
-  const xscale = model.scale(X);
-  const yscale = model.scale(Y);
-  return (xscale && isSelectionDomain(xscale.domain)) ||
-    (yscale && isSelectionDomain(yscale.domain)) ? {clip: true} : {};
+  const xScaleDomain = model.scaleDomain(X);
+  const yScaleDomain = model.scaleDomain(Y);
+  return (xScaleDomain && isSelectionDomain(xScaleDomain)) ||
+    (yScaleDomain && isSelectionDomain(yScaleDomain)) ? {clip: true} : {};
 }

--- a/src/compile/mark/mixins.ts
+++ b/src/compile/mark/mixins.ts
@@ -54,7 +54,7 @@ export function nonPosition(channel: typeof NONSPATIAL_SCALE_CHANNELS[0], model:
   const defaultRef = opt.defaultRef || (defaultValue !== undefined ? {value: defaultValue} : undefined);
 
   const channelDef = model.encoding[channel];
-  const valueRef = ref.midPoint(channel, channelDef, model.scaleName(channel), model.scale(channel), defaultRef);
+  const valueRef = ref.midPoint(channel, channelDef, model.scaleName(channel), model.getScaleComponent(channel), defaultRef);
 
   return wrapCondition(model, channelDef && channelDef.condition, vgChannel || channel, valueRef);
 }
@@ -161,7 +161,7 @@ export function pointPosition(channel: 'x'|'y', model: UnitModel, defaultRef: Vg
   // TODO: refactor how refer to scale as discussed in https://github.com/vega/vega-lite/pull/1613
 
   const {encoding, stack} = model;
-  const valueRef = ref.stackable(channel, encoding[channel], model.scaleName(channel), model.scale(channel), stack, defaultRef);
+  const valueRef = ref.stackable(channel, encoding[channel], model.scaleName(channel), model.getScaleComponent(channel), stack, defaultRef);
 
   return {
     [vgChannel || channel]: valueRef
@@ -177,6 +177,6 @@ export function pointPosition2(model: UnitModel, defaultRef: 'zeroOrMin' | 'zero
   channel = channel || (markDef.orient === 'horizontal' ? 'x2' : 'y2');
   const baseChannel = channel === 'x2' ? 'x' : 'y';
 
-  const valueRef = ref.stackable2(channel, encoding[baseChannel], encoding[channel], model.scaleName(baseChannel), model.scale(baseChannel), stack, defaultRef);
+  const valueRef = ref.stackable2(channel, encoding[baseChannel], encoding[channel], model.scaleName(baseChannel), model.getScaleComponent(baseChannel), stack, defaultRef);
   return {[channel]: valueRef};
 }

--- a/src/compile/mark/rect.ts
+++ b/src/compile/mark/rect.ts
@@ -26,7 +26,7 @@ export const rect: MarkCompiler = {
 function x(model: UnitModel) {
   const xDef = model.encoding.x;
   const x2Def = model.encoding.x2;
-  const xScale = model.scale(X);
+  const xScale = model.getScaleComponent(X);
 
   if (isFieldDef(xDef) && xDef.bin && !x2Def) {
     return mixins.binnedPosition('x', model, 0);
@@ -49,7 +49,7 @@ function x(model: UnitModel) {
 function y(model: UnitModel) {
   const yDef = model.encoding.y;
   const y2Def = model.encoding.y2;
-  const yScale = model.scale(Y);
+  const yScale = model.getScaleComponent(Y);
 
   if (isFieldDef(yDef) && yDef.bin && !y2Def) {
     return mixins.binnedPosition('y', model, 0);

--- a/src/compile/mark/tick.ts
+++ b/src/compile/mark/tick.ts
@@ -38,6 +38,7 @@ function defaultSize(model: UnitModel): number {
   const {config} = model;
   const orient = model.markDef.orient;
 
+  // TODO: replace model.scale() with model.getScaleComponent() once rangeStep is a part of scale component
   const scaleRangeStep: number | null = (model.scale(orient === 'horizontal' ? 'x' : 'y') || {}).rangeStep;
 
   if (config.tick.bandSize !== undefined) {

--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -5,10 +5,10 @@
 import {Channel, X, X2, Y, Y2} from '../../channel';
 import {Config} from '../../config';
 import {ChannelDef, field, FieldDef, FieldRefOption, isFieldDef, TextFieldDef, ValueDef} from '../../fielddef';
-import {hasDiscreteDomain, isBinScale, Scale, ScaleType} from '../../scale';
+import {hasDiscreteDomain, isBinScale, ScaleType} from '../../scale';
 import {StackProperties} from '../../stack';
 import {contains} from '../../util';
-import {VgValueRef} from '../../vega.schema';
+import {VgScale, VgValueRef} from '../../vega.schema';
 import {formatSignalRef, numberFormat} from '../common';
 
 // TODO: we need to find a way to refactor these so that scaleName is a part of scale
@@ -17,7 +17,7 @@ import {formatSignalRef, numberFormat} from '../common';
 /**
  * @return Vega ValueRef for stackable x or y
  */
-export function stackable(channel: 'x' | 'y', channelDef: ChannelDef<string>, scaleName: string, scale: Scale,
+export function stackable(channel: 'x' | 'y', channelDef: ChannelDef<string>, scaleName: string, scale: VgScale,
     stack: StackProperties, defaultRef: VgValueRef): VgValueRef {
   if (channelDef && stack && channel === stack.fieldChannel) {
     // x or y use stack_end so that stacked line's point mark use stack_end too.
@@ -29,7 +29,7 @@ export function stackable(channel: 'x' | 'y', channelDef: ChannelDef<string>, sc
 /**
  * @return Vega ValueRef for stackable x2 or y2
  */
-export function stackable2(channel: 'x2' | 'y2', aFieldDef: FieldDef<string>, a2fieldDef: FieldDef<string>, scaleName: string, scale: Scale,
+export function stackable2(channel: 'x2' | 'y2', aFieldDef: FieldDef<string>, a2fieldDef: FieldDef<string>, scaleName: string, scale: VgScale,
     stack: StackProperties, defaultRef: VgValueRef): VgValueRef {
   if (aFieldDef && stack &&
       // If fieldChannel is X and channel is X2 (or Y and Y2)
@@ -87,7 +87,7 @@ function binMidSignal(fieldDef: FieldDef<string>, scaleName: string) {
 /**
  * @returns {VgValueRef} Value Ref for xc / yc or mid point for other channels.
  */
-export function midPoint(channel: Channel, channelDef: ChannelDef<string>, scaleName: string, scale: Scale,
+export function midPoint(channel: Channel, channelDef: ChannelDef<string>, scaleName: string, scale: VgScale,
   defaultRef: VgValueRef | 'zeroOrMin' | 'zeroOrMax'): VgValueRef {
   // TODO: datum support
 
@@ -177,7 +177,7 @@ export function midY(height: number, config: Config): VgValueRef {
   return {value: config.scale.rangeStep / 2};
 }
 
-function zeroOrMinX(scaleName: string, scale: Scale): VgValueRef {
+function zeroOrMinX(scaleName: string, scale: VgScale): VgValueRef {
   if (scaleName) {
     // Log / Time / UTC scale do not support zero
     if (!contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.type) &&
@@ -196,7 +196,7 @@ function zeroOrMinX(scaleName: string, scale: Scale): VgValueRef {
 /**
  * @returns {VgValueRef} base value if scale exists and return max value if scale does not exist
  */
-function zeroOrMaxX(scaleName: string, scale: Scale): VgValueRef {
+function zeroOrMaxX(scaleName: string, scale: VgScale): VgValueRef {
   if (scaleName) {
     // Log / Time / UTC scale do not support zero
     if (!contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.type) &&
@@ -211,7 +211,7 @@ function zeroOrMaxX(scaleName: string, scale: Scale): VgValueRef {
   return {field: {group: 'width'}};
 }
 
-function zeroOrMinY(scaleName: string, scale: Scale): VgValueRef {
+function zeroOrMinY(scaleName: string, scale: VgScale): VgValueRef {
   if (scaleName) {
     // Log / Time / UTC scale do not support zero
     if (!contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.type) &&
@@ -230,7 +230,7 @@ function zeroOrMinY(scaleName: string, scale: Scale): VgValueRef {
 /**
  * @returns {VgValueRef} base value if scale exists and return max value if scale does not exist
  */
-function zeroOrMaxY(scaleName: string, scale: Scale): VgValueRef {
+function zeroOrMaxY(scaleName: string, scale: VgScale): VgValueRef {
   if (scaleName) {
     // Log / Time / UTC scale do not support zero
     if (!contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.type) &&

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -122,7 +122,7 @@ export abstract class Model {
         outputNodes: parent ? parent.component.data.outputNodes : {},
         outputNodeRefCounts: parent ? parent.component.data.outputNodeRefCounts : {}
       },
-      mark: null, scales: null, axes: {x: null, y: null},
+      mark: null, scales: {}, axes: {x: null, y: null},
       layoutHeaders:{row: {}, column: {}}, legends: null, selection: null
     };
   }
@@ -366,7 +366,7 @@ export abstract class Model {
    * @param name Name of the component
    */
   public getScaleComponent(name: string): ScaleComponent {
-    return this.component.scales[name] || this.parent.getScaleComponent(name);
+    return this.component.scales[name] || (this.parent ? this.parent.getScaleComponent(name) : undefined);
   }
 
   public getSelectionComponent(name: string): SelectionComponent {

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -6,7 +6,7 @@ import * as vlEncoding from '../encoding'; // TODO: remove
 import {field, FieldDef, FieldRefOption, isFieldDef} from '../fielddef';
 import {Legend} from '../legend';
 import {FILL_STROKE_CONFIG, isMarkDef, Mark, MarkDef, TEXT as TEXT_MARK} from '../mark';
-import {defaultScaleConfig, hasDiscreteDomain, Scale} from '../scale';
+import {defaultScaleConfig, Domain, hasDiscreteDomain, Scale} from '../scale';
 import {SelectionDef} from '../selection';
 import {SortField, SortOrder} from '../sort';
 import {UnitSize, UnitSpec} from '../spec';
@@ -99,6 +99,15 @@ export class UnitModel extends ModelWithField {
 
   public scale(channel: Channel) {
     return this.scales[channel];
+  }
+
+  /**
+   * Return specified Vega-lite scale domain for a particular channel
+   * @param channel
+   */
+  public scaleDomain(channel: Channel): Domain {
+    const scale = this.scales[channel];
+    return scale ? scale.domain : undefined;
   }
 
   public hasDiscreteDomain(channel: Channel) {

--- a/test/compile/axis/encode.test.ts
+++ b/test/compile/axis/encode.test.ts
@@ -3,13 +3,13 @@
 import {assert} from 'chai';
 
 import * as encode from '../../../src/compile/axis/encode';
-import {parseModel, parseUnitModel} from '../../util';
+import {parseUnitModelWithScale} from '../../util';
 
 
 describe('compile/axis', () => {
   describe('encode.labels()', function () {
     it('should rotate label', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         mark: "point",
         encoding: {
           x: {field: "a", type: "temporal", timeUnit: "month"}
@@ -20,7 +20,7 @@ describe('compile/axis', () => {
     });
 
     it('should have correct text.signal for quarter timeUnits', function () {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         mark: "point",
         encoding: {
           x: {field: "a", type: "temporal", timeUnit: "quarter"}
@@ -32,7 +32,7 @@ describe('compile/axis', () => {
     });
 
     it('should have correct text.signal for yearquartermonth timeUnits', function () {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         mark: "point",
         encoding: {
           x: {field: "a", type: "temporal", timeUnit: "yearquartermonth"}

--- a/test/compile/data/nonpositivefilter.test.ts
+++ b/test/compile/data/nonpositivefilter.test.ts
@@ -4,11 +4,11 @@ import {assert} from 'chai';
 
 import {NonPositiveFilterNode} from '../../../src/compile/data/nonpositivefilter';
 import {VgTransform} from '../../../src/vega.schema';
-import {parseUnitModel} from '../../util';
+import {parseUnitModelWithScale} from '../../util';
 
 describe('compile/data/nonpositivefilter', function () {
   it('should produce the correct nonPositiveFilter' ,function () {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       mark: "point",
       encoding: {
         x: {field: 'a', type: "temporal"},

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -81,6 +81,7 @@ describe('FacetModel', function() {
         }
       });
 
+      model.parseScale();
       model.parseData();
       model.parseMark();
 

--- a/test/compile/legend/encode.test.ts
+++ b/test/compile/legend/encode.test.ts
@@ -5,7 +5,7 @@ import {COLOR, SHAPE} from '../../../src/channel';
 import * as encode from '../../../src/compile/legend/encode';
 import {TimeUnit} from '../../../src/timeunit';
 import {TEMPORAL} from '../../../src/type';
-import {parseUnitModel} from '../../util';
+import {parseUnitModel, parseUnitModelWithScale} from '../../util';
 
 describe('compile/legend', function() {
   describe('encode.symbols', function() {
@@ -44,14 +44,13 @@ describe('compile/legend', function() {
 
   describe('encode.labels', function() {
     it('should return correct expression for the timeUnit: TimeUnit.MONTH', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         mark: "point",
         encoding: {
           x: {field: "a", type: "temporal"},
           color: {field: "a", type: "temporal", timeUnit: "month"}
         }
       });
-      model.parseScale();
 
       const fieldDef = {field: 'a', type: TEMPORAL, timeUnit: TimeUnit.MONTH};
       const label = encode.labels(fieldDef, {}, model, COLOR);
@@ -60,13 +59,12 @@ describe('compile/legend', function() {
     });
 
     it('should return correct expression for the timeUnit: TimeUnit.QUARTER', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         mark: "point",
         encoding: {
           x: {field: "a", type: "temporal"},
           color: {field: "a", type: "temporal", timeUnit: "quarter"}}
       });
-      model.parseScale();
 
       const fieldDef = {field: 'a', type: TEMPORAL, timeUnit: TimeUnit.QUARTER};
       const label = encode.labels(fieldDef, {}, model, COLOR);

--- a/test/compile/legend/encode.test.ts
+++ b/test/compile/legend/encode.test.ts
@@ -48,8 +48,11 @@ describe('compile/legend', function() {
         mark: "point",
         encoding: {
           x: {field: "a", type: "temporal"},
-          color: {field: "a", type: "temporal", timeUnit: "month"}}
+          color: {field: "a", type: "temporal", timeUnit: "month"}
+        }
       });
+      model.parseScale();
+
       const fieldDef = {field: 'a', type: TEMPORAL, timeUnit: TimeUnit.MONTH};
       const label = encode.labels(fieldDef, {}, model, COLOR);
       const expected = `timeFormat(datum.value, '%b')`;
@@ -63,6 +66,8 @@ describe('compile/legend', function() {
           x: {field: "a", type: "temporal"},
           color: {field: "a", type: "temporal", timeUnit: "quarter"}}
       });
+      model.parseScale();
+
       const fieldDef = {field: 'a', type: TEMPORAL, timeUnit: TimeUnit.QUARTER};
       const label = encode.labels(fieldDef, {}, model, COLOR);
       const expected = `'Q' + quarter(datum.value)`;

--- a/test/compile/legend/parse.test.ts
+++ b/test/compile/legend/parse.test.ts
@@ -4,19 +4,18 @@ import {assert} from 'chai';
 import {COLOR, OPACITY, SHAPE, SIZE} from '../../../src/channel';
 import * as legendParse from '../../../src/compile/legend/parse';
 import {UnitSpec} from '../../../src/spec';
-import {parseUnitModel} from '../../util';
+import {parseUnitModel, parseUnitModelWithScale} from '../../util';
 
 describe('compile/legend', function() {
   describe('parseLegend()', function() {
     it('should produce a Vega legend object with correct type and scale for color', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         mark: "point",
         encoding: {
           x: {field: "a", type: "nominal"},
           color: {field: "a", type: "quantitative"}
         }
       });
-      model.parseScale();
 
       const def = legendParse.parseLegend(model, COLOR);
       assert.isObject(def);
@@ -35,8 +34,7 @@ describe('compile/legend', function() {
         };
         s.encoding[channel] = {field: "a", type: "nominal"};
 
-        const model = parseUnitModel(s);
-        model.parseScale();
+        const model = parseUnitModelWithScale(s);
 
         const def = legendParse.parseLegend(model, channel);
         assert.isObject(def);

--- a/test/compile/legend/parse.test.ts
+++ b/test/compile/legend/parse.test.ts
@@ -16,6 +16,8 @@ describe('compile/legend', function() {
           color: {field: "a", type: "quantitative"}
         }
       });
+      model.parseScale();
+
       const def = legendParse.parseLegend(model, COLOR);
       assert.isObject(def);
       assert.equal(def.title, 'a');
@@ -32,7 +34,9 @@ describe('compile/legend', function() {
           }
         };
         s.encoding[channel] = {field: "a", type: "nominal"};
+
         const model = parseUnitModel(s);
+        model.parseScale();
 
         const def = legendParse.parseLegend(model, channel);
         assert.isObject(def);

--- a/test/compile/mark/area.test.ts
+++ b/test/compile/mark/area.test.ts
@@ -5,7 +5,7 @@ import {COLOR, X, Y} from '../../../src/channel';
 import {area} from '../../../src/compile/mark/area';
 import {UnitSpec} from '../../../src/spec';
 import {extend} from '../../../src/util';
-import {parseUnitModel} from '../../util';
+import {parseUnitModelWithScale} from '../../util';
 
 describe('Mark: Area', function() {
   function verticalArea(moreEncoding = {}): UnitSpec {
@@ -23,7 +23,7 @@ describe('Mark: Area', function() {
   }
 
   describe('vertical area, with log', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "area",
       "encoding": {
         "x": {"bin": true, "type": "quantitative", "field": "IMDB_Rating"},
@@ -43,7 +43,7 @@ describe('Mark: Area', function() {
   });
 
   describe('vertical area, with zero=false', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "area",
       "encoding": {
         "x": {"bin": true, "type": "quantitative", "field": "IMDB_Rating"},
@@ -63,7 +63,7 @@ describe('Mark: Area', function() {
   });
 
   describe('vertical area', function() {
-    const model = parseUnitModel(verticalArea());
+    const model = parseUnitModelWithScale(verticalArea());
     const props = area.encodeEntry(model);
 
     it('should have scale for x', function() {
@@ -80,7 +80,7 @@ describe('Mark: Area', function() {
   });
 
   describe('vertical stacked area with color', function () {
-    const model = parseUnitModel(verticalArea({
+    const model = parseUnitModelWithScale(verticalArea({
       "color": {"field": "Origin", "type": "quantitative"}
     }));
 
@@ -115,7 +115,7 @@ describe('Mark: Area', function() {
   }
 
   describe('horizontal area', function() {
-    const model = parseUnitModel(horizontalArea());
+    const model = parseUnitModelWithScale(horizontalArea());
     const props = area.encodeEntry(model);
 
     it('should have scale for y', function() {
@@ -132,7 +132,7 @@ describe('Mark: Area', function() {
   });
 
   describe('horizontal area, with log', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "area",
       "encoding": {
         "y": {"bin": true, "type": "quantitative", "field": "IMDB_Rating"},
@@ -153,7 +153,7 @@ describe('Mark: Area', function() {
   });
 
   describe('horizontal area, with zero=false', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "area",
       "encoding": {
         "y": {"bin": true, "type": "quantitative", "field": "IMDB_Rating"},
@@ -174,7 +174,7 @@ describe('Mark: Area', function() {
   });
 
   describe('horizontal stacked area with color', function () {
-    const model = parseUnitModel(horizontalArea({
+    const model = parseUnitModelWithScale(horizontalArea({
       "color": {"field": "Origin", "type": "nominal"}
     }));
 
@@ -196,7 +196,7 @@ describe('Mark: Area', function() {
 
   describe('ranged area', function () {
     it ('vertical area should work with aggregate', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "data": {"url": "data/cars.json"},
         "mark": "area",
         "encoding": {
@@ -212,7 +212,7 @@ describe('Mark: Area', function() {
     });
 
     it ('horizontal area should work with aggregate', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "data": {"url": "data/cars.json"},
         "mark": "area",
         "encoding": {

--- a/test/compile/mark/bar.test.ts
+++ b/test/compile/mark/bar.test.ts
@@ -5,11 +5,11 @@ import {bar} from '../../../src/compile/mark/bar';
 import * as log from '../../../src/log';
 import {defaultBarConfig} from '../../../src/mark';
 import {defaultScaleConfig} from '../../../src/scale';
-import {parseUnitModel} from '../../util';
+import {parseUnitModelWithScale} from '../../util';
 
 describe('Mark: Bar', function() {
   describe('simple vertical', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
       "encoding": {
@@ -29,7 +29,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('simple horizontal', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
       "encoding": {
@@ -49,7 +49,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('simple horizontal with point scale', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
       "encoding": {
@@ -69,7 +69,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('simple horizontal with size value', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
       "encoding": {
@@ -87,7 +87,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('simple horizontal with size field', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
       "encoding": {
@@ -114,7 +114,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('horizontal binned', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
       "encoding": {
@@ -132,7 +132,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('vertical binned', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
       "encoding": {
@@ -151,7 +151,7 @@ describe('Mark: Bar', function() {
 
 
   describe('horizontal binned with no spacing', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
       "encoding": {
@@ -170,7 +170,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('vertical binned with no spacing', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
       "encoding": {
@@ -189,7 +189,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('simple horizontal binned with size', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
       "encoding": {
@@ -207,7 +207,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('vertical binned with size', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
       "encoding": {
@@ -225,7 +225,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('vertical, with log', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
       "encoding": {
@@ -242,7 +242,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('horizontal, with log', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
       "encoding": {
@@ -260,7 +260,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('vertical, with fit mode', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "width": 120,
       "height": 120,
       "data": {"url": 'data/cars.json'},
@@ -285,7 +285,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('horizontal, with fit mode', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "width": 120,
       "height": 120,
       "data": {"url": 'data/cars.json'},
@@ -310,7 +310,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('vertical with zero=false', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
       "encoding": {
@@ -327,7 +327,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('horizontal with zero=false', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "bar",
       "encoding": {
@@ -344,7 +344,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('1D vertical', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
         "mark": "bar",
         "encoding": {"y": {"type": "quantitative", "field": 'US_Gross', "aggregate": "sum"}},
         "data": {"url": 'data/movies.json'}
@@ -362,7 +362,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('1D vertical with size value', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
         "mark": "bar",
         "encoding": {
           "y": {"type": "quantitative", "field": 'US_Gross', "aggregate": "sum"},
@@ -378,7 +378,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('1D vertical with barSize config', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
         "data": {"url": 'data/movies.json'},
         "mark": "bar",
         "encoding": {
@@ -396,7 +396,7 @@ describe('Mark: Bar', function() {
   });
 
   describe('1D horizontal', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "bar",
       "encoding": {"x": {"type": "quantitative", "field": 'US_Gross', "aggregate": 'sum'}},
       "data": {"url": 'data/movies.json'}
@@ -415,7 +415,7 @@ describe('Mark: Bar', function() {
     // This is generally a terrible idea, but we should still test
     // if the output show expected results
 
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
         "data": {"url": 'data/cars.json'},
         "mark": "bar",
         "encoding": {
@@ -440,7 +440,7 @@ describe('Mark: Bar', function() {
     // This is generally a terrible idea, but we should still test
     // if the output show expected results
 
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
         "data": {"url": 'data/cars.json'},
         "mark": "bar",
         "encoding": {
@@ -465,7 +465,7 @@ describe('Mark: Bar', function() {
     // This is generally a terrible idea, but we should still test
     // if the output show expected results
     it('should produce vertical bar using x, width', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "data": {"url": 'data/cars.json'},
         "mark": "bar",
         "encoding": {
@@ -488,7 +488,7 @@ describe('Mark: Bar', function() {
     // TODO: gantt chart with ordinal
 
     it('vertical bars should work with aggregate', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "data": {"url": "data/population.json"},
         "mark": "bar",
         "encoding": {
@@ -505,7 +505,7 @@ describe('Mark: Bar', function() {
     });
 
     it('horizontal bars should work with aggregate', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "data": {"url": "data/population.json"},
         "mark": "bar",
         "encoding": {

--- a/test/compile/mark/init.test.ts
+++ b/test/compile/mark/init.test.ts
@@ -4,13 +4,13 @@ import * as log from '../../../src/log';
 
 import {assert} from 'chai';
 import {BAR} from '../../../src/mark';
-import {parseUnitModel} from '../../util';
+import {parseUnitModelWithScale} from '../../util';
 
 describe('compile/mark/init', function() {
   describe('orient', function() {
     it('should return correct default for QxQ', function() {
       log.runLocalLogger((localLogger) => {
-        const model = parseUnitModel({
+        const model = parseUnitModelWithScale({
           "mark": "bar",
           "encoding": {
             "y": {"type": "quantitative", "field": "foo"},
@@ -24,7 +24,7 @@ describe('compile/mark/init', function() {
 
     it('should return correct default for empty plot', () => {
       log.runLocalLogger((localLogger) => {
-        const model = parseUnitModel({
+        const model = parseUnitModelWithScale({
           "mark": "bar",
           encoding: {}
         });
@@ -35,7 +35,7 @@ describe('compile/mark/init', function() {
 
     it('should return correct orient for bar with both axes discrete', function() {
       log.runLocalLogger((localLogger) => {
-        const model = parseUnitModel({
+        const model = parseUnitModelWithScale({
           "mark": "bar",
           "encoding": {
             "x": {"type": "ordinal", "field": "foo"},
@@ -49,7 +49,7 @@ describe('compile/mark/init', function() {
 
 
     it('should return correct orient for vertical bar', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "bar",
         "encoding": {
           "y": {"type": "quantitative", "field": "foo"},
@@ -60,7 +60,7 @@ describe('compile/mark/init', function() {
     });
 
     it('should return correct orient for horizontal bar', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "bar",
         "encoding": {
           "x": {"type": "quantitative", "field": "foo"},
@@ -71,7 +71,7 @@ describe('compile/mark/init', function() {
     });
 
     it('should return correct orient for vertical bar with raw temporal dimension', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "bar",
         "encoding": {
           "y": {"type": "quantitative", "field": "foo"},
@@ -82,7 +82,7 @@ describe('compile/mark/init', function() {
     });
 
     it('should return correct orient for horizontal bar with raw temporal dimension', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "bar",
         "encoding": {
           "x": {"type": "quantitative", "field": "foo"},
@@ -93,7 +93,7 @@ describe('compile/mark/init', function() {
     });
 
     it('should return correct orient for vertical tick', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "tick",
         "encoding": {
           "x": {"type": "quantitative", "field": "foo"},
@@ -104,7 +104,7 @@ describe('compile/mark/init', function() {
     });
 
     it('should return correct orient for vertical tick with bin', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "tick",
         "encoding": {
           "x": {"type": "quantitative", "field": "foo"},
@@ -115,7 +115,7 @@ describe('compile/mark/init', function() {
     });
 
     it('should return correct orient for vertical tick of continuous timeUnit dotplot', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "tick",
         "encoding": {
           "x": {"type": "temporal", "field": "foo", "timeUnit": "yearmonthdate"},
@@ -126,7 +126,7 @@ describe('compile/mark/init', function() {
     });
 
     it('should return correct orient for horizontal tick', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "tick",
         "encoding": {
           "y": {"type": "quantitative", "field": "foo"},
@@ -137,7 +137,7 @@ describe('compile/mark/init', function() {
     });
 
     it('should return correct orient for vertical rule', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "rule",
         "encoding": {
           "x": {"value": 0},
@@ -147,7 +147,7 @@ describe('compile/mark/init', function() {
     });
 
     it('should return correct orient for horizontal rule', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "rule",
         "encoding": {
           "y": {"value": 0},
@@ -157,7 +157,7 @@ describe('compile/mark/init', function() {
     });
 
     it('should return correct orient for horizontal rules without x2 ', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "rule",
         "encoding": {
           "x": {"field": "b", "type": "quantitative"},
@@ -169,7 +169,7 @@ describe('compile/mark/init', function() {
     });
 
     it('should return correct orient for vertical rules without y2 ', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "rule",
         "encoding": {
           "y": {"field": "b", "type": "quantitative"},
@@ -181,7 +181,7 @@ describe('compile/mark/init', function() {
     });
 
     it('should return correct orient for vertical rule with range', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "rule",
         "encoding": {
           "x": {"type": "ordinal", "field": "foo"},
@@ -193,7 +193,7 @@ describe('compile/mark/init', function() {
     });
 
     it('should return correct orient for horizontal rule with range', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "rule",
         "encoding": {
           "y": {"type": "ordinal", "field": "foo"},
@@ -205,7 +205,7 @@ describe('compile/mark/init', function() {
     });
 
     it('should return correct orient for horizontal rule with range and no ordinal', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "rule",
         "encoding": {
           "x": {"type": "quantitative", "field": "bar"},
@@ -216,7 +216,7 @@ describe('compile/mark/init', function() {
     });
 
     it('should return correct orient for vertical rule with range and no ordinal', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "rule",
         "encoding": {
           "y": {"type": "quantitative", "field": "bar"},

--- a/test/compile/mark/line.test.ts
+++ b/test/compile/mark/line.test.ts
@@ -1,7 +1,7 @@
 /* tslint:disable quotemark */
 
 import {assert} from 'chai';
-import {parseUnitModel} from '../../util';
+import {parseUnitModelWithScale} from '../../util';
 
 import * as log from '../../../src/log';
 
@@ -12,7 +12,7 @@ import {LINE} from '../../../src/mark';
 describe('Mark: Line', function() {
 
   describe('with x, y', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": "data/barley.json"},
       "mark": "line",
       "encoding": {
@@ -32,7 +32,7 @@ describe('Mark: Line', function() {
   });
 
   describe('with x, y, color', function () {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": "data/barley.json"},
       "mark": "line",
       "encoding": {
@@ -52,7 +52,7 @@ describe('Mark: Line', function() {
   describe('with x, y, size', function () {
     it('should have scale for size', function () {
       log.runLocalLogger((localLogger) => {
-        const model = parseUnitModel({
+        const model = parseUnitModelWithScale({
           "data": {"url": "data/barley.json"},
           "mark": "line",
           "encoding": {
@@ -69,7 +69,7 @@ describe('Mark: Line', function() {
 
     it('should drop aggregate size field', function () {
       log.runLocalLogger((localLogger) => {
-        const model = parseUnitModel({
+        const model = parseUnitModelWithScale({
           "data": {"url": "data/barley.json"},
           "mark": "line",
           "encoding": {
@@ -88,7 +88,7 @@ describe('Mark: Line', function() {
   });
 
   describe('with stacked y', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": "data/barley.json"},
       "mark": "line",
       "encoding": {
@@ -106,7 +106,7 @@ describe('Mark: Line', function() {
   });
 
   describe('with stacked x', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": "data/barley.json"},
       "mark": "line",
       "encoding": {

--- a/test/compile/mark/mark.test.ts
+++ b/test/compile/mark/mark.test.ts
@@ -4,14 +4,14 @@ import {assert} from 'chai';
 
 import {parseMark} from '../../../src/compile/mark/mark';
 import {UnitModel} from '../../../src/compile/unit';
-import {parseFacetModel, parseUnitModel} from '../../util';
+import {parseFacetModel, parseUnitModelWithScale} from '../../util';
 
 describe('Mark', function() {
   describe('parseMark', function() {
     // PATH
     describe('Multi-series Line', () => {
       it('should have a facet directive and a nested mark group that uses the faceted data.', () => {
-        const model = parseUnitModel({
+        const model = parseUnitModelWithScale({
           "mark": {"type": "line", "role": "trend"},
           "encoding": {
             "x": {"field": "date", "type": "temporal", "axis": {"format": "%Y"}},
@@ -38,7 +38,7 @@ describe('Mark', function() {
 
     describe('Single Line', () => {
       it('should have a facet directive and a nested mark group', () => {
-        const model = parseUnitModel({
+        const model = parseUnitModelWithScale({
           "mark": "line",
           "encoding": {
             "x": {"field": "date", "type": "temporal", "axis": {"format": "%Y"}},
@@ -55,7 +55,7 @@ describe('Mark', function() {
     // NON-PATH
     describe('Aggregated Bar with a color with binned x', () => {
       it(' should use main stacked data source', () => {
-        const model = parseUnitModel({
+        const model = parseUnitModelWithScale({
           "mark": "bar",
           "encoding": {
             "x": {"type": "quantitative", "field": "Cost__Other", "aggregate": "sum"},
@@ -84,6 +84,8 @@ describe('Mark', function() {
             }
           }
         });
+        model.parseScale();
+
         const markGroup = parseMark(model.child as UnitModel);
         assert.equal(markGroup[0].from.data, 'child_main');
       });
@@ -91,7 +93,7 @@ describe('Mark', function() {
 
     describe('Aggregated bar', () => {
       it('should use main aggregated data source', () => {
-        const model = parseUnitModel({
+        const model = parseUnitModelWithScale({
           "mark": "bar",
           "encoding": {
             "x": {"type": "quantitative", "field": "Cost__Other", "aggregate": "sum"},
@@ -105,7 +107,7 @@ describe('Mark', function() {
 
     describe('Bar with tooltip', () => {
       it('should pass tooltip value to encoding', () => {
-        const model = parseUnitModel({
+        const model = parseUnitModelWithScale({
           "mark": "bar",
           "encoding": {
             "x": {"type": "quantitative", "field": "Cost__Other", "aggregate": "sum"},

--- a/test/compile/mark/mixins.test.ts
+++ b/test/compile/mark/mixins.test.ts
@@ -2,12 +2,12 @@
 
 import {assert} from 'chai';
 import {color} from '../../../src/compile/mark/mixins';
-import {parseUnitModel} from '../../util';
+import {parseUnitModelWithScale} from '../../util';
 
 describe('compile/mark/mixins', () => {
   describe('color()', function() {
     it('color should be mapped to fill for bar', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "bar",
         "encoding": {
           "x": {
@@ -28,7 +28,7 @@ describe('compile/mark/mixins', () => {
     });
 
     it('color should be mapped to stroke for point', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "point",
         "encoding": {
           "x": {

--- a/test/compile/mark/point.test.ts
+++ b/test/compile/mark/point.test.ts
@@ -6,7 +6,7 @@ import {circle, point, square} from '../../../src/compile/mark/point';
 import {defaultMarkConfig} from '../../../src/mark';
 import {UnitSpec} from '../../../src/spec';
 import {extend} from '../../../src/util';
-import {parseUnitModel} from '../../util';
+import {parseUnitModelWithScale} from '../../util';
 
 describe('Mark: Point', function() {
 
@@ -25,7 +25,7 @@ describe('Mark: Point', function() {
   }
 
   describe('with x', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "point",
       "encoding": {"x": {"field": "year", "type": "ordinal"}},
       "data": {"url": "data/barley.json"}
@@ -45,7 +45,7 @@ describe('Mark: Point', function() {
   describe('with stacked x', function() {
     // This is a simplified example for stacked point.
     // In reality this will be used as stacked's overlayed marker
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "point",
       "encoding": {
         "x": {"aggregate": "sum", "field": "a", "type": "quantitative"},
@@ -63,7 +63,7 @@ describe('Mark: Point', function() {
   });
 
   describe('with y', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "point",
       "encoding": {"y": {"field": "year", "type": "ordinal"}},
       "data": {"url": "data/barley.json"}
@@ -83,7 +83,7 @@ describe('Mark: Point', function() {
   describe('with stacked y', function() {
     // This is a simplified example for stacked point.
     // In reality this will be used as stacked's overlayed marker
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "point",
       "encoding": {
         "y": {"aggregate": "sum", "field": "a", "type": "quantitative"},
@@ -101,7 +101,7 @@ describe('Mark: Point', function() {
   });
 
   describe('with x and y', function() {
-    const model = parseUnitModel(pointXY());
+    const model = parseUnitModelWithScale(pointXY());
     const props = point.encodeEntry(model);
 
     it('should scale on x', function() {
@@ -120,7 +120,7 @@ describe('Mark: Point', function() {
 
   describe('with band x and quantitative y', () => {
     it('should offset band position by half band', () => {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "data": {"url": "data/barley.json"},
         "mark": "point",
         "encoding":{
@@ -134,7 +134,7 @@ describe('Mark: Point', function() {
   });
 
   describe('with x, y, size', function () {
-    const model = parseUnitModel(pointXY({
+    const model = parseUnitModelWithScale(pointXY({
       "size": {"aggregate": "count", "type": "quantitative"}
     }));
     const props = point.encodeEntry(model);
@@ -145,7 +145,7 @@ describe('Mark: Point', function() {
   });
 
   describe('with x, y, color', function () {
-    const model = parseUnitModel(pointXY({
+    const model = parseUnitModelWithScale(pointXY({
       "color": {"field": "yield", "type": "quantitative"}
     }));
     const props = point.encodeEntry(model);
@@ -156,7 +156,7 @@ describe('Mark: Point', function() {
   });
 
   describe('with x, y, shape', function () {
-    const model = parseUnitModel(pointXY({
+    const model = parseUnitModelWithScale(pointXY({
       "shape": {"field": "site", "type": "nominal"}
     }));
     const props = point.encodeEntry(model);
@@ -167,7 +167,7 @@ describe('Mark: Point', function() {
   });
 
   describe('with constant color, shape, and size', function() {
-    const model = parseUnitModel(pointXY({
+    const model = parseUnitModelWithScale(pointXY({
       "shape": {"value": "circle"},
       "color": {"value": "red"},
       "size": {"value": 23}
@@ -182,7 +182,7 @@ describe('Mark: Point', function() {
 
   describe('with configs', function() {
     it('should apply color from mark-specific config over general mark config', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "point",
         "encoding": {
           "x": {"field": "Horsepower","type": "quantitative"},
@@ -195,7 +195,7 @@ describe('Mark: Point', function() {
     });
 
     it('should apply color config and not apply stroke config', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "point",
         "encoding": {
           "x": {"field": "Horsepower","type": "quantitative"},
@@ -208,7 +208,7 @@ describe('Mark: Point', function() {
     });
 
     it('should not apply stroke config but instead output default color', function() {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         "mark": "point",
         "encoding": {
           "x": {"field": "Horsepower","type": "quantitative"},
@@ -224,7 +224,7 @@ describe('Mark: Point', function() {
 
 describe('Mark: Square', function() {
   it('should have correct shape', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "square",
       "encoding": {
         "color": {"value": "blue"}
@@ -236,7 +236,7 @@ describe('Mark: Square', function() {
   });
 
   it('should be filled by default', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "square",
       "encoding": {
         "color": {"value": "blue"}
@@ -248,7 +248,7 @@ describe('Mark: Square', function() {
   });
 
   it('with config.mark.filled:false should have transparent fill', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "square",
       "encoding": {
         "color": {"value": "blue"}
@@ -268,7 +268,7 @@ describe('Mark: Square', function() {
 });
 
 describe('Mark: Circle', function() {
-  const model = parseUnitModel({
+  const model = parseUnitModelWithScale({
     "mark": "circle",
     "encoding": {
       "color": {"value": "blue"}
@@ -285,7 +285,7 @@ describe('Mark: Circle', function() {
   });
 
   it('with config.mark.filled:false should have transparent fill', function() {
-    const filledCircleModel = parseUnitModel({
+    const filledCircleModel = parseUnitModelWithScale({
       "mark": "circle",
       "encoding": {
         "color": {"value": "blue"}

--- a/test/compile/mark/rect.test.ts
+++ b/test/compile/mark/rect.test.ts
@@ -2,11 +2,11 @@
 import {assert} from 'chai';
 import {rect} from '../../../src/compile/mark/rect';
 import * as log from '../../../src/log';
-import {parseUnitModel} from '../../util';
+import {parseUnitModelWithScale} from '../../util';
 
 describe('Mark: Rect', function() {
   describe('simple vertical', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "rect",
       "encoding": {
@@ -26,7 +26,7 @@ describe('Mark: Rect', function() {
   });
 
   describe('simple horizontal', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "rect",
       "encoding": {
@@ -46,7 +46,7 @@ describe('Mark: Rect', function() {
   });
 
   describe('simple horizontal with size field', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "rect",
       "encoding": {
@@ -73,7 +73,7 @@ describe('Mark: Rect', function() {
   });
 
   describe('horizontal binned', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "rect",
       "encoding": {
@@ -91,7 +91,7 @@ describe('Mark: Rect', function() {
   });
 
   describe('vertical binned', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "rect",
       "encoding": {
@@ -110,7 +110,7 @@ describe('Mark: Rect', function() {
 
 
   describe('simple ranged', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": 'data/cars.json'},
       "mark": "rect",
       "encoding": {
@@ -131,7 +131,7 @@ describe('Mark: Rect', function() {
   });
 
   describe('simple heatmap', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "data": {"url": "data/cars.json"},
       "mark": "rect",
       "encoding": {

--- a/test/compile/mark/rule.test.ts
+++ b/test/compile/mark/rule.test.ts
@@ -3,12 +3,12 @@
 import {assert} from 'chai';
 import {COLOR, X, Y} from '../../../src/channel';
 import {rule} from '../../../src/compile/mark/rule';
-import {parseUnitModel} from '../../util';
+import {parseUnitModelWithScale} from '../../util';
 
 describe('Mark: Rule', function() {
 
   describe('with x-only', () => {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "rule",
       "encoding": {"x": {"field": "a", "type": "quantitative"}}
     });
@@ -23,7 +23,7 @@ describe('Mark: Rule', function() {
   });
 
   describe('with y-only', () => {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "rule",
       "encoding": {"y": {"field": "a", "type": "quantitative"}}
     });
@@ -38,7 +38,7 @@ describe('Mark: Rule', function() {
   });
 
   describe('with x and x2 only', () => {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "rule",
       "encoding": {
         "x": {"field": "a", "type": "quantitative"},
@@ -56,7 +56,7 @@ describe('Mark: Rule', function() {
   });
 
   describe('with y and y2 only', () => {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "rule",
       "encoding": {
         "y": {"field": "a", "type": "quantitative"},
@@ -74,7 +74,7 @@ describe('Mark: Rule', function() {
   });
 
   describe('with x, x2, and y', () => {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "rule",
       "encoding": {
         "x": {"field": "a", "type": "quantitative"},
@@ -93,7 +93,7 @@ describe('Mark: Rule', function() {
   });
 
   describe('with y, y2, and x', () => {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "rule",
       "encoding": {
         "y": {"field": "a", "type": "quantitative"},
@@ -112,7 +112,7 @@ describe('Mark: Rule', function() {
   });
 
   describe('with nominal x, quantitative y with no y2', () => {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "rule",
       "encoding": {
         "x": {"field": "a", "type": "ordinal"},
@@ -132,7 +132,7 @@ describe('Mark: Rule', function() {
   });
 
   describe('with nominal y, quantitative x with no y2', () => {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "rule",
       "encoding": {
         "y": {"field": "a", "type": "ordinal"},
@@ -153,7 +153,7 @@ describe('Mark: Rule', function() {
 
 
   describe('horizontal stacked rule with color', function () {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "rule",
       "encoding": {
         "y": {"field": "a", "type": "ordinal"},
@@ -175,7 +175,7 @@ describe('Mark: Rule', function() {
   });
 
   describe('vertical stacked rule with color', function () {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "rule",
       "encoding": {
         "x": {"field": "a", "type": "ordinal"},

--- a/test/compile/mark/text.test.ts
+++ b/test/compile/mark/text.test.ts
@@ -4,13 +4,13 @@ import {assert} from 'chai';
 import {X, Y} from '../../../src/channel';
 import {text} from '../../../src/compile/mark/text';
 import {FacetedCompositeUnitSpec, UnitSpec} from '../../../src/spec';
-import {parseModel, parseUnitModel} from '../../util';
+import {parseModelWithScale, parseUnitModelWithScale} from '../../util';
 
 describe('Mark: Text', function() {
   describe('with stacked x', function() {
     // This is a simplified example for stacked text.
     // In reality this will be used as stacked's overlayed marker
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "text",
       "encoding": {
         "x": {"aggregate": "sum", "field": "a", "type": "quantitative"},
@@ -30,7 +30,7 @@ describe('Mark: Text', function() {
   describe('with stacked y', function() {
     // This is a simplified example for stacked text.
     // In reality this will be used as stacked's overlayed marker
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "text",
       "encoding": {
         "y": {"aggregate": "sum", "field": "a", "type": "quantitative"},
@@ -54,7 +54,7 @@ describe('Mark: Text', function() {
         "text": {"field": "foo", "type": "quantitative", "format": "d"}
       }
     };
-    const model = parseUnitModel(spec);
+    const model = parseUnitModelWithScale(spec);
     const props = text.encodeEntry(model);
 
     it('should use number template', function() {
@@ -69,7 +69,7 @@ describe('Mark: Text', function() {
         "text": {"bin": true, "field": "foo", "type": "quantitative", "format": "d"}
       }
     };
-    const model = parseUnitModel(spec);
+    const model = parseUnitModelWithScale(spec);
     const props = text.encodeEntry(model);
 
     it('should output correct bin range', function() {
@@ -84,7 +84,7 @@ describe('Mark: Text', function() {
         "text": {"field": "foo", "type": "temporal"}
       }
     };
-    const model = parseUnitModel(spec);
+    const model = parseUnitModelWithScale(spec);
     const props = text.encodeEntry(model);
 
     it('should use date template', function() {
@@ -102,7 +102,7 @@ describe('Mark: Text', function() {
       },
       "data": {"url": "data/cars.json"}
     };
-    const model = parseUnitModel(spec);
+    const model = parseUnitModelWithScale(spec);
     const props = text.encodeEntry(model);
 
     it('should scale on x', function() {
@@ -133,7 +133,7 @@ describe('Mark: Text', function() {
         },
         "data": {"url": "data/cars.json"}
       };
-    const model = parseModel(spec);
+    const model = parseModelWithScale(spec);
     const props = text.encodeEntry(model.children[0] as any);
 
     it('should fit cell on x', function() {
@@ -152,14 +152,14 @@ describe('Mark: Text', function() {
 
     it('should map color to fill', function() {
       assert.deepEqual(props.fill, {
-        scale: 'child_color',
+        scale: 'color',
         field: 'mean_Acceleration'
       });
     });
 
     it('should map size to fontSize', function() {
       assert.deepEqual(props.fontSize, {
-        scale: 'child_size',
+        scale: 'size',
         field: 'mean_Acceleration'
       });
     });

--- a/test/compile/mark/tick.test.ts
+++ b/test/compile/mark/tick.test.ts
@@ -10,13 +10,13 @@
 import {assert} from 'chai';
 import {SIZE, X, Y} from '../../../src/channel';
 import {tick} from '../../../src/compile/mark/tick';
-import {parseUnitModel} from '../../util';
+import {parseUnitModelWithScale} from '../../util';
 
 describe('Mark: Tick', function() {
   describe('with stacked x', function() {
     // This is a simplified example for stacked tick.
     // In reality this will be used as stacked's overlayed marker
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "tick",
       "encoding": {
         "x": {"aggregate": "sum", "field": "a", "type": "quantitative"},
@@ -37,7 +37,7 @@ describe('Mark: Tick', function() {
   describe('with stacked y', function() {
     // This is a simplified example for stacked tick.
     // In reality this will be used as stacked's overlayed marker
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       "mark": "tick",
       "encoding": {
         "y": {"aggregate": "sum", "field": "a", "type": "quantitative"},
@@ -55,7 +55,7 @@ describe('Mark: Tick', function() {
   });
 
   describe('with quantitative x', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       'mark': 'tick',
       'encoding': {'x': {'field': 'Horsepower', 'type': 'quantitative'}},
       'data': {'url': 'data/cars.json'}
@@ -76,7 +76,7 @@ describe('Mark: Tick', function() {
   });
 
   describe('with quantitative y', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       'mark': 'tick',
       'encoding': {'y': {'field': 'Cylinders','type': 'quantitative'}},
       'data': {'url': 'data/cars.json'}
@@ -97,7 +97,7 @@ describe('Mark: Tick', function() {
   });
 
   describe('with quantitative x and ordinal y', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       'mark': 'tick',
       'encoding':
         {
@@ -126,7 +126,7 @@ describe('Mark: Tick', function() {
   });
 
   describe('width should be mapped to size', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       'mark': 'tick',
       'config': {'mark': {'orient': 'vertical'}},
       'encoding':
@@ -144,7 +144,7 @@ describe('Mark: Tick', function() {
   });
 
   describe('height should be mapped to size', function() {
-    const model = parseUnitModel({
+    const model = parseUnitModelWithScale({
       'mark': 'tick',
       'encoding':
         {

--- a/test/compile/selection/predicate.test.ts
+++ b/test/compile/selection/predicate.test.ts
@@ -39,6 +39,8 @@ function getModel(selectionDef: any) {
 describe('Selection Predicate', function() {
   it('generates Vega production rules', function() {
     const single = getModel({type: 'single'});
+    single.parseScale();
+
     assert.deepEqual(nonPosition('color', single), {
       color: [
         {test: "!vlPoint(\"one_store\", \"\", datum, \"union\", \"all\")", value: "grey"},
@@ -54,6 +56,8 @@ describe('Selection Predicate', function() {
     });
 
     const multi = getModel({type: 'multi'});
+    multi.parseScale();
+
     assert.deepEqual(nonPosition('color', multi), {
       color: [
         {test: "!vlPoint(\"one_store\", \"\", datum, \"union\", \"all\")", value: "grey"},
@@ -69,6 +73,8 @@ describe('Selection Predicate', function() {
     });
 
     const interval = getModel({type: 'interval'});
+    interval.parseScale();
+
     assert.deepEqual(nonPosition('color', interval), {
       color: [
         {test: "!vlInterval(\"one_store\", \"\", datum, \"union\", \"all\")", value: "grey"},

--- a/test/util.ts
+++ b/test/util.ts
@@ -15,8 +15,20 @@ export function parseModel(inputSpec: TopLevelExtendedSpec): Model {
   return buildModel(spec, null, '', undefined, undefined, config);
 }
 
+export function parseModelWithScale(inputSpec: TopLevelExtendedSpec): Model {
+  const model = parseModel(inputSpec);
+  model.parseScale();
+  return model;
+}
+
 export function parseUnitModel(spec: TopLevel<UnitSpec>) {
   return new UnitModel(spec, null, '', undefined, undefined, initConfig(spec.config));
+}
+
+export function parseUnitModelWithScale(spec: TopLevel<UnitSpec>) {
+  const model = parseUnitModel(spec);
+  model.parseScale();
+  return model;
 }
 
 export function parseLayerModel(spec: TopLevel<LayerSpec>) {


### PR DESCRIPTION
This way we read the right scale properties (including type, etc.) post merging. 

A small step toward #2251