### PR TITLE
Support structured logical composition of selections

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1036,7 +1036,7 @@
       "additionalProperties": false,
       "properties": {
         "selection": {
-          "type": "string"
+          "$ref": "#/definitions/LogicalOperand"
         },
         "value": {
           "type": [
@@ -1055,7 +1055,7 @@
       "additionalProperties": false,
       "properties": {
         "selection": {
-          "type": "string"
+          "$ref": "#/definitions/LogicalOperand"
         },
         "value": {
           "type": [
@@ -1075,7 +1075,7 @@
       "additionalProperties": false,
       "properties": {
         "selection": {
-          "type": "string"
+          "$ref": "#/definitions/LogicalOperand"
         },
         "value": {
           "type": "number"
@@ -1091,7 +1091,7 @@
       "additionalProperties": false,
       "properties": {
         "selection": {
-          "type": "string"
+          "$ref": "#/definitions/LogicalOperand"
         },
         "value": {
           "type": "string"
@@ -2816,6 +2816,64 @@
       },
       "type": "object"
     },
+    "LogicalAnd": {
+      "additionalProperties": false,
+      "properties": {
+        "and": {
+          "items": {
+            "$ref": "#/definitions/LogicalOperand"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "and"
+      ],
+      "type": "object"
+    },
+    "LogicalNot": {
+      "additionalProperties": false,
+      "properties": {
+        "not": {
+          "$ref": "#/definitions/LogicalOperand"
+        }
+      },
+      "required": [
+        "not"
+      ],
+      "type": "object"
+    },
+    "LogicalOperand": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LogicalNot"
+        },
+        {
+          "$ref": "#/definitions/LogicalAnd"
+        },
+        {
+          "$ref": "#/definitions/LogicalOr"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "LogicalOr": {
+      "additionalProperties": false,
+      "properties": {
+        "or": {
+          "items": {
+            "$ref": "#/definitions/LogicalOperand"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "or"
+      ],
+      "type": "object"
+    },
     "LookupData": {
       "additionalProperties": false,
       "properties": {
@@ -3901,8 +3959,8 @@
       "additionalProperties": false,
       "properties": {
         "selection": {
-          "description": "Filter using a selection name.",
-          "type": "string"
+          "$ref": "#/definitions/LogicalOperand",
+          "description": "Filter using a selection name."
         }
       },
       "required": [

--- a/examples/specs/brush.vl.json
+++ b/examples/specs/brush.vl.json
@@ -12,7 +12,7 @@
     "x": {"field": "Horsepower", "type": "quantitative"},
     "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
     "color": {
-      "condition": {"selection": "!brush", "value": "grey"},
+      "condition": {"selection": {"not": "brush"}, "value": "grey"},
       "field": "Cylinders", "type": "ordinal"
     }
   }

--- a/examples/specs/interactive_splom.vl.json
+++ b/examples/specs/interactive_splom.vl.json
@@ -33,7 +33,7 @@
       "color": {
         "field": "Origin","type": "nominal",
         "condition": {
-          "selection": "!brush", "value": "grey"
+          "selection": {"not": "brush"}, "value": "grey"
         }
       }
     }

--- a/examples/specs/layered_selections.vl.json
+++ b/examples/specs/layered_selections.vl.json
@@ -36,7 +36,7 @@
       "x": {"field": "Horsepower", "type": "quantitative"},
       "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
       "color": {
-        "condition": {"selection": "!brush", "value": "grey"},
+        "condition": {"selection": {"not": "brush"}, "value": "grey"},
         "field": "Cylinders", "type": "ordinal"
       },
       "size": {

--- a/examples/specs/query_widgets.vl.json
+++ b/examples/specs/query_widgets.vl.json
@@ -19,7 +19,7 @@
       "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
       "color": {
         "field": "Origin", "type": "nominal",
-        "condition": {"selection": "!CylYr", "value": "grey"}
+        "condition": {"selection": {"not": "CylYr"}, "value": "grey"}
       }
     }
   }, {

--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -344,7 +344,7 @@
                     },
                     "stroke": [
                         {
-                            "test": "!vlInterval(\"brush_store\", \"\", datum, \"union\", \"all\")",
+                            "test": "!(vlInterval(\"brush_store\", \"\", datum, \"union\", \"all\"))",
                             "value": "grey"
                         },
                         {

--- a/examples/vg-specs/interactive_splom.vg.json
+++ b/examples/vg-specs/interactive_splom.vg.json
@@ -505,7 +505,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "!vlInterval(\"brush_store\", \"child_Horsepower_Horsepower_\", datum, \"union\", \"all\")",
+                                    "test": "!(vlInterval(\"brush_store\", \"child_Horsepower_Horsepower_\", datum, \"union\", \"all\"))",
                                     "value": "grey"
                                 },
                                 {
@@ -1063,7 +1063,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "!vlInterval(\"brush_store\", \"child_Horsepower_Miles_per_Gallon_\", datum, \"union\", \"all\")",
+                                    "test": "!(vlInterval(\"brush_store\", \"child_Horsepower_Miles_per_Gallon_\", datum, \"union\", \"all\"))",
                                     "value": "grey"
                                 },
                                 {
@@ -1622,7 +1622,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "!vlInterval(\"brush_store\", \"child_Acceleration_Horsepower_\", datum, \"union\", \"all\")",
+                                    "test": "!(vlInterval(\"brush_store\", \"child_Acceleration_Horsepower_\", datum, \"union\", \"all\"))",
                                     "value": "grey"
                                 },
                                 {
@@ -2181,7 +2181,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "!vlInterval(\"brush_store\", \"child_Acceleration_Miles_per_Gallon_\", datum, \"union\", \"all\")",
+                                    "test": "!(vlInterval(\"brush_store\", \"child_Acceleration_Miles_per_Gallon_\", datum, \"union\", \"all\"))",
                                     "value": "grey"
                                 },
                                 {

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -616,7 +616,7 @@
                     },
                     "fill": [
                         {
-                            "test": "!vlInterval(\"brush_store\", \"layer_1_\", datum, \"union\", \"all\")",
+                            "test": "!(vlInterval(\"brush_store\", \"layer_1_\", datum, \"union\", \"all\"))",
                             "value": "grey"
                         },
                         {

--- a/examples/vg-specs/query_widgets.vg.json
+++ b/examples/vg-specs/query_widgets.vg.json
@@ -190,7 +190,7 @@
                     },
                     "fill": [
                         {
-                            "test": "!vlPoint(\"CylYr_store\", \"layer_0_\", datum, \"union\", \"all\")",
+                            "test": "!(vlPoint(\"CylYr_store\", \"layer_0_\", datum, \"union\", \"all\"))",
                             "value": "grey"
                         },
                         {

--- a/scripts/rename-schema.sh
+++ b/scripts/rename-schema.sh
@@ -7,3 +7,7 @@ perl -pi -e s,'GenericVConcatSpec<CompositeUnitSpec>','VConcatSpec',g build/vega
 perl -pi -e s,'GenericHConcatSpec<CompositeUnitSpec>','HConcatSpec',g build/vega-lite-schema.json
 perl -pi -e s,'GenericUnitSpec<EncodingWithFacet\,AnyMark>','FacetedCompositeUnitSpecAlias',g build/vega-lite-schema.json
 perl -pi -e s,'GenericUnitSpec<Encoding\,AnyMark>','CompositeUnitSpecAlias',g build/vega-lite-schema.json
+perl -pi -e s,'LogicalOperand<string>','LogicalOperand',g build/vega-lite-schema.json
+perl -pi -e s,'LogicalAnd<string>','LogicalAnd',g build/vega-lite-schema.json
+perl -pi -e s,'LogicalOr<string>','LogicalOr',g build/vega-lite-schema.json
+perl -pi -e s,'LogicalNot<string>','LogicalNot',g build/vega-lite-schema.json

--- a/src/compile/mark/mixins.ts
+++ b/src/compile/mark/mixins.ts
@@ -68,22 +68,13 @@ function wrapCondition(model: UnitModel, condition: Condition<any>, vgChannel: s
     const {selection, value} = condition;
     return {
       [vgChannel]: [
-        {test: selectionTest(model, selection), value},
+        {test: predicate(model, selection), value},
         ...(valueRef !== undefined ? [valueRef] : [])
       ]
     };
   } else {
     return valueRef !== undefined ? {[vgChannel]: valueRef} : {};
   }
-}
-
-function selectionTest(model: UnitModel, selectionName: string) {
-  const negate = selectionName.charAt(0) === '!';
-  const name = negate ? selectionName.slice(1) : selectionName;
-  const selection = model.getSelectionComponent(name);
-
-  return (negate ? '!' : '') +
-    predicate(model, selection.name, selection.type, selection.resolve);
 }
 
 export function text(model: UnitModel, vgChannel: 'text' | 'tooltip' = 'text') {

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -9,13 +9,13 @@ import {Config} from './config';
 import {Field} from './fielddef';
 import {Legend} from './legend';
 import * as log from './log';
+import {LogicalOperand} from './logical';
 import {Scale, ScaleType} from './scale';
 import {SortField, SortOrder} from './sort';
 import {StackOffset} from './stack';
 import {isDiscreteByDefault, TimeUnit} from './timeunit';
 import {getFullName, Type} from './type';
 import {isBoolean, isString, stringValue} from './util';
-
 /**
  * Definition object for a constant value of an encoding channel.
  */
@@ -90,7 +90,7 @@ export interface FieldDef<F> {
 }
 
 export interface Condition<T> {
-  selection: string;
+  selection: LogicalOperand<string>;
   value: T;
 }
 

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -4,6 +4,7 @@ import {DateTime, dateTimeExpr, isDateTime} from './datetime';
 import {field} from './fielddef';
 import {fieldExpr as timeUnitFieldExpr, isSingleTimeUnit, TimeUnit} from './timeunit';
 import {isArray, isString} from './util';
+import {LogicalOperand} from './logical';
 
 export type Filter = EqualFilter | RangeFilter | OneOfFilter | SelectionFilter | string;
 
@@ -11,7 +12,7 @@ export interface SelectionFilter {
   /**
    * Filter using a selection name.
    */
-  selection: string;
+  selection: LogicalOperand<string>;
 }
 
 export function isSelectionFilter(filter: Filter): filter is SelectionFilter {
@@ -110,8 +111,7 @@ export function expression(model: Model, filter: Filter): string {
   if (isString(filter)) {
     return filter;
   } else if (isSelectionFilter(filter)) {
-    const selection = model.getSelectionComponent(filter.selection);
-    return predicate(model, filter.selection, selection.type, selection.resolve, null);
+    return predicate(model, filter.selection);
   } else { // Filter Object
     const fieldExpr = filter.timeUnit ?
       // For timeUnit, cast into integer with time() so we can use ===, inrange, indexOf to compare values directly.

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -2,9 +2,9 @@ import {Model} from './compile/model';
 import {predicate} from './compile/selection/selection';
 import {DateTime, dateTimeExpr, isDateTime} from './datetime';
 import {field} from './fielddef';
+import {LogicalOperand} from './logical';
 import {fieldExpr as timeUnitFieldExpr, isSingleTimeUnit, TimeUnit} from './timeunit';
 import {isArray, isString} from './util';
-import {LogicalOperand} from './logical';
 
 export type Filter = EqualFilter | RangeFilter | OneOfFilter | SelectionFilter | string;
 

--- a/src/logical.ts
+++ b/src/logical.ts
@@ -1,0 +1,25 @@
+export type LogicalOperand<T> = LogicalNot<T> | LogicalAnd<T> | LogicalOr<T> | T;
+
+export interface LogicalOr<T> {
+  or: LogicalOperand<T>[];
+}
+
+export interface LogicalAnd<T> {
+  and: LogicalOperand<T>[];
+}
+
+export interface LogicalNot<T> {
+  not: LogicalOperand<T>;
+}
+
+export function isLogicalOr(op: LogicalOperand<any>): op is LogicalOr<any> {
+  return !!op.or;
+}
+
+export function isLogicalAnd(op: LogicalOperand<any>): op is LogicalAnd<any> {
+  return !!op.and;
+}
+
+export function isLogicalNot(op: LogicalOperand<any>): op is LogicalNot<any> {
+  return !!op.not;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -213,11 +213,11 @@ export function varName(s: string): string {
 
 export function logicalExpr<T>(op: LogicalOperand<T>, cb: Function): string {
   if (isLogicalNot(op)) {
-    return '!' + logicalExpr(op.not, cb);
+    return '!(' + logicalExpr(op.not, cb) + ')';
   } else if (isLogicalAnd(op)) {
-    return '(' + op.and.map((and: LogicalOperand<T>) => logicalExpr(and, cb)).join(' && ') + ')';
+    return '(' + op.and.map((and: LogicalOperand<T>) => logicalExpr(and, cb)).join(') && (') + ')';
   } else if (isLogicalOr(op)) {
-    return '(' + op.or.map((or: LogicalOperand<T>) => logicalExpr(or, cb)).join(' || ') + ')';
+    return '(' + op.or.map((or: LogicalOperand<T>) => logicalExpr(or, cb)).join(') || (') + ')';
   } else {
     return cb(op);
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
 import * as stringify from 'json-stable-stringify';
 export {extend, isArray, isObject, isNumber, isString, truncate, toSet, stringValue} from 'vega-util';
-import {isArray, isNumber, isString} from 'vega-util';
+import {isArray, isNumber, isObject, isString} from 'vega-util';
+import {isLogicalAnd, isLogicalNot, isLogicalOr, LogicalOperand} from './logical';
 
 /**
  * Creates an object composed of the picked object properties.
@@ -208,4 +209,16 @@ export function varName(s: string): string {
 
   // Add _ if the string has leading numbers.
   return (s.match(/^\d+/) ? '_' : '') + alphanumericS;
+}
+
+export function logicalExpr<T>(op: LogicalOperand<T>, cb: Function): string {
+  if (isLogicalNot(op)) {
+    return '!' + logicalExpr(op.not, cb);
+  } else if (isLogicalAnd(op)) {
+    return '(' + op.and.map((and: LogicalOperand<T>) => logicalExpr(and, cb)).join(' && ') + ')';
+  } else if (isLogicalOr(op)) {
+    return '(' + op.or.map((or: LogicalOperand<T>) => logicalExpr(or, cb)).join(' || ') + ')';
+  } else {
+    return cb(op);
+  }
 }

--- a/test/compile/selection/predicate.test.ts
+++ b/test/compile/selection/predicate.test.ts
@@ -44,21 +44,21 @@ describe('Selection Predicate', function() {
       'vlPoint("one_store", "", datum, "union", "all")');
 
     assert.equal(predicate(model, {"not": "one"}),
-      '!vlPoint("one_store", "", datum, "union", "all")');
+      '!(vlPoint("one_store", "", datum, "union", "all"))');
 
     assert.equal(predicate(model, {"not": {"and": ["one", "two"]}}),
-      '!(vlPoint("one_store", "", datum, "union", "all") && ' +
-      'vlPoint("two_store", "", datum, "union", "all"))');
+      '!((vlPoint("one_store", "", datum, "union", "all")) && ' +
+      '(vlPoint("two_store", "", datum, "union", "all")))');
 
     assert.equal(predicate(model, {"and": ["one", "two", {"not": "three"}]}),
-      '(vlPoint("one_store", "", datum, "union", "all") && ' +
-      'vlPoint("two_store", "", datum, "union", "all") && ' +
-      '!vlInterval("three_store", "", datum, "intersect", "others"))');
+      '(vlPoint("one_store", "", datum, "union", "all")) && ' +
+      '(vlPoint("two_store", "", datum, "union", "all")) && ' +
+      '(!(vlInterval("three_store", "", datum, "intersect", "others")))');
 
     assert.equal(predicate(model, {"or": ["one", {"and": ["two", {"not": "three"}]}]}),
-      '(vlPoint("one_store", "", datum, "union", "all") || ' +
-      '(vlPoint("two_store", "", datum, "union", "all") && ' +
-      '!vlInterval("three_store", "", datum, "intersect", "others")))');
+      '(vlPoint("one_store", "", datum, "union", "all")) || ' +
+      '((vlPoint("two_store", "", datum, "union", "all")) && ' +
+      '(!(vlInterval("three_store", "", datum, "intersect", "others"))))');
   });
 
   it('generates Vega production rules', function() {
@@ -71,9 +71,9 @@ describe('Selection Predicate', function() {
 
     assert.deepEqual(nonPosition('opacity', model), {
       opacity: [
-        {test: '(vlPoint("one_store", "", datum, "union", "all") || ' +
-              '(vlPoint("two_store", "", datum, "union", "all") && ' +
-              '!vlInterval("three_store", "", datum, "intersect", "others")))',
+        {test: '(vlPoint("one_store", "", datum, "union", "all")) || ' +
+              '((vlPoint("two_store", "", datum, "union", "all")) && ' +
+              '(!(vlInterval("three_store", "", datum, "intersect", "others"))))',
           value: 0.5},
         {scale: "opacity", field: "Origin"}
       ]
@@ -85,20 +85,20 @@ describe('Selection Predicate', function() {
       'vlPoint("one_store", "", datum, "union", "all")');
 
     assert.equal(expression(model, {"selection": {"not": "one"}}),
-      '!vlPoint("one_store", "", datum, "union", "all")');
+      '!(vlPoint("one_store", "", datum, "union", "all"))');
 
     assert.equal(expression(model, {"selection": {"not": {"and": ["one", "two"]}}}),
-      '!(vlPoint("one_store", "", datum, "union", "all") && ' +
-      'vlPoint("two_store", "", datum, "union", "all"))');
+      '!((vlPoint("one_store", "", datum, "union", "all")) && ' +
+      '(vlPoint("two_store", "", datum, "union", "all")))');
 
     assert.equal(expression(model, {"selection": {"and": ["one", "two", {"not": "three"}]}}),
-      '(vlPoint("one_store", "", datum, "union", "all") && ' +
-      'vlPoint("two_store", "", datum, "union", "all") && ' +
-      '!vlInterval("three_store", "", datum, "intersect", "others"))');
+      '(vlPoint("one_store", "", datum, "union", "all")) && ' +
+      '(vlPoint("two_store", "", datum, "union", "all")) && ' +
+      '(!(vlInterval("three_store", "", datum, "intersect", "others")))');
 
     assert.equal(expression(model, {"selection": {"or": ["one", {"and": ["two", {"not": "three"}]}]}}),
-      '(vlPoint("one_store", "", datum, "union", "all") || ' +
-      '(vlPoint("two_store", "", datum, "union", "all") && ' +
-      '!vlInterval("three_store", "", datum, "intersect", "others")))');
+      '(vlPoint("one_store", "", datum, "union", "all")) || ' +
+      '((vlPoint("two_store", "", datum, "union", "all")) && ' +
+      '(!(vlInterval("three_store", "", datum, "intersect", "others"))))');
   });
 });


### PR DESCRIPTION
This PR resolves #2322 by allowing structured logical composition of selections in both the `condition` and selection `filter`. A general purpose `logicalComposition` utility (and associated type definitions) has been introduced for future use with the filter transform as well. 