### PR TITLE
Cleaner approach for SelectionDomain

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -3938,22 +3938,40 @@
       "type": "object"
     },
     "SelectionDomain": {
-      "additionalProperties": false,
-      "properties": {
-        "encoding": {
-          "type": "string"
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "field": {
+              "type": "string"
+            },
+            "selection": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "selection",
+            "field"
+          ],
+          "type": "object"
         },
-        "field": {
-          "type": "string"
-        },
-        "selection": {
-          "type": "string"
+        {
+          "additionalProperties": false,
+          "properties": {
+            "encoding": {
+              "type": "string"
+            },
+            "selection": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "selection",
+            "encoding"
+          ],
+          "type": "object"
         }
-      },
-      "required": [
-        "selection"
-      ],
-      "type": "object"
+      ]
     },
     "SelectionFilter": {
       "additionalProperties": false,

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -3948,11 +3948,11 @@
         },
         "selection": {
           "type": "string"
-        },
-        "signal": {
-          "type": "string"
         }
       },
+      "required": [
+        "selection"
+      ],
       "type": "object"
     },
     "SelectionFilter": {

--- a/examples/vg-specs/overview_detail.vg.json
+++ b/examples/vg-specs/overview_detail.vg.json
@@ -550,7 +550,7 @@
                         480
                     ],
                     "domainRaw": {
-                        "signal": "vlIntervalDomain(\"brush_store\", \"x\", null, \"union\")"
+                        "signal": "vlIntervalDomain(\"brush_store\", \"x\", null, \"union\", \"all\")"
                     },
                     "round": true
                 },

--- a/src/compile/scale/assemble.ts
+++ b/src/compile/scale/assemble.ts
@@ -8,12 +8,17 @@ import {isRawSelectionDomain, scaleDomain} from '../selection/selection';
 
 export function assembleScale(model: Model) {
     return vals(model.component.scales).map(scale => {
-      // Correct any raw selection domains.
+      // As scale parsing occurs before selection parsing, a temporary signal
+      // is used for domainRaw. Here, we detect if this temporary signal
+      // is set, and replace it with the correct domainRaw signal.
+      // For more information, see isRawSelectionDomain in selection.ts.
       if (scale.domainRaw && isRawSelectionDomain(scale.domainRaw)) {
         scale.domainRaw = scaleDomain(model, scale.domainRaw);
       }
 
-      // Correct references to data
+      // Correct references to data as the original domain's data was determined
+      // in parseScale, which happens before parseData. Thus the original data
+      // reference can be incorrect.
       const domain = scale.domain;
       if (isDataRefDomain(domain) || isFieldRefUnionDomain(domain)) {
         domain.data = model.lookupDataSource(domain.data);

--- a/src/compile/scale/assemble.ts
+++ b/src/compile/scale/assemble.ts
@@ -4,37 +4,16 @@ import {isSelectionDomain} from '../../scale';
 import {stringValue, vals} from '../../util';
 import {isDataRefDomain, isDataRefUnionedDomain, isFieldRefUnionDomain, isSignalRefDomain, VgDataRef} from '../../vega.schema';
 import {Model} from '../model';
-
-const SELECTION_OPS = {
-  global: 'union', independent: 'intersect',
-  union: 'union', union_others: 'union',
-  intersect: 'intersect', intersect_others: 'intersect'
-};
+import {isRawSelectionDomain, scaleDomain} from '../selection/selection';
 
 export function assembleScale(model: Model) {
     return vals(model.component.scales).map(scale => {
-      // As selections are parsed _after_ scales, we can only shim in a domainRaw
-      // in the output Vega during assembly. FIXME: This should be moved to
-      // selection.ts, but any reference to it throws an error. Possible circular dependency?
-      const raw = scale.domainRaw;
-      if (raw && raw.selection) {
-        raw.field = raw.field || null;
-        raw.encoding = raw.encoding || null;
-        const selName = raw.selection;
-        let selCmpt = model.component.selection && model.component.selection[selName];
-        if (selCmpt) {
-          log.warn('Use "bind": "scales" to setup a binding for scales and selections within the same view.');
-        } else {
-          selCmpt = model.getSelectionComponent(selName);
-          scale.domainRaw = {
-            signal: (selCmpt.type === 'interval' ? 'vlIntervalDomain' : 'vlPointDomain') +
-            `(${stringValue(selCmpt.name + '_store')}, ${stringValue(raw.encoding)}, ${stringValue(raw.field)}, ` +
-            `${stringValue(SELECTION_OPS[selCmpt.resolve])})`
-          };
-        }
+      // Correct any raw selection domains.
+      if (scale.domainRaw && isRawSelectionDomain(scale.domainRaw)) {
+        scale.domainRaw = scaleDomain(model, scale.domainRaw);
       }
 
-      // correct references to data
+      // Correct references to data
       const domain = scale.domain;
       if (isDataRefDomain(domain) || isFieldRefUnionDomain(domain)) {
         domain.data = model.lookupDataSource(domain.data);

--- a/src/compile/scale/parse.ts
+++ b/src/compile/scale/parse.ts
@@ -11,6 +11,8 @@ import {ScaleComponent, ScaleComponentIndex} from './component';
 import {parseDomain, unionDomains} from './domain';
 import {parseRange} from './range';
 
+import {SELECTION_DOMAIN} from '../selection/selection';
+
 /**
  * Parse scales for all channels of a model.
  */
@@ -53,8 +55,11 @@ export function parseScale(model: UnitModel, channel: Channel) {
     range: parseRange(scale)
   };
 
+  // See comment in selection.ts for why such a hack is necessary.
   if (isSelectionDomain(scale.domain)) {
-    scaleComponent.domainRaw = scale.domain;
+    scaleComponent.domainRaw = {
+      signal: SELECTION_DOMAIN + JSON.stringify(scale.domain)
+    };
   }
 
   NON_TYPE_DOMAIN_RANGE_VEGA_SCALE_PROPERTIES.forEach((property) => {

--- a/src/compile/scale/parse.ts
+++ b/src/compile/scale/parse.ts
@@ -55,8 +55,11 @@ export function parseScale(model: UnitModel, channel: Channel) {
     range: parseRange(scale)
   };
 
-  // See comment in selection.ts for why such a hack is necessary.
   if (isSelectionDomain(scale.domain)) {
+    // As scale parsing occurs before selection parsing, we use a temporary
+    // signal here and append the scale.domain definition. This is replaced
+    // with the correct domainRaw signal during scale assembly.
+    // For more information, see isRawSelectionDomain in selection.ts.
     scaleComponent.domainRaw = {
       signal: SELECTION_DOMAIN + JSON.stringify(scale.domain)
     };

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -11,6 +11,7 @@ export const BRUSH = '_brush';
 
 const interval:SelectionCompiler = {
   predicate: 'vlInterval',
+  scaleDomain: 'vlIntervalDomain',
 
   signals: function(model, selCmpt) {
     const signals: any[] = [];

--- a/src/compile/selection/multi.ts
+++ b/src/compile/selection/multi.ts
@@ -4,6 +4,7 @@ import nearest from './transforms/nearest';
 
 const multi:SelectionCompiler = {
   predicate: 'vlPoint',
+  scaleDomain: 'VlPointDomain',
 
   signals: function(model, selCmpt) {
     const proj = selCmpt.project;

--- a/src/compile/selection/multi.ts
+++ b/src/compile/selection/multi.ts
@@ -4,7 +4,7 @@ import nearest from './transforms/nearest';
 
 const multi:SelectionCompiler = {
   predicate: 'vlPoint',
-  scaleDomain: 'VlPointDomain',
+  scaleDomain: 'vlPointDomain',
 
   signals: function(model, selCmpt) {
     const proj = selCmpt.project;

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -1,10 +1,11 @@
 import {selector as parseSelector} from 'vega-event-selector';
 import {Channel} from '../../channel';
+import {warn} from '../../log';
 import {LogicalOperand} from '../../logical';
 import {SelectionDomain} from '../../scale';
 import {SelectionDef, SelectionResolutions, SelectionTypes} from '../../selection';
 import {Dict, extend, isString, logicalExpr, stringValue} from '../../util';
-import {VgBinding, VgData, VgEventStream, VgSignalRef, VgScale, VgDomain, isSignalRefDomain} from '../../vega.schema';
+import {isSignalRefDomain, VgBinding, VgData, VgDomain, VgEventStream, VgScale, VgSignalRef} from '../../vega.schema';
 import {LayerModel} from '../layer';
 import {Model} from '../model';
 import {UnitModel} from '../unit';
@@ -13,7 +14,6 @@ import multiCompiler from './multi';
 import {SelectionComponent} from './selection';
 import singleCompiler from './single';
 import {forEachTransform} from './transforms/transforms';
-import {warn} from '../../log';
 
 export const STORE = '_store';
 export const TUPLE  = '_tuple';

--- a/src/compile/selection/single.ts
+++ b/src/compile/selection/single.ts
@@ -4,6 +4,7 @@ import {SelectionCompiler, STORE, TUPLE} from './selection';
 
 const single:SelectionCompiler = {
   predicate: multi.predicate,
+  scaleDomain: multi.scaleDomain,
 
   signals: multi.signals,
 

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -282,7 +282,7 @@ export interface ExtendedScheme {
   count?: number;
 }
 
-export type SelectionDomain = {selection: string, field?: string, encoding?: string};
+export type SelectionDomain = {selection: string, field: string} | {selection: string, encoding: string};
 export type Domain = number[] | string[] | DateTime[] | 'unaggregated' | SelectionDomain;
 export type Scheme = string | ExtendedScheme;
 

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -282,8 +282,7 @@ export interface ExtendedScheme {
   count?: number;
 }
 
-// FIXME: Once `domainRaw` is a simple VgSignalRef, we can drop signal here.
-export type SelectionDomain = {signal?: string, selection?: string, field?: string, encoding?: string};
+export type SelectionDomain = {selection: string, field?: string, encoding?: string};
 export type Domain = number[] | string[] | DateTime[] | 'unaggregated' | SelectionDomain;
 export type Scheme = string | ExtendedScheme;
 

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,7 +1,6 @@
 import {VgBinding} from './vega.schema';
 
 export type SelectionTypes = 'single' | 'multi' | 'interval';
-export type SelectionDomain = 'data' | 'visual';
 export type SelectionResolutions = 'global' | 'independent' | 'union' |
   'union_others' | 'intersect' | 'intersect_others';
 

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -83,8 +83,7 @@ export type VgScale = {
   name: string,
   type: ScaleType,
   domain: VgDomain,
-  // FIXME: Should be a VgSignalRef.
-  domainRaw?: SelectionDomain,
+  domainRaw?: VgSignalRef,
   range: VgRange,
 
   clamp?: boolean,

--- a/test/compile/scale/parse.test.ts
+++ b/test/compile/scale/parse.test.ts
@@ -4,8 +4,8 @@ import {assert} from 'chai';
 
 import {parseScale} from '../../../src/compile/scale/parse';
 import {NON_TYPE_DOMAIN_RANGE_VEGA_SCALE_PROPERTIES} from '../../../src/compile/scale/parse';
+import {SELECTION_DOMAIN} from '../../../src/compile/selection/selection';
 import {parseUnitModel} from '../../util';
-
 
 import {SCALE_PROPERTIES} from '../../../src/scale';
 import {toSet, without} from '../../../src/util';
@@ -175,6 +175,34 @@ describe('src/compile', function() {
       it('should add correct scales', function() {
         assert.equal(scales.name, 'color');
         assert.equal(scales.type, 'sequential');
+      });
+    });
+
+    describe('selection domain', function() {
+      const model = parseUnitModel({
+        mark: "area",
+        encoding: {
+          x: {
+            field: "date", type: "temporal",
+            scale: {domain: {selection: "brush", encoding: "x"}},
+          },
+          y: {
+            field: "date", type: "temporal",
+            scale: {domain: {selection: "foobar", field: "Miles_per_Gallon"}},
+          }
+        }
+      });
+
+      const xscale = parseScale(model, 'x');
+      const yscale = parseScale(model, 'y');
+      it('should add a raw selection domain', function() {
+        assert.property(xscale, 'domainRaw');
+        assert.propertyVal(xscale.domainRaw, 'signal',
+          SELECTION_DOMAIN + '{"selection":"brush","encoding":"x"}');
+
+        assert.property(yscale, 'domainRaw');
+        assert.propertyVal(yscale.domainRaw, 'signal',
+          SELECTION_DOMAIN + '{"selection":"foobar","field":"Miles_per_Gallon"}');
       });
     });
   });

--- a/test/compile/selection/scales.test.ts
+++ b/test/compile/selection/scales.test.ts
@@ -1,0 +1,76 @@
+/* tslint:disable:quotemark */
+
+import {assert} from 'chai';
+import {assembleScale} from '../../../src/compile/scale/assemble';
+import {parseScale} from '../../../src/compile/scale/parse';
+import {parseConcatModel} from '../../util';
+
+describe('Selection + Scales', function() {
+  it('assembles domainRaw from selection parameter', function() {
+    const model = parseConcatModel({
+      vconcat: [
+        {
+          mark: "area",
+          selection: {
+            brush: {type: "interval", encodings: ["x"]},
+            brush2: {type: "multi", fields: ["price"], resolve: "intersect"}
+          },
+          encoding: {
+            x: {field: "date", type: "temporal"},
+            y: {field: "price", type: "quantitative"}
+          }
+        },
+        {
+          selection: {
+            brush3: {type: "interval"}
+          },
+          mark: "area",
+          encoding: {
+            x: {
+              field: "date", type: "temporal",
+              scale: {domain: {selection: "brush", encoding: "x"}}
+            },
+            y: {
+              field: "price", type: "quantitative",
+              scale: {domain: {selection: "brush2", field: "price"}}
+            },
+            color: {
+              field: "symbol", type: "nominal",
+              scale: {domain: {selection: "brush2"}}
+            },
+            opacity: {
+              field: "symbol", type: "nominal",
+              scale: {domain: {selection: "brush3"}}
+            }
+          }
+        }
+      ]});
+
+    model.parseScale();
+    model.parseSelection();
+
+    const scales = assembleScale(model.children[1]);
+    const xscale = scales[0];
+    const yscale = scales[1];
+    const cscale = scales[2];
+    const oscale = scales[3];
+
+    assert.isObject(xscale.domain);
+    assert.property(xscale, 'domainRaw');
+    assert.propertyVal(xscale.domainRaw, 'signal',
+      "vlIntervalDomain(\"brush_store\", \"x\", null, \"union\", \"all\")");
+
+    assert.isObject(yscale.domain);
+    assert.property(yscale, 'domainRaw');
+    assert.deepPropertyVal(yscale.domainRaw, 'signal',
+      "vlPointDomain(\"brush2_store\", null, \"price\", \"intersect\", \"all\")");
+
+    assert.isObject(cscale.domain);
+    assert.property(cscale, 'domainRaw');
+    assert.propertyVal(cscale.domainRaw, 'signal', 'null');
+
+    assert.isObject(oscale.domain);
+    assert.property(oscale, 'domainRaw');
+    assert.propertyVal(oscale.domainRaw, 'signal', 'null');
+  });
+});


### PR DESCRIPTION
In 77ff32c, we introduced a hack to allow scale domains to be parameterized by selections. The motivation for the hack still persists: scales are parsed before selections, but we need selections to be parsed in order to find their component in the model tree. 

However, rather than polluting our type/interface definitions, this PR resolves #2470 by piggybacking off `scale.domainRaw` using a special key (`SELECTION_DOMAIN`). If this key is found during scale assembly, it is replaced with the correct expression function. 

(The circular dependency issue we experienced in 77ff32c seems to have resolved itself, phew!). 

Because this is still somewhat hacky, I've also added tests to ensure that the correct things are happening at both scale parsing and assembly. 