### PR TITLE
Support structured composition of Filters

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1977,7 +1977,7 @@
       "additionalProperties": false,
       "properties": {
         "filter": {
-          "$ref": "#/definitions/Filter",
+          "$ref": "#/definitions/FilterOperand",
           "description": "A string containing the filter Vega expression. Use `datum` to refer to the current data object."
         }
       },
@@ -2816,6 +2816,21 @@
       },
       "type": "object"
     },
+    "AndFilter": {
+      "additionalProperties": false,
+      "properties": {
+        "and": {
+          "items": {
+            "$ref": "#/definitions/FilterOperand"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "and"
+      ],
+      "type": "object"
+    },
     "LogicalAnd": {
       "additionalProperties": false,
       "properties": {
@@ -2831,6 +2846,18 @@
       ],
       "type": "object"
     },
+    "NotFilter": {
+      "additionalProperties": false,
+      "properties": {
+        "not": {
+          "$ref": "#/definitions/FilterOperand"
+        }
+      },
+      "required": [
+        "not"
+      ],
+      "type": "object"
+    },
     "LogicalNot": {
       "additionalProperties": false,
       "properties": {
@@ -2842,6 +2869,22 @@
         "not"
       ],
       "type": "object"
+    },
+    "FilterOperand": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/NotFilter"
+        },
+        {
+          "$ref": "#/definitions/AndFilter"
+        },
+        {
+          "$ref": "#/definitions/OrFilter"
+        },
+        {
+          "$ref": "#/definitions/Filter"
+        }
+      ]
     },
     "LogicalOperand": {
       "anyOf": [
@@ -2858,6 +2901,21 @@
           "type": "string"
         }
       ]
+    },
+    "OrFilter": {
+      "additionalProperties": false,
+      "properties": {
+        "or": {
+          "items": {
+            "$ref": "#/definitions/FilterOperand"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "or"
+      ],
+      "type": "object"
     },
     "LogicalOr": {
       "additionalProperties": false,

--- a/scripts/rename-schema.sh
+++ b/scripts/rename-schema.sh
@@ -11,3 +11,7 @@ perl -pi -e s,'LogicalOperand<string>','LogicalOperand',g build/vega-lite-schema
 perl -pi -e s,'LogicalAnd<string>','LogicalAnd',g build/vega-lite-schema.json
 perl -pi -e s,'LogicalOr<string>','LogicalOr',g build/vega-lite-schema.json
 perl -pi -e s,'LogicalNot<string>','LogicalNot',g build/vega-lite-schema.json
+perl -pi -e s,'LogicalOperand<Filter>','FilterOperand',g build/vega-lite-schema.json
+perl -pi -e s,'LogicalAnd<Filter>','AndFilter',g build/vega-lite-schema.json
+perl -pi -e s,'LogicalOr<Filter>','OrFilter',g build/vega-lite-schema.json
+perl -pi -e s,'LogicalNot<Filter>','NotFilter',g build/vega-lite-schema.json

--- a/src/compile/data/transforms.ts
+++ b/src/compile/data/transforms.ts
@@ -2,11 +2,12 @@ import {isArray, isNumber, isString} from 'vega-util';
 import {DateTime, isDateTime} from '../../datetime';
 import {expression, Filter, isEqualFilter, isOneOfFilter, isRangeFilter} from '../../filter';
 import * as log from '../../log';
+import {LogicalOperand} from '../../logical';
 import {CalculateTransform, FilterTransform, isBin, isCalculate, isFilter, isLookup, isSummarize, isTimeUnit, LookupTransform} from '../../transform';
 import {duplicate, keys, StringSet, toSet} from '../../util';
 import {VgFilterTransform, VgFormulaTransform, VgLookupTransform} from '../../vega.schema';
-import {Model} from '../model';
 import {ModelWithField} from '../model';
+import {Model} from '../model';
 import {AggregateNode} from './aggregate';
 import {BinNode} from './bin';
 import {DataFlowNode, OutputNode} from './dataflow';
@@ -20,7 +21,7 @@ export class FilterNode extends DataFlowNode {
     return new FilterNode(this.model, duplicate(this.filter));
   }
 
-  constructor(private readonly model: Model, private filter: Filter) {
+  constructor(private readonly model: Model, private filter: LogicalOperand<Filter>) {
     super();
   }
 

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -4,7 +4,7 @@ import {DateTime, dateTimeExpr, isDateTime} from './datetime';
 import {field} from './fielddef';
 import {LogicalOperand} from './logical';
 import {fieldExpr as timeUnitFieldExpr, isSingleTimeUnit, TimeUnit} from './timeunit';
-import {isArray, isString} from './util';
+import {isArray, isString, logicalExpr} from './util';
 
 export type Filter = EqualFilter | RangeFilter | OneOfFilter | SelectionFilter | string;
 
@@ -15,7 +15,7 @@ export interface SelectionFilter {
   selection: LogicalOperand<string>;
 }
 
-export function isSelectionFilter(filter: Filter): filter is SelectionFilter {
+export function isSelectionFilter(filter: LogicalOperand<Filter>): filter is SelectionFilter {
   return filter && filter['selection'];
 }
 
@@ -107,43 +107,45 @@ export function isOneOfFilter(filter: any): filter is OneOfFilter {
  * Converts a filter into an expression.
  */
 // model is only used for selection filters.
-export function expression(model: Model, filter: Filter): string {
-  if (isString(filter)) {
-    return filter;
-  } else if (isSelectionFilter(filter)) {
-    return predicate(model, filter.selection);
-  } else { // Filter Object
-    const fieldExpr = filter.timeUnit ?
-      // For timeUnit, cast into integer with time() so we can use ===, inrange, indexOf to compare values directly.
-        // TODO: We calculate timeUnit on the fly here. Consider if we would like to consolidate this with timeUnit pipeline
-        // TODO: support utc
-      ('time(' + timeUnitFieldExpr(filter.timeUnit, filter.field) + ')') :
-      field(filter, {expr: 'datum'});
+export function expression(model: Model, filterOp: LogicalOperand<Filter>): string {
+  return logicalExpr(filterOp, (filter: Filter) => {
+    if (isString(filter)) {
+      return filter;
+    } else if (isSelectionFilter(filter)) {
+      return predicate(model, filter.selection);
+    } else { // Filter Object
+      const fieldExpr = filter.timeUnit ?
+        // For timeUnit, cast into integer with time() so we can use ===, inrange, indexOf to compare values directly.
+          // TODO: We calculate timeUnit on the fly here. Consider if we would like to consolidate this with timeUnit pipeline
+          // TODO: support utc
+        ('time(' + timeUnitFieldExpr(filter.timeUnit, filter.field) + ')') :
+        field(filter, {expr: 'datum'});
 
-    if (isEqualFilter(filter)) {
-      return fieldExpr + '===' + valueExpr(filter.equal, filter.timeUnit);
-    } else if (isOneOfFilter(filter)) {
-      // "oneOf" was formerly "in" -- so we need to add backward compatibility
-      const oneOf: OneOfFilter[] = filter.oneOf || filter['in'];
-      return 'indexof([' +
-        oneOf.map((v) => valueExpr(v, filter.timeUnit)).join(',') +
-        '], ' + fieldExpr + ') !== -1';
-    } else if (isRangeFilter(filter)) {
-      const lower = filter.range[0];
-      const upper = filter.range[1];
+      if (isEqualFilter(filter)) {
+        return fieldExpr + '===' + valueExpr(filter.equal, filter.timeUnit);
+      } else if (isOneOfFilter(filter)) {
+        // "oneOf" was formerly "in" -- so we need to add backward compatibility
+        const oneOf: OneOfFilter[] = filter.oneOf || filter['in'];
+        return 'indexof([' +
+          oneOf.map((v) => valueExpr(v, filter.timeUnit)).join(',') +
+          '], ' + fieldExpr + ') !== -1';
+      } else if (isRangeFilter(filter)) {
+        const lower = filter.range[0];
+        const upper = filter.range[1];
 
-      if (lower !== null &&  upper !== null) {
-        return 'inrange(' + fieldExpr + ', ' +
-          valueExpr(lower, filter.timeUnit) + ', ' +
-          valueExpr(upper, filter.timeUnit) + ')';
-      } else if (lower !== null) {
-        return fieldExpr + ' >= ' + lower;
-      } else if (upper !== null) {
-        return fieldExpr + ' <= ' + upper;
+        if (lower !== null &&  upper !== null) {
+          return 'inrange(' + fieldExpr + ', ' +
+            valueExpr(lower, filter.timeUnit) + ', ' +
+            valueExpr(upper, filter.timeUnit) + ')';
+        } else if (lower !== null) {
+          return fieldExpr + ' >= ' + lower;
+        } else if (upper !== null) {
+          return fieldExpr + ' <= ' + upper;
+        }
       }
     }
-  }
-  return undefined;
+    return undefined;
+  });
 }
 
 function valueExpr(v: any, timeUnit: TimeUnit) {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -2,6 +2,7 @@ import {AggregateOp} from './aggregate';
 import {Bin} from './bin';
 import {Data} from './data';
 import {Filter} from './filter';
+import {LogicalOperand} from './logical';
 import {TimeUnit} from './timeunit';
 import {VgFieldRef} from './vega.schema';
 
@@ -9,7 +10,7 @@ export interface FilterTransform {
   /**
    * A string containing the filter Vega expression. Use `datum` to refer to the current data object.
    */
-  filter: Filter;
+  filter: LogicalOperand<Filter>;
 }
 
 export function isFilter(t: Transform): t is FilterTransform {

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -111,4 +111,28 @@ describe('filter', () => {
       assert.equal(expr, 'datum["x"]===5');
     });
   });
+
+  it('generates expressions for composed filters', () => {
+    let expr = expression(null, {not: {field: 'color', equal: 'red'}});
+    assert.equal(expr, '!(datum["color"]==="red")');
+
+    expr = expression(null, {and: [
+      {field: 'color', equal: 'red'},
+      {field: 'x', range: [0, 5]}
+    ]});
+
+    assert.equal(expr, '(datum["color"]==="red") && (inrange(datum["x"], 0, 5))');
+
+    expr = expression(null, {and: [
+      {field: 'color', oneOf: ['red', 'yellow']},
+      {or: [
+        {field: 'x', range: [0, null]},
+        'datum.price > 10',
+        {not: 'datum["x"]===5'}
+      ]}
+    ]});
+
+    assert.equal(expr, '(indexof(["red","yellow"], datum["color"]) !== -1) && ' +
+      '((datum["x"] >= 0) || (datum.price > 10) || (!(datum["x"]===5)))');
+  });
 });


### PR DESCRIPTION
#2471 introduced structured composition of logical operators but only applied it to composition of selection predicates. This PR extends it to support all `Filter` operators. 

~Note: the previously requested changes to parenthesis (11fa46e) were buggy. This PR fixes this bug as well -- parentheses should wrap the base operand as well as group operands that are and'd/or'd together.~ 