### PR TITLE
Make `value` and `type` required for `ValueDef` and `FieldDef` respectively

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1118,6 +1118,9 @@
           ]
         }
       },
+      "required": [
+        "value"
+      ],
       "type": "object"
     },
     "ConditionalValueDef<number>": {
@@ -1131,6 +1134,9 @@
           "type": "number"
         }
       },
+      "required": [
+        "value"
+      ],
       "type": "object"
     },
     "ConditionalValueDef<string>": {
@@ -1144,6 +1150,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "value"
+      ],
       "type": "object"
     },
     "Config": {
@@ -1897,6 +1906,9 @@
           "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case-insensitive."
         }
       },
+      "required": [
+        "type"
+      ],
       "type": "object"
     },
     "FacetedUnitSpec": {
@@ -1950,6 +1962,45 @@
         "type": {
           "$ref": "#/definitions/Type",
           "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case-insensitive."
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
+    "FieldDefBase": {
+      "additionalProperties": false,
+      "properties": {
+        "aggregate": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AggregateOp"
+            },
+            {
+              "$ref": "#/definitions/CompositeAggregate"
+            }
+          ],
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/Bin"
+            }
+          ],
+          "description": "Flag for binning a `quantitative` field, or a bin property object\nfor binning parameters."
+        },
+        "field": {
+          "$ref": "#/definitions/Field",
+          "description": "__Required.__ Name of the field from which to pull a data value.\n\n__Note:__ `field` is not required if `aggregate` is `count`."
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit for a `temporal` field  (e.g., `year`, `yearmonth`, `month`, `hour`).\n\n__Default value:__ `undefined` (None)"
         }
       },
       "type": "object"
@@ -2747,6 +2798,9 @@
           "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case-insensitive."
         }
       },
+      "required": [
+        "type"
+      ],
       "type": "object"
     },
     "LegendFieldDef<Field,string>": {
@@ -2814,6 +2868,9 @@
           "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case-insensitive."
         }
       },
+      "required": [
+        "type"
+      ],
       "type": "object"
     },
     "AndFilter": {
@@ -3357,6 +3414,9 @@
           "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case-insensitive."
         }
       },
+      "required": [
+        "type"
+      ],
       "type": "object"
     },
     "Orient": {
@@ -3474,6 +3534,9 @@
           "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case-insensitive."
         }
       },
+      "required": [
+        "type"
+      ],
       "type": "object"
     },
     "Range": {
@@ -3875,6 +3938,9 @@
           "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case-insensitive."
         }
       },
+      "required": [
+        "type"
+      ],
       "type": "object"
     },
     "ScaleType": {
@@ -4363,6 +4429,9 @@
           "description": "The encoded field's type of measurement. This can be either a full type\nname (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`,  and `\"nominal\"`)\nor an initial character of the type name (`\"Q\"`, `\"T\"`, `\"O\"`, `\"N\"`).\nThis property is case-insensitive."
         }
       },
+      "required": [
+        "type"
+      ],
       "type": "object"
     },
     "TickConfig": {
@@ -5155,6 +5224,9 @@
           ]
         }
       },
+      "required": [
+        "value"
+      ],
       "type": "object"
     },
     "ValueDef<number>": {
@@ -5166,6 +5238,9 @@
           "type": "number"
         }
       },
+      "required": [
+        "value"
+      ],
       "type": "object"
     },
     "ValueDef<string>": {
@@ -5177,6 +5252,9 @@
           "type": "string"
         }
       },
+      "required": [
+        "value"
+      ],
       "type": "object"
     },
     "VerticalAlign": {

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -45,9 +45,9 @@ function x(model: UnitModel, stack: StackProperties): VgEncodeEntry {
   } else { // vertical
     if (isFieldDef(xDef)) {
       if (!sizeDef && isBinScale(xScale.type)) {
-        return mixins.binnedPosition('x', model, config.bar.binSpacing);
+        return mixins.binnedPosition(xDef, 'x', model.scaleName('x'), config.bar.binSpacing);
       } else if (xScale.type === ScaleType.BAND) {
-        return mixins.bandPosition('x', model);
+        return mixins.bandPosition(xDef, 'x', model);
       }
     }
     // sized bin, normal point-ordinal axis, quantitative x-axis, or no x
@@ -77,9 +77,9 @@ function y(model: UnitModel, stack: StackProperties) {
   } else {
     if (isFieldDef(yDef)) {
       if (yDef.bin && !sizeDef) {
-        return mixins.binnedPosition('y', model, config.bar.binSpacing);
+        return mixins.binnedPosition(yDef, 'y', model.scaleName('y'), config.bar.binSpacing);
       } else if (yScale.type === ScaleType.BAND) {
-        return mixins.bandPosition('y', model);
+        return mixins.bandPosition(yDef, 'y', model);
       }
     }
     // TODO: replace model.scale(X) with model.getScaleComponent once rangeStep is a part of scale component

--- a/src/compile/mark/mixins.ts
+++ b/src/compile/mark/mixins.ts
@@ -8,7 +8,7 @@ import {UnitModel} from '../unit';
 import * as ref from './valueref';
 
 import {NONSPATIAL_SCALE_CHANNELS} from '../../channel';
-import {Condition, isFieldDef, isValueDef} from '../../fielddef';
+import {Condition, FieldDef, isFieldDef, isValueDef} from '../../fielddef';
 import {predicate} from '../selection/selection';
 
 export function color(model: UnitModel) {
@@ -83,8 +83,7 @@ export function text(model: UnitModel, vgChannel: 'text' | 'tooltip' = 'text') {
   return wrapCondition(model, channelDef && channelDef.condition, vgChannel, valueRef);
 }
 
-export function bandPosition(channel: 'x'|'y', model: UnitModel) {
-  const fieldDef = model.encoding[channel];
+export function bandPosition(fieldDef: FieldDef<string>, channel: 'x'|'y', model: UnitModel) {
   const scaleName = model.scaleName(channel);
   const sizeChannel = channel === 'x' ? 'width' : 'height';
 
@@ -129,9 +128,7 @@ export function centeredBandPosition(channel: 'x' | 'y', model: UnitModel, defau
   };
 }
 
-export function binnedPosition(channel: 'x'|'y', model: UnitModel, spacing: number) {
-  const fieldDef = model.encoding[channel];
-  const scaleName = model.scaleName(channel);
+export function binnedPosition(fieldDef: FieldDef<string>, channel: 'x'|'y', scaleName: string, spacing: number) {
   if (channel === 'x') {
     return {
       x2: ref.bin(fieldDef, scaleName, 'start', spacing),

--- a/src/compile/mark/rect.ts
+++ b/src/compile/mark/rect.ts
@@ -29,11 +29,11 @@ function x(model: UnitModel) {
   const xScale = model.getScaleComponent(X);
 
   if (isFieldDef(xDef) && xDef.bin && !x2Def) {
-    return mixins.binnedPosition('x', model, 0);
-  } else if (xScale && hasDiscreteDomain(xScale.type)) {
+    return mixins.binnedPosition(xDef, 'x', model.scaleName('x'), 0);
+  } else if (isFieldDef(xDef) && xScale && hasDiscreteDomain(xScale.type)) {
     /* istanbul ignore else */
     if (xScale.type === ScaleType.BAND) {
-      return mixins.bandPosition('x', model);
+      return mixins.bandPosition(xDef, 'x', model);
     } else {
       // We don't support rect mark with point/ordinal scale
       throw new Error(log.message.scaleTypeNotWorkWithMark(RECT, xScale.type));
@@ -52,11 +52,11 @@ function y(model: UnitModel) {
   const yScale = model.getScaleComponent(Y);
 
   if (isFieldDef(yDef) && yDef.bin && !y2Def) {
-    return mixins.binnedPosition('y', model, 0);
-  } else if (yScale && hasDiscreteDomain(yScale.type)) {
+    return mixins.binnedPosition(yDef, 'y', model.scaleName('y'), 0);
+  } else if (isFieldDef(yDef) && yScale && hasDiscreteDomain(yScale.type)) {
     /* istanbul ignore else */
     if (yScale.type === ScaleType.BAND) {
-      return mixins.bandPosition('y', model);
+      return mixins.bandPosition(yDef, 'y', model);
     } else {
       // We don't support rect mark with point/ordinal scale
       throw new Error(log.message.scaleTypeNotWorkWithMark(RECT, yScale.type));

--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -19,7 +19,7 @@ import {formatSignalRef, numberFormat} from '../common';
  */
 export function stackable(channel: 'x' | 'y', channelDef: ChannelDef<string>, scaleName: string, scale: VgScale,
     stack: StackProperties, defaultRef: VgValueRef): VgValueRef {
-  if (channelDef && stack && channel === stack.fieldChannel) {
+  if (isFieldDef(channelDef) && stack && channel === stack.fieldChannel) {
     // x or y use stack_end so that stacked line's point mark use stack_end too.
     return fieldRef(channelDef, scaleName, {suffix: 'end'});
   }
@@ -29,9 +29,9 @@ export function stackable(channel: 'x' | 'y', channelDef: ChannelDef<string>, sc
 /**
  * @return Vega ValueRef for stackable x2 or y2
  */
-export function stackable2(channel: 'x2' | 'y2', aFieldDef: FieldDef<string>, a2fieldDef: FieldDef<string>, scaleName: string, scale: VgScale,
+export function stackable2(channel: 'x2' | 'y2', aFieldDef: ChannelDef<string>, a2fieldDef: ChannelDef<string>, scaleName: string, scale: VgScale,
     stack: StackProperties, defaultRef: VgValueRef): VgValueRef {
-  if (aFieldDef && stack &&
+  if (isFieldDef(aFieldDef) && stack &&
       // If fieldChannel is X and channel is X2 (or Y and Y2)
       channel.charAt(0) === stack.fieldChannel.charAt(0)
       ) {

--- a/src/compile/scale/init.ts
+++ b/src/compile/scale/init.ts
@@ -37,9 +37,8 @@ export const NON_TYPE_RANGE_SCALE_PROPERTIES: (keyof Scale)[] = [
  * - range depends on zero and size (width and height) depends on range
  */
 export default function init(
-    channel: Channel, fieldDef: ScaleFieldDef<string>, config: Config,
+    channel: Channel, fieldDef: FieldDef<string>, specifiedScale: Scale = {}, config: Config,
     mark: Mark | undefined, topLevelSize: number | undefined, xyRangeSteps: number[]): Scale {
-  const specifiedScale = (fieldDef || {}).scale || {};
 
   const scale: Scale = {
     type: scaleType(

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -148,12 +148,23 @@ export class UnitModel extends ModelWithField {
     const xyRangeSteps: number[] = [];
 
     return UNIT_SCALE_CHANNELS.reduce((scales, channel) => {
-      if (vlEncoding.channelHasField(encoding, channel) ||
-          (channel === X && vlEncoding.channelHasField(encoding, X2)) ||
-          (channel === Y && vlEncoding.channelHasField(encoding, Y2))
-        ) {
+      let fieldDef: FieldDef<string>;
+      let specifiedScale: Scale;
+
+      const channelDef = encoding[channel];
+
+      if (isFieldDef(channelDef)) {
+        fieldDef = channelDef;
+        specifiedScale = channelDef.scale;
+      } else if (channel === 'x') {
+        fieldDef = vlEncoding.getFieldDef(encoding, 'x2');
+      } else if (channel === 'y') {
+        fieldDef = vlEncoding.getFieldDef(encoding, 'y2');
+      }
+
+      if (fieldDef) {
         const scale = scales[channel] = initScale(
-          channel, encoding[channel], this.config, mark,
+          channel, fieldDef, specifiedScale, this.config, mark,
           channel === X ? topLevelWidth : channel === Y ? topLevelHeight : undefined,
           xyRangeSteps // for determine point / bar size
         );

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -1,6 +1,6 @@
 import {COLUMN, ROW, X, X2, Y, Y2} from './channel';
-import * as compositeMark from './compositemark';
 import {CompositeMark} from './compositemark';
+import * as compositeMark from './compositemark';
 import {Config} from './config';
 import {Data} from './data';
 import {channelHasField, Encoding, EncodingWithFacet, isRanged} from './encoding';
@@ -15,7 +15,7 @@ import {SelectionDef} from './selection';
 import {stack} from './stack';
 import {TopLevelProperties} from './toplevelprops';
 import {Transform} from './transform';
-import {contains, duplicate, hash, vals} from './util';
+import {contains, Dict, duplicate, hash, vals} from './util';
 
 
 export type TopLevel<S extends BaseSpec> = S & TopLevelProperties & {
@@ -432,8 +432,8 @@ function accumulate(dict: any, fieldDefs: FieldDef<Field>[]): any {
 }
 
 /* Recursively get fieldDefs from a spec, returns a dictionary of fieldDefs */
-function fieldDefIndex(spec: GenericSpec<GenericUnitSpec<any, any>>, dict: any = {}): any {
-  // TODO: Support repeat and concat
+function fieldDefIndex<T>(spec: GenericSpec<GenericUnitSpec<any, any>>, dict: Dict<FieldDef<T>> = {}): Dict<FieldDef<T>> {
+  // FIXME(https://github.com/vega/vega-lite/issues/2207): Support fieldDefIndex for repeat
   if (isLayerSpec(spec)) {
     spec.layer.forEach(layer => {
       if (isUnitSpec(layer)) {
@@ -464,7 +464,7 @@ function fieldDefIndex(spec: GenericSpec<GenericUnitSpec<any, any>>, dict: any =
 }
 
 /* Returns all non-duplicate fieldDefs in a spec in a flat array */
-export function fieldDefs(spec: GenericSpec<GenericUnitSpec<any, any>>): FieldDef<Field>[] {
+export function fieldDefs(spec: GenericSpec<GenericUnitSpec<any, any>>): FieldDef<any>[] {
   return vals(fieldDefIndex(spec));
 }
 

--- a/test/compile/data/bin.test.ts
+++ b/test/compile/data/bin.test.ts
@@ -75,12 +75,12 @@ describe('compile/data/bin', function() {
         x: {
           bin: true,
           field: "Rotten_Tomatoes_Rating",
-          type: "q"
+          type: "quantitative"
         },
         color: {
           bin: {"maxbins": 10},
           field: "Rotten_Tomatoes_Rating",
-          type: "q"
+          type: "quantitative"
         }
       }
     });
@@ -121,11 +121,11 @@ describe('compile/data/bin', function() {
     encoding: {
       x: {
         field: "Rotten_Tomatoes_Rating",
-        type: "q"
+        type: "quantitative"
       },
       color: {
         field: "Rotten_Tomatoes_Rating",
-        type: "q"
+        type: "quantitative"
       }
     }
   });
@@ -150,11 +150,11 @@ describe('compile/data/bin', function() {
     encoding: {
       x: {
         field: "Rotten_Tomatoes_Rating",
-        type: "q"
+        type: "quantitative"
       },
       color: {
         field: "Rotten_Tomatoes_Rating",
-        type: "q"
+        type: "quantitative"
       }
     }
   });

--- a/test/compile/legend/encode.test.ts
+++ b/test/compile/legend/encode.test.ts
@@ -10,7 +10,7 @@ import {parseUnitModel, parseUnitModelWithScale} from '../../util';
 describe('compile/legend', function() {
   describe('encode.symbols', function() {
     it('should not have strokeDash and strokeDashOffset', function() {
-      const symbol = encode.symbols({field: 'a'}, {}, parseUnitModel({
+      const symbol = encode.symbols({field: 'a', type: 'nominal'}, {}, parseUnitModel({
           mark: "point",
           encoding: {
             x: {field: "a", type: "nominal"},
@@ -22,7 +22,7 @@ describe('compile/legend', function() {
     });
 
     it('should return not override size of the symbol for shape channel', function() {
-      const symbol = encode.symbols({field: 'a'}, {}, parseUnitModel({
+      const symbol = encode.symbols({field: 'a', type: 'nominal'}, {}, parseUnitModel({
           mark: "point",
           encoding: {
             x: {field: "a", type: "nominal"},
@@ -32,7 +32,7 @@ describe('compile/legend', function() {
     });
 
     it('should return specific symbols.shape.value if user has specified', function() {
-      const symbol = encode.symbols({field: 'a'}, {}, parseUnitModel({
+      const symbol = encode.symbols({field: 'a', type: 'nominal'}, {}, parseUnitModel({
           mark: "point",
           encoding: {
             x: {field: "a", type: "nominal"},

--- a/test/compile/legend/rules.test.ts
+++ b/test/compile/legend/rules.test.ts
@@ -8,12 +8,12 @@ import {defaultConfig} from '../../../src/config';
 describe('compile/legend', function() {
   describe('title()', function () {
     it('should add explicitly specified title', function () {
-      const title = rules.title({title: 'Custom'}, {field: 'a'}, defaultConfig);
+      const title = rules.title({title: 'Custom'}, {field: 'a', type: 'nominal'}, defaultConfig);
       assert.equal(title, 'Custom');
     });
 
     it('should add return fieldTitle by default', function () {
-      const title = rules.title({}, {field: 'a'}, defaultConfig);
+      const title = rules.title({}, {field: 'a', type: 'nominal'}, defaultConfig);
       assert.equal(title, 'a');
     });
   });

--- a/test/compile/mark/area.test.ts
+++ b/test/compile/mark/area.test.ts
@@ -3,12 +3,13 @@
 import {assert} from 'chai';
 import {COLOR, X, Y} from '../../../src/channel';
 import {area} from '../../../src/compile/mark/area';
+import {Encoding} from '../../../src/encoding';
 import {UnitSpec} from '../../../src/spec';
 import {extend} from '../../../src/util';
 import {parseUnitModelWithScale} from '../../util';
 
 describe('Mark: Area', function() {
-  function verticalArea(moreEncoding = {}): UnitSpec {
+  function verticalArea(moreEncoding: Encoding<string> = {}): UnitSpec {
     return {
       "mark": "area",
       "encoding": extend(
@@ -100,7 +101,7 @@ describe('Mark: Area', function() {
     });
   });
 
-  function horizontalArea(moreEncoding = {}): UnitSpec {
+  function horizontalArea(moreEncoding: Encoding<string> = {}): UnitSpec {
     return {
       "mark": "area",
       "encoding": extend(

--- a/test/compile/mark/point.test.ts
+++ b/test/compile/mark/point.test.ts
@@ -3,6 +3,7 @@
 import {assert} from 'chai';
 import {COLOR, SHAPE, SIZE, X, Y} from '../../../src/channel';
 import {circle, point, square} from '../../../src/compile/mark/point';
+import {Encoding} from '../../../src/encoding';
 import {defaultMarkConfig} from '../../../src/mark';
 import {UnitSpec} from '../../../src/spec';
 import {extend} from '../../../src/util';
@@ -10,7 +11,7 @@ import {parseUnitModelWithScale} from '../../util';
 
 describe('Mark: Point', function() {
 
-  function pointXY(moreEncoding = {}): UnitSpec {
+  function pointXY(moreEncoding: Encoding<string> = {}): UnitSpec {
     return {
       "mark": "point",
       "encoding": extend(

--- a/test/compile/repeat.test.ts
+++ b/test/compile/repeat.test.ts
@@ -1,5 +1,6 @@
 import {assert} from 'chai';
 import {replaceRepeaterInEncoding} from '../../src/compile/repeat';
+import {Encoding} from '../../src/encoding';
 import * as log from '../../src/log';
 import {keys} from '../../src/util';
 import {DataRefUnionDomain, isDataRefUnionedDomain} from '../../src/vega.schema';
@@ -9,21 +10,21 @@ describe('Repeat', function() {
   describe('resolveRepeat', () => {
     it('should resolve repeated fields', () => {
       const resolved = replaceRepeaterInEncoding({
-        x: {field: {repeat: 'row'}},
-        y: {field: 'bar'}
+        x: {field: {repeat: 'row'}, type: 'quantitative'},
+        y: {field: 'bar', type: 'quantitative'}
       }, {row: 'foo'});
 
-      assert.deepEqual(resolved, {
-        x: {field: 'foo'},
-        y: {field: 'bar'}
+      assert.deepEqual<Encoding<string>>(resolved, {
+        x: {field: 'foo', type: 'quantitative'},
+        y: {field: 'bar', type: 'quantitative'}
       });
     });
 
     it('should show warning if repeat cannot be resolved', () => {
       log.runLocalLogger((localLogger) => {
         const resolved = replaceRepeaterInEncoding({
-          x: {field: {repeat: 'row'}},
-          y: {field: 'bar'}
+          x: {field: {repeat: 'row'}, type: 'quantitative'},
+          y: {field: 'bar', type: 'quantitative'}
         }, {column: 'foo'});
 
         assert.equal(localLogger.warns[0], log.message.noSuchRepeatedValue('row'));
@@ -32,11 +33,14 @@ describe('Repeat', function() {
 
     it('should support arrays fo field defs', () => {
       const resolved = replaceRepeaterInEncoding({
-        detail: [{field: {repeat: 'row'}}, {field: 'bar'}]
+        detail: [
+          {field: {repeat: 'row'}, type: 'quantitative'},
+          {field: 'bar', type: 'quantitative'}
+        ]
       }, {row: 'foo'});
 
-      assert.deepEqual(resolved, {
-        detail: [{field: 'foo'}, {field: 'bar'}]
+      assert.deepEqual<Encoding<string>>(resolved, {
+        detail: [{field: 'foo', type: 'quantitative'}, {field: 'bar', type: 'quantitative'}]
       });
     });
   });

--- a/test/compile/scale/domain.test.ts
+++ b/test/compile/scale/domain.test.ts
@@ -6,7 +6,8 @@ import {MAIN} from '../../../src/data';
 import {PositionFieldDef} from '../../../src/fielddef';
 import * as log from '../../../src/log';
 import {ScaleType} from '../../../src/scale';
-import {FieldRefUnionDomain, VgDataRef, VgDomain, VgSortField} from '../../../src/vega.schema';
+import {SortField} from '../../../src/sort';
+import {FieldRefUnionDomain, VgDataRef, VgDomain} from '../../../src/vega.schema';
 import {parseUnitModel} from '../../util';
 
 
@@ -255,7 +256,7 @@ describe('compile/scale', () => {
 
         it('should return the correct domain for yearmonth T when specify sort',
           function() {
-            const sortDef: VgSortField = {op: 'mean', field: 'precipitation', order: 'descending'} ;
+            const sortDef: SortField = {op: 'mean', field: 'precipitation', order: 'descending'} ;
             const model = parseUnitModel({
               mark: "line",
               encoding: {
@@ -303,7 +304,7 @@ describe('compile/scale', () => {
 
     describe('for ordinal', function() {
       it('should return correct domain with the provided sort property', function() {
-        const sortDef: VgSortField = {op: 'min' as 'min', field:'Acceleration'};
+        const sortDef: SortField = {op: 'min' as 'min', field:'Acceleration'};
         const model = parseUnitModel({
             mark: "point",
             encoding: {
@@ -318,7 +319,7 @@ describe('compile/scale', () => {
       });
 
       it('should return correct domain with the provided sort property with order property', function() {
-        const sortDef: VgSortField = {op: 'min', field:'Acceleration', order: "descending"} ;
+        const sortDef: SortField = {op: 'min', field:'Acceleration', order: "descending"} ;
         const model = parseUnitModel({
             mark: "point",
             encoding: {

--- a/test/compile/scale/init.test.ts
+++ b/test/compile/scale/init.test.ts
@@ -18,8 +18,10 @@ describe('compile/scale', () => {
   describe('init', () => {
     it('should output only padding without default paddingInner and paddingOuter if padding is specified for a band scale', () => {
       const scale = initScale(
-        'x', {field: 'a', type: 'ordinal', scale: {type: 'band', padding: 0.6}}, defaultConfig,
-        'bar', 100, []
+        'x',
+        {field: 'a', type: 'ordinal'},
+        {type: 'band', padding: 0.6},
+        defaultConfig, 'bar', 100, []
       );
       assert.equal(scale.padding, 0.6);
       assert.isUndefined(scale.paddingInner);
@@ -28,7 +30,9 @@ describe('compile/scale', () => {
 
     it('should output default paddingInner and paddingOuter = paddingInner/2 if none of padding properties is specified for a band scale', () => {
       const scale = initScale(
-        'x', {field: 'a', type: 'ordinal', scale: {type: 'band'}}, {scale: {bandPaddingInner: 0.3}},
+        'x', {field: 'a', type: 'ordinal'},
+        {type: 'band'},
+        {scale: {bandPaddingInner: 0.3}},
         'bar', 100, []
       );
       assert.equal(scale.paddingInner, 0.3);

--- a/test/compile/selection/inputs.test.ts
+++ b/test/compile/selection/inputs.test.ts
@@ -11,7 +11,7 @@ describe('Inputs Selection Transform', function() {
     "encoding": {
       "x": {"field": "Horsepower","type": "quantitative"},
       "y": {"field": "Miles_per_Gallon","type": "quantitative"},
-      "color": {"field": "Origin", "type": "N"}
+      "color": {"field": "Origin", "type": "nominal"}
     }
   });
 

--- a/test/compile/selection/interval.test.ts
+++ b/test/compile/selection/interval.test.ts
@@ -13,7 +13,7 @@ describe('Interval Selections', function() {
     "encoding": {
       "x": {"field": "Horsepower","type": "quantitative"},
       "y": {"field": "Miles_per_Gallon","type": "quantitative"},
-      "color": {"field": "Origin", "type": "N"}
+      "color": {"field": "Origin", "type": "nominal"}
     }
   });
   model.parseScale();

--- a/test/compile/selection/layers.test.ts
+++ b/test/compile/selection/layers.test.ts
@@ -15,7 +15,7 @@ describe('Layered Selections', function() {
       "encoding": {
         "x": {"field": "Horsepower","type": "quantitative"},
         "y": {"field": "Miles_per_Gallon","type": "quantitative"},
-        "color": {"field": "Origin", "type": "N"}
+        "color": {"field": "Origin", "type": "nominal"}
       }
     }, {
       "selection": {
@@ -25,7 +25,7 @@ describe('Layered Selections', function() {
       "encoding": {
         "x": {"field": "Horsepower","type": "quantitative"},
         "y": {"field": "Miles_per_Gallon","type": "quantitative"},
-        "color": {"field": "Origin", "type": "N"}
+        "color": {"field": "Origin", "type": "nominal"}
       }
     }]
   });

--- a/test/compile/selection/multi.test.ts
+++ b/test/compile/selection/multi.test.ts
@@ -11,7 +11,7 @@ describe('Multi Selection', function() {
     "encoding": {
       "x": {"field": "Horsepower","type": "quantitative"},
       "y": {"field": "Miles_per_Gallon","type": "quantitative", "bin": true},
-      "color": {"field": "Origin", "type": "N"}
+      "color": {"field": "Origin", "type": "nominal"}
     }
   });
 

--- a/test/compile/selection/nearest.test.ts
+++ b/test/compile/selection/nearest.test.ts
@@ -11,7 +11,7 @@ function getModel(markType: any) {
     "encoding": {
       "x": {"field": "Horsepower","type": "quantitative"},
       "y": {"field": "Miles_per_Gallon","type": "quantitative"},
-      "color": {"field": "Origin", "type": "N"}
+      "color": {"field": "Origin", "type": "nominal"}
     }
   });
 

--- a/test/compile/selection/parse.test.ts
+++ b/test/compile/selection/parse.test.ts
@@ -11,7 +11,7 @@ describe('Selection', function() {
     "encoding": {
       "x": {"field": "Horsepower","type": "quantitative"},
       "y": {"field": "Miles_per_Gallon","type": "quantitative"},
-      "color": {"field": "Origin", "type": "N"}
+      "color": {"field": "Origin", "type": "nominal"}
     }
   });
 

--- a/test/compile/selection/predicate.test.ts
+++ b/test/compile/selection/predicate.test.ts
@@ -15,14 +15,14 @@ describe('Selection Predicate', function() {
       "x": {"field": "Horsepower","type": "quantitative"},
       "y": {"field": "Miles_per_Gallon","type": "quantitative"},
       "color": {
-        "field": "Cylinders", "type": "O",
+        "field": "Cylinders", "type": "ordinal",
         "condition": {
           "selection": "one",
           "value": "grey"
         }
       },
       "opacity": {
-        "field": "Origin", "type": "N",
+        "field": "Origin", "type": "nominal",
         "condition": {
           "selection": {"or": ["one", {"and": ["two", {"not": "three"}]}]},
           "value": 0.5

--- a/test/compile/selection/scales.test.ts
+++ b/test/compile/selection/scales.test.ts
@@ -3,6 +3,7 @@
 import {assert} from 'chai';
 import {assembleScale} from '../../../src/compile/scale/assemble';
 import {parseScale} from '../../../src/compile/scale/parse';
+import {Domain} from '../../../src/scale';
 import {parseConcatModel} from '../../util';
 
 describe('Selection + Scales', function() {
@@ -36,11 +37,11 @@ describe('Selection + Scales', function() {
             },
             color: {
               field: "symbol", type: "nominal",
-              scale: {domain: {selection: "brush2"}}
+              scale: {domain: {selection: "brush2"} as Domain}
             },
             opacity: {
               field: "symbol", type: "nominal",
-              scale: {domain: {selection: "brush3"}}
+              scale: {domain: {selection: "brush3"} as Domain}
             }
           }
         }

--- a/test/compile/selection/single.test.ts
+++ b/test/compile/selection/single.test.ts
@@ -11,7 +11,7 @@ describe('Single Selection', function() {
     "encoding": {
       "x": {"field": "Horsepower","type": "quantitative"},
       "y": {"field": "Miles_per_Gallon","type": "quantitative", "bin": true},
-      "color": {"field": "Origin", "type": "N"}
+      "color": {"field": "Origin", "type": "nominal"}
     }
   });
 

--- a/test/compile/selection/toggle.test.ts
+++ b/test/compile/selection/toggle.test.ts
@@ -11,7 +11,7 @@ describe('Toggle Selection Transform', function() {
     "encoding": {
       "x": {"field": "Horsepower","type": "quantitative"},
       "y": {"field": "Miles_per_Gallon","type": "quantitative"},
-      "color": {"field": "Origin", "type": "N"}
+      "color": {"field": "Origin", "type": "nominal"}
     }
   });
 

--- a/test/compile/selection/translate.test.ts
+++ b/test/compile/selection/translate.test.ts
@@ -12,7 +12,7 @@ describe('Translate Selection Transform', function() {
     "encoding": {
       "x": {"field": "Horsepower","type": "quantitative"},
       "y": {"field": "Miles_per_Gallon","type": "quantitative"},
-      "color": {"field": "Origin", "type": "N"}
+      "color": {"field": "Origin", "type": "nominal"}
     }
   });
 

--- a/test/compile/selection/zoom.test.ts
+++ b/test/compile/selection/zoom.test.ts
@@ -12,7 +12,7 @@ describe('Zoom Selection Transform', function() {
     "encoding": {
       "x": {"field": "Horsepower","type": "quantitative"},
       "y": {"field": "Miles_per_Gallon","type": "quantitative"},
-      "color": {"field": "Origin", "type": "N"}
+      "color": {"field": "Origin", "type": "nominal"}
     }
   });
 

--- a/test/compile/unit.test.ts
+++ b/test/compile/unit.test.ts
@@ -42,14 +42,12 @@ describe('UnitModel', function() {
           encoding: {
             detail: [
               {field: 'a', type: 'ordinal'},
-              {value: 'b'},
               {type: 'quantitative'}
             ]
           }
         });
         assert.deepEqual<FieldDef<string> | FieldDef<string>[]>(model.encoding.detail, [
-          {field: 'a', type: 'ordinal'},
-          {value: 'b'}
+          {field: 'a', type: 'ordinal'}
         ]);
         assert.equal(localLogger.warns[0], log.message.emptyFieldDef({type: QUANTITATIVE}, DETAIL));
       });

--- a/test/fielddef.test.ts
+++ b/test/fielddef.test.ts
@@ -1,7 +1,7 @@
 import {assert} from 'chai';
 
 import {Channel} from '../src/channel';
-import {channelCompatibility, defaultType, FieldDef, normalize, title} from '../src/fielddef';
+import {channelCompatibility, ChannelDef, defaultType, FieldDef, normalize, title} from '../src/fielddef';
 import * as log from '../src/log';
 import {TimeUnit} from '../src/timeunit';
 import {QUANTITATIVE, TEMPORAL} from '../src/type';
@@ -9,42 +9,42 @@ import {QUANTITATIVE, TEMPORAL} from '../src/type';
 describe('fieldDef', () => {
   describe('defaultType()', () => {
     it('should return temporal if there is timeUnit', () => {
-      assert.equal(defaultType({timeUnit: 'month', field: 'a'}, 'x'), 'temporal');
+      assert.equal(defaultType({timeUnit: 'month', field: 'a'} as FieldDef<string>, 'x'), 'temporal');
     });
 
     it('should return quantitative if there is bin', () => {
-      assert.equal(defaultType({bin: 'true', field: 'a'}, 'x'), 'quantitative');
+      assert.equal(defaultType({bin: true, field: 'a'} as FieldDef<string>, 'x'), 'quantitative');
     });
 
     it('should return quantitative for a channel that supports measure', () => {
       for (const c of ['x', 'y', 'size', 'opacity', 'order'] as Channel[]) {
-        assert.equal(defaultType({field: 'a'}, c), 'quantitative', c);
+        assert.equal(defaultType({field: 'a'} as FieldDef<string>, c), 'quantitative', c);
       }
     });
 
     it('should return nominal for a channel that does not support measure', () => {
       for (const c of ['color', 'shape', 'row', 'column'] as Channel[]) {
-        assert.equal(defaultType({field: 'a'}, c), 'nominal', c);
+        assert.equal(defaultType({field: 'a'} as FieldDef<string>, c), 'nominal', c);
       }
     });
   });
 
   describe('normalize()', () => {
     it('should return fieldDef with full type name.', () => {
-      const fieldDef = {field: 'a', type: 'q' as any};
-      assert.deepEqual(normalize(fieldDef, 'x'), {field: 'a', type: 'quantitative'});
+      const fieldDef: FieldDef<string> = {field: 'a', type: 'q' as any};
+      assert.deepEqual<ChannelDef<string>>(normalize(fieldDef, 'x'), {field: 'a', type: 'quantitative'});
     });
 
     it('should return fieldDef with default type and throw warning if type is missing.', log.wrap((localLogger) => {
-      const fieldDef = {field: 'a'};
-      assert.deepEqual(normalize(fieldDef, 'x'), {field: 'a', type: 'quantitative'});
+      const fieldDef = {field: 'a'} as FieldDef<string>;
+      assert.deepEqual<ChannelDef<string>>(normalize(fieldDef, 'x'), {field: 'a', type: 'quantitative'});
       assert.equal(localLogger.warns[0], log.message.emptyOrInvalidFieldType(undefined, 'x', 'quantitative'));
     }));
 
     it('should drop invalid aggregate ops and throw warning.', log.wrap((localLogger) => {
-      const fieldDef = {aggregate: 'boxplot', field: 'a', type: 'quantitative'};
-      assert.deepEqual(normalize(fieldDef, 'x'), {field: 'a', type: 'quantitative'});
-      assert.equal(localLogger.warns[0], log.message.invalidAggregate('boxplot'));
+      const fieldDef: FieldDef<string> = {aggregate: 'box-plot', field: 'a', type: 'quantitative'};
+      assert.deepEqual<ChannelDef<string>>(normalize(fieldDef, 'x'), {field: 'a', type: 'quantitative'});
+      assert.equal(localLogger.warns[0], log.message.invalidAggregate('box-plot'));
     }));
   });
 

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -8,23 +8,23 @@ describe('vl.validate', function() {
       assert.isNull(getEncodingMappingError({
         mark: BAR,
         encoding: {
-          x: {field: 'a'}
+          x: {field: 'a', type: 'quantitative'}
         }
       }));
 
       assert.isNull(getEncodingMappingError({
         mark: LINE,
         encoding: {
-          x: {field: 'b'},
-          y: {field: 'a'}
+          x: {field: 'b', type: 'quantitative'},
+          y: {field: 'a', type: 'quantitative'}
         }
       }));
 
       assert.isNull(getEncodingMappingError({
         mark: AREA,
         encoding: {
-          x: {field: 'a'},
-          y: {field: 'b'}
+          x: {field: 'a', type: 'quantitative'},
+          y: {field: 'b', type: 'quantitative'}
         }
       }));
     });
@@ -33,42 +33,42 @@ describe('vl.validate', function() {
       assert.isNotNull(getEncodingMappingError({
         mark: LINE,
         encoding: {
-          x: {field: 'b'} // missing y
+          x: {field: 'b', type: 'quantitative'} // missing y
         }
       }));
 
       assert.isNotNull(getEncodingMappingError({
         mark: AREA,
         encoding: {
-          y: {field: 'b'} // missing x
+          y: {field: 'b', type: 'quantitative'} // missing x
         }
       }));
 
       assert.isNotNull(getEncodingMappingError({
         mark: TEXT,
         encoding: {
-          y: {field: 'b'} // missing text
+          y: {field: 'b', type: 'quantitative'} // missing text
         }
       }));
 
       assert.isNotNull(getEncodingMappingError({
         mark: LINE,
         encoding: {
-          shape: {field: 'b'} // using shape with line
+          shape: {field: 'b', type: 'quantitative'} // using shape with line
         }
       }));
 
       assert.isNotNull(getEncodingMappingError({
         mark: AREA,
         encoding: {
-          shape: {field: 'b'} // using shape with area
+          shape: {field: 'b', type: 'quantitative'} // using shape with area
         }
       }));
 
       assert.isNotNull(getEncodingMappingError({
         mark: BAR,
         encoding: {
-          shape: {field: 'b'} // using shape with bar
+          shape: {field: 'b', type: 'quantitative'} // using shape with bar
         }
       }));
     });

--- a/typings/vega-util.d.ts
+++ b/typings/vega-util.d.ts
@@ -21,7 +21,7 @@ declare module 'vega-util' {
 
   export function truncate(a: string, length: number): string;
 
-  export function isArray<T>(a: T | T[]): a is T[];
+  export function isArray(a: any | any[]): a is any[];
   export function isObject(a: any): a is any;
   export function isString(a: any): a is string;
   export function isNumber(a: any): a is number;


### PR DESCRIPTION
Make `value` and `type` required for `ValueDef` and `FieldDef` respectively.

(I was trying to implement condition with fieldDef inside the condition as discover that value and type are somehow not required.) 

This actually helps me discover a few bugs and refactor the codebase.

- Refactor method signature for mark mixins
- Make sure to call `isFieldDef` in many places
- Add type in many places
- Correct logic for array of fieldDefs for `detail` and `order` channel


cc: @mattwchun  -- please look at reference changes in `boxplot.ts`