### PR TITLE
Add Split<Scale/ScaleComponent> and uses them as return types of `initScale, parseScale`	

### DIFF
--- a/examples/vg-specs/area.vg.json
+++ b/examples/vg-specs/area.vg.json
@@ -108,8 +108,8 @@
                 0,
                 300
             ],
-            "round": true,
-            "nice": "month"
+            "nice": "month",
+            "round": true
         },
         {
             "name": "y",

--- a/examples/vg-specs/box-plot_minmax_2D_horizontal.vg.json
+++ b/examples/vg-specs/box-plot_minmax_2D_horizontal.vg.json
@@ -179,7 +179,7 @@
         },
         {
             "name": "layer_2_height",
-            "update": "bandspace(domain('y').length, 0.1, 0.05) * 21"
+            "update": "bandspace(domain('y').length, 1, 0.5) * 21"
         },
         {
             "name": "layer_3_width",

--- a/examples/vg-specs/box-plot_minmax_2D_vertical.vg.json
+++ b/examples/vg-specs/box-plot_minmax_2D_vertical.vg.json
@@ -175,7 +175,7 @@
         },
         {
             "name": "layer_2_width",
-            "update": "bandspace(domain('x').length, 0.1, 0.05) * 21"
+            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
         },
         {
             "name": "layer_2_height",

--- a/examples/vg-specs/bubble_health_income.vg.json
+++ b/examples/vg-specs/bubble_health_income.vg.json
@@ -105,9 +105,9 @@
                 300,
                 0
             ],
+            "zero": false,
             "round": true,
-            "nice": true,
-            "zero": false
+            "nice": true
         },
         {
             "name": "size",

--- a/examples/vg-specs/concat_selections.vg.json
+++ b/examples/vg-specs/concat_selections.vg.json
@@ -733,16 +733,16 @@
                         "data": "data_1",
                         "field": "Displacement"
                     },
+                    "domainRaw": {
+                        "signal": "grid_Displacement"
+                    },
                     "range": [
                         0,
                         200
                     ],
                     "round": true,
                     "nice": true,
-                    "zero": true,
-                    "domainRaw": {
-                        "signal": "grid_Displacement"
-                    }
+                    "zero": true
                 },
                 {
                     "name": "concat_1_y",
@@ -751,16 +751,16 @@
                         "data": "data_1",
                         "field": "Acceleration"
                     },
+                    "domainRaw": {
+                        "signal": "grid_Acceleration"
+                    },
                     "range": [
                         200,
                         0
                     ],
                     "round": true,
                     "nice": true,
-                    "zero": true,
-                    "domainRaw": {
-                        "signal": "grid_Acceleration"
-                    }
+                    "zero": true
                 }
             ],
             "axes": [

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -746,16 +746,16 @@
                 "data": "source_0",
                 "field": "X"
             },
+            "domainRaw": {
+                "signal": "grid_X"
+            },
             "range": [
                 0,
                 200
             ],
-            "round": true,
-            "nice": true,
             "zero": false,
-            "domainRaw": {
-                "signal": "grid_X"
-            }
+            "round": true,
+            "nice": true
         },
         {
             "name": "y",
@@ -764,16 +764,16 @@
                 "data": "source_0",
                 "field": "Y"
             },
+            "domainRaw": {
+                "signal": "grid_Y"
+            },
             "range": [
                 200,
                 0
             ],
-            "round": true,
-            "nice": true,
             "zero": false,
-            "domainRaw": {
-                "signal": "grid_Y"
-            }
+            "round": true,
+            "nice": true
         }
     ]
 }

--- a/examples/vg-specs/interactive_splom.vg.json
+++ b/examples/vg-specs/interactive_splom.vg.json
@@ -578,16 +578,16 @@
                         "data": "data_0",
                         "field": "Horsepower"
                     },
+                    "domainRaw": {
+                        "signal": "grid_Horsepower"
+                    },
                     "range": [
                         200,
                         0
                     ],
                     "round": true,
                     "nice": true,
-                    "zero": true,
-                    "domainRaw": {
-                        "signal": "grid_Horsepower"
-                    }
+                    "zero": true
                 }
             ],
             "axes": [
@@ -1119,16 +1119,16 @@
                         "data": "data_1",
                         "field": "Horsepower"
                     },
+                    "domainRaw": {
+                        "signal": "grid_Horsepower"
+                    },
                     "range": [
                         0,
                         200
                     ],
                     "round": true,
                     "nice": true,
-                    "zero": true,
-                    "domainRaw": {
-                        "signal": "grid_Horsepower"
-                    }
+                    "zero": true
                 },
                 {
                     "name": "child_Horsepower_Miles_per_Gallon_y",
@@ -1137,16 +1137,16 @@
                         "data": "data_1",
                         "field": "Miles_per_Gallon"
                     },
+                    "domainRaw": {
+                        "signal": "grid_Miles_per_Gallon"
+                    },
                     "range": [
                         200,
                         0
                     ],
                     "round": true,
                     "nice": true,
-                    "zero": true,
-                    "domainRaw": {
-                        "signal": "grid_Miles_per_Gallon"
-                    }
+                    "zero": true
                 }
             ],
             "axes": [
@@ -1678,16 +1678,16 @@
                         "data": "data_2",
                         "field": "Acceleration"
                     },
+                    "domainRaw": {
+                        "signal": "grid_Acceleration"
+                    },
                     "range": [
                         0,
                         200
                     ],
                     "round": true,
                     "nice": true,
-                    "zero": true,
-                    "domainRaw": {
-                        "signal": "grid_Acceleration"
-                    }
+                    "zero": true
                 },
                 {
                     "name": "child_Acceleration_Horsepower_y",
@@ -1696,16 +1696,16 @@
                         "data": "data_2",
                         "field": "Horsepower"
                     },
+                    "domainRaw": {
+                        "signal": "grid_Horsepower"
+                    },
                     "range": [
                         200,
                         0
                     ],
                     "round": true,
                     "nice": true,
-                    "zero": true,
-                    "domainRaw": {
-                        "signal": "grid_Horsepower"
-                    }
+                    "zero": true
                 }
             ],
             "axes": [
@@ -2237,16 +2237,16 @@
                         "data": "data_3",
                         "field": "Acceleration"
                     },
+                    "domainRaw": {
+                        "signal": "grid_Acceleration"
+                    },
                     "range": [
                         0,
                         200
                     ],
                     "round": true,
                     "nice": true,
-                    "zero": true,
-                    "domainRaw": {
-                        "signal": "grid_Acceleration"
-                    }
+                    "zero": true
                 },
                 {
                     "name": "child_Acceleration_Miles_per_Gallon_y",
@@ -2255,16 +2255,16 @@
                         "data": "data_3",
                         "field": "Miles_per_Gallon"
                     },
+                    "domainRaw": {
+                        "signal": "grid_Miles_per_Gallon"
+                    },
                     "range": [
                         200,
                         0
                     ],
                     "round": true,
                     "nice": true,
-                    "zero": true,
-                    "domainRaw": {
-                        "signal": "grid_Miles_per_Gallon"
-                    }
+                    "zero": true
                 }
             ],
             "axes": [

--- a/examples/vg-specs/layer_bar_dual_axis.vg.json
+++ b/examples/vg-specs/layer_bar_dual_axis.vg.json
@@ -124,7 +124,7 @@
         },
         {
             "name": "layer_1_width",
-            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+            "update": "bandspace(domain('x').length, 0.1, 0.05) * 21"
         },
         {
             "name": "layer_1_height",

--- a/examples/vg-specs/layer_bar_dual_axis.vg.json
+++ b/examples/vg-specs/layer_bar_dual_axis.vg.json
@@ -239,9 +239,9 @@
                 200,
                 0
             ],
+            "zero": false,
             "round": true,
-            "nice": true,
-            "zero": false
+            "nice": true
         }
     ],
     "axes": [

--- a/examples/vg-specs/layer_bar_dual_axis_minmax.vg.json
+++ b/examples/vg-specs/layer_bar_dual_axis_minmax.vg.json
@@ -180,7 +180,7 @@
         },
         {
             "name": "layer_1_layer_0_width",
-            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+            "update": "bandspace(domain('x').length, 0.1, 0.05) * 21"
         },
         {
             "name": "layer_1_layer_0_height",
@@ -188,7 +188,7 @@
         },
         {
             "name": "layer_1_layer_1_width",
-            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+            "update": "bandspace(domain('x').length, 0.1, 0.05) * 21"
         },
         {
             "name": "layer_1_layer_1_height",

--- a/examples/vg-specs/layer_bar_dual_axis_minmax.vg.json
+++ b/examples/vg-specs/layer_bar_dual_axis_minmax.vg.json
@@ -340,9 +340,9 @@
                 200,
                 0
             ],
+            "zero": false,
             "round": true,
-            "nice": true,
-            "zero": false
+            "nice": true
         }
     ],
     "axes": [

--- a/examples/vg-specs/layer_bar_line.vg.json
+++ b/examples/vg-specs/layer_bar_line.vg.json
@@ -111,7 +111,7 @@
         },
         {
             "name": "layer_1_width",
-            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+            "update": "bandspace(domain('x').length, 0.1, 0.05) * 21"
         },
         {
             "name": "layer_1_height",

--- a/examples/vg-specs/layer_bar_line_union.vg.json
+++ b/examples/vg-specs/layer_bar_line_union.vg.json
@@ -120,7 +120,7 @@
         },
         {
             "name": "layer_1_width",
-            "update": "bandspace(domain('x').length, 1, 0.5) * 21"
+            "update": "bandspace(domain('x').length, 0.1, 0.05) * 21"
         },
         {
             "name": "layer_1_height",

--- a/examples/vg-specs/layer_box_plot_circle.vg.json
+++ b/examples/vg-specs/layer_box_plot_circle.vg.json
@@ -202,7 +202,7 @@
         },
         {
             "name": "layer_0_layer_2_height",
-            "update": "bandspace(domain('y').length, 0.1, 0.05) * 21"
+            "update": "bandspace(domain('y').length, 1, 0.5) * 21"
         },
         {
             "name": "layer_0_layer_3_width",

--- a/examples/vg-specs/layer_precipitation_mean.vg.json
+++ b/examples/vg-specs/layer_precipitation_mean.vg.json
@@ -105,7 +105,7 @@
         },
         {
             "name": "layer_1_width",
-            "update": "21"
+            "update": "bandspace(domain('undefined').length, 0.1, 0.05) * 21"
         },
         {
             "name": "layer_1_height",

--- a/examples/vg-specs/layered_box_plot.vg.json
+++ b/examples/vg-specs/layered_box_plot.vg.json
@@ -154,7 +154,7 @@
         },
         {
             "name": "layer_2_height",
-            "update": "bandspace(domain('y').length, 0.1, 0.05) * 21"
+            "update": "bandspace(domain('y').length, 1, 0.5) * 21"
         },
         {
             "name": "layer_3_width",

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -714,16 +714,16 @@
                 ],
                 "sort": true
             },
+            "domainRaw": {
+                "signal": "grid_Horsepower"
+            },
             "range": [
                 0,
                 200
             ],
             "round": true,
             "nice": true,
-            "zero": true,
-            "domainRaw": {
-                "signal": "grid_Horsepower"
-            }
+            "zero": true
         },
         {
             "name": "y",
@@ -741,16 +741,16 @@
                 ],
                 "sort": true
             },
+            "domainRaw": {
+                "signal": "grid_Miles_per_Gallon"
+            },
             "range": [
                 200,
                 0
             ],
             "round": true,
             "nice": true,
-            "zero": true,
-            "domainRaw": {
-                "signal": "grid_Miles_per_Gallon"
-            }
+            "zero": true
         },
         {
             "name": "color",

--- a/examples/vg-specs/line_slope.vg.json
+++ b/examples/vg-specs/line_slope.vg.json
@@ -127,8 +127,8 @@
             "range": {
                 "step": 50
             },
-            "round": true,
-            "padding": 0.5
+            "padding": 0.5,
+            "round": true
         },
         {
             "name": "y",

--- a/examples/vg-specs/overview_detail.vg.json
+++ b/examples/vg-specs/overview_detail.vg.json
@@ -545,13 +545,13 @@
                         "data": "data_1",
                         "field": "date"
                     },
+                    "domainRaw": {
+                        "signal": "vlIntervalDomain(\"brush_store\", \"x\", null, \"union\", \"all\")"
+                    },
                     "range": [
                         0,
                         480
                     ],
-                    "domainRaw": {
-                        "signal": "vlIntervalDomain(\"brush_store\", \"x\", null, \"union\", \"all\")"
-                    },
                     "round": true
                 },
                 {

--- a/examples/vg-specs/panzoom_scatter.vg.json
+++ b/examples/vg-specs/panzoom_scatter.vg.json
@@ -215,16 +215,16 @@
                 75,
                 150
             ],
+            "domainRaw": {
+                "signal": "grid_Horsepower"
+            },
             "range": [
                 0,
                 200
             ],
             "round": true,
             "nice": true,
-            "zero": false,
-            "domainRaw": {
-                "signal": "grid_Horsepower"
-            }
+            "zero": false
         },
         {
             "name": "y",
@@ -233,16 +233,16 @@
                 20,
                 40
             ],
+            "domainRaw": {
+                "signal": "grid_Miles_per_Gallon"
+            },
             "range": [
                 200,
                 0
             ],
             "round": true,
             "nice": true,
-            "zero": false,
-            "domainRaw": {
-                "signal": "grid_Miles_per_Gallon"
-            }
+            "zero": false
         },
         {
             "name": "size",

--- a/examples/vg-specs/repeat_splom_iris.vg.json
+++ b/examples/vg-specs/repeat_splom_iris.vg.json
@@ -512,9 +512,9 @@
                         0,
                         200
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 },
                 {
                     "name": "child_petalWidth_sepalLength_y",
@@ -527,9 +527,9 @@
                         200,
                         0
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 }
             ],
             "axes": [
@@ -633,9 +633,9 @@
                         0,
                         200
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 },
                 {
                     "name": "child_petalWidth_sepalWidth_y",
@@ -648,9 +648,9 @@
                         200,
                         0
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 }
             ],
             "axes": [
@@ -754,9 +754,9 @@
                         0,
                         200
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 },
                 {
                     "name": "child_petalWidth_petalLength_y",
@@ -769,9 +769,9 @@
                         200,
                         0
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 }
             ],
             "axes": [
@@ -875,9 +875,9 @@
                         0,
                         200
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 },
                 {
                     "name": "child_petalWidth_petalWidth_y",
@@ -890,9 +890,9 @@
                         200,
                         0
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 }
             ],
             "axes": [
@@ -996,9 +996,9 @@
                         0,
                         200
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 },
                 {
                     "name": "child_petalLength_sepalLength_y",
@@ -1011,9 +1011,9 @@
                         200,
                         0
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 }
             ],
             "axes": [
@@ -1117,9 +1117,9 @@
                         0,
                         200
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 },
                 {
                     "name": "child_petalLength_sepalWidth_y",
@@ -1132,9 +1132,9 @@
                         200,
                         0
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 }
             ],
             "axes": [
@@ -1238,9 +1238,9 @@
                         0,
                         200
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 },
                 {
                     "name": "child_petalLength_petalLength_y",
@@ -1253,9 +1253,9 @@
                         200,
                         0
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 }
             ],
             "axes": [
@@ -1359,9 +1359,9 @@
                         0,
                         200
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 },
                 {
                     "name": "child_petalLength_petalWidth_y",
@@ -1374,9 +1374,9 @@
                         200,
                         0
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 }
             ],
             "axes": [
@@ -1480,9 +1480,9 @@
                         0,
                         200
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 },
                 {
                     "name": "child_sepalWidth_sepalLength_y",
@@ -1495,9 +1495,9 @@
                         200,
                         0
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 }
             ],
             "axes": [
@@ -1601,9 +1601,9 @@
                         0,
                         200
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 },
                 {
                     "name": "child_sepalWidth_sepalWidth_y",
@@ -1616,9 +1616,9 @@
                         200,
                         0
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 }
             ],
             "axes": [
@@ -1722,9 +1722,9 @@
                         0,
                         200
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 },
                 {
                     "name": "child_sepalWidth_petalLength_y",
@@ -1737,9 +1737,9 @@
                         200,
                         0
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 }
             ],
             "axes": [
@@ -1843,9 +1843,9 @@
                         0,
                         200
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 },
                 {
                     "name": "child_sepalWidth_petalWidth_y",
@@ -1858,9 +1858,9 @@
                         200,
                         0
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 }
             ],
             "axes": [
@@ -1964,9 +1964,9 @@
                         0,
                         200
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 },
                 {
                     "name": "child_sepalLength_sepalLength_y",
@@ -1979,9 +1979,9 @@
                         200,
                         0
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 }
             ],
             "axes": [
@@ -2085,9 +2085,9 @@
                         0,
                         200
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 },
                 {
                     "name": "child_sepalLength_sepalWidth_y",
@@ -2100,9 +2100,9 @@
                         200,
                         0
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 }
             ],
             "axes": [
@@ -2206,9 +2206,9 @@
                         0,
                         200
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 },
                 {
                     "name": "child_sepalLength_petalLength_y",
@@ -2221,9 +2221,9 @@
                         200,
                         0
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 }
             ],
             "axes": [
@@ -2327,9 +2327,9 @@
                         0,
                         200
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 },
                 {
                     "name": "child_sepalLength_petalWidth_y",
@@ -2342,9 +2342,9 @@
                         200,
                         0
                     ],
+                    "zero": false,
                     "round": true,
-                    "nice": true,
-                    "zero": false
+                    "nice": true
                 }
             ],
             "axes": [

--- a/examples/vg-specs/scatter_connected.vg.json
+++ b/examples/vg-specs/scatter_connected.vg.json
@@ -178,9 +178,9 @@
                 0,
                 200
             ],
+            "zero": false,
             "round": true,
-            "nice": true,
-            "zero": false
+            "nice": true
         },
         {
             "name": "y",
@@ -202,9 +202,9 @@
                 200,
                 0
             ],
+            "zero": false,
             "round": true,
-            "nice": true,
-            "zero": false
+            "nice": true
         }
     ],
     "axes": [

--- a/examples/vg-specs/stacked_area.vg.json
+++ b/examples/vg-specs/stacked_area.vg.json
@@ -172,8 +172,8 @@
                 0,
                 300
             ],
-            "round": true,
-            "nice": "month"
+            "nice": "month",
+            "round": true
         },
         {
             "name": "y",

--- a/examples/vg-specs/stacked_area_normalize.vg.json
+++ b/examples/vg-specs/stacked_area_normalize.vg.json
@@ -171,8 +171,8 @@
                 0,
                 300
             ],
-            "round": true,
-            "nice": "month"
+            "nice": "month",
+            "round": true
         },
         {
             "name": "y",

--- a/examples/vg-specs/stacked_area_stream.vg.json
+++ b/examples/vg-specs/stacked_area_stream.vg.json
@@ -171,8 +171,8 @@
                 0,
                 300
             ],
-            "round": true,
-            "nice": "month"
+            "nice": "month",
+            "round": true
         },
         {
             "name": "y",

--- a/examples/vg-specs/trellis_anscombe.vg.json
+++ b/examples/vg-specs/trellis_anscombe.vg.json
@@ -283,9 +283,9 @@
                 0,
                 200
             ],
+            "zero": false,
             "round": true,
-            "nice": true,
-            "zero": false
+            "nice": true
         },
         {
             "name": "y",
@@ -298,9 +298,9 @@
                 200,
                 0
             ],
+            "zero": false,
             "round": true,
-            "nice": true,
-            "zero": false
+            "nice": true
         }
     ]
 }

--- a/examples/vg-specs/trellis_barley.vg.json
+++ b/examples/vg-specs/trellis_barley.vg.json
@@ -292,9 +292,9 @@
                 0,
                 200
             ],
+            "zero": false,
             "round": true,
-            "nice": true,
-            "zero": false
+            "nice": true
         },
         {
             "name": "trellis_barley_y",

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -84,6 +84,12 @@ export const UNIT_SCALE_CHANNELS = [X, Y, SIZE, SHAPE, COLOR, OPACITY];
 export const SCALE_CHANNELS = [X, Y, SIZE, SHAPE, COLOR, OPACITY, ROW, COLUMN];
 export type ScaleChannel = typeof SCALE_CHANNELS[0];
 
+const SCALE_CHANNEL_INDEX = toSet(SCALE_CHANNELS);
+
+export function isScaleChannel(channel: Channel): channel is ScaleChannel {
+  return !!SCALE_CHANNEL_INDEX[channel];
+}
+
 // UNIT_CHANNELS without X, Y, X2, Y2;
 export const NONSPATIAL_CHANNELS = [SIZE, SHAPE, COLOR, ORDER, OPACITY, TEXT, DETAIL, TOOLTIP];
 

--- a/src/compile/axis/encode.ts
+++ b/src/compile/axis/encode.ts
@@ -19,7 +19,7 @@ export function labels(model: UnitModel, channel: SpatialScaleChannel, labelsSpe
 
   // Text
   if (fieldDef.type === TEMPORAL) {
-    const isUTCScale = model.getScaleComponent(channel).type === ScaleType.UTC;
+    const isUTCScale = model.getScaleComponent(channel).get('type') === ScaleType.UTC;
     labelsSpec = extend({
       text: {
         signal: timeFormatExpression('datum.value', fieldDef.timeUnit, axis.format, config.axis.shortTimeLabels, config.timeFormat, isUTCScale)

--- a/src/compile/concat.ts
+++ b/src/compile/concat.ts
@@ -11,6 +11,7 @@ import {parseData} from './data/parse';
 import {moveSharedLegendUp} from './legend/parse';
 import {Model} from './model';
 import {RepeaterValue} from './repeat';
+import {ScaleComponentIndex} from './scale/component';
 import {moveSharedScaleUp} from './scale/parse';
 
 
@@ -57,7 +58,7 @@ export class ConcatModel extends Model {
   public parseScale() {
     const model = this;
 
-    const scaleComponent: Dict<VgScale> = this.component.scales = {};
+    const scaleComponent: ScaleComponentIndex = this.component.scales = {};
 
     for (const child of this.children) {
       child.parseScale();

--- a/src/compile/data/aggregate.ts
+++ b/src/compile/data/aggregate.ts
@@ -6,6 +6,7 @@ import {Dict, differ, duplicate, extend, keys, StringSet} from '../../util';
 import {VgAggregateTransform} from '../../vega.schema';
 import {UnitModel} from './../unit';
 
+import {isScaleChannel} from '../../channel';
 import {Summarize, SummarizeTransform} from '../../transform';
 import {Model} from '../model';
 import {DataFlowNode} from './dataflow';
@@ -83,8 +84,8 @@ export class AggregateNode extends DataFlowNode {
           meas[fieldDef.field] = meas[fieldDef.field] || {};
           meas[fieldDef.field][fieldDef.aggregate] = field(fieldDef);
 
-          // add min/max so we can use their union as unaggregated domain
-          if (model.scaleDomain(channel) === 'unaggregated') {
+          // For scale channel with domain === 'unaggregated', add min/max so we can use their union as unaggregated domain
+          if (isScaleChannel(channel) && model.scaleDomain(channel) === 'unaggregated') {
             meas[fieldDef.field]['min'] = field(fieldDef, {aggregate: 'min'});
             meas[fieldDef.field]['max'] = field(fieldDef, {aggregate: 'max'});
           }

--- a/src/compile/data/nonpositivefilter.ts
+++ b/src/compile/data/nonpositivefilter.ts
@@ -25,7 +25,7 @@ export class NonPositiveFilterNode extends DataFlowNode {
         // don't set anything
         return nonPositiveComponent;
       }
-      nonPositiveComponent[model.field(channel)] = scale.type === ScaleType.LOG;
+      nonPositiveComponent[model.field(channel)] = scale.get('type') === ScaleType.LOG;
       return nonPositiveComponent;
     }, {});
 

--- a/src/compile/data/stack.ts
+++ b/src/compile/data/stack.ts
@@ -15,7 +15,7 @@ function getStackByFields(model: UnitModel): string[] {
 
     const scale = model.getScaleComponent(channel);
     const _field = field(fieldDef, {
-      binSuffix: scale && hasDiscreteDomain(scale.type) ? 'range' : 'start'
+      binSuffix: scale && hasDiscreteDomain(scale.get('type')) ? 'range' : 'start'
     });
     if (_field) {
       fields.push(_field);

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -26,6 +26,7 @@ import {labels} from './legend/encode';
 import {moveSharedLegendUp} from './legend/parse';
 import {Model, ModelWithField} from './model';
 import {RepeaterValue, replaceRepeaterInFacet} from './repeat';
+import {ScaleComponentIndex} from './scale/component';
 import {moveSharedScaleUp} from './scale/parse';
 
 export class FacetModel extends ModelWithField {
@@ -101,14 +102,14 @@ export class FacetModel extends ModelWithField {
 
     child.parseScale();
 
-    const scaleComponent: Dict<VgScale> = this.component.scales = {};
+    const scaleComponent: ScaleComponentIndex = this.component.scales = {};
 
     keys(child.component.scales).forEach((channel: ScaleChannel) => {
       if (this.resolve[channel].scale === 'shared') {
         const scale = moveSharedScaleUp(this, scaleComponent, child, channel);
 
         // Replace the scale domain with data output from a cloned subtree after the facet.
-        const domain = scale.domain;
+        const domain = scale.get('domain');
 
         if (isDataRefDomain(domain) || isFieldRefUnionDomain(domain)) {
           domain.data = FACET_SCALE_PREFIX + this.getName(domain.data);

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -16,6 +16,7 @@ import {parseData} from './data/parse';
 import {assembleLayoutLayerSignals} from './layout/index';
 import {moveSharedLegendUp} from './legend/parse';
 import {RepeaterValue} from './repeat';
+import {ScaleComponent} from './scale/component';
 import {unionDomains} from './scale/domain';
 import {moveSharedScaleUp} from './scale/parse';
 import {assembleLayerSelectionMarks} from './selection/selection';
@@ -77,7 +78,7 @@ export class LayerModel extends Model {
   }
 
   public parseScale(this: LayerModel) {
-    const scaleComponent: Dict<VgScale> = this.component.scales = {};
+    const scaleComponent: Dict<ScaleComponent> = this.component.scales = {};
 
     for (const child of this.children) {
       child.parseScale();

--- a/src/compile/layout/index.ts
+++ b/src/compile/layout/index.ts
@@ -3,7 +3,7 @@ import {Channel, COLUMN, ROW, X, Y} from '../../channel';
 import {MAIN} from '../../data';
 import {hasDiscreteDomain} from '../../scale';
 import {extend, isArray, keys, StringSet} from '../../util';
-import {VgData, VgFormulaTransform, VgSignal, VgTransform} from '../../vega.schema';
+import {isVgRangeStep, VgData, VgFormulaTransform, VgSignal, VgTransform} from '../../vega.schema';
 
 import {FacetModel} from '../facet';
 import {LayerModel} from '../layer';
@@ -34,11 +34,9 @@ export function assembleLayoutUnitSignals(model: UnitModel): VgSignal[] {
 export function unitSizeExpr(model: UnitModel, sizeType: 'width' | 'height'): string {
   const channel = sizeType==='width' ? 'x' : 'y';
 
-  // TODO: remove this once rangeStep is a part of scale component
-  const splitScale = model.scale(channel);
-  if (splitScale) {
-    const scale = splitScale.combine();
-    if (hasDiscreteDomain(scale.type) && scale.rangeStep) {
+  const scale = model.getScaleComponent(channel);
+  if (scale) {
+    if (hasDiscreteDomain(scale.type) && isVgRangeStep(scale.range)) {
       const scaleName = model.scaleName(channel);
 
       const cardinality = `domain('${scaleName}').length`;
@@ -50,7 +48,7 @@ export function unitSizeExpr(model: UnitModel, sizeType: 'width' | 'height'): st
         // it's equivalent to have paddingInner = 1 since there is only n-1 steps between n points.
         1;
 
-      return `bandspace(${cardinality}, ${paddingInner}, ${paddingOuter}) * ${scale.rangeStep}`;
+      return `bandspace(${cardinality}, ${paddingInner}, ${paddingOuter}) * ${scale.range.step}`;
     }
   }
   return `${model[sizeType]}`;

--- a/src/compile/layout/index.ts
+++ b/src/compile/layout/index.ts
@@ -8,6 +8,7 @@ import {isVgRangeStep, VgData, VgFormulaTransform, VgSignal, VgTransform} from '
 import {FacetModel} from '../facet';
 import {LayerModel} from '../layer';
 import {Model, ModelWithField} from '../model';
+import {ScaleComponent} from '../scale/component';
 import {UnitModel} from '../unit';
 
 
@@ -34,8 +35,9 @@ export function assembleLayoutUnitSignals(model: UnitModel): VgSignal[] {
 export function unitSizeExpr(model: UnitModel, sizeType: 'width' | 'height'): string {
   const channel = sizeType==='width' ? 'x' : 'y';
 
-  const scale = model.getScaleComponent(channel);
-  if (scale) {
+  const scaleComponent = model.getScaleComponent(channel);
+  if (scaleComponent) {
+    const scale = scaleComponent.combine();
     if (hasDiscreteDomain(scale.type) && isVgRangeStep(scale.range)) {
       const scaleName = model.scaleName(channel);
 

--- a/src/compile/layout/index.ts
+++ b/src/compile/layout/index.ts
@@ -35,8 +35,9 @@ export function unitSizeExpr(model: UnitModel, sizeType: 'width' | 'height'): st
   const channel = sizeType==='width' ? 'x' : 'y';
 
   // TODO: remove this once rangeStep is a part of scale component
-  const scale = model.scale(channel);
-  if (scale) {
+  const splitScale = model.scale(channel);
+  if (splitScale) {
+    const scale = splitScale.combine();
     if (hasDiscreteDomain(scale.type) && scale.rangeStep) {
       const scaleName = model.scaleName(channel);
 

--- a/src/compile/legend/encode.ts
+++ b/src/compile/legend/encode.ts
@@ -77,7 +77,7 @@ export function labels(fieldDef: FieldDef<string>, labelsSpec: any, model: UnitM
   let labels:any = {};
 
   if (fieldDef.type === TEMPORAL) {
-    const isUTCScale = model.getScaleComponent(channel).type === ScaleType.UTC;
+    const isUTCScale = model.getScaleComponent(channel).get('type') === ScaleType.UTC;
     labelsSpec = extend({
       text: {
         signal: timeFormatExpression('datum.value', fieldDef.timeUnit, legend.format, config.legend.shortTimeLabels, config.timeFormat, isUTCScale)

--- a/src/compile/legend/parse.ts
+++ b/src/compile/legend/parse.ts
@@ -75,7 +75,7 @@ function getSpecifiedOrDefaultValue(property: keyof VgLegend, specifiedLegend: L
     case 'values':
       return rules.values(specifiedLegend);
     case 'type':
-      return rules.type(specifiedLegend, fieldDef.type, channel, model.getScaleComponent(channel).type);
+      return rules.type(specifiedLegend, fieldDef.type, channel, model.getScaleComponent(channel).get('type'));
   }
 
   // Otherwise, return specified property.

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -48,8 +48,12 @@ function x(model: UnitModel, stack: StackProperties): VgEncodeEntry {
     if (isFieldDef(xDef)) {
       if (xDef.bin && !sizeDef) {
         return mixins.binnedPosition(xDef, 'x', model.scaleName('x'), config.bar.binSpacing);
-      } else if (xScale.type === ScaleType.BAND) {
-        return mixins.bandPosition(xDef, 'x', model);
+      } else {
+        const xScaleType = xScale.get('type');
+
+        if (xScaleType === ScaleType.BAND) {
+          return mixins.bandPosition(xDef, 'x', model);
+        }
       }
     }
     // sized bin, normal point-ordinal axis, quantitative x-axis, or no x
@@ -77,9 +81,10 @@ function y(model: UnitModel, stack: StackProperties) {
     };
   } else {
     if (isFieldDef(yDef)) {
+      const yScaleType = yScale.get('type');
       if (yDef.bin && !sizeDef) {
         return mixins.binnedPosition(yDef, 'y', model.scaleName('y'), config.bar.binSpacing);
-      } else if (yScale.type === ScaleType.BAND) {
+      } else if (yScaleType === ScaleType.BAND) {
         return mixins.bandPosition(yDef, 'y', model);
       }
     }
@@ -95,12 +100,14 @@ function defaultSizeRef(scaleName: string, scale: ScaleComponent, config: Config
   }
 
   if (scale) {
-    if (scale.type === ScaleType.POINT) {
-      if (isVgRangeStep(scale.range)) {
-        return {value: scale.range.step - 1};
+    const scaleType = scale.get('type');
+    if (scaleType === ScaleType.POINT) {
+      const scaleRange = scale.get('range');
+      if (isVgRangeStep(scaleRange)) {
+        return {value: scaleRange.step - 1};
       }
       log.warn(log.message.BAR_WITH_POINT_SCALE_AND_RANGESTEP_NULL);
-    } else if (scale.type === ScaleType.BAND) {
+    } else if (scaleType === ScaleType.BAND) {
       return ref.band(scaleName);
     } else { // non-ordinal scale
       return {value: config.bar.continuousBandSize};

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -10,6 +10,7 @@ import {VgValueRef} from '../../vega.schema';
 import {UnitModel} from '../unit';
 import * as mixins from './mixins';
 
+import {Split} from '../split';
 import {MarkCompiler} from './base';
 import * as ref from './valueref';
 
@@ -82,17 +83,20 @@ function y(model: UnitModel, stack: StackProperties) {
         return mixins.bandPosition(yDef, 'y', model);
       }
     }
-    // TODO: replace model.scale(X) with model.getScaleComponent once rangeStep is a part of scale component
-    return mixins.centeredBandPosition('y', model, ref.midY(height, config), defaultSizeRef(yScaleName, model.scale(Y), config));
+    return mixins.centeredBandPosition('y', model, ref.midY(height, config),
+      // TODO: replace model.scale(X) with model.getScaleComponent once rangeStep is a part of scale component
+      defaultSizeRef(yScaleName, model.scale(Y), config)
+    );
   }
 }
 
-function defaultSizeRef(scaleName: string, scale: Scale, config: Config): VgValueRef {
+function defaultSizeRef(scaleName: string, splitScale: Split<Scale>, config: Config): VgValueRef {
   if (config.bar.discreteBandSize) {
     return {value: config.bar.discreteBandSize};
   }
 
-  if (scale) {
+  if (splitScale) {
+    const scale = splitScale.combine();
     if (scale.type === ScaleType.POINT) {
       if (scale.rangeStep !== null) {
         return {value: scale.rangeStep - 1};

--- a/src/compile/mark/init.ts
+++ b/src/compile/mark/init.ts
@@ -76,8 +76,8 @@ function orient(mark: Mark, encoding: Encoding<string>, scales: ScaleIndex, spec
 
   switch (mark) {
     case TICK:
-      const xScaleType = scales['x'] ? scales['x'].type : null;
-      const yScaleType = scales['y'] ? scales['y'].type : null;
+      const xScaleType = scales['x'] ? scales['x'].get('type') : null;
+      const yScaleType = scales['y'] ? scales['y'].get('type') : null;
 
       // Tick is opposite to bar, line, area and never have ranged mark.
       if (!hasDiscreteDomain(xScaleType) && (

--- a/src/compile/mark/rect.ts
+++ b/src/compile/mark/rect.ts
@@ -27,16 +27,17 @@ function x(model: UnitModel) {
   const xDef = model.encoding.x;
   const x2Def = model.encoding.x2;
   const xScale = model.getScaleComponent(X);
+  const xScaleType = xScale ? xScale.get('type') : undefined;
 
   if (isFieldDef(xDef) && xDef.bin && !x2Def) {
     return mixins.binnedPosition(xDef, 'x', model.scaleName('x'), 0);
-  } else if (isFieldDef(xDef) && xScale && hasDiscreteDomain(xScale.type)) {
+  } else if (isFieldDef(xDef) && xScale && hasDiscreteDomain(xScaleType)) {
     /* istanbul ignore else */
-    if (xScale.type === ScaleType.BAND) {
+    if (xScaleType === ScaleType.BAND) {
       return mixins.bandPosition(xDef, 'x', model);
     } else {
       // We don't support rect mark with point/ordinal scale
-      throw new Error(log.message.scaleTypeNotWorkWithMark(RECT, xScale.type));
+      throw new Error(log.message.scaleTypeNotWorkWithMark(RECT, xScaleType));
     }
   } else { // continuous scale or no scale
     return {
@@ -50,16 +51,17 @@ function y(model: UnitModel) {
   const yDef = model.encoding.y;
   const y2Def = model.encoding.y2;
   const yScale = model.getScaleComponent(Y);
+  const yScaleType = yScale ? yScale.get('type') : undefined;
 
   if (isFieldDef(yDef) && yDef.bin && !y2Def) {
     return mixins.binnedPosition(yDef, 'y', model.scaleName('y'), 0);
-  } else if (isFieldDef(yDef) && yScale && hasDiscreteDomain(yScale.type)) {
+  } else if (isFieldDef(yDef) && yScale && hasDiscreteDomain(yScaleType)) {
     /* istanbul ignore else */
-    if (yScale.type === ScaleType.BAND) {
+    if (yScaleType === ScaleType.BAND) {
       return mixins.bandPosition(yDef, 'y', model);
     } else {
       // We don't support rect mark with point/ordinal scale
-      throw new Error(log.message.scaleTypeNotWorkWithMark(RECT, yScale.type));
+      throw new Error(log.message.scaleTypeNotWorkWithMark(RECT, yScaleType));
     }
   } else { // continuous scale or no scale
     return {

--- a/src/compile/mark/tick.ts
+++ b/src/compile/mark/tick.ts
@@ -39,7 +39,8 @@ function defaultSize(model: UnitModel): number {
   const orient = model.markDef.orient;
 
   // TODO: replace model.scale() with model.getScaleComponent() once rangeStep is a part of scale component
-  const scaleRangeStep: number | null = (model.scale(orient === 'horizontal' ? 'x' : 'y') || {}).rangeStep;
+  const splitScale = model.scale(orient === 'horizontal' ? 'x' : 'y');
+  const scaleRangeStep: number | null = splitScale ? splitScale.get('rangeStep') : undefined;
 
   if (config.tick.bandSize !== undefined) {
     return config.tick.bandSize;

--- a/src/compile/mark/tick.ts
+++ b/src/compile/mark/tick.ts
@@ -43,8 +43,9 @@ function defaultSize(model: UnitModel): number {
   if (config.tick.bandSize !== undefined) {
     return config.tick.bandSize;
   } else {
-    const rangeStep = scale && isVgRangeStep(scale.range) ?
-      scale.range.step :
+    const scaleRange = scale ? scale.get('range') : undefined;
+    const rangeStep = scaleRange && isVgRangeStep(scaleRange) ?
+      scaleRange.step :
       config.scale.rangeStep;
     if (typeof rangeStep !== 'number') {
       // FIXME consolidate this log

--- a/src/compile/mark/tick.ts
+++ b/src/compile/mark/tick.ts
@@ -3,6 +3,7 @@
 import {UnitModel} from '../unit';
 import * as mixins from './mixins';
 
+import {isVgRangeStep} from '../../vega.schema';
 import {MarkCompiler} from './base';
 import * as ref from './valueref';
 
@@ -37,16 +38,13 @@ export const tick: MarkCompiler = {
 function defaultSize(model: UnitModel): number {
   const {config} = model;
   const orient = model.markDef.orient;
-
-  // TODO: replace model.scale() with model.getScaleComponent() once rangeStep is a part of scale component
-  const splitScale = model.scale(orient === 'horizontal' ? 'x' : 'y');
-  const scaleRangeStep: number | null = splitScale ? splitScale.get('rangeStep') : undefined;
+  const scale = model.getScaleComponent(orient === 'horizontal' ? 'x' : 'y');
 
   if (config.tick.bandSize !== undefined) {
     return config.tick.bandSize;
   } else {
-    const rangeStep = scaleRangeStep !== undefined ?
-      scaleRangeStep :
+    const rangeStep = scale && isVgRangeStep(scale.range) ?
+      scale.range.step :
       config.scale.rangeStep;
     if (typeof rangeStep !== 'number') {
       // FIXME consolidate this log

--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -2,7 +2,7 @@
  * Utility files for producing Vega ValueRef for marks
  */
 
-import {Channel, X, X2, Y, Y2} from '../../channel';
+import {Channel, ScaleChannel, X, X2, Y, Y2} from '../../channel';
 import {Config} from '../../config';
 import {ChannelDef, Conditional, field, FieldDef, FieldRefOption, isFieldDef, isValueDef, TextFieldDef, ValueDef} from '../../fielddef';
 import {hasDiscreteDomain, ScaleType} from '../../scale';
@@ -10,6 +10,7 @@ import {StackProperties} from '../../stack';
 import {contains} from '../../util';
 import {VgScale, VgValueRef} from '../../vega.schema';
 import {formatSignalRef, numberFormat} from '../common';
+import {ScaleComponent} from '../scale/component';
 
 // TODO: we need to find a way to refactor these so that scaleName is a part of scale
 // but that's complicated.  For now, this is a huge step moving forward.
@@ -17,7 +18,7 @@ import {formatSignalRef, numberFormat} from '../common';
 /**
  * @return Vega ValueRef for stackable x or y
  */
-export function stackable(channel: 'x' | 'y', channelDef: ChannelDef<string>, scaleName: string, scale: VgScale,
+export function stackable(channel: 'x' | 'y', channelDef: ChannelDef<string>, scaleName: string, scale: ScaleComponent,
     stack: StackProperties, defaultRef: VgValueRef): VgValueRef {
   if (isFieldDef(channelDef) && stack && channel === stack.fieldChannel) {
     // x or y use stack_end so that stacked line's point mark use stack_end too.
@@ -29,7 +30,7 @@ export function stackable(channel: 'x' | 'y', channelDef: ChannelDef<string>, sc
 /**
  * @return Vega ValueRef for stackable x2 or y2
  */
-export function stackable2(channel: 'x2' | 'y2', aFieldDef: ChannelDef<string>, a2fieldDef: ChannelDef<string>, scaleName: string, scale: VgScale,
+export function stackable2(channel: 'x2' | 'y2', aFieldDef: ChannelDef<string>, a2fieldDef: ChannelDef<string>, scaleName: string, scale: ScaleComponent,
     stack: StackProperties, defaultRef: VgValueRef): VgValueRef {
   if (isFieldDef(aFieldDef) && stack &&
       // If fieldChannel is X and channel is X2 (or Y and Y2)
@@ -87,7 +88,7 @@ function binMidSignal(fieldDef: FieldDef<string>, scaleName: string) {
 /**
  * @returns {VgValueRef} Value Ref for xc / yc or mid point for other channels.
  */
-export function midPoint(channel: Channel, channelDef: ChannelDef<string>, scaleName: string, scale: VgScale,
+export function midPoint(channel: Channel, channelDef: ChannelDef<string>, scaleName: string, scale: ScaleComponent,
   defaultRef: VgValueRef | 'zeroOrMin' | 'zeroOrMax'): VgValueRef {
   // TODO: datum support
 
@@ -104,8 +105,9 @@ export function midPoint(channel: Channel, channelDef: ChannelDef<string>, scale
         return fieldRef(channelDef, scaleName, {binSuffix: 'start'});
       }
 
-      if (hasDiscreteDomain(scale.type)) {
-        if (scale.type === 'band') {
+      const scaleType = scale.get('type');
+      if (hasDiscreteDomain(scaleType)) {
+        if (scaleType === 'band') {
           // For band, to get mid point, need to offset by half of the band
           return fieldRef(channelDef, scaleName, {binSuffix: 'range'}, {band: 0.5});
         }
@@ -178,11 +180,11 @@ export function midY(height: number, config: Config): VgValueRef {
   return {value: config.scale.rangeStep / 2};
 }
 
-function zeroOrMinX(scaleName: string, scale: VgScale): VgValueRef {
+function zeroOrMinX(scaleName: string, scale: ScaleComponent): VgValueRef {
   if (scaleName) {
     // Log / Time / UTC scale do not support zero
-    if (!contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.type) &&
-      scale.zero !== false) {
+    if (!contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.get('type')) &&
+      scale.get('zero') !== false) {
 
       return {
         scale: scaleName,
@@ -197,11 +199,11 @@ function zeroOrMinX(scaleName: string, scale: VgScale): VgValueRef {
 /**
  * @returns {VgValueRef} base value if scale exists and return max value if scale does not exist
  */
-function zeroOrMaxX(scaleName: string, scale: VgScale): VgValueRef {
+function zeroOrMaxX(scaleName: string, scale: ScaleComponent): VgValueRef {
   if (scaleName) {
     // Log / Time / UTC scale do not support zero
-    if (!contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.type) &&
-      scale.zero !== false) {
+    if (!contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.get('type')) &&
+      scale.get('zero') !== false) {
 
       return {
         scale: scaleName,
@@ -212,11 +214,11 @@ function zeroOrMaxX(scaleName: string, scale: VgScale): VgValueRef {
   return {field: {group: 'width'}};
 }
 
-function zeroOrMinY(scaleName: string, scale: VgScale): VgValueRef {
+function zeroOrMinY(scaleName: string, scale: ScaleComponent): VgValueRef {
   if (scaleName) {
     // Log / Time / UTC scale do not support zero
-    if (!contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.type) &&
-      scale.zero !== false) {
+    if (!contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.get('type')) &&
+      scale.get('zero') !== false) {
 
       return {
         scale: scaleName,
@@ -231,11 +233,11 @@ function zeroOrMinY(scaleName: string, scale: VgScale): VgValueRef {
 /**
  * @returns {VgValueRef} base value if scale exists and return max value if scale does not exist
  */
-function zeroOrMaxY(scaleName: string, scale: VgScale): VgValueRef {
+function zeroOrMaxY(scaleName: string, scale: ScaleComponent): VgValueRef {
   if (scaleName) {
     // Log / Time / UTC scale do not support zero
-    if (!contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.type) &&
-      scale.zero !== false) {
+    if (!contains([ScaleType.LOG, ScaleType.TIME, ScaleType.UTC], scale.get('type')) &&
+      scale.get('zero') !== false) {
 
       return {
         scale: scaleName,

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -21,6 +21,7 @@ import {RepeaterValue} from './repeat';
 import {assembleScale} from './scale/assemble';
 import {ScaleComponent, ScaleComponentIndex} from './scale/component';
 import {SelectionComponent} from './selection/selection';
+import {Split} from './split';
 import {UnitModel} from './unit';
 
 /**
@@ -313,7 +314,7 @@ export abstract class Model {
   }
 
   // FIXME: remove this, but currently the scaleName() method below depends on this.
-  public scale(channel: Channel): Scale {
+  public scale(channel: Channel): Split<Scale> {
     return null;
   }
 

--- a/src/compile/scale/assemble.ts
+++ b/src/compile/scale/assemble.ts
@@ -2,24 +2,28 @@ import {isArray} from 'vega-util';
 import * as log from '../../log';
 import {isSelectionDomain} from '../../scale';
 import {stringValue, vals} from '../../util';
-import {isDataRefDomain, isDataRefUnionedDomain, isFieldRefUnionDomain, isSignalRefDomain, VgDataRef} from '../../vega.schema';
+import {isDataRefDomain, isDataRefUnionedDomain, isFieldRefUnionDomain, isSignalRefDomain, VgDataRef, VgScale} from '../../vega.schema';
 import {Model} from '../model';
 import {isRawSelectionDomain, scaleDomain} from '../selection/selection';
 
-export function assembleScale(model: Model) {
-    return vals(model.component.scales).map(scale => {
+export function assembleScale(model: Model): VgScale[] {
+    return vals(model.component.scales).map(scaleComponent => {
+      // We need to cast here as combine returns Partial<VgScale> by default.
+      const scale = scaleComponent.combine() as VgScale;
+
+      const domainRaw = scaleComponent.get('domainRaw');
       // As scale parsing occurs before selection parsing, a temporary signal
       // is used for domainRaw. Here, we detect if this temporary signal
       // is set, and replace it with the correct domainRaw signal.
       // For more information, see isRawSelectionDomain in selection.ts.
-      if (scale.domainRaw && isRawSelectionDomain(scale.domainRaw)) {
-        scale.domainRaw = scaleDomain(model, scale.domainRaw);
+      if (domainRaw && isRawSelectionDomain(domainRaw)) {
+        scale.domainRaw = scaleDomain(model, domainRaw);
       }
 
       // Correct references to data as the original domain's data was determined
       // in parseScale, which happens before parseData. Thus the original data
       // reference can be incorrect.
-      const domain = scale.domain;
+      const domain = scaleComponent.get('domain');
       if (isDataRefDomain(domain) || isFieldRefUnionDomain(domain)) {
         domain.data = model.lookupDataSource(domain.data);
         return scale;

--- a/src/compile/scale/assemble.ts
+++ b/src/compile/scale/assemble.ts
@@ -9,7 +9,7 @@ import {isRawSelectionDomain, scaleDomain} from '../selection/selection';
 export function assembleScale(model: Model): VgScale[] {
     return vals(model.component.scales).map(scaleComponent => {
       // We need to cast here as combine returns Partial<VgScale> by default.
-      const scale = scaleComponent.combine() as VgScale;
+      const scale = scaleComponent.combine(['name', 'type', 'domain', 'domainRaw', 'range']) as VgScale;
 
       const domainRaw = scaleComponent.get('domainRaw');
       // As scale parsing occurs before selection parsing, a temporary signal

--- a/src/compile/scale/component.ts
+++ b/src/compile/scale/component.ts
@@ -3,7 +3,7 @@ import {Scale} from '../../scale';
 import {VgScale} from '../../vega.schema';
 import {Split} from '../split';
 
-export type ScaleComponent = VgScale;
+export type ScaleComponent = Split<Partial<VgScale>>;
 
 export type ScaleComponentIndex = {[P in ScaleChannel]?: ScaleComponent};
 

--- a/src/compile/scale/component.ts
+++ b/src/compile/scale/component.ts
@@ -1,9 +1,10 @@
 import {ScaleChannel} from '../../channel';
 import {Scale} from '../../scale';
 import {VgScale} from '../../vega.schema';
+import {Split} from '../split';
 
 export type ScaleComponent = VgScale;
 
 export type ScaleComponentIndex = {[P in ScaleChannel]?: ScaleComponent};
 
-export type ScaleIndex = {[P in ScaleChannel]?: Scale};
+export type ScaleIndex = {[P in ScaleChannel]?: Split<Scale>};

--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -22,16 +22,16 @@ import {VgSignalRef} from '../../vega.schema';
 import {UnitModel} from '../unit';
 
 
-export function initDomain(domain: Domain, fieldDef: FieldDef<string>, scale: ScaleType, scaleConfig: ScaleConfig) {
+export function initDomain(domain: Domain, fieldDef: FieldDef<string>, scaleType: ScaleType, scaleConfig: ScaleConfig) {
   if (domain === 'unaggregated') {
-    const {valid, reason} = canUseUnaggregatedDomain(fieldDef, scale);
+    const {valid, reason} = canUseUnaggregatedDomain(fieldDef, scaleType);
     if(!valid) {
       log.warn(reason);
       return undefined;
     }
   } else if (domain === undefined && scaleConfig.useUnaggregatedDomain) {
     // Apply config if domain is not specified.
-    const {valid} = canUseUnaggregatedDomain(fieldDef, scale);
+    const {valid} = canUseUnaggregatedDomain(fieldDef, scaleType);
     if (valid) {
       return 'unaggregated';
     }
@@ -44,7 +44,7 @@ export function initDomain(domain: Domain, fieldDef: FieldDef<string>, scale: Sc
 // parseDomain must be called separately after parseScale
 export function parseDomain(model: UnitModel, channel: ScaleChannel): VgDomain {
   // FIXME replace this with getScaleComponent once parseScaleDomain a separate parseStep from scale
-  const scaleType = model.scale(channel).type;
+  const scaleType = model.scale(channel).get('type');
   const domain = model.scaleDomain(channel);
 
   // If channel is either X or Y then union them with X2 & Y2 if they exist

--- a/src/compile/scale/parse.ts
+++ b/src/compile/scale/parse.ts
@@ -47,25 +47,28 @@ export function parseScale(model: UnitModel, channel: ScaleChannel) {
   const scale = model.scale(channel);
   const sort = model.sort(channel);
 
+  // FIXME parseScale should return something similar to Split<VgScale>
   const scaleComponent: VgScale = {
     name: model.scaleName(channel + '', true),
-    type: scale.type,
+    type: scale.get('type'),
     domain: parseDomain(model, channel),
     range: parseRange(scale)
   };
 
-  if (isSelectionDomain(scale.domain)) {
+  if (isSelectionDomain(scale.get('domain'))) {
     // As scale parsing occurs before selection parsing, we use a temporary
     // signal here and append the scale.domain definition. This is replaced
     // with the correct domainRaw signal during scale assembly.
     // For more information, see isRawSelectionDomain in selection.ts.
+
+    // FIXME: replace this with an explicit property in the scaleComponent
     scaleComponent.domainRaw = {
-      signal: SELECTION_DOMAIN + JSON.stringify(scale.domain)
+      signal: SELECTION_DOMAIN + JSON.stringify(scale.get('domain'))
     };
   }
 
   NON_TYPE_DOMAIN_RANGE_VEGA_SCALE_PROPERTIES.forEach((property) => {
-    scaleComponent[property] = scale[property];
+    scaleComponent[property] = scale.get(property);
   });
 
   return scaleComponent;

--- a/src/compile/scale/rules.ts
+++ b/src/compile/scale/rules.ts
@@ -4,6 +4,7 @@ import {FieldDef} from '../../fielddef';
 import {NiceTime, Scale, ScaleConfig, ScaleType} from '../../scale';
 import {smallestUnit} from '../../timeunit';
 import * as util from '../../util';
+import {Split} from '../split';
 
 export function nice(scaleType: ScaleType, channel: Channel, fieldDef: FieldDef<string>): boolean | NiceTime {
   if (util.contains([ScaleType.TIME, ScaleType.UTC], scaleType)) {
@@ -70,7 +71,7 @@ export function round(channel: Channel, scaleConfig: ScaleConfig) {
   return undefined;
 }
 
-export function zero(specifiedScale: Scale, channel: Channel, fieldDef: FieldDef<string>) {
+export function zero(splitScale: Split<Scale>, channel: Channel, fieldDef: FieldDef<string>) {
   // By default, return true only for the following cases:
 
   // 1) using quantitative field with size
@@ -83,7 +84,7 @@ export function zero(specifiedScale: Scale, channel: Channel, fieldDef: FieldDef
   // 2) non-binned, quantitative x-scale or y-scale if no custom domain is provided.
   // (For binning, we should not include zero by default because binning are calculated without zero.
   // Similar, if users explicitly provide a domain range, we should not augment zero as that will be unexpected.)
-  if (!specifiedScale.domain && !fieldDef.bin && util.contains([X, Y], channel)) {
+  if (!splitScale.get('domain') && !fieldDef.bin && util.contains([X, Y], channel)) {
     return true;
   }
   return false;

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -138,7 +138,8 @@ function channelSignals(model: UnitModel, selCmpt: SelectionComponent, channel: 
   const hasScales = scales.has(selCmpt);
   const scaleName = model.scaleName(channel);
   const scaleStr = stringValue(scaleName);
-  const scaleType = model.getScaleComponent(channel).type;
+  const scale = model.getScaleComponent(channel);
+  const scaleType = scale ? scale.get('type') : undefined;
   const size  = model.getSizeSignalRef(channel === X ? 'width' : 'height').signal;
   const coord = `${channel}(unit)`;
 

--- a/src/compile/selection/transforms/scales.ts
+++ b/src/compile/selection/transforms/scales.ts
@@ -20,13 +20,14 @@ const scaleBindings:TransformCompiler = {
     selCmpt.project.forEach(function(p) {
       const channel = p.encoding;
       const scale = model.getScaleComponent(channel);
+      const scaleType = scale ? scale.get('type') : undefined;
 
-      if (!scale || !hasContinuousDomain(scale.type) || isBinScale(scale.type)) {
+      if (!scale || !hasContinuousDomain(scaleType) || isBinScale(scaleType)) {
         warn('Scale bindings are currently only supported for scales with unbinned, continuous domains.');
         return;
       }
 
-      scale.domainRaw = {signal: channelSignalName(selCmpt, channel, 'data')};
+      scale.set('domainRaw', {signal: channelSignalName(selCmpt, channel, 'data')}, true);
       bound.push(channel);
     });
   },

--- a/src/compile/split.ts
+++ b/src/compile/split.ts
@@ -1,0 +1,39 @@
+/**
+ * Generic classs for storing properties that are explicitly specified and implicitly determined by the compiler.
+ */
+
+
+export class Split<T extends Object> {
+  constructor(public readonly explicit: T = {} as T, public readonly implicit: T = {} as T) {}
+
+  public combine() {
+    // FIXME remove "as any".
+    // Add "as any" to avoid an error "Spread types may only be created from object types".
+
+    return {
+      ...this.implicit as any,
+      ...this.explicit as any
+    };
+  }
+
+  public get<K extends keyof T>(key: K): T[K] {
+    return this.implicit[key] !== undefined ? this.implicit[key] : this.explicit[key];
+  }
+
+  public set<K extends keyof T>(key: K, value: T[K], explicit: boolean) {
+    this[explicit ? 'explicit' : 'implicit'][key] = value;
+  }
+
+  public extend(mixins: T, explicit: boolean) {
+    return new Split<T>(
+      explicit ? {
+        ...this.explicit as any,
+        ...mixins as any
+      } : this.explicit,
+      explicit ? this.implicit : {
+        ...this.implicit as any,
+        ...mixins as any
+      }
+    );
+  }
+}

--- a/src/compile/split.ts
+++ b/src/compile/split.ts
@@ -6,13 +6,21 @@
 export class Split<T extends Object> {
   constructor(public readonly explicit: T = {} as T, public readonly implicit: T = {} as T) {}
 
-  public combine(): T {
+  public combine(keys: (keyof T)[] = []): T {
+    const base = keys.reduce((b, key) => {
+      const value = this.get(key);
+      if (value) {
+        b[key] = value;
+      }
+      return b;
+    }, {} as Partial<T>);
+
     // FIXME remove "as any".
     // Add "as any" to avoid an error "Spread types may only be created from object types".
-
     return {
-      ...this.implicit as any,
-      ...this.explicit as any // Explicit has higher precedence
+      ...base as any,
+      ...this.explicit as any, // Explicit properties comes first
+      ...this.implicit as any
     };
   }
 

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -93,6 +93,7 @@ export type VgScale = {
 
   clamp?: boolean,
   exponent?: number,
+  interpolate?: 'rgb'| 'lab' | 'hcl' | 'hsl' | 'hsl-long' | 'hcl-long' | 'cubehelix' | 'cubehelix-long';
   nice?: boolean | NiceTime,
   padding?: number,
   paddingInner?: number,

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -73,7 +73,12 @@ export type FieldRefUnionDomain = {
 };
 
 export type VgRangeScheme = {scheme: string, extent?: number[], count?: number};
-export type VgRange = string | VgDataRef | (number|string|VgDataRef)[] | VgRangeScheme | {step: number};
+export type VgRange = string | VgDataRef | (number|string|VgDataRef)[] | VgRangeScheme | VgRangeStep;
+
+export type VgRangeStep = {step: number};
+export function isVgRangeStep(range: VgRange): range is VgRangeStep {
+  return !!range['step'];
+}
 
 export type VgDomain = any[] | VgDataRef | DataRefUnionDomain | FieldRefUnionDomain | VgSignalRef;
 

--- a/test/compile/layer.test.ts
+++ b/test/compile/layer.test.ts
@@ -24,7 +24,7 @@ describe('Layer', function() {
       assert.equal(model.children.length, 2);
       model.parseScale();
 
-      assert.deepEqual(model.component.scales['x'].domain, {
+      assert.deepEqual(model.component.scales['x'].implicit.domain, {
         fields: [{
           data: 'layer_0_main',
           field: 'a'
@@ -52,7 +52,7 @@ describe('Layer', function() {
       });
       model.parseScale();
 
-      assert.deepEqual(model.component.scales['x'].domain, {
+      assert.deepEqual(model.component.scales['x'].explicit.domain, {
         fields: [
           [1, 2, 3],
           {
@@ -91,11 +91,11 @@ describe('Layer', function() {
       model.parseScale();
 
       assert.equal(model.component.scales['x'], undefined);
-      assert.deepEqual(model.children[0].component.scales['x'].domain, {
+      assert.deepEqual(model.children[0].component.scales['x'].implicit.domain, {
         data: 'layer_0_main',
         field: 'a'
       });
-      assert.deepEqual(model.children[1].component.scales['x'].domain, {
+      assert.deepEqual(model.children[1].component.scales['x'].implicit.domain, {
         data: 'layer_1_main',
         field: 'b'
       });

--- a/test/compile/layout/index.test.ts
+++ b/test/compile/layout/index.test.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:quotemark */
 
 import {assert} from 'chai';
-import {parseUnitModel} from '../../util';
+import {parseUnitModelWithScale} from '../../util';
 
 import {X, Y} from '../../../src/channel';
 import {unitSizeExpr} from '../../../src/compile/layout';
@@ -10,7 +10,7 @@ import * as log from '../../../src/log';
 describe('compile/layout', () => {
   describe('unitSizeExpr', () => {
     it('should return correct formula for ordinal-point scale', () => {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         mark: 'point', // point mark produce ordinal-point scale by default
         encoding: {
           x: {field: 'a', type: 'ordinal'}
@@ -22,7 +22,7 @@ describe('compile/layout', () => {
     });
 
     it('should return correct formula for ordinal-band scale with custom padding', () => {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         mark: 'rect', // rect produces ordinal-band by default
         encoding: {
           x: {field: 'a', type: 'ordinal', scale: {padding: 0.3}},
@@ -34,7 +34,7 @@ describe('compile/layout', () => {
     });
 
     it('should return correct formula for ordinal-band scale with custom paddingInner', () => {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         mark: 'rect', // rect produces ordinal-band by default
         encoding: {
           x: {field: 'a', type: 'ordinal', scale: {paddingInner: 0.3}},
@@ -46,7 +46,7 @@ describe('compile/layout', () => {
     });
 
     it('should return static cell size for ordinal x-scale with null', () => {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         mark: 'point',
         encoding: {
           x: {field: 'a', type: 'ordinal', scale: {rangeStep: null}}
@@ -59,7 +59,7 @@ describe('compile/layout', () => {
 
 
     it('should return static cell size for ordinal y-scale with null', () => {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         mark: 'point',
         encoding: {
           y: {field: 'a', type: 'ordinal', scale: {rangeStep: null}}
@@ -71,7 +71,7 @@ describe('compile/layout', () => {
     });
 
     it('should return static cell size for ordinal scale with top-level width', () => {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         width: 205,
         mark: 'point',
         encoding: {
@@ -85,7 +85,7 @@ describe('compile/layout', () => {
 
     it('should return static cell size for ordinal scale with top-level width even if there is numeric rangeStep', () => {
       log.runLocalLogger((localLogger) => {
-        const model = parseUnitModel({
+        const model = parseUnitModelWithScale({
           width: 205,
           mark: 'point',
           encoding: {
@@ -100,7 +100,7 @@ describe('compile/layout', () => {
     });
 
     it('should return static cell width for non-ordinal x-scale', () => {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         mark: 'point',
         encoding: {
           x: {field: 'a', type: 'quantitative'}
@@ -113,7 +113,7 @@ describe('compile/layout', () => {
 
 
     it('should return static cell size for non-ordinal y-scale', () => {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         mark: 'point',
         encoding: {
           y: {field: 'a', type: 'quantitative'}
@@ -125,7 +125,7 @@ describe('compile/layout', () => {
     });
 
     it('should return default rangeStep if axis is not mapped', () => {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         mark: 'point',
         encoding: {},
         config: {scale: {rangeStep: 17}}
@@ -135,7 +135,7 @@ describe('compile/layout', () => {
     });
 
     it('should return textXRangeStep if axis is not mapped for X of text mark', () => {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         mark: 'text',
         encoding: {},
         config: {scale: {textXRangeStep: 91}}

--- a/test/compile/repeat.test.ts
+++ b/test/compile/repeat.test.ts
@@ -99,8 +99,8 @@ describe('Repeat', function() {
       model.parseScale();
       const colorScale = model.component.scales['color'];
 
-      assert(isDataRefUnionedDomain(colorScale.domain));
-      assert.deepEqual((colorScale.domain as DataRefUnionDomain).fields.length, 4);
+      assert(isDataRefUnionedDomain(colorScale.implicit.domain));
+      assert.deepEqual((colorScale.implicit.domain as DataRefUnionDomain).fields.length, 4);
 
       model.parseLegend();
 

--- a/test/compile/scale/init.test.ts
+++ b/test/compile/scale/init.test.ts
@@ -23,9 +23,9 @@ describe('compile/scale', () => {
         {type: 'band', padding: 0.6},
         defaultConfig, 'bar', 100, []
       );
-      assert.equal(scale.padding, 0.6);
-      assert.isUndefined(scale.paddingInner);
-      assert.isUndefined(scale.paddingOuter);
+      assert.equal(scale.explicit.padding, 0.6);
+      assert.isUndefined(scale.get('paddingInner'));
+      assert.isUndefined(scale.get('paddingOuter'));
     });
 
     it('should output default paddingInner and paddingOuter = paddingInner/2 if none of padding properties is specified for a band scale', () => {
@@ -35,9 +35,9 @@ describe('compile/scale', () => {
         {scale: {bandPaddingInner: 0.3}},
         'bar', 100, []
       );
-      assert.equal(scale.paddingInner, 0.3);
-      assert.equal(scale.paddingOuter, 0.15);
-      assert.isUndefined(scale.padding);
+      assert.equal(scale.implicit.paddingInner, 0.3);
+      assert.equal(scale.implicit.paddingOuter, 0.15);
+      assert.isUndefined(scale.get('padding'));
     });
   });
 });

--- a/test/compile/scale/parse.test.ts
+++ b/test/compile/scale/parse.test.ts
@@ -27,9 +27,9 @@ describe('src/compile', function() {
             x: {field: 'origin', type: "nominal"}
           }
         });
-        const scales = parseScale(model, 'x');
-        assert.equal(scales.type, 'point');
-        assert.deepEqual(scales.range, {step: 21});
+        const scale = parseScale(model, 'x');
+        assert.equal(scale.implicit.type, 'point');
+        assert.deepEqual(scale.implicit.range, {step: 21});
       });
     });
 
@@ -41,17 +41,17 @@ describe('src/compile', function() {
         }
       });
 
-      const scales = parseScale(model, 'color');
+      const scale = parseScale(model, 'color');
 
       it('should create correct color scale', function() {
-        assert.equal(scales.name, 'color');
-        assert.equal(scales.type, 'ordinal');
-        assert.deepEqual(scales.domain, {
+        assert.equal(scale.implicit.name, 'color');
+        assert.equal(scale.implicit.type, 'ordinal');
+        assert.deepEqual(scale.implicit.domain, {
           data: 'main',
           field: 'origin',
           sort: true
         });
-        assert.equal(scales.range, 'category');
+        assert.equal(scale.implicit.range, 'category');
       });
     });
 
@@ -63,13 +63,13 @@ describe('src/compile', function() {
         }
       });
 
-      const scales = parseScale(model, 'color');
+      const scale = parseScale(model, 'color');
 
       it('should create sequential color scale', function() {
-        assert.equal(scales.name, 'color');
-        assert.equal(scales.type, 'sequential');
+        assert.equal(scale.implicit.name, 'color');
+        assert.equal(scale.implicit.type, 'sequential');
 
-        assert.deepEqual(scales.domain, {
+        assert.deepEqual(scale.implicit.domain, {
           data: 'main',
           field: 'origin'
         });
@@ -84,14 +84,14 @@ describe('src/compile', function() {
           }
         });
 
-      const scales = parseScale(model, 'color');
+      const scale = parseScale(model, 'color');
 
       it('should create linear color scale', function() {
-        assert.equal(scales.name, 'color');
-        assert.equal(scales.type, 'sequential');
-        assert.equal(scales.range, 'ramp');
+        assert.equal(scale.implicit.name, 'color');
+        assert.equal(scale.implicit.type, 'sequential');
+        assert.equal(scale.implicit.range, 'ramp');
 
-        assert.deepEqual(scales.domain, {
+        assert.deepEqual(scale.implicit.domain, {
           data: 'main',
           field: 'origin'
         });
@@ -106,11 +106,11 @@ describe('src/compile', function() {
           }
         });
 
-      const scales = parseScale(model, 'color');
+      const scale = parseScale(model, 'color');
 
       it('should add correct scales', function() {
-        assert.equal(scales.name, 'color');
-        assert.equal(scales.type, 'bin-ordinal');
+        assert.equal(scale.implicit.name, 'color');
+        assert.equal(scale.implicit.type, 'bin-ordinal');
       });
     });
 
@@ -122,11 +122,11 @@ describe('src/compile', function() {
           }
         });
 
-      const scales = parseScale(model, 'color');
+      const scale = parseScale(model, 'color');
 
       it('should add correct scales', function() {
-        assert.equal(scales.name, 'color');
-        assert.equal(scales.type, 'sequential');
+        assert.equal(scale.implicit.name, 'color');
+        assert.equal(scale.implicit.type, 'sequential');
       });
     });
 
@@ -138,11 +138,11 @@ describe('src/compile', function() {
           }
         });
 
-      const scales = parseScale(model, 'opacity');
+      const scale = parseScale(model, 'opacity');
 
       it('should add correct scales', function() {
-        assert.equal(scales.name, 'opacity');
-        assert.equal(scales.type, 'bin-linear');
+        assert.equal(scale.implicit.name, 'opacity');
+        assert.equal(scale.implicit.type, 'bin-linear');
       });
     });
 
@@ -154,11 +154,11 @@ describe('src/compile', function() {
           }
         });
 
-      const scales = parseScale(model, 'size');
+      const scale = parseScale(model, 'size');
 
       it('should add correct scales', function() {
-        assert.equal(scales.name, 'size');
-        assert.equal(scales.type, 'bin-linear');
+        assert.equal(scale.implicit.name, 'size');
+        assert.equal(scale.implicit.type, 'bin-linear');
       });
     });
 
@@ -170,11 +170,11 @@ describe('src/compile', function() {
           }
         });
 
-      const scales = parseScale(model, 'color');
+      const scale = parseScale(model, 'color');
 
       it('should add correct scales', function() {
-        assert.equal(scales.name, 'color');
-        assert.equal(scales.type, 'sequential');
+        assert.equal(scale.implicit.name, 'color');
+        assert.equal(scale.implicit.type, 'sequential');
       });
     });
 
@@ -193,15 +193,15 @@ describe('src/compile', function() {
         }
       });
 
-      const xscale = parseScale(model, 'x');
+      const xScale = parseScale(model, 'x');
       const yscale = parseScale(model, 'y');
       it('should add a raw selection domain', function() {
-        assert.property(xscale, 'domainRaw');
-        assert.propertyVal(xscale.domainRaw, 'signal',
+        assert.property(xScale.explicit, 'domainRaw');
+        assert.propertyVal(xScale.explicit.domainRaw, 'signal',
           SELECTION_DOMAIN + '{"selection":"brush","encoding":"x"}');
 
-        assert.property(yscale, 'domainRaw');
-        assert.propertyVal(yscale.domainRaw, 'signal',
+        assert.property(yscale.explicit, 'domainRaw');
+        assert.propertyVal(yscale.explicit.domainRaw, 'signal',
           SELECTION_DOMAIN + '{"selection":"foobar","field":"Miles_per_Gallon"}');
       });
     });

--- a/test/compile/scale/range.test.ts
+++ b/test/compile/scale/range.test.ts
@@ -4,17 +4,19 @@ import {assert} from 'chai';
 
 import {default as rangeMixins, parseRange} from '../../../src/compile/scale/range';
 
+import {ScaleComponent} from '../../../src/compile/scale/component';
 import {Split} from '../../../src/compile/split';
 import {defaultConfig} from '../../../src/config';
 import * as log from '../../../src/log';
 import {Mark} from '../../../src/mark';
 import {CONTINUOUS_TO_CONTINUOUS_SCALES, Scale, ScaleType} from '../../../src/scale';
 import {NOMINAL, ORDINAL, QUANTITATIVE} from '../../../src/type';
+import {VgScale} from '../../../src/vega.schema';
 
 describe('compile/scale', () => {
   describe('parseRange()', () => {
     function testParseRange(scale: Scale) {
-      return parseRange(new Split<Scale>(scale));
+      return parseRange(new Split<Scale>(scale)).range;
     }
     it('should return correct range.step', () => {
       assert.deepEqual(testParseRange({rangeStep: 123}), {step: 123});

--- a/test/compile/scale/rules.test.ts
+++ b/test/compile/scale/rules.test.ts
@@ -3,9 +3,10 @@
 import {assert} from 'chai';
 
 import {Channel, NONSPATIAL_SCALE_CHANNELS} from '../../../src/channel';
-import {ScaleType} from '../../../src/scale';
+import {Scale, ScaleType} from '../../../src/scale';
 
 import * as rules from '../../../src/compile/scale/rules';
+import {Split} from '../../../src/compile/split';
 
 describe('compile/scale', () => {
   describe('nice', () => {
@@ -94,28 +95,28 @@ describe('compile/scale', () => {
 
   describe('zero', () => {
     it('should return true when mapping a quantitative field to size', () => {
-      assert(rules.zero({}, 'size', {field: 'a', type: 'quantitative'}));
+      assert(rules.zero(new Split<Scale>(), 'size', {field: 'a', type: 'quantitative'}));
     });
 
     it('should return false when mapping a ordinal field to size', () => {
-      assert(!rules.zero({}, 'size', {field: 'a', type: 'ordinal'}));
+      assert(!rules.zero(new Split<Scale>(), 'size', {field: 'a', type: 'ordinal'}));
     });
 
     it('should return true when mapping a non-binned quantitative field to x/y', () => {
       for (const channel of ['x', 'y'] as Channel[]) {
-        assert(rules.zero({}, channel, {field: 'a', type: 'quantitative'}));
+        assert(rules.zero(new Split<Scale>(), channel, {field: 'a', type: 'quantitative'}));
       }
     });
 
     it('should return false when mapping a binned quantitative field to x/y', () => {
       for (const channel of ['x', 'y'] as Channel[]) {
-        assert(!rules.zero({}, channel, {bin: true, field: 'a', type: 'quantitative'}));
+        assert(!rules.zero(new Split<Scale>(), channel, {bin: true, field: 'a', type: 'quantitative'}));
       }
     });
 
     it('should return false when mapping a non-binned quantitative field with custom domain to x/y', () => {
       for (const channel of ['x', 'y'] as Channel[]) {
-        assert(!rules.zero({domain: [1, 5]}, channel, {
+        assert(!rules.zero(new Split<Scale>({domain: [1, 5]}), channel, {
           bin: true, field: 'a', type: 'quantitative'
         }));
       }


### PR DESCRIPTION
This is a first step for scale refactor #2251.

With more details about explicitly specified properties and one that are from our rules, we can improve scale merging logic.  

cc: @willium 
