### PR TITLE
Proxy scale reactions to prevent infinite loop w/interval selection filters

### DIFF
--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -88,9 +88,9 @@
                 },
                 {
                     "events": {
-                        "scale": "x"
+                        "signal": "brush_scale_trigger"
                     },
-                    "update": "!isArray(brush_Horsepower) ? brush_x : [scale(\"x\", brush_Horsepower[0]), scale(\"x\", brush_Horsepower[1])]"
+                    "update": "[scale(\"x\", brush_Horsepower[0]), scale(\"x\", brush_Horsepower[1])]"
                 },
                 {
                     "events": {
@@ -154,9 +154,9 @@
                 },
                 {
                     "events": {
-                        "scale": "y"
+                        "signal": "brush_scale_trigger"
                     },
-                    "update": "!isArray(brush_Miles_per_Gallon) ? brush_y : [scale(\"y\", brush_Miles_per_Gallon[0]), scale(\"y\", brush_Miles_per_Gallon[1])]"
+                    "update": "[scale(\"y\", brush_Miles_per_Gallon[0]), scale(\"y\", brush_Miles_per_Gallon[1])]"
                 },
                 {
                     "events": {
@@ -180,6 +180,23 @@
                         "signal": "brush_y"
                     },
                     "update": "invert(\"y\", brush_y)"
+                }
+            ]
+        },
+        {
+            "name": "brush_scale_trigger",
+            "value": {},
+            "on": [
+                {
+                    "events": [
+                        {
+                            "scale": "x"
+                        },
+                        {
+                            "scale": "y"
+                        }
+                    ],
+                    "update": "(!isArray(brush_Horsepower) || (invert(\"x\", brush_x)[0] === brush_Horsepower[0] && invert(\"x\", brush_x)[1] === brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (invert(\"y\", brush_y)[0] === brush_Miles_per_Gallon[0] && invert(\"y\", brush_y)[1] === brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
                 }
             ]
         },

--- a/examples/vg-specs/concat_selections.vg.json
+++ b/examples/vg-specs/concat_selections.vg.json
@@ -156,9 +156,9 @@
                         },
                         {
                             "events": {
-                                "scale": "concat_0_x"
+                                "signal": "brush_scale_trigger"
                             },
-                            "update": "!isArray(brush_Miles_per_Gallon) ? brush_x : [scale(\"concat_0_x\", brush_Miles_per_Gallon[0]), scale(\"concat_0_x\", brush_Miles_per_Gallon[1])]"
+                            "update": "[scale(\"concat_0_x\", brush_Miles_per_Gallon[0]), scale(\"concat_0_x\", brush_Miles_per_Gallon[1])]"
                         },
                         {
                             "events": {
@@ -222,9 +222,9 @@
                         },
                         {
                             "events": {
-                                "scale": "concat_0_y"
+                                "signal": "brush_scale_trigger"
                             },
-                            "update": "!isArray(brush_Horsepower) ? brush_y : [scale(\"concat_0_y\", brush_Horsepower[0]), scale(\"concat_0_y\", brush_Horsepower[1])]"
+                            "update": "[scale(\"concat_0_y\", brush_Horsepower[0]), scale(\"concat_0_y\", brush_Horsepower[1])]"
                         },
                         {
                             "events": {
@@ -248,6 +248,23 @@
                                 "signal": "brush_y"
                             },
                             "update": "invert(\"concat_0_y\", brush_y)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "scale": "concat_0_x"
+                                },
+                                {
+                                    "scale": "concat_0_y"
+                                }
+                            ],
+                            "update": "(!isArray(brush_Miles_per_Gallon) || (invert(\"concat_0_x\", brush_x)[0] === brush_Miles_per_Gallon[0] && invert(\"concat_0_x\", brush_x)[1] === brush_Miles_per_Gallon[1])) && (!isArray(brush_Horsepower) || (invert(\"concat_0_y\", brush_y)[0] === brush_Horsepower[0] && invert(\"concat_0_y\", brush_y)[1] === brush_Horsepower[1])) ? brush_scale_trigger : {}"
                         }
                     ]
                 },

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -299,9 +299,9 @@
                         },
                         {
                             "events": {
-                                "scale": "x"
+                                "signal": "brush_scale_trigger"
                             },
-                            "update": "!isArray(brush_X) ? brush_x : [scale(\"x\", brush_X[0]), scale(\"x\", brush_X[1])]"
+                            "update": "[scale(\"x\", brush_X[0]), scale(\"x\", brush_X[1])]"
                         },
                         {
                             "events": {
@@ -325,6 +325,20 @@
                                 "signal": "brush_x"
                             },
                             "update": "invert(\"x\", brush_x)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "scale": "x"
+                                }
+                            ],
+                            "update": "(!isArray(brush_X) || (invert(\"x\", brush_x)[0] === brush_X[0] && invert(\"x\", brush_x)[1] === brush_X[1])) ? brush_scale_trigger : {}"
                         }
                     ]
                 },

--- a/examples/vg-specs/interactive_splom.vg.json
+++ b/examples/vg-specs/interactive_splom.vg.json
@@ -211,9 +211,9 @@
                         },
                         {
                             "events": {
-                                "scale": "child_Horsepower_Horsepower_y"
+                                "signal": "brush_scale_trigger"
                             },
-                            "update": "!isArray(brush_Horsepower) ? brush_y : [scale(\"child_Horsepower_Horsepower_y\", brush_Horsepower[0]), scale(\"child_Horsepower_Horsepower_y\", brush_Horsepower[1])]"
+                            "update": "[scale(\"child_Horsepower_Horsepower_y\", brush_Horsepower[0]), scale(\"child_Horsepower_Horsepower_y\", brush_Horsepower[1])]"
                         },
                         {
                             "events": {
@@ -237,6 +237,20 @@
                                 "signal": "brush_y"
                             },
                             "update": "invert(\"child_Horsepower_Horsepower_y\", brush_y)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "scale": "child_Horsepower_Horsepower_y"
+                                }
+                            ],
+                            "update": "(!isArray(brush_Horsepower) || (invert(\"child_Horsepower_Horsepower_y\", brush_y)[0] === brush_Horsepower[0] && invert(\"child_Horsepower_Horsepower_y\", brush_y)[1] === brush_Horsepower[1])) ? brush_scale_trigger : {}"
                         }
                     ]
                 },
@@ -686,9 +700,9 @@
                         },
                         {
                             "events": {
-                                "scale": "child_Horsepower_Miles_per_Gallon_x"
+                                "signal": "brush_scale_trigger"
                             },
-                            "update": "!isArray(brush_Horsepower) ? brush_x : [scale(\"child_Horsepower_Miles_per_Gallon_x\", brush_Horsepower[0]), scale(\"child_Horsepower_Miles_per_Gallon_x\", brush_Horsepower[1])]"
+                            "update": "[scale(\"child_Horsepower_Miles_per_Gallon_x\", brush_Horsepower[0]), scale(\"child_Horsepower_Miles_per_Gallon_x\", brush_Horsepower[1])]"
                         },
                         {
                             "events": {
@@ -753,9 +767,9 @@
                         },
                         {
                             "events": {
-                                "scale": "child_Horsepower_Miles_per_Gallon_y"
+                                "signal": "brush_scale_trigger"
                             },
-                            "update": "!isArray(brush_Miles_per_Gallon) ? brush_y : [scale(\"child_Horsepower_Miles_per_Gallon_y\", brush_Miles_per_Gallon[0]), scale(\"child_Horsepower_Miles_per_Gallon_y\", brush_Miles_per_Gallon[1])]"
+                            "update": "[scale(\"child_Horsepower_Miles_per_Gallon_y\", brush_Miles_per_Gallon[0]), scale(\"child_Horsepower_Miles_per_Gallon_y\", brush_Miles_per_Gallon[1])]"
                         },
                         {
                             "events": {
@@ -779,6 +793,23 @@
                                 "signal": "brush_y"
                             },
                             "update": "invert(\"child_Horsepower_Miles_per_Gallon_y\", brush_y)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "scale": "child_Horsepower_Miles_per_Gallon_x"
+                                },
+                                {
+                                    "scale": "child_Horsepower_Miles_per_Gallon_y"
+                                }
+                            ],
+                            "update": "(!isArray(brush_Horsepower) || (invert(\"child_Horsepower_Miles_per_Gallon_x\", brush_x)[0] === brush_Horsepower[0] && invert(\"child_Horsepower_Miles_per_Gallon_x\", brush_x)[1] === brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (invert(\"child_Horsepower_Miles_per_Gallon_y\", brush_y)[0] === brush_Miles_per_Gallon[0] && invert(\"child_Horsepower_Miles_per_Gallon_y\", brush_y)[1] === brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
                         }
                     ]
                 },
@@ -1245,9 +1276,9 @@
                         },
                         {
                             "events": {
-                                "scale": "child_Acceleration_Horsepower_x"
+                                "signal": "brush_scale_trigger"
                             },
-                            "update": "!isArray(brush_Acceleration) ? brush_x : [scale(\"child_Acceleration_Horsepower_x\", brush_Acceleration[0]), scale(\"child_Acceleration_Horsepower_x\", brush_Acceleration[1])]"
+                            "update": "[scale(\"child_Acceleration_Horsepower_x\", brush_Acceleration[0]), scale(\"child_Acceleration_Horsepower_x\", brush_Acceleration[1])]"
                         },
                         {
                             "events": {
@@ -1312,9 +1343,9 @@
                         },
                         {
                             "events": {
-                                "scale": "child_Acceleration_Horsepower_y"
+                                "signal": "brush_scale_trigger"
                             },
-                            "update": "!isArray(brush_Horsepower) ? brush_y : [scale(\"child_Acceleration_Horsepower_y\", brush_Horsepower[0]), scale(\"child_Acceleration_Horsepower_y\", brush_Horsepower[1])]"
+                            "update": "[scale(\"child_Acceleration_Horsepower_y\", brush_Horsepower[0]), scale(\"child_Acceleration_Horsepower_y\", brush_Horsepower[1])]"
                         },
                         {
                             "events": {
@@ -1338,6 +1369,23 @@
                                 "signal": "brush_y"
                             },
                             "update": "invert(\"child_Acceleration_Horsepower_y\", brush_y)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "scale": "child_Acceleration_Horsepower_x"
+                                },
+                                {
+                                    "scale": "child_Acceleration_Horsepower_y"
+                                }
+                            ],
+                            "update": "(!isArray(brush_Acceleration) || (invert(\"child_Acceleration_Horsepower_x\", brush_x)[0] === brush_Acceleration[0] && invert(\"child_Acceleration_Horsepower_x\", brush_x)[1] === brush_Acceleration[1])) && (!isArray(brush_Horsepower) || (invert(\"child_Acceleration_Horsepower_y\", brush_y)[0] === brush_Horsepower[0] && invert(\"child_Acceleration_Horsepower_y\", brush_y)[1] === brush_Horsepower[1])) ? brush_scale_trigger : {}"
                         }
                     ]
                 },
@@ -1804,9 +1852,9 @@
                         },
                         {
                             "events": {
-                                "scale": "child_Acceleration_Miles_per_Gallon_x"
+                                "signal": "brush_scale_trigger"
                             },
-                            "update": "!isArray(brush_Acceleration) ? brush_x : [scale(\"child_Acceleration_Miles_per_Gallon_x\", brush_Acceleration[0]), scale(\"child_Acceleration_Miles_per_Gallon_x\", brush_Acceleration[1])]"
+                            "update": "[scale(\"child_Acceleration_Miles_per_Gallon_x\", brush_Acceleration[0]), scale(\"child_Acceleration_Miles_per_Gallon_x\", brush_Acceleration[1])]"
                         },
                         {
                             "events": {
@@ -1871,9 +1919,9 @@
                         },
                         {
                             "events": {
-                                "scale": "child_Acceleration_Miles_per_Gallon_y"
+                                "signal": "brush_scale_trigger"
                             },
-                            "update": "!isArray(brush_Miles_per_Gallon) ? brush_y : [scale(\"child_Acceleration_Miles_per_Gallon_y\", brush_Miles_per_Gallon[0]), scale(\"child_Acceleration_Miles_per_Gallon_y\", brush_Miles_per_Gallon[1])]"
+                            "update": "[scale(\"child_Acceleration_Miles_per_Gallon_y\", brush_Miles_per_Gallon[0]), scale(\"child_Acceleration_Miles_per_Gallon_y\", brush_Miles_per_Gallon[1])]"
                         },
                         {
                             "events": {
@@ -1897,6 +1945,23 @@
                                 "signal": "brush_y"
                             },
                             "update": "invert(\"child_Acceleration_Miles_per_Gallon_y\", brush_y)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "scale": "child_Acceleration_Miles_per_Gallon_x"
+                                },
+                                {
+                                    "scale": "child_Acceleration_Miles_per_Gallon_y"
+                                }
+                            ],
+                            "update": "(!isArray(brush_Acceleration) || (invert(\"child_Acceleration_Miles_per_Gallon_x\", brush_x)[0] === brush_Acceleration[0] && invert(\"child_Acceleration_Miles_per_Gallon_x\", brush_x)[1] === brush_Acceleration[1])) && (!isArray(brush_Miles_per_Gallon) || (invert(\"child_Acceleration_Miles_per_Gallon_y\", brush_y)[0] === brush_Miles_per_Gallon[0] && invert(\"child_Acceleration_Miles_per_Gallon_y\", brush_y)[1] === brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
                         }
                     ]
                 },

--- a/examples/vg-specs/layered_crossfilter.vg.json
+++ b/examples/vg-specs/layered_crossfilter.vg.json
@@ -479,9 +479,9 @@
                         },
                         {
                             "events": {
-                                "scale": "child_distance_x"
+                                "signal": "brush_scale_trigger"
                             },
-                            "update": "!isArray(brush_distance) ? brush_x : [scale(\"child_distance_x\", brush_distance[0]), scale(\"child_distance_x\", brush_distance[1])]"
+                            "update": "[scale(\"child_distance_x\", brush_distance[0]), scale(\"child_distance_x\", brush_distance[1])]"
                         },
                         {
                             "events": {
@@ -505,6 +505,20 @@
                                 "signal": "brush_x"
                             },
                             "update": "invert(\"child_distance_x\", brush_x)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "scale": "child_distance_x"
+                                }
+                            ],
+                            "update": "(!isArray(brush_distance) || (invert(\"child_distance_x\", brush_x)[0] === brush_distance[0] && invert(\"child_distance_x\", brush_x)[1] === brush_distance[1])) ? brush_scale_trigger : {}"
                         }
                     ]
                 },
@@ -932,9 +946,9 @@
                         },
                         {
                             "events": {
-                                "scale": "child_delay_x"
+                                "signal": "brush_scale_trigger"
                             },
-                            "update": "!isArray(brush_delay) ? brush_x : [scale(\"child_delay_x\", brush_delay[0]), scale(\"child_delay_x\", brush_delay[1])]"
+                            "update": "[scale(\"child_delay_x\", brush_delay[0]), scale(\"child_delay_x\", brush_delay[1])]"
                         },
                         {
                             "events": {
@@ -958,6 +972,20 @@
                                 "signal": "brush_x"
                             },
                             "update": "invert(\"child_delay_x\", brush_x)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "scale": "child_delay_x"
+                                }
+                            ],
+                            "update": "(!isArray(brush_delay) || (invert(\"child_delay_x\", brush_x)[0] === brush_delay[0] && invert(\"child_delay_x\", brush_x)[1] === brush_delay[1])) ? brush_scale_trigger : {}"
                         }
                     ]
                 },
@@ -1385,9 +1413,9 @@
                         },
                         {
                             "events": {
-                                "scale": "child_time_x"
+                                "signal": "brush_scale_trigger"
                             },
-                            "update": "!isArray(brush_time) ? brush_x : [scale(\"child_time_x\", brush_time[0]), scale(\"child_time_x\", brush_time[1])]"
+                            "update": "[scale(\"child_time_x\", brush_time[0]), scale(\"child_time_x\", brush_time[1])]"
                         },
                         {
                             "events": {
@@ -1411,6 +1439,20 @@
                                 "signal": "brush_x"
                             },
                             "update": "invert(\"child_time_x\", brush_x)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "scale": "child_time_x"
+                                }
+                            ],
+                            "update": "(!isArray(brush_time) || (invert(\"child_time_x\", brush_x)[0] === brush_time[0] && invert(\"child_time_x\", brush_x)[1] === brush_time[1])) ? brush_scale_trigger : {}"
                         }
                     ]
                 },

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -313,9 +313,9 @@
                 },
                 {
                     "events": {
-                        "scale": "x"
+                        "signal": "brush_scale_trigger"
                     },
-                    "update": "!isArray(brush_Horsepower) ? brush_x : [scale(\"x\", brush_Horsepower[0]), scale(\"x\", brush_Horsepower[1])]"
+                    "update": "[scale(\"x\", brush_Horsepower[0]), scale(\"x\", brush_Horsepower[1])]"
                 },
                 {
                     "events": {
@@ -380,9 +380,9 @@
                 },
                 {
                     "events": {
-                        "scale": "y"
+                        "signal": "brush_scale_trigger"
                     },
-                    "update": "!isArray(brush_Miles_per_Gallon) ? brush_y : [scale(\"y\", brush_Miles_per_Gallon[0]), scale(\"y\", brush_Miles_per_Gallon[1])]"
+                    "update": "[scale(\"y\", brush_Miles_per_Gallon[0]), scale(\"y\", brush_Miles_per_Gallon[1])]"
                 },
                 {
                     "events": {
@@ -406,6 +406,23 @@
                         "signal": "brush_y"
                     },
                     "update": "invert(\"y\", brush_y)"
+                }
+            ]
+        },
+        {
+            "name": "brush_scale_trigger",
+            "value": {},
+            "on": [
+                {
+                    "events": [
+                        {
+                            "scale": "x"
+                        },
+                        {
+                            "scale": "y"
+                        }
+                    ],
+                    "update": "(!isArray(brush_Horsepower) || (invert(\"x\", brush_x)[0] === brush_Horsepower[0] && invert(\"x\", brush_x)[1] === brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (invert(\"y\", brush_y)[0] === brush_Miles_per_Gallon[0] && invert(\"y\", brush_y)[1] === brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
                 }
             ]
         },

--- a/examples/vg-specs/overview_detail.vg.json
+++ b/examples/vg-specs/overview_detail.vg.json
@@ -161,9 +161,9 @@
                         },
                         {
                             "events": {
-                                "scale": "concat_0_x"
+                                "signal": "brush_scale_trigger"
                             },
-                            "update": "!isArray(brush_date) ? brush_x : [scale(\"concat_0_x\", brush_date[0]), scale(\"concat_0_x\", brush_date[1])]"
+                            "update": "[scale(\"concat_0_x\", brush_date[0]), scale(\"concat_0_x\", brush_date[1])]"
                         },
                         {
                             "events": {
@@ -187,6 +187,20 @@
                                 "signal": "brush_x"
                             },
                             "update": "invert(\"concat_0_x\", brush_x)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "scale": "concat_0_x"
+                                }
+                            ],
+                            "update": "(!isArray(brush_date) || (invert(\"concat_0_x\", brush_x)[0] === brush_date[0] && invert(\"concat_0_x\", brush_x)[1] === brush_date[1])) ? brush_scale_trigger : {}"
                         }
                     ]
                 },

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "typescript": "^2.3.4",
     "typescript-to-json-schema": "vega/typescript-to-json-schema#v0.5.0",
     "uglify-js": "^3.0.15",
-    "vega": "3.0.0-beta.33",
+    "vega": "^3.0.0-beta.35",
     "vega-datasets": "vega/vega-datasets#gh-pages",
     "vega-embed": "3.0.0-beta.17",
     "watchify": "^3.9.0",

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -182,12 +182,11 @@ function channelSignals(model: UnitModel, selCmpt: SelectionComponent, channel: 
   // React to pan/zooms of continuous scales. Non-continuous scales
   // (bin-linear, band, point) cannot be pan/zoomed and any other changes
   // to their domains (e.g., filtering) should clear the brushes.
-  if (hasContinuousDomain(scaleType) && !isBinScale(scaleType)) {
-    on.push({
-      events: {signal: selCmpt.name + SCALE_TRIGGER},
-      update: `[scale(${scaleStr}, ${dname}[0]), scale(${scaleStr}, ${dname}[1])]`
-    });
-  }
+  on.push({
+    events: {signal: selCmpt.name + SCALE_TRIGGER},
+    update: hasContinuousDomain(scaleType) && !isBinScale(scaleType) ?
+      `[scale(${scaleStr}, ${dname}[0]), scale(${scaleStr}, ${dname}[1])]` : `[0, 0]`
+  });
 
   return hasScales ? [{name: dname, on: []}] : [{
     name: vname, value: [], on: on

--- a/test/compile/selection/interval.test.ts
+++ b/test/compile/selection/interval.test.ts
@@ -52,8 +52,8 @@ describe('Interval Selections', function() {
             "update": "[one_x[0], clamp(x(unit), 0, width)]"
           },
           {
-            "events": {"scale": "x"},
-            "update": "!isArray(one_Horsepower) ? one_x : [scale(\"x\", one_Horsepower[0]), scale(\"x\", one_Horsepower[1])]"
+            "events": {"signal": "one_scale_trigger"},
+            "update": "[scale(\"x\", one_Horsepower[0]), scale(\"x\", one_Horsepower[1])]"
           }
         ]
       }, {
@@ -61,6 +61,13 @@ describe('Interval Selections', function() {
         "on": [{
           "events": {"signal": "one_x"},
           "update": "invert(\"x\", one_x)"
+        }]
+      }, {
+        "name": "one_scale_trigger",
+        "value": {},
+        "on": [{
+          "events": [{"scale": "x"}],
+          "update": "(!isArray(one_Horsepower) || (invert(\"x\", one_x)[0] === one_Horsepower[0] && invert(\"x\", one_x)[1] === one_Horsepower[1])) ? one_scale_trigger : {}"
         }]
       }]);
 
@@ -93,8 +100,8 @@ describe('Interval Selections', function() {
               "update": "[thr_ee_x[0], clamp(x(unit), 0, width)]"
             },
             {
-              "events": {"scale": "x"},
-              "update": "!isArray(thr_ee_Horsepower) ? thr_ee_x : [scale(\"x\", thr_ee_Horsepower[0]), scale(\"x\", thr_ee_Horsepower[1])]"
+              "events": {"signal": "thr_ee_scale_trigger"},
+              "update": "[scale(\"x\", thr_ee_Horsepower[0]), scale(\"x\", thr_ee_Horsepower[1])]"
             }
           ]
         },
@@ -126,8 +133,8 @@ describe('Interval Selections', function() {
               "update": "[thr_ee_y[0], clamp(y(unit), 0, height)]"
             },
             {
-              "events": {"scale": "y"},
-              "update": "!isArray(thr_ee_Miles_per_Gallon) ? thr_ee_y : [scale(\"y\", thr_ee_Miles_per_Gallon[0]), scale(\"y\", thr_ee_Miles_per_Gallon[1])]"
+              "events": {"signal": "thr_ee_scale_trigger"},
+              "update": "[scale(\"y\", thr_ee_Miles_per_Gallon[0]), scale(\"y\", thr_ee_Miles_per_Gallon[1])]"
             }
           ]
         },
@@ -136,6 +143,14 @@ describe('Interval Selections', function() {
           "on": [{
             "events": {"signal": "thr_ee_y"},
             "update": "invert(\"y\", thr_ee_y)"
+          }]
+        },
+        {
+          "name": "thr_ee_scale_trigger",
+          "value": {},
+          "on": [{
+            "events": [{"scale": "x"}, {"scale": "y"}],
+            "update": "(!isArray(thr_ee_Horsepower) || (invert(\"x\", thr_ee_x)[0] === thr_ee_Horsepower[0] && invert(\"x\", thr_ee_x)[1] === thr_ee_Horsepower[1])) && (!isArray(thr_ee_Miles_per_Gallon) || (invert(\"y\", thr_ee_y)[0] === thr_ee_Miles_per_Gallon[0] && invert(\"y\", thr_ee_y)[1] === thr_ee_Miles_per_Gallon[1])) ? thr_ee_scale_trigger : {}"
           }]
         }
       ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4713,7 +4713,7 @@ vega-dataflow@>=2.0.0-beta, vega-dataflow@>=2.0.0-beta.4:
     vega-statistics "1"
     vega-util "^1.1"
 
-vega-datasets@vega/vega-datasets#gh-pages:
+"vega-datasets@github:vega/vega-datasets#gh-pages", vega-datasets@vega/vega-datasets#gh-pages:
   version "1.8.0"
   resolved "https://codeload.github.com/vega/vega-datasets/tar.gz/26bddc53d6112cff239436cdc85f56249c39e9e0"
 
@@ -4879,9 +4879,33 @@ vega-wordcloud@>=1.0.0-beta:
   optionalDependencies:
     canvas "^1.6.0"
 
-vega@3.0.0-beta.33, vega@^3.0.0-beta.32:
+vega@^3.0.0-beta.32:
   version "3.0.0-beta.33"
   resolved "https://registry.yarnpkg.com/vega/-/vega-3.0.0-beta.33.tgz#1ed389a04dc8f33d9313b0b24cc3804012853647"
+  dependencies:
+    vega-crossfilter ">=1.0.0-beta"
+    vega-dataflow ">=2.0.0-beta"
+    vega-datasets vega/vega-datasets#gh-pages
+    vega-encode ">=1.0.0-beta"
+    vega-expression "2"
+    vega-force ">=1.0.0-beta"
+    vega-geo ">=1.0.0-beta"
+    vega-hierarchy ">=1.0.0-beta"
+    vega-loader ">=2.0.0-beta.5"
+    vega-parser ">=1.0.0-beta"
+    vega-runtime ">=1.0.0-beta"
+    vega-scale ">=2.0.0-beta"
+    vega-scenegraph ">=2.0.0-beta.11"
+    vega-statistics "1"
+    vega-util "^1.2"
+    vega-view ">=1.0.0-beta"
+    vega-voronoi ">=1.0.0-beta"
+    vega-wordcloud ">=1.0.0-beta"
+    yargs "4"
+
+vega@^3.0.0-beta.35:
+  version "3.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/vega/-/vega-3.0.0-beta.35.tgz#014fcd987dd00ffcddab48f76beb1f0efd72e60a"
   dependencies:
     vega-crossfilter ">=1.0.0-beta"
     vega-dataflow ">=2.0.0-beta"


### PR DESCRIPTION
As described in #2493, the switch to a linear scale in #2492 revealed an infinite loop when interval selections filter datasets that back scales in its view (e.g., cross filtering). The specific flow is interaction events fire `modify` calls to the selection's backing store. These updates trigger reevaluations of the selection predicate applied to the source/raw dataset. This in turn marks scale functions as modified, which would loop back to keep brushes in sync with scale changes. 

This PR instead proxies the final part of that cycle. Instead of having the brush signals react directly to scale changes, a new `scale_trigger` signal is introduced. This new signal reacts to scale changes and determines if the brush coordinates should change. If they should, propagation continues and the brush coordinates update (as they now listen to the `scale_trigger` signal rather than the actual scale). If brush coordinates remain the same, propagation is stopped by returning an unchanged `scale_trigger` value.