### PR TITLE
Define axis/legend.encoding for using Vega's axis/legend.encode

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -60,8 +60,8 @@
           "description": "A boolean flag indicating if the domain (the axis baseline) should be included as part of the axis (default true).",
           "type": "boolean"
         },
-        "encode": {
-          "$ref": "#/definitions/VgAxisEncode",
+        "encoding": {
+          "$ref": "#/definitions/AxisEncoding",
           "description": "Optional mark definitions for custom axis encoding."
         },
         "format": {
@@ -375,6 +375,36 @@
         "axisY": {
           "$ref": "#/definitions/VgAxisConfig",
           "description": "Y-axis specific config."
+        }
+      },
+      "type": "object"
+    },
+    "AxisEncoding": {
+      "additionalProperties": false,
+      "properties": {
+        "axis": {
+          "$ref": "#/definitions/GuideEncodingEntry",
+          "description": "Custom encoding for the axis container."
+        },
+        "domain": {
+          "$ref": "#/definitions/GuideEncodingEntry",
+          "description": "Custom encoding for the axis domain rule mark."
+        },
+        "grid": {
+          "$ref": "#/definitions/GuideEncodingEntry",
+          "description": "Custom encoding for axis gridline rule marks."
+        },
+        "labels": {
+          "$ref": "#/definitions/GuideEncodingEntry",
+          "description": "Custom encoding for axis label text marks."
+        },
+        "ticks": {
+          "$ref": "#/definitions/GuideEncodingEntry",
+          "description": "Custom encoding for axis tick rule marks."
+        },
+        "title": {
+          "$ref": "#/definitions/GuideEncodingEntry",
+          "description": "Custom encoding for the axis title text mark."
         }
       },
       "type": "object"
@@ -2748,6 +2778,190 @@
       },
       "type": "object"
     },
+    "GuideEncodingEntry": {
+      "additionalProperties": false,
+      "properties": {
+        "align": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "angle": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "baseline": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "clip": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "cursor": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "dir": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "dx": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "dy": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "ellipsis": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "endAngle": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "fill": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "fillOpacity": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "font": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "fontSize": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "fontStyle": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "fontWeight": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "height": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "innerRadius": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "interpolate": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "limit": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "opacity": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "orient": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "outerRadius": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "path": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "radius": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "shape": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "size": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "startAngle": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "stroke": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "strokeDash": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "strokeDashOffset": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "strokeOpacity": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "strokeWidth": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "tension": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "text": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "theta": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "url": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "width": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "x": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "x2": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "xc": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "y": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "y2": {
+          "$ref": "#/definitions/ValueDef"
+        },
+        "yc": {
+          "$ref": "#/definitions/ValueDef"
+        }
+      },
+      "required": [
+        "x",
+        "x2",
+        "xc",
+        "width",
+        "y",
+        "y2",
+        "yc",
+        "height",
+        "opacity",
+        "fill",
+        "fillOpacity",
+        "stroke",
+        "strokeWidth",
+        "strokeOpacity",
+        "strokeDash",
+        "strokeDashOffset",
+        "cursor",
+        "clip",
+        "size",
+        "shape",
+        "path",
+        "innerRadius",
+        "outerRadius",
+        "startAngle",
+        "endAngle",
+        "interpolate",
+        "tension",
+        "orient",
+        "url",
+        "align",
+        "baseline",
+        "text",
+        "dir",
+        "ellipsis",
+        "limit",
+        "dx",
+        "dy",
+        "radius",
+        "theta",
+        "angle",
+        "font",
+        "fontSize",
+        "fontWeight",
+        "fontStyle"
+      ],
+      "type": "object"
+    },
     "Header": {
       "additionalProperties": false,
       "description": "Headers of row / column channels for faceted plots.",
@@ -2812,8 +3026,8 @@
       "additionalProperties": false,
       "description": "Properties of a legend or boolean flag for determining whether to show it.",
       "properties": {
-        "encode": {
-          "$ref": "#/definitions/VgLegendEncode",
+        "encoding": {
+          "$ref": "#/definitions/LegendEncoding",
           "description": "Optional mark definitions for custom legend encoding."
         },
         "entryPadding": {
@@ -2834,6 +3048,15 @@
         },
         "orient": {
           "description": "The orientation of the legend. One of `\"left\"` or `\"right\"`. This determines how the legend is positioned within the scene. The default is `\"right\"`.\n\n__Default value:__  `\"right\"`",
+          "enum": [
+            "left",
+            "right",
+            "top-left",
+            "top-right",
+            "bottom-left",
+            "bottom-right",
+            "none"
+          ],
           "type": "string"
         },
         "padding": {
@@ -2973,6 +3196,15 @@
         },
         "orient": {
           "description": "The orientation of the legend. One of `\"left\"` or `\"right\"`. This determines how the legend is positioned within the scene. The default is `\"right\"`.\n\n__Default value:__  `\"right\"`",
+          "enum": [
+            "left",
+            "right",
+            "top-left",
+            "top-right",
+            "bottom-left",
+            "bottom-right",
+            "none"
+          ],
           "type": "string"
         },
         "padding": {
@@ -3050,6 +3282,27 @@
         "titlePadding": {
           "description": "The padding, in pixels, between title and legend.",
           "type": "number"
+        }
+      },
+      "type": "object"
+    },
+    "LegendEncoding": {
+      "additionalProperties": false,
+      "properties": {
+        "gradient": {
+          "$ref": "#/definitions/GuideEncodingEntry"
+        },
+        "labels": {
+          "$ref": "#/definitions/GuideEncodingEntry"
+        },
+        "legend": {
+          "$ref": "#/definitions/GuideEncodingEntry"
+        },
+        "symbols": {
+          "$ref": "#/definitions/GuideEncodingEntry"
+        },
+        "title": {
+          "$ref": "#/definitions/GuideEncodingEntry"
         }
       },
       "type": "object"
@@ -5469,6 +5722,19 @@
       ],
       "type": "object"
     },
+    "ValueDef": {
+      "additionalProperties": false,
+      "description": "Definition object for a constant value of an encoding channel.",
+      "properties": {
+        "value": {
+          "description": "A constant value in visual domain."
+        }
+      },
+      "required": [
+        "value"
+      ],
+      "type": "object"
+    },
     "NumberValueDef": {
       "additionalProperties": false,
       "description": "Definition object for a constant value of an encoding channel.",
@@ -5735,27 +6001,6 @@
       },
       "type": "object"
     },
-    "VgAxisEncode": {
-      "additionalProperties": false,
-      "properties": {
-        "domain": {
-          "$ref": "#/definitions/VgGuideEncode"
-        },
-        "grid": {
-          "$ref": "#/definitions/VgGuideEncode"
-        },
-        "labels": {
-          "$ref": "#/definitions/VgGuideEncode"
-        },
-        "ticks": {
-          "$ref": "#/definitions/VgGuideEncode"
-        },
-        "title": {
-          "$ref": "#/definitions/VgGuideEncode"
-        }
-      },
-      "type": "object"
-    },
     "VgBinding": {
       "anyOf": [
         {
@@ -5808,8 +6053,6 @@
       ],
       "type": "object"
     },
-    "VgGuideEncode": {
-    },
     "VgLegendBase": {
       "additionalProperties": false,
       "properties": {
@@ -5827,6 +6070,15 @@
         },
         "orient": {
           "description": "The orientation of the legend. One of `\"left\"` or `\"right\"`. This determines how the legend is positioned within the scene. The default is `\"right\"`.\n\n__Default value:__  `\"right\"`",
+          "enum": [
+            "left",
+            "right",
+            "top-left",
+            "top-right",
+            "bottom-left",
+            "bottom-right",
+            "none"
+          ],
           "type": "string"
         },
         "padding": {
@@ -5922,6 +6174,15 @@
         },
         "orient": {
           "description": "The orientation of the legend. One of `\"left\"` or `\"right\"`. This determines how the legend is positioned within the scene. The default is `\"right\"`.\n\n__Default value:__  `\"right\"`",
+          "enum": [
+            "left",
+            "right",
+            "top-left",
+            "top-right",
+            "bottom-left",
+            "bottom-right",
+            "none"
+          ],
           "type": "string"
         },
         "padding": {
@@ -5995,27 +6256,6 @@
         "titlePadding": {
           "description": "The padding, in pixels, between title and legend.",
           "type": "number"
-        }
-      },
-      "type": "object"
-    },
-    "VgLegendEncode": {
-      "additionalProperties": false,
-      "properties": {
-        "gradient": {
-          "$ref": "#/definitions/VgGuideEncode"
-        },
-        "labels": {
-          "$ref": "#/definitions/VgGuideEncode"
-        },
-        "legend": {
-          "$ref": "#/definitions/VgGuideEncode"
-        },
-        "symbols": {
-          "$ref": "#/definitions/VgGuideEncode"
-        },
-        "title": {
-          "$ref": "#/definitions/VgGuideEncode"
         }
       },
       "type": "object"

--- a/scripts/rename-schema.sh
+++ b/scripts/rename-schema.sh
@@ -16,6 +16,7 @@ perl -pi -e s,'TopLevel<(.*)>','TopLevel\1',g build/vega-lite-schema.json
 perl -pi -e s,'ValueDef<\(string\|number\|boolean\)>','TextValueDef',g build/vega-lite-schema.json
 perl -pi -e s,'ValueDef<string>','StringValueDef',g build/vega-lite-schema.json
 perl -pi -e s,'ValueDef<number>','NumberValueDef',g build/vega-lite-schema.json
+perl -pi -e s,'ValueDef<any>','ValueDef',g build/vega-lite-schema.json
 
 perl -pi -e s,'Condition<(.*)>','Condition\1',g build/vega-lite-schema.json
 

--- a/site/docs/axis.md
+++ b/site/docs/axis.md
@@ -89,3 +89,4 @@ To provide themes for all axes, the axis config `config: {axis: {...}}` can cont
 ### Title
 
 {% include table.html props="maxExtent,minExtent,titleAlign,titleAngle,titleBaseline,titleColor,titleFont,titleLimit,titleFontWeight,titleFontSize,titlePadding,titleMaxLength" source="AxisConfig" %}
+

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -1,5 +1,5 @@
 import {DateTime} from './datetime';
-import {Guide, VlOnlyGuideConfig} from './guide';
+import {Guide, GuideEncodingEntry, VlOnlyGuideConfig} from './guide';
 import {VgAxisBase, VgAxisConfig, VgAxisEncode} from './vega.schema';
 
 export type AxisOrient = 'top' | 'right' | 'left' | 'bottom';
@@ -61,14 +61,44 @@ export interface Axis extends VgAxisBase, Guide {
   /**
    * Optional mark definitions for custom axis encoding.
    */
-  encode?: VgAxisEncode;
+  encoding?: AxisEncoding;
+}
+
+export interface AxisEncoding {
+  /**
+   * Custom encoding for the axis container.
+   */
+  axis?: GuideEncodingEntry;
+
+  /**
+   * Custom encoding for the axis domain rule mark.
+   */
+  domain?: GuideEncodingEntry;
+
+  /**
+   * Custom encoding for axis gridline rule marks.
+   */
+  grid?: GuideEncodingEntry;
+
+  /**
+   * Custom encoding for axis label text marks.
+   */
+  labels?: GuideEncodingEntry;
+
+  /**
+   * Custom encoding for axis tick rule marks.
+   */
+  ticks?: GuideEncodingEntry;
+
+  /**
+   * Custom encoding for the axis title text mark.
+   */
+  title?: GuideEncodingEntry;
 }
 
 export const AXIS_PROPERTIES:(keyof Axis)[] = [
   'domain', 'format', 'grid', 'labelPadding', 'labels', 'maxExtent', 'minExtent', 'offset', 'orient', 'position', 'tickCount', 'ticks', 'tickSize', 'title', 'titlePadding', 'values', 'zindex'
 ];
-
-
 
 export interface AxisConfigMixins {
   /** Generic axis config. */

--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -1,4 +1,4 @@
-import {Axis, AXIS_PROPERTIES} from '../../axis';
+import {Axis, AXIS_PROPERTIES, AxisEncoding} from '../../axis';
 import {Channel, SpatialScaleChannel} from '../../channel';
 import {VgAxis} from '../../vega.schema';
 
@@ -9,7 +9,7 @@ import {Dict, keys, some} from '../../util';
 import {UnitModel} from '../unit';
 import {AxisComponent, AxisComponentIndex} from './component';
 
-type AxisPart = 'domain' | 'grid' | 'labels' | 'ticks' | 'title';
+type AxisPart = keyof AxisEncoding;
 const AXIS_PARTS: AxisPart[] = ['domain', 'grid', 'labels', 'ticks', 'title'];
 
 export function parseAxisComponent(model: UnitModel, axisChannels: SpatialScaleChannel[]): AxisComponentIndex {
@@ -90,7 +90,7 @@ function parseAxis(channel: SpatialScaleChannel, model: UnitModel, isGridAxis: b
 
   // 2) Add guide encode definition groups
 
-  const encodeSpec = axis.encode || {};
+  const axisEncoding = axis.encoding || {};
   AXIS_PARTS.forEach(function(part) {
     if (!hasAxisPart(vgAxis, part)) {
       // No need to create encode for a disabled part.
@@ -100,9 +100,9 @@ function parseAxis(channel: SpatialScaleChannel, model: UnitModel, isGridAxis: b
     // as different require different parameters.
     let value;
     if (part === 'labels') {
-        value = encode.labels(model, channel, encodeSpec.labels || {}, vgAxis);
+      value = encode.labels(model, channel, axisEncoding.labels || {}, vgAxis);
     } else {
-        value = encodeSpec[part] || {};
+      value = axisEncoding[part] || {};
     }
 
     if (value !== undefined && keys(value).length > 0) {

--- a/src/compile/legend/parse.ts
+++ b/src/compile/legend/parse.ts
@@ -50,11 +50,11 @@ export function parseLegend(model: UnitModel, channel: NonspatialScaleChannel): 
   });
 
   // 2) Add mark property definition groups
-  const encodeSpec = legend.encode || {};
+  const legendEncoding = legend.encoding || {};
   ['labels', 'legend', 'title', 'symbols'].forEach(function(part) {
     const value = encode[part] ?
-      encode[part](fieldDef, encodeSpec[part], model, channel) : // apply rule
-      encodeSpec[part]; // no rule -- just default values
+      encode[part](fieldDef, legendEncoding[part], model, channel) : // apply rule
+      legendEncoding[part]; // no rule -- just default values
     if (value !== undefined && keys(value).length > 0) {
       def.encode = def.encode || {};
       def.encode[part] = {update: value};

--- a/src/guide.ts
+++ b/src/guide.ts
@@ -1,3 +1,6 @@
+import {ValueDef} from './fielddef';
+import {VgEncodeChannel} from './vega.schema';
+
 export interface Guide {
   /**
    * The formatting pattern for labels. This is D3's [number format pattern](https://github.com/mbostock/d3/wiki/Formatting) for quantitative fields and D3's [time format pattern](https://github.com/mbostock/d3/wiki/Time-Formatting) for time field.
@@ -23,5 +26,9 @@ export interface VlOnlyGuideConfig {
   shortTimeLabels?: boolean;
 }
 
+
+export type GuideEncodingEntry = {
+  [k in VgEncodeChannel]: ValueDef<any>;
+};
 
 export const VL_ONLY_GUIDE_CONFIG: (keyof VlOnlyGuideConfig)[] = ['shortTimeLabels'];

--- a/src/legend.ts
+++ b/src/legend.ts
@@ -1,5 +1,5 @@
 import {DateTime} from './datetime';
-import {Guide, VlOnlyGuideConfig} from './guide';
+import {Guide, GuideEncodingEntry, VlOnlyGuideConfig} from './guide';
 import {VgLegendBase, VgLegendConfig, VgLegendEncode} from './vega.schema';
 
 export interface LegendConfig extends VgLegendConfig, VlOnlyGuideConfig {}
@@ -11,7 +11,7 @@ export interface Legend extends VgLegendBase, Guide {
   /**
    * Optional mark definitions for custom legend encoding.
    */
-  encode?: VgLegendEncode;
+  encoding?: LegendEncoding;
 
   /**
    * The desired number of tick values for quantitative legends.
@@ -37,6 +37,34 @@ export interface Legend extends VgLegendBase, Guide {
    */
   zindex?: number;
 }
+
+export type LegendEncoding = {
+  /**
+   * Custom encoding for the legend container.
+   * This can be useful for creating legend with custom x, y position.
+   */
+  legend?: GuideEncodingEntry;
+
+  /**
+   * Custom encoding for the legend title text mark.
+   */
+  title?: GuideEncodingEntry;
+
+  /**
+   * Custom encoding for legend label text marks.
+   */
+  labels?: GuideEncodingEntry;
+
+  /**
+   * Custom encoding for legend symbol marks.
+   */
+  symbols?: GuideEncodingEntry;
+
+  /**
+   * Custom encoding for legend gradient filled rect marks.
+   */
+  gradient?: GuideEncodingEntry;
+};
 
 export const defaultLegendConfig: LegendConfig = {
   orient: undefined, // implicitly "right"

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -549,7 +549,7 @@ export interface VgLegendBase {
    *
    * __Default value:__  `"right"`
    */
-  orient?: string;
+  orient?: 'left' | 'right' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right' | 'none';
 
   /**
    * The offset, in pixels, by which to displace the legend from the edge of the enclosing group or data rectangle.


### PR DESCRIPTION
Part of #1874 

~~This doesn't work yet as the json schema generator doesn't support [Mapped Types](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-1.html) for the following lines yet:~~

```
+export type AxisEncoding = {
+  [k in keyof VgAxisEncode]?: GuideEncodingEntry;
+};
```