### PR TITLE
Apply nullFilter only to fields with continuous domain scales

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1708,9 +1708,12 @@
           "$ref": "#/definitions/FacetConfig",
           "description": "Facet Config "
         },
-        "filterInvalid": {
-          "description": "Whether to filter invalid values (`null` and `NaN`) from the data.\n- If set to `true` (default), all data items with null values are filtered.\n- If `false`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
-          "type": "boolean"
+        "invalidValues": {
+          "description": "Defines how Vega-Lite should handle invalid values (`null` and `NaN`).\n- If set to `\"filter\"` (default), all data items with null values are filtered.\n- If `null`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
+          "enum": [
+            "filter"
+          ],
+          "type": "string"
         },
         "legend": {
           "$ref": "#/definitions/LegendConfig",
@@ -5713,9 +5716,12 @@
           "$ref": "#/definitions/FacetConfig",
           "description": "Facet Config "
         },
-        "filterInvalid": {
-          "description": "Whether to filter invalid values (`null` and `NaN`) from the data.\n- If set to `true` (default), all data items with null values are filtered.\n- If `false`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
-          "type": "boolean"
+        "invalidValues": {
+          "description": "Defines how Vega-Lite should handle invalid values (`null` and `NaN`).\n- If set to `\"filter\"` (default), all data items with null values are filtered.\n- If `null`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
+          "enum": [
+            "filter"
+          ],
+          "type": "string"
         },
         "numberFormat": {
           "description": "D3 Number format for axis labels and text tables. For example \"s\" for SI units.(in the form of [D3 number format pattern](https://github.com/mbostock/d3/wiki/Formatting)).\n\n__Default value:__ `\"s\"` (except for text marks that encode a count field, the default value is `\"d\"`).",

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1709,7 +1709,7 @@
           "description": "Facet Config "
         },
         "filterInvalid": {
-          "description": "Whether to filter invalid values (`null` and `NaN`) from the data.\n- By default (`undefined`), only quantitative and temporal fields are filtered.\n- If set to `true`, all data items with null values are filtered.\n- If `false`, all data items are included. In this case, null values will be interpreted as zeroes.",
+          "description": "Whether to filter invalid values (`null` and `NaN`) from the data.\n- If set to `true` (default), all data items with null values are filtered.\n- If `false`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
           "type": "boolean"
         },
         "legend": {
@@ -5714,7 +5714,7 @@
           "description": "Facet Config "
         },
         "filterInvalid": {
-          "description": "Whether to filter invalid values (`null` and `NaN`) from the data.\n- By default (`undefined`), only quantitative and temporal fields are filtered.\n- If set to `true`, all data items with null values are filtered.\n- If `false`, all data items are included. In this case, null values will be interpreted as zeroes.",
+          "description": "Whether to filter invalid values (`null` and `NaN`) from the data.\n- If set to `true` (default), all data items with null values are filtered.\n- If `false`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
           "type": "boolean"
         },
         "numberFormat": {

--- a/examples/specs/area.vl.json
+++ b/examples/specs/area.vl.json
@@ -11,7 +11,7 @@
       "axis": {"format": "%Y", "labelAngle": 0}
     },
     "y": {
-      "aggregate": "sum", "field": "count","type": "quantitative"
+      "aggregate": "sum", "field": "count", "type": "quantitative"
     }
   }
 }

--- a/examples/vg-specs/area.vg.json
+++ b/examples/vg-specs/area.vg.json
@@ -23,7 +23,7 @@
             "transform": [
                 {
                     "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"count\"] !== null && !isNaN(datum[\"count\"])"
+                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/area_vertical.vg.json
+++ b/examples/vg-specs/area_vertical.vg.json
@@ -24,7 +24,7 @@
             "transform": [
                 {
                     "type": "filter",
-                    "expr": "datum[\"Weight_in_lbs\"] !== null && !isNaN(datum[\"Weight_in_lbs\"]) && datum[\"Year\"] !== null && !isNaN(datum[\"Year\"])"
+                    "expr": "datum[\"Year\"] !== null && !isNaN(datum[\"Year\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/bar_1d.vg.json
+++ b/examples/vg-specs/bar_1d.vg.json
@@ -25,10 +25,6 @@
                     "expr": "datum.year == 2000"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [],
                     "ops": [

--- a/examples/vg-specs/bar_1d_rangestep_config.vg.json
+++ b/examples/vg-specs/bar_1d_rangestep_config.vg.json
@@ -25,10 +25,6 @@
                     "expr": "datum.year == 2000"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [],
                     "ops": [

--- a/examples/vg-specs/bar_aggregate.vg.json
+++ b/examples/vg-specs/bar_aggregate.vg.json
@@ -26,10 +26,6 @@
                     "expr": "datum.year == 2000"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age"

--- a/examples/vg-specs/bar_aggregate_size.vg.json
+++ b/examples/vg-specs/bar_aggregate_size.vg.json
@@ -26,10 +26,6 @@
                     "expr": "datum.year == 2000"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age"

--- a/examples/vg-specs/bar_aggregate_vertical.vg.json
+++ b/examples/vg-specs/bar_aggregate_vertical.vg.json
@@ -21,10 +21,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"Acceleration\"] !== null && !isNaN(datum[\"Acceleration\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "Cylinders"

--- a/examples/vg-specs/bar_array_aggregate.vg.json
+++ b/examples/vg-specs/bar_array_aggregate.vg.json
@@ -61,10 +61,6 @@
                     "as": "b"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"b\"] !== null && !isNaN(datum[\"b\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "a"

--- a/examples/vg-specs/bar_distinct.vg.json
+++ b/examples/vg-specs/bar_distinct.vg.json
@@ -18,10 +18,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"Name\"] !== null"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "Origin"

--- a/examples/vg-specs/bar_grouped.vg.json
+++ b/examples/vg-specs/bar_grouped.vg.json
@@ -23,10 +23,6 @@
                     "as": "gender"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "gender",

--- a/examples/vg-specs/bar_grouped_horizontal.vg.json
+++ b/examples/vg-specs/bar_grouped_horizontal.vg.json
@@ -23,10 +23,6 @@
                     "as": "gender"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "gender",

--- a/examples/vg-specs/bar_layered_transparent.vg.json
+++ b/examples/vg-specs/bar_layered_transparent.vg.json
@@ -31,10 +31,6 @@
                     "as": "gender"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age",

--- a/examples/vg-specs/bar_month.vg.json
+++ b/examples/vg-specs/bar_month.vg.json
@@ -22,10 +22,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"temp\"] !== null && !isNaN(datum[\"temp\"])"
-                },
-                {
                     "type": "formula",
                     "as": "month_date",
                     "expr": "datetime(0, month(datum[\"date\"]), 1, 0, 0, 0, 0)"

--- a/examples/vg-specs/bar_swap_axes.vg.json
+++ b/examples/vg-specs/bar_swap_axes.vg.json
@@ -61,10 +61,6 @@
                     "as": "b"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"b\"] !== null && !isNaN(datum[\"b\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "a"

--- a/examples/vg-specs/bar_swap_custom.vg.json
+++ b/examples/vg-specs/bar_swap_custom.vg.json
@@ -61,10 +61,6 @@
                     "as": "b"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"b\"] !== null && !isNaN(datum[\"b\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "a"

--- a/examples/vg-specs/bar_yearmonth.vg.json
+++ b/examples/vg-specs/bar_yearmonth.vg.json
@@ -24,7 +24,7 @@
             "transform": [
                 {
                     "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"temp\"] !== null && !isNaN(datum[\"temp\"])"
+                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/box-plot_minmax_1D_horizontal.vg.json
+++ b/examples/vg-specs/box-plot_minmax_1D_horizontal.vg.json
@@ -28,10 +28,6 @@
                     "as": "people"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [],
                     "ops": [
@@ -57,10 +53,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"people\"])",
                     "as": "people"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
                 },
                 {
                     "type": "aggregate",
@@ -90,10 +82,6 @@
                     "as": "people"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [],
                     "ops": [
@@ -119,10 +107,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"people\"])",
                     "as": "people"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
                 },
                 {
                     "type": "aggregate",

--- a/examples/vg-specs/box-plot_minmax_1D_vertical.vg.json
+++ b/examples/vg-specs/box-plot_minmax_1D_vertical.vg.json
@@ -28,10 +28,6 @@
                     "as": "people"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [],
                     "ops": [
@@ -57,10 +53,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"people\"])",
                     "as": "people"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
                 },
                 {
                     "type": "aggregate",
@@ -90,10 +82,6 @@
                     "as": "people"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [],
                     "ops": [
@@ -119,10 +107,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"people\"])",
                     "as": "people"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
                 },
                 {
                     "type": "aggregate",

--- a/examples/vg-specs/box-plot_minmax_2D_horizontal.vg.json
+++ b/examples/vg-specs/box-plot_minmax_2D_horizontal.vg.json
@@ -28,10 +28,6 @@
                     "as": "people"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age"
@@ -59,10 +55,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"people\"])",
                     "as": "people"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
                 },
                 {
                     "type": "aggregate",
@@ -94,10 +86,6 @@
                     "as": "people"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age"
@@ -125,10 +113,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"people\"])",
                     "as": "people"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
                 },
                 {
                     "type": "aggregate",

--- a/examples/vg-specs/box-plot_minmax_2D_vertical.vg.json
+++ b/examples/vg-specs/box-plot_minmax_2D_vertical.vg.json
@@ -28,10 +28,6 @@
                     "as": "people"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age"
@@ -59,10 +55,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"people\"])",
                     "as": "people"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
                 },
                 {
                     "type": "aggregate",
@@ -94,10 +86,6 @@
                     "as": "people"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age"
@@ -125,10 +113,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"people\"])",
                     "as": "people"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
                 },
                 {
                     "type": "aggregate",

--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -464,14 +464,13 @@
         },
         {
             "name": "color",
-            "type": "sequential",
+            "type": "ordinal",
             "domain": {
                 "data": "source_0",
-                "field": "Cylinders"
+                "field": "Cylinders",
+                "sort": true
             },
-            "range": "ramp",
-            "nice": false,
-            "zero": false
+            "range": "ordinal"
         }
     ],
     "axes": [

--- a/examples/vg-specs/errorbar_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_aggregate.vg.json
@@ -34,10 +34,6 @@
                     "as": "people"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age"
@@ -67,10 +63,6 @@
                     "as": "people"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age"
@@ -97,10 +89,6 @@
                     "as": "people"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age"
@@ -125,10 +113,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"people\"])",
                     "as": "people"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
                 },
                 {
                     "type": "aggregate",

--- a/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
@@ -34,10 +34,6 @@
                     "as": "people"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age"
@@ -67,10 +63,6 @@
                     "as": "people"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age"
@@ -97,10 +89,6 @@
                     "as": "people"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age"
@@ -125,10 +113,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"people\"])",
                     "as": "people"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
                 },
                 {
                     "type": "aggregate",

--- a/examples/vg-specs/github_punchcard.vg.json
+++ b/examples/vg-specs/github_punchcard.vg.json
@@ -22,10 +22,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"time\"] !== null && !isNaN(datum[\"time\"]) && datum[\"count\"] !== null && !isNaN(datum[\"count\"])"
-                },
-                {
                     "type": "formula",
                     "as": "day_time",
                     "expr": "datetime(2006, 0, day(datum[\"time\"])+1, 0, 0, 0, 0)"

--- a/examples/vg-specs/histogram_sort_mean.vg.json
+++ b/examples/vg-specs/histogram_sort_mean.vg.json
@@ -18,13 +18,7 @@
                 "parse": {
                     "Horsepower": "number"
                 }
-            },
-            "transform": [
-                {
-                    "type": "filter",
-                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
-                }
-            ]
+            }
         },
         {
             "name": "data_0",

--- a/examples/vg-specs/layer_bar_dual_axis.vg.json
+++ b/examples/vg-specs/layer_bar_dual_axis.vg.json
@@ -32,10 +32,6 @@
                     "as": "precipitation"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"precipitation\"] !== null && !isNaN(datum[\"precipitation\"])"
-                },
-                {
                     "type": "formula",
                     "as": "month_date",
                     "expr": "datetime(0, month(datum[\"date\"]), 1, 0, 0, 0, 0)"
@@ -70,10 +66,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"temp_max\"])",
                     "as": "temp_max"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"temp_max\"] !== null && !isNaN(datum[\"temp_max\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/layer_bar_dual_axis_minmax.vg.json
+++ b/examples/vg-specs/layer_bar_dual_axis_minmax.vg.json
@@ -33,10 +33,6 @@
                     "as": "precipitation"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"precipitation\"] !== null && !isNaN(datum[\"precipitation\"])"
-                },
-                {
                     "type": "formula",
                     "as": "month_date",
                     "expr": "datetime(0, month(datum[\"date\"]), 1, 0, 0, 0, 0)"
@@ -71,10 +67,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"temp_max\"])",
                     "as": "temp_max"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"temp_max\"] !== null && !isNaN(datum[\"temp_max\"])"
                 },
                 {
                     "type": "formula",
@@ -118,10 +110,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"temp_min\"])",
                     "as": "temp_min"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"temp_min\"] !== null && !isNaN(datum[\"temp_min\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/layer_box_plot_circle.vg.json
+++ b/examples/vg-specs/layer_box_plot_circle.vg.json
@@ -43,10 +43,6 @@
                     "as": "people"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age"
@@ -74,10 +70,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"people\"])",
                     "as": "people"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
                 },
                 {
                     "type": "aggregate",
@@ -109,10 +101,6 @@
                     "as": "people"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age"
@@ -140,10 +128,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"people\"])",
                     "as": "people"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
                 },
                 {
                     "type": "aggregate",

--- a/examples/vg-specs/layer_line_color_rule.vg.json
+++ b/examples/vg-specs/layer_line_color_rule.vg.json
@@ -55,10 +55,6 @@
                     "as": "price"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"price\"] !== null && !isNaN(datum[\"price\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "symbol"

--- a/examples/vg-specs/layer_overlay.vg.json
+++ b/examples/vg-specs/layer_overlay.vg.json
@@ -25,10 +25,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"Horsepower\"])",
                     "as": "Horsepower"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
                 }
             ]
         },
@@ -68,10 +64,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"Horsepower\"])",
                     "as": "Horsepower"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
                 }
             ]
         },
@@ -106,10 +98,6 @@
                     "as": "Horsepower"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "Cylinders"
@@ -141,10 +129,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"Horsepower\"])",
                     "as": "Horsepower"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
                 },
                 {
                     "type": "aggregate",

--- a/examples/vg-specs/layer_precipitation_mean.vg.json
+++ b/examples/vg-specs/layer_precipitation_mean.vg.json
@@ -32,10 +32,6 @@
                     "as": "precipitation"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"precipitation\"] !== null && !isNaN(datum[\"precipitation\"])"
-                },
-                {
                     "type": "formula",
                     "as": "month_date",
                     "expr": "datetime(0, month(datum[\"date\"]), 1, 0, 0, 0, 0)"
@@ -65,10 +61,6 @@
                     "type": "formula",
                     "expr": "toNumber(datum[\"precipitation\"])",
                     "as": "precipitation"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"precipitation\"] !== null && !isNaN(datum[\"precipitation\"])"
                 },
                 {
                     "type": "aggregate",

--- a/examples/vg-specs/layered_box_plot.vg.json
+++ b/examples/vg-specs/layered_box_plot.vg.json
@@ -63,7 +63,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "datum[\"people_min\"] !== null && !isNaN(datum[\"people_min\"]) && datum[\"people_q1\"] !== null && !isNaN(datum[\"people_q1\"])"
+                    "expr": "datum[\"people_min\"] !== null && !isNaN(datum[\"people_min\"])"
                 }
             ]
         },
@@ -83,7 +83,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "datum[\"people_q3\"] !== null && !isNaN(datum[\"people_q3\"]) && datum[\"people_max\"] !== null && !isNaN(datum[\"people_max\"])"
+                    "expr": "datum[\"people_q3\"] !== null && !isNaN(datum[\"people_q3\"])"
                 }
             ]
         },
@@ -103,7 +103,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "datum[\"people_q1\"] !== null && !isNaN(datum[\"people_q1\"]) && datum[\"people_q3\"] !== null && !isNaN(datum[\"people_q3\"])"
+                    "expr": "datum[\"people_q1\"] !== null && !isNaN(datum[\"people_q1\"])"
                 }
             ]
         },

--- a/examples/vg-specs/layered_falkensee.vg.json
+++ b/examples/vg-specs/layered_falkensee.vg.json
@@ -267,7 +267,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "datum[\"start\"] !== null && !isNaN(datum[\"start\"]) && datum[\"end\"] !== null && !isNaN(datum[\"end\"])"
+                    "expr": "datum[\"start\"] !== null && !isNaN(datum[\"start\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -771,7 +771,7 @@
         },
         {
             "name": "color",
-            "type": "sequential",
+            "type": "ordinal",
             "domain": {
                 "fields": [
                     {
@@ -785,9 +785,7 @@
                 ],
                 "sort": true
             },
-            "range": "ramp",
-            "nice": false,
-            "zero": false
+            "range": "ordinal"
         }
     ],
     "axes": [

--- a/examples/vg-specs/line_calculate.vg.json
+++ b/examples/vg-specs/line_calculate.vg.json
@@ -26,10 +26,6 @@
                     "as": "temp_range"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"temp_range\"] !== null && !isNaN(datum[\"temp_range\"])"
-                },
-                {
                     "type": "formula",
                     "as": "month_date",
                     "expr": "datetime(0, month(datum[\"date\"]), 1, 0, 0, 0, 0)"

--- a/examples/vg-specs/line_color_binned.vg.json
+++ b/examples/vg-specs/line_color_binned.vg.json
@@ -25,7 +25,7 @@
             "transform": [
                 {
                     "type": "filter",
-                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Year\"] !== null && !isNaN(datum[\"Year\"]) && datum[\"Acceleration\"] !== null && !isNaN(datum[\"Acceleration\"])"
+                    "expr": "datum[\"Year\"] !== null && !isNaN(datum[\"Year\"])"
                 },
                 {
                     "type": "extent",

--- a/examples/vg-specs/line_max_year.vg.json
+++ b/examples/vg-specs/line_max_year.vg.json
@@ -23,7 +23,7 @@
             "transform": [
                 {
                     "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"temp_max\"] !== null && !isNaN(datum[\"temp_max\"])"
+                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/line_mean_month.vg.json
+++ b/examples/vg-specs/line_mean_month.vg.json
@@ -22,10 +22,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"precipitation\"] !== null && !isNaN(datum[\"precipitation\"])"
-                },
-                {
                     "type": "formula",
                     "as": "month_date",
                     "expr": "datetime(0, month(datum[\"date\"]), 1, 0, 0, 0, 0)"

--- a/examples/vg-specs/line_mean_year.vg.json
+++ b/examples/vg-specs/line_mean_year.vg.json
@@ -23,7 +23,7 @@
             "transform": [
                 {
                     "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"temp_max\"] !== null && !isNaN(datum[\"temp_max\"])"
+                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/line_month.vg.json
+++ b/examples/vg-specs/line_month.vg.json
@@ -22,10 +22,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"temp\"] !== null && !isNaN(datum[\"temp\"])"
-                },
-                {
                     "type": "formula",
                     "as": "month_date",
                     "expr": "datetime(0, month(datum[\"date\"]), 1, 0, 0, 0, 0)"

--- a/examples/vg-specs/line_quarter.vg.json
+++ b/examples/vg-specs/line_quarter.vg.json
@@ -16,17 +16,9 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"])"
-                },
-                {
                     "type": "formula",
                     "as": "year_date",
                     "expr": "datetime(year(datum[\"date\"]), 0, 1, 0, 0, 0, 0)"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"price\"] !== null && !isNaN(datum[\"price\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/line_quarter_legend.vg.json
+++ b/examples/vg-specs/line_quarter_legend.vg.json
@@ -24,7 +24,7 @@
             "transform": [
                 {
                     "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"price\"] !== null && !isNaN(datum[\"price\"])"
+                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/line_slope.vg.json
+++ b/examples/vg-specs/line_slope.vg.json
@@ -22,10 +22,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"yield\"] !== null && !isNaN(datum[\"yield\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "year",

--- a/examples/vg-specs/lookup.vg.json
+++ b/examples/vg-specs/lookup.vg.json
@@ -42,10 +42,6 @@
                     "as": "age"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"age\"] !== null && !isNaN(datum[\"age\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "group"

--- a/examples/vg-specs/parse_local_time.vg.json
+++ b/examples/vg-specs/parse_local_time.vg.json
@@ -32,10 +32,6 @@
                     "as": "date"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"])"
-                },
-                {
                     "type": "formula",
                     "as": "hours_date",
                     "expr": "datetime(0, 0, 1, hours(datum[\"date\"]), 0, 0, 0)"

--- a/examples/vg-specs/parse_utc_time.vg.json
+++ b/examples/vg-specs/parse_utc_time.vg.json
@@ -24,7 +24,7 @@
             "transform": [
                 {
                     "type": "filter",
-                    "expr": "datum[\"Year\"] !== null && !isNaN(datum[\"Year\"]) && datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
+                    "expr": "datum[\"Year\"] !== null && !isNaN(datum[\"Year\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/parse_utc_time_format.vg.json
+++ b/examples/vg-specs/parse_utc_time_format.vg.json
@@ -32,10 +32,6 @@
                     "as": "date"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"])"
-                },
-                {
                     "type": "formula",
                     "as": "hours_date",
                     "expr": "datetime(0, 0, 1, hours(datum[\"date\"]), 0, 0, 0)"

--- a/examples/vg-specs/point_2d_aggregate.vg.json
+++ b/examples/vg-specs/point_2d_aggregate.vg.json
@@ -61,10 +61,6 @@
                     "as": "b"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"b\"] !== null && !isNaN(datum[\"b\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "a"

--- a/examples/vg-specs/point_dot_timeunit_color.vg.json
+++ b/examples/vg-specs/point_dot_timeunit_color.vg.json
@@ -23,7 +23,7 @@
             "transform": [
                 {
                     "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"temp\"] !== null && !isNaN(datum[\"temp\"])"
+                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/point_ordinal_color.vg.json
+++ b/examples/vg-specs/point_ordinal_color.vg.json
@@ -141,14 +141,13 @@
         },
         {
             "name": "color",
-            "type": "sequential",
+            "type": "ordinal",
             "domain": {
                 "data": "data_0",
-                "field": "a"
+                "field": "a",
+                "sort": true
             },
-            "range": "ramp",
-            "nice": false,
-            "zero": false
+            "range": "ordinal"
         }
     ],
     "axes": [

--- a/examples/vg-specs/rect_heatmap.vg.json
+++ b/examples/vg-specs/rect_heatmap.vg.json
@@ -21,10 +21,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "Origin",

--- a/examples/vg-specs/rule_color_mean.vg.json
+++ b/examples/vg-specs/rule_color_mean.vg.json
@@ -22,10 +22,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"price\"] !== null && !isNaN(datum[\"price\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "symbol"

--- a/examples/vg-specs/scatter_aggregate_detail.vg.json
+++ b/examples/vg-specs/scatter_aggregate_detail.vg.json
@@ -23,10 +23,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Displacement\"] !== null && !isNaN(datum[\"Displacement\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "Origin"

--- a/examples/vg-specs/scatter_binned_color.vg.json
+++ b/examples/vg-specs/scatter_binned_color.vg.json
@@ -25,7 +25,7 @@
             "transform": [
                 {
                     "type": "filter",
-                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"]) && datum[\"Acceleration\"] !== null && !isNaN(datum[\"Acceleration\"])"
+                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 },
                 {
                     "type": "extent",

--- a/examples/vg-specs/scatter_color_ordinal.vg.json
+++ b/examples/vg-specs/scatter_color_ordinal.vg.json
@@ -103,14 +103,13 @@
         },
         {
             "name": "color",
-            "type": "sequential",
+            "type": "ordinal",
             "domain": {
                 "data": "source_0",
-                "field": "Cylinders"
+                "field": "Cylinders",
+                "sort": true
             },
-            "range": "ramp",
-            "nice": false,
-            "zero": false
+            "range": "ordinal"
         }
     ],
     "axes": [

--- a/examples/vg-specs/scatter_color_ordinal_custom.vg.json
+++ b/examples/vg-specs/scatter_color_ordinal_custom.vg.json
@@ -103,17 +103,16 @@
         },
         {
             "name": "color",
-            "type": "sequential",
+            "type": "ordinal",
             "domain": {
                 "data": "source_0",
-                "field": "Cylinders"
+                "field": "Cylinders",
+                "sort": true
             },
             "range": [
                 "pink",
                 "red"
-            ],
-            "nice": false,
-            "zero": false
+            ]
         }
     ],
     "axes": [

--- a/examples/vg-specs/scatter_connected.vg.json
+++ b/examples/vg-specs/scatter_connected.vg.json
@@ -38,7 +38,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "datum[\"miles\"] !== null && !isNaN(datum[\"miles\"]) && datum[\"gas\"] !== null && !isNaN(datum[\"gas\"]) && datum[\"year\"] !== null && !isNaN(datum[\"year\"])"
+                    "expr": "datum[\"miles\"] !== null && !isNaN(datum[\"miles\"]) && datum[\"gas\"] !== null && !isNaN(datum[\"gas\"])"
                 },
                 {
                     "type": "collect",
@@ -74,7 +74,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "datum[\"miles\"] !== null && !isNaN(datum[\"miles\"]) && datum[\"gas\"] !== null && !isNaN(datum[\"gas\"]) && datum[\"year\"] !== null && !isNaN(datum[\"year\"])"
+                    "expr": "datum[\"miles\"] !== null && !isNaN(datum[\"miles\"]) && datum[\"gas\"] !== null && !isNaN(datum[\"gas\"])"
                 }
             ]
         }

--- a/examples/vg-specs/stacked_area.vg.json
+++ b/examples/vg-specs/stacked_area.vg.json
@@ -24,7 +24,7 @@
             "transform": [
                 {
                     "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"count\"] !== null && !isNaN(datum[\"count\"])"
+                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/stacked_area_binned.vg.json
+++ b/examples/vg-specs/stacked_area_binned.vg.json
@@ -23,7 +23,7 @@
             "transform": [
                 {
                     "type": "filter",
-                    "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Acceleration\"] !== null && !isNaN(datum[\"Acceleration\"])"
+                    "expr": "datum[\"Acceleration\"] !== null && !isNaN(datum[\"Acceleration\"])"
                 },
                 {
                     "type": "extent",

--- a/examples/vg-specs/stacked_area_normalize.vg.json
+++ b/examples/vg-specs/stacked_area_normalize.vg.json
@@ -23,7 +23,7 @@
             "transform": [
                 {
                     "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"count\"] !== null && !isNaN(datum[\"count\"])"
+                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/stacked_area_ordinal.vg.json
+++ b/examples/vg-specs/stacked_area_ordinal.vg.json
@@ -23,7 +23,7 @@
             "transform": [
                 {
                     "type": "filter",
-                    "expr": "datum[\"Year\"] !== null && !isNaN(datum[\"Year\"]) && datum[\"Weight_in_lbs\"] !== null && !isNaN(datum[\"Weight_in_lbs\"])"
+                    "expr": "datum[\"Year\"] !== null && !isNaN(datum[\"Year\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/stacked_area_ordinal.vg.json
+++ b/examples/vg-specs/stacked_area_ordinal.vg.json
@@ -197,14 +197,13 @@
         },
         {
             "name": "color",
-            "type": "sequential",
+            "type": "ordinal",
             "domain": {
                 "data": "source_0",
-                "field": "Cylinders"
+                "field": "Cylinders",
+                "sort": true
             },
-            "range": "ramp",
-            "nice": false,
-            "zero": false
+            "range": "ordinal"
         }
     ],
     "axes": [

--- a/examples/vg-specs/stacked_area_stream.vg.json
+++ b/examples/vg-specs/stacked_area_stream.vg.json
@@ -23,7 +23,7 @@
             "transform": [
                 {
                     "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"count\"] !== null && !isNaN(datum[\"count\"])"
+                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/stacked_bar_1d.vg.json
+++ b/examples/vg-specs/stacked_bar_1d.vg.json
@@ -21,10 +21,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"Acceleration\"] !== null && !isNaN(datum[\"Acceleration\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "Origin"

--- a/examples/vg-specs/stacked_bar_count.vg.json
+++ b/examples/vg-specs/stacked_bar_count.vg.json
@@ -21,10 +21,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"])"
-                },
-                {
                     "type": "formula",
                     "as": "month_date",
                     "expr": "datetime(0, month(datum[\"date\"]), 1, 0, 0, 0, 0)"

--- a/examples/vg-specs/stacked_bar_h.vg.json
+++ b/examples/vg-specs/stacked_bar_h.vg.json
@@ -21,10 +21,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"yield\"] !== null && !isNaN(datum[\"yield\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "variety",

--- a/examples/vg-specs/stacked_bar_h_order.vg.json
+++ b/examples/vg-specs/stacked_bar_h_order.vg.json
@@ -21,10 +21,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"yield\"] !== null && !isNaN(datum[\"yield\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "variety",

--- a/examples/vg-specs/stacked_bar_normalize.vg.json
+++ b/examples/vg-specs/stacked_bar_normalize.vg.json
@@ -30,10 +30,6 @@
                     "as": "gender"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age",

--- a/examples/vg-specs/stacked_bar_population.vg.json
+++ b/examples/vg-specs/stacked_bar_population.vg.json
@@ -31,10 +31,6 @@
                     "as": "gender"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age",

--- a/examples/vg-specs/stacked_bar_size.vg.json
+++ b/examples/vg-specs/stacked_bar_size.vg.json
@@ -21,10 +21,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"])"
-                },
-                {
                     "type": "formula",
                     "as": "month_date",
                     "expr": "datetime(0, month(datum[\"date\"]), 1, 0, 0, 0, 0)"

--- a/examples/vg-specs/stacked_bar_v.vg.json
+++ b/examples/vg-specs/stacked_bar_v.vg.json
@@ -21,10 +21,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"yield\"] !== null && !isNaN(datum[\"yield\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "variety",

--- a/examples/vg-specs/stacked_bar_weather.vg.json
+++ b/examples/vg-specs/stacked_bar_weather.vg.json
@@ -21,10 +21,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"])"
-                },
-                {
                     "type": "formula",
                     "as": "month_date",
                     "expr": "datetime(0, month(datum[\"date\"]), 1, 0, 0, 0, 0)"

--- a/examples/vg-specs/trellis_bar.vg.json
+++ b/examples/vg-specs/trellis_bar.vg.json
@@ -24,10 +24,6 @@
                     "as": "gender"
                 },
                 {
-                    "type": "filter",
-                    "expr": "datum[\"people\"] !== null && !isNaN(datum[\"people\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "age",

--- a/examples/vg-specs/trellis_barley.vg.json
+++ b/examples/vg-specs/trellis_barley.vg.json
@@ -12,13 +12,7 @@
                 "parse": {
                     "yield": "number"
                 }
-            },
-            "transform": [
-                {
-                    "type": "filter",
-                    "expr": "datum[\"yield\"] !== null && !isNaN(datum[\"yield\"])"
-                }
-            ]
+            }
         },
         {
             "name": "trellis_barley_row",

--- a/examples/vg-specs/trellis_column_year.vg.json
+++ b/examples/vg-specs/trellis_column_year.vg.json
@@ -16,17 +16,9 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"])"
-                },
-                {
                     "type": "formula",
                     "as": "year_date",
                     "expr": "datetime(year(datum[\"date\"]), 0, 1, 0, 0, 0, 0)"
-                },
-                {
-                    "type": "filter",
-                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"price\"] !== null && !isNaN(datum[\"price\"])"
                 },
                 {
                     "type": "formula",

--- a/examples/vg-specs/trellis_scatter_binned_row.vg.json
+++ b/examples/vg-specs/trellis_scatter_binned_row.vg.json
@@ -17,10 +17,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"Acceleration\"] !== null && !isNaN(datum[\"Acceleration\"])"
-                },
-                {
                     "type": "extent",
                     "field": "Acceleration",
                     "signal": "bin_maxbins_6_Acceleration_extent"

--- a/examples/vg-specs/trellis_stacked_bar.vg.json
+++ b/examples/vg-specs/trellis_stacked_bar.vg.json
@@ -14,10 +14,6 @@
             },
             "transform": [
                 {
-                    "type": "filter",
-                    "expr": "datum[\"yield\"] !== null && !isNaN(datum[\"yield\"])"
-                },
-                {
                     "type": "aggregate",
                     "groupby": [
                         "variety",

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -43,9 +43,10 @@ A Vega-Lite `config` object can have the following top-level properties:
 
 {:#format}
 
-{% include table.html props="background,countTitle,filterInvalid,numberFormat,padding,range,timeFormat" source="Config" %}
+{% include table.html props="background,countTitle,invalidValues,numberFormat,padding,range,timeFormat" source="Config" %}
 
 <!-- TODO: consider adding width, height, numberFormat, timeFormat  -->
+<!-- TODO: move range to its own section -->
 
 {:#cell-config}
 ## Cell Configuration  (`config.cell.*`)

--- a/src/compile/data/nullfilter.ts
+++ b/src/compile/data/nullfilter.ts
@@ -24,7 +24,7 @@ export class NullFilterNode extends DataFlowNode {
 
   public static make(model: ModelWithField) {
     const fields = model.reduceFieldDef((aggregator: Dict<FieldDef<string>>, fieldDef, channel) => {
-      if (model.config.filterInvalid && !fieldDef.aggregate && fieldDef.field) {
+      if (model.config.invalidValues === 'filter' && !fieldDef.aggregate && fieldDef.field) {
         // Vega's aggregate operator already handle invalid values, so we only have to consider non-aggregate field here.
 
         const scaleComponent = isScaleChannel(channel) && model.getScaleComponent(channel);

--- a/src/compile/data/nullfilter.ts
+++ b/src/compile/data/nullfilter.ts
@@ -1,19 +1,13 @@
 import {isCountingAggregateOp} from '../../aggregate';
-import {FieldDef} from '../../fielddef';
+import {isScaleChannel} from '../../channel';
+import {FieldDef, isContinuous, isDiscrete} from '../../fielddef';
+import {hasContinuousDomain} from '../../scale';
 import {QUANTITATIVE, TEMPORAL} from '../../type';
 import {contains, Dict, differ, differArray, duplicate, extend, hash, keys, stringValue} from '../../util';
 import {VgFilterTransform} from '../../vega.schema';
 import {ModelWithField} from '../model';
 import {Model} from './../model';
 import {DataFlowNode} from './dataflow';
-
-
-const DEFAULT_NULL_FILTERS = {
-  nominal: false,
-  ordinal: false,
-  quantitative: true,
-  temporal: true
-};
 
 export class NullFilterNode extends DataFlowNode {
   private _filteredFields: Dict<FieldDef<string>>;
@@ -29,15 +23,18 @@ export class NullFilterNode extends DataFlowNode {
   }
 
   public static make(model: ModelWithField) {
-    const fields = model.reduceFieldDef((aggregator: Dict<FieldDef<string>>, fieldDef) => {
-      if (fieldDef.aggregate !== 'count') { // Ignore * for count(*) fields.
-        if (model.config.filterInvalid ||
-          (model.config.filterInvalid === undefined && (fieldDef.field && DEFAULT_NULL_FILTERS[fieldDef.type]))) {
-          aggregator[fieldDef.field] = fieldDef;
-        } else {
-          // define this so we know that we don't filter nulls for this field
-          // this makes it easier to merge into parents
-          aggregator[fieldDef.field] = null;
+    const fields = model.reduceFieldDef((aggregator: Dict<FieldDef<string>>, fieldDef, channel) => {
+      if (model.config.filterInvalid && !fieldDef.aggregate && fieldDef.field) {
+        // Vega's aggregate operator already handle invalid values, so we only have to consider non-aggregate field here.
+
+        const scaleComponent = isScaleChannel(channel) && model.getScaleComponent(channel);
+        if (scaleComponent) {
+          const scaleType = scaleComponent.get('type');
+
+          // only automatically filter null for continuous domain since discrete domain scales can handle invalid values.
+          if (hasContinuousDomain(scaleType)) {
+            aggregator[fieldDef.field] = fieldDef;
+          }
         }
       }
       return aggregator;
@@ -69,7 +66,7 @@ export class NullFilterNode extends DataFlowNode {
       const fieldDef = this._filteredFields[field];
       if (fieldDef !== null) {
         _filters.push(`datum[${stringValue(fieldDef.field)}] !== null`);
-        if (contains([QUANTITATIVE, TEMPORAL], fieldDef.type) && !isCountingAggregateOp(fieldDef.aggregate)) {
+        if (contains([QUANTITATIVE, TEMPORAL], fieldDef.type)) {
           // TODO(https://github.com/vega/vega-lite/issues/1436):
           // We can be even smarter and add NaN filter for N,O that are numbers
           // based on the `parse` property once we have it.

--- a/src/compile/scale/type.ts
+++ b/src/compile/scale/type.ts
@@ -65,9 +65,11 @@ function defaultType(channel: Channel, fieldDef: FieldDef<string>, mark: Mark,
 
     case 'ordinal':
       if (channel === 'color') {
-        return 'sequential';
+        return 'ordinal';
       } else if (rangeType(channel) === 'discrete') {
-        log.warn(log.message.discreteChannelCannotEncode(channel, 'ordinal'));
+        if (channel !== 'text' && channel !=='tooltip') {
+          log.warn(log.message.discreteChannelCannotEncode(channel, 'ordinal'));
+        }
         return 'ordinal';
       }
       return discreteToContinuousType(channel, mark, specifiedRangeStep, scaleConfig);

--- a/src/config.ts
+++ b/src/config.ts
@@ -147,11 +147,11 @@ export interface VLOnlyConfig {
   countTitle?: string;
 
   /**
-   * Whether to filter invalid values (`null` and `NaN`) from the data.
-   * - If set to `true` (default), all data items with null values are filtered.
-   * - If `false`, all data items are included. In this case, invalid values will be interpreted as zeroes.
+   * Defines how Vega-Lite should handle invalid values (`null` and `NaN`).
+   * - If set to `"filter"` (default), all data items with null values are filtered.
+   * - If `null`, all data items are included. In this case, invalid values will be interpreted as zeroes.
    */
-  filterInvalid?: boolean;
+  invalidValues?: 'filter';
 
   /**
    * D3 Number format for axis labels and text tables. For example "s" for SI units.(in the form of [D3 number format pattern](https://github.com/mbostock/d3/wiki/Formatting)).
@@ -222,7 +222,7 @@ export const defaultConfig: Config = {
   timeFormat: '%b %d, %Y',
   countTitle: 'Number of Records',
 
-  filterInvalid: true,
+  invalidValues: 'filter',
 
   cell: defaultCellConfig,
 
@@ -267,7 +267,7 @@ export function initConfig(config: Config) {
 
 const MARK_ROLES = [].concat(PRIMITIVE_MARKS, COMPOSITE_MARK_ROLES) as (Mark | typeof COMPOSITE_MARK_ROLES[0])[];
 
-const VL_ONLY_CONFIG_PROPERTIES: (keyof Config)[] = ['padding', 'numberFormat', 'timeFormat', 'countTitle', 'cell', 'stack', 'overlay', 'scale', 'facet', 'selection', 'filterInvalid'];
+const VL_ONLY_CONFIG_PROPERTIES: (keyof Config)[] = ['padding', 'numberFormat', 'timeFormat', 'countTitle', 'cell', 'stack', 'overlay', 'scale', 'facet', 'selection', 'invalidValues'];
 
 const VL_ONLY_ALL_MARK_SPECIFIC_CONFIG_PROPERTY_INDEX = {
   ...VL_ONLY_MARK_SPECIFIC_CONFIG_PROPERTY_INDEX,

--- a/src/config.ts
+++ b/src/config.ts
@@ -148,9 +148,8 @@ export interface VLOnlyConfig {
 
   /**
    * Whether to filter invalid values (`null` and `NaN`) from the data.
-   * - By default (`undefined`), only quantitative and temporal fields are filtered.
-   * - If set to `true`, all data items with null values are filtered.
-   * - If `false`, all data items are included. In this case, null values will be interpreted as zeroes.
+   * - If set to `true` (default), all data items with null values are filtered.
+   * - If `false`, all data items are included. In this case, invalid values will be interpreted as zeroes.
    */
   filterInvalid?: boolean;
 
@@ -222,6 +221,8 @@ export const defaultConfig: Config = {
   padding: 5,
   timeFormat: '%b %d, %Y',
   countTitle: 'Number of Records',
+
+  filterInvalid: true,
 
   cell: defaultCellConfig,
 

--- a/test/compile/data/nullfilter.test.ts
+++ b/test/compile/data/nullfilter.test.ts
@@ -34,10 +34,10 @@ describe('compile/data/nullfilter', function() {
       });
     });
 
-    it('should add filterNull for Q and T when filterInvalid is specified true.', function () {
+    it('should add filterNull for Q and T when invalidValues is "filter".', function () {
       const model = parseUnitModelWithScale(mergeDeep(spec, {
         config: {
-          filterInvalid: true
+          invalidValues: 'filter'
         }
       }));
       assert.deepEqual<Dict<FieldDef<string>>>(parse(model).filteredFields, {
@@ -46,10 +46,10 @@ describe('compile/data/nullfilter', function() {
       });
     });
 
-    it('should add no null filter if filterInvalid is false', function () {
+    it('should add no null filter if when invalidValues is null', function () {
       const model = parseUnitModelWithScale(mergeDeep(spec, {
         config: {
-          filterInvalid: false
+          invalidValues: null
         }
       }));
       assert.deepEqual(parse(model), null);

--- a/test/compile/data/nullfilter.test.ts
+++ b/test/compile/data/nullfilter.test.ts
@@ -8,7 +8,7 @@ import {NullFilterNode} from '../../../src/compile/data/nullfilter';
 import {ModelWithField} from '../../../src/compile/model';
 import {FieldDef} from '../../../src/fielddef';
 import {Dict, mergeDeep} from '../../../src/util';
-import {parseUnitModel} from '../../util';
+import {parseUnitModelWithScale} from '../../util';
 
 function parse(model: ModelWithField) {
   return NullFilterNode.make(model);
@@ -21,47 +21,42 @@ describe('compile/data/nullfilter', function() {
       encoding: {
         y: {field: 'qq', type: "quantitative"},
         x: {field: 'tt', type: "temporal"},
-        color: {field: 'oo', type: "ordinal"}
+        color: {field: 'oo', type: "ordinal"},
+        shape: {field: 'nn', type: "nominal"}
       }
     };
 
     it('should add filterNull for Q and T by default', function () {
-      const model = parseUnitModel(spec);
+      const model = parseUnitModelWithScale(spec);
       assert.deepEqual<Dict<FieldDef<string>>>(parse(model).filteredFields, {
         qq: {field: 'qq', type: "quantitative"},
-        tt: {field: 'tt', type: "temporal"},
-        oo: null
+        tt: {field: 'tt', type: "temporal"}
       });
     });
 
-    it('should add filterNull for O when specified', function () {
-      const model = parseUnitModel(mergeDeep(spec, {
+    it('should add filterNull for Q and T when filterInvalid is specified true.', function () {
+      const model = parseUnitModelWithScale(mergeDeep(spec, {
         config: {
           filterInvalid: true
         }
       }));
       assert.deepEqual<Dict<FieldDef<string>>>(parse(model).filteredFields, {
         qq: {field: 'qq', type: "quantitative"},
-        tt: {field: 'tt', type: "temporal"},
-        oo: {field: 'oo', type: "ordinal"}
+        tt: {field: 'tt', type: "temporal"}
       });
     });
 
     it('should add no null filter if filterInvalid is false', function () {
-      const model = parseUnitModel(mergeDeep(spec, {
+      const model = parseUnitModelWithScale(mergeDeep(spec, {
         config: {
           filterInvalid: false
         }
       }));
-      assert.deepEqual(parse(model).filteredFields, {
-        qq: null,
-        tt: null,
-        oo: null
-      });
+      assert.deepEqual(parse(model), null);
     });
 
     it ('should add no null filter for count field', () => {
-      const model = parseUnitModel({
+      const model = parseUnitModelWithScale({
         mark: "point",
         encoding: {
           y: {aggregate: 'count', field: '*', type: "quantitative"}

--- a/test/compile/scale/parse.test.ts
+++ b/test/compile/scale/parse.test.ts
@@ -223,11 +223,12 @@ describe('src/compile', function() {
 
       it('should create sequential color scale', function() {
         assert.equal(scale.implicit.name, 'color');
-        assert.equal(scale.implicit.type, 'sequential');
+        assert.equal(scale.implicit.type, 'ordinal');
 
         assert.deepEqual(scale.implicit.domain, {
           data: 'main',
-          field: 'origin'
+          field: 'origin',
+          sort: true
         });
       });
     });
@@ -282,7 +283,7 @@ describe('src/compile', function() {
 
       it('should add correct scales', function() {
         assert.equal(scale.implicit.name, 'color');
-        assert.equal(scale.implicit.type, 'sequential');
+        assert.equal(scale.implicit.type, 'ordinal');
       });
     });
 


### PR DESCRIPTION
- To make results consistent among multiple subplots, we should apply filter invalid values  only when necessary (fields with continuous domain scales)
- Fix ordinal scale type for color (discovered bug while implementing this). 
- Change config's `filterInvalid: boolean` to `invalidValues: "filter"` to support future extension for other ways to handle invalid values. For example, we could have a config where we make invalid values grey (to help distinguish them from zero values) instead of filtering
-- See https://github.com/vega/vega-lite/issues/2544.  (Note that it was `transform.filterInvalid` in VL1.0 anyway so even if we don't change, we don't really prevent breaking changes.) 
  
Fix #2066.  