### PR TITLE
Exclude overlay config from the schema, …

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -45,14 +45,6 @@
         }
       ]
     },
-    "AreaOverlay": {
-      "enum": [
-        "line",
-        "linepoint",
-        "none"
-      ],
-      "type": "string"
-    },
     "Axis": {
       "additionalProperties": false,
       "properties": {
@@ -1727,10 +1719,6 @@
         "numberFormat": {
           "description": "D3 Number format for axis labels and text tables. For example \"s\" for SI units.(in the form of [D3 number format pattern](https://github.com/mbostock/d3/wiki/Formatting)).\n\n__Default value:__ `\"s\"` (except for text marks that encode a count field, the default value is `\"d\"`).",
           "type": "string"
-        },
-        "overlay": {
-          "$ref": "#/definitions/OverlayConfig",
-          "description": "Mark Overlay Config "
         },
         "padding": {
           "$ref": "#/definitions/Padding",
@@ -3979,20 +3967,6 @@
       ],
       "type": "string"
     },
-    "OverlayConfig": {
-      "additionalProperties": false,
-      "properties": {
-        "area": {
-          "$ref": "#/definitions/AreaOverlay",
-          "description": "Type of overlay for area mark (line or linepoint)"
-        },
-        "line": {
-          "description": "Whether to overlay line with point.\n\n__Default value:__ `false`",
-          "type": "boolean"
-        }
-      },
-      "type": "object"
-    },
     "Padding": {
       "anyOf": [
         {
@@ -5720,10 +5694,6 @@
         "numberFormat": {
           "description": "D3 Number format for axis labels and text tables. For example \"s\" for SI units.(in the form of [D3 number format pattern](https://github.com/mbostock/d3/wiki/Formatting)).\n\n__Default value:__ `\"s\"` (except for text marks that encode a count field, the default value is `\"d\"`).",
           "type": "string"
-        },
-        "overlay": {
-          "$ref": "#/definitions/OverlayConfig",
-          "description": "Mark Overlay Config "
         },
         "scale": {
           "$ref": "#/definitions/ScaleConfig",

--- a/src/config.ts
+++ b/src/config.ts
@@ -114,26 +114,6 @@ export const defaultFacetConfig: FacetConfig = {
   cell: defaultFacetCellConfig
 };
 
-export type AreaOverlay = 'line' | 'linepoint' | 'none';
-
-export interface OverlayConfig {
-  /**
-   * Whether to overlay line with point.
-   *
-   * __Default value:__ `false`
-   */
-  line?: boolean;
-
-  /**
-   * Type of overlay for area mark (line or linepoint)
-   */
-  area?: AreaOverlay;
-}
-
-export const defaultOverlayConfig: OverlayConfig = {
-  line: false
-};
-
 export type RangeConfig = (number|string)[] | VgRangeScheme | {step: number};
 
 export interface VLOnlyConfig {
@@ -178,11 +158,6 @@ export interface VLOnlyConfig {
   /** Facet Config */
   facet?: FacetConfig;
 
-  // FIXME: move this to line/area
-  /** Mark Overlay Config */
-  overlay?: OverlayConfig;
-
-
   /** Scale Config */
   scale?: ScaleConfig;
 
@@ -191,7 +166,6 @@ export interface VLOnlyConfig {
 
   /** Default stack offset for stackable mark. */
   stack?: StackOffset;
-
 }
 
 export interface Config extends TopLevelProperties, VLOnlyConfig, MarkConfigMixins, CompositeMarkConfigMixins, AxisConfigMixins {
@@ -241,7 +215,6 @@ export const defaultConfig: Config = {
   boxWhisker: {},
   boxMid: {},
 
-  overlay: defaultOverlayConfig,
   scale: defaultScaleConfig,
   axis: {},
   axisX: {},

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -321,6 +321,20 @@ function isNonFacetUnitSpecWithPrimitiveMark(spec: GenericUnitSpec<Encoding<Fiel
     return isPrimitiveMark(spec.mark);
 }
 
+type AreaOverlay = 'line' | 'linepoint' | 'none';
+
+interface OverlayConfig {
+  /**
+   * Whether to overlay line with point.
+   */
+  line?: boolean;
+
+  /**
+   * Type of overlay for area mark (line or linepoint)
+   */
+  area?: AreaOverlay;
+}
+
 function normalizeNonFacetUnit(spec: GenericUnitSpec<Encoding<Field>, AnyMark>, config: Config) {
   if (isNonFacetUnitSpecWithPrimitiveMark(spec)) {
     // TODO: thoroughly test
@@ -328,7 +342,7 @@ function normalizeNonFacetUnit(spec: GenericUnitSpec<Encoding<Field>, AnyMark>, 
       return normalizeRangedUnit(spec);
     }
 
-    const overlayConfig = config && config.overlay;
+    const overlayConfig: OverlayConfig = config && config.overlay;
     const overlayWithLine = overlayConfig  && spec.mark === AREA &&
       contains(['linepoint', 'line'], overlayConfig.area);
     const overlayWithPoint = overlayConfig && (


### PR DESCRIPTION
so it's a secret feature only for Voyager and CompassQL for now.

(This will allow us to punt on https://github.com/vega/vega-lite/issues/1804 without making breaking changes in the future.) 