### PR TITLE
Exclude build from .vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,8 @@
   "files.exclude": {
     "coverage/**/*": true,
     "_site/**/*": true,
-    ".nyc_output": true
+    ".nyc_output": true,
+    "build": true
   },
   "search.exclude": {
     "build": true


### PR DESCRIPTION
This screws up imports all the time, I don't know why we need build inside vscode.  