### PR TITLE
Triggers should register as scale dependencies not listeners.

### DIFF
--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -185,20 +185,7 @@
         },
         {
             "name": "brush_scale_trigger",
-            "value": {},
-            "on": [
-                {
-                    "events": [
-                        {
-                            "scale": "x"
-                        },
-                        {
-                            "scale": "y"
-                        }
-                    ],
-                    "update": "(!isArray(brush_Horsepower) || (invert(\"x\", brush_x)[0] === brush_Horsepower[0] && invert(\"x\", brush_x)[1] === brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (invert(\"y\", brush_y)[0] === brush_Miles_per_Gallon[0] && invert(\"y\", brush_y)[1] === brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
-                }
-            ]
+            "update": "(!isArray(brush_Horsepower) || (invert(\"x\", brush_x)[0] === brush_Horsepower[0] && invert(\"x\", brush_x)[1] === brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (invert(\"y\", brush_y)[0] === brush_Miles_per_Gallon[0] && invert(\"y\", brush_y)[1] === brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
         },
         {
             "name": "brush_tuple",

--- a/examples/vg-specs/concat_selections.vg.json
+++ b/examples/vg-specs/concat_selections.vg.json
@@ -253,20 +253,7 @@
                 },
                 {
                     "name": "brush_scale_trigger",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "scale": "concat_0_x"
-                                },
-                                {
-                                    "scale": "concat_0_y"
-                                }
-                            ],
-                            "update": "(!isArray(brush_Miles_per_Gallon) || (invert(\"concat_0_x\", brush_x)[0] === brush_Miles_per_Gallon[0] && invert(\"concat_0_x\", brush_x)[1] === brush_Miles_per_Gallon[1])) && (!isArray(brush_Horsepower) || (invert(\"concat_0_y\", brush_y)[0] === brush_Horsepower[0] && invert(\"concat_0_y\", brush_y)[1] === brush_Horsepower[1])) ? brush_scale_trigger : {}"
-                        }
-                    ]
+                    "update": "(!isArray(brush_Miles_per_Gallon) || (invert(\"concat_0_x\", brush_x)[0] === brush_Miles_per_Gallon[0] && invert(\"concat_0_x\", brush_x)[1] === brush_Miles_per_Gallon[1])) && (!isArray(brush_Horsepower) || (invert(\"concat_0_y\", brush_y)[0] === brush_Horsepower[0] && invert(\"concat_0_y\", brush_y)[1] === brush_Horsepower[1])) ? brush_scale_trigger : {}"
                 },
                 {
                     "name": "brush_tuple",

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -329,17 +329,7 @@
                 },
                 {
                     "name": "brush_scale_trigger",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "scale": "x"
-                                }
-                            ],
-                            "update": "(!isArray(brush_X) || (invert(\"x\", brush_x)[0] === brush_X[0] && invert(\"x\", brush_x)[1] === brush_X[1])) ? brush_scale_trigger : {}"
-                        }
-                    ]
+                    "update": "(!isArray(brush_X) || (invert(\"x\", brush_x)[0] === brush_X[0] && invert(\"x\", brush_x)[1] === brush_X[1])) ? brush_scale_trigger : {}"
                 },
                 {
                     "name": "brush_tuple",

--- a/examples/vg-specs/interactive_splom.vg.json
+++ b/examples/vg-specs/interactive_splom.vg.json
@@ -242,17 +242,7 @@
                 },
                 {
                     "name": "brush_scale_trigger",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "scale": "child_Horsepower_Horsepower_y"
-                                }
-                            ],
-                            "update": "(!isArray(brush_Horsepower) || (invert(\"child_Horsepower_Horsepower_y\", brush_y)[0] === brush_Horsepower[0] && invert(\"child_Horsepower_Horsepower_y\", brush_y)[1] === brush_Horsepower[1])) ? brush_scale_trigger : {}"
-                        }
-                    ]
+                    "update": "(!isArray(brush_Horsepower) || (invert(\"child_Horsepower_Horsepower_y\", brush_y)[0] === brush_Horsepower[0] && invert(\"child_Horsepower_Horsepower_y\", brush_y)[1] === brush_Horsepower[1])) ? brush_scale_trigger : {}"
                 },
                 {
                     "name": "brush_tuple",
@@ -795,20 +785,7 @@
                 },
                 {
                     "name": "brush_scale_trigger",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "scale": "child_Horsepower_Miles_per_Gallon_x"
-                                },
-                                {
-                                    "scale": "child_Horsepower_Miles_per_Gallon_y"
-                                }
-                            ],
-                            "update": "(!isArray(brush_Horsepower) || (invert(\"child_Horsepower_Miles_per_Gallon_x\", brush_x)[0] === brush_Horsepower[0] && invert(\"child_Horsepower_Miles_per_Gallon_x\", brush_x)[1] === brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (invert(\"child_Horsepower_Miles_per_Gallon_y\", brush_y)[0] === brush_Miles_per_Gallon[0] && invert(\"child_Horsepower_Miles_per_Gallon_y\", brush_y)[1] === brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
-                        }
-                    ]
+                    "update": "(!isArray(brush_Horsepower) || (invert(\"child_Horsepower_Miles_per_Gallon_x\", brush_x)[0] === brush_Horsepower[0] && invert(\"child_Horsepower_Miles_per_Gallon_x\", brush_x)[1] === brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (invert(\"child_Horsepower_Miles_per_Gallon_y\", brush_y)[0] === brush_Miles_per_Gallon[0] && invert(\"child_Horsepower_Miles_per_Gallon_y\", brush_y)[1] === brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
                 },
                 {
                     "name": "brush_tuple",
@@ -1368,20 +1345,7 @@
                 },
                 {
                     "name": "brush_scale_trigger",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "scale": "child_Acceleration_Horsepower_x"
-                                },
-                                {
-                                    "scale": "child_Acceleration_Horsepower_y"
-                                }
-                            ],
-                            "update": "(!isArray(brush_Acceleration) || (invert(\"child_Acceleration_Horsepower_x\", brush_x)[0] === brush_Acceleration[0] && invert(\"child_Acceleration_Horsepower_x\", brush_x)[1] === brush_Acceleration[1])) && (!isArray(brush_Horsepower) || (invert(\"child_Acceleration_Horsepower_y\", brush_y)[0] === brush_Horsepower[0] && invert(\"child_Acceleration_Horsepower_y\", brush_y)[1] === brush_Horsepower[1])) ? brush_scale_trigger : {}"
-                        }
-                    ]
+                    "update": "(!isArray(brush_Acceleration) || (invert(\"child_Acceleration_Horsepower_x\", brush_x)[0] === brush_Acceleration[0] && invert(\"child_Acceleration_Horsepower_x\", brush_x)[1] === brush_Acceleration[1])) && (!isArray(brush_Horsepower) || (invert(\"child_Acceleration_Horsepower_y\", brush_y)[0] === brush_Horsepower[0] && invert(\"child_Acceleration_Horsepower_y\", brush_y)[1] === brush_Horsepower[1])) ? brush_scale_trigger : {}"
                 },
                 {
                     "name": "brush_tuple",
@@ -1941,20 +1905,7 @@
                 },
                 {
                     "name": "brush_scale_trigger",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "scale": "child_Acceleration_Miles_per_Gallon_x"
-                                },
-                                {
-                                    "scale": "child_Acceleration_Miles_per_Gallon_y"
-                                }
-                            ],
-                            "update": "(!isArray(brush_Acceleration) || (invert(\"child_Acceleration_Miles_per_Gallon_x\", brush_x)[0] === brush_Acceleration[0] && invert(\"child_Acceleration_Miles_per_Gallon_x\", brush_x)[1] === brush_Acceleration[1])) && (!isArray(brush_Miles_per_Gallon) || (invert(\"child_Acceleration_Miles_per_Gallon_y\", brush_y)[0] === brush_Miles_per_Gallon[0] && invert(\"child_Acceleration_Miles_per_Gallon_y\", brush_y)[1] === brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
-                        }
-                    ]
+                    "update": "(!isArray(brush_Acceleration) || (invert(\"child_Acceleration_Miles_per_Gallon_x\", brush_x)[0] === brush_Acceleration[0] && invert(\"child_Acceleration_Miles_per_Gallon_x\", brush_x)[1] === brush_Acceleration[1])) && (!isArray(brush_Miles_per_Gallon) || (invert(\"child_Acceleration_Miles_per_Gallon_y\", brush_y)[0] === brush_Miles_per_Gallon[0] && invert(\"child_Acceleration_Miles_per_Gallon_y\", brush_y)[1] === brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
                 },
                 {
                     "name": "brush_tuple",

--- a/examples/vg-specs/layered_crossfilter.vg.json
+++ b/examples/vg-specs/layered_crossfilter.vg.json
@@ -510,17 +510,7 @@
                 },
                 {
                     "name": "brush_scale_trigger",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "scale": "child_distance_x"
-                                }
-                            ],
-                            "update": "(!isArray(brush_distance) || (invert(\"child_distance_x\", brush_x)[0] === brush_distance[0] && invert(\"child_distance_x\", brush_x)[1] === brush_distance[1])) ? brush_scale_trigger : {}"
-                        }
-                    ]
+                    "update": "(!isArray(brush_distance) || (invert(\"child_distance_x\", brush_x)[0] === brush_distance[0] && invert(\"child_distance_x\", brush_x)[1] === brush_distance[1])) ? brush_scale_trigger : {}"
                 },
                 {
                     "name": "brush_tuple",
@@ -974,17 +964,7 @@
                 },
                 {
                     "name": "brush_scale_trigger",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "scale": "child_delay_x"
-                                }
-                            ],
-                            "update": "(!isArray(brush_delay) || (invert(\"child_delay_x\", brush_x)[0] === brush_delay[0] && invert(\"child_delay_x\", brush_x)[1] === brush_delay[1])) ? brush_scale_trigger : {}"
-                        }
-                    ]
+                    "update": "(!isArray(brush_delay) || (invert(\"child_delay_x\", brush_x)[0] === brush_delay[0] && invert(\"child_delay_x\", brush_x)[1] === brush_delay[1])) ? brush_scale_trigger : {}"
                 },
                 {
                     "name": "brush_tuple",
@@ -1438,17 +1418,7 @@
                 },
                 {
                     "name": "brush_scale_trigger",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "scale": "child_time_x"
-                                }
-                            ],
-                            "update": "(!isArray(brush_time) || (invert(\"child_time_x\", brush_x)[0] === brush_time[0] && invert(\"child_time_x\", brush_x)[1] === brush_time[1])) ? brush_scale_trigger : {}"
-                        }
-                    ]
+                    "update": "(!isArray(brush_time) || (invert(\"child_time_x\", brush_x)[0] === brush_time[0] && invert(\"child_time_x\", brush_x)[1] === brush_time[1])) ? brush_scale_trigger : {}"
                 },
                 {
                     "name": "brush_tuple",

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -411,20 +411,7 @@
         },
         {
             "name": "brush_scale_trigger",
-            "value": {},
-            "on": [
-                {
-                    "events": [
-                        {
-                            "scale": "x"
-                        },
-                        {
-                            "scale": "y"
-                        }
-                    ],
-                    "update": "(!isArray(brush_Horsepower) || (invert(\"x\", brush_x)[0] === brush_Horsepower[0] && invert(\"x\", brush_x)[1] === brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (invert(\"y\", brush_y)[0] === brush_Miles_per_Gallon[0] && invert(\"y\", brush_y)[1] === brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
-                }
-            ]
+            "update": "(!isArray(brush_Horsepower) || (invert(\"x\", brush_x)[0] === brush_Horsepower[0] && invert(\"x\", brush_x)[1] === brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (invert(\"y\", brush_y)[0] === brush_Miles_per_Gallon[0] && invert(\"y\", brush_y)[1] === brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
         },
         {
             "name": "brush_tuple",

--- a/examples/vg-specs/overview_detail.vg.json
+++ b/examples/vg-specs/overview_detail.vg.json
@@ -192,17 +192,7 @@
                 },
                 {
                     "name": "brush_scale_trigger",
-                    "value": {},
-                    "on": [
-                        {
-                            "events": [
-                                {
-                                    "scale": "concat_0_x"
-                                }
-                            ],
-                            "update": "(!isArray(brush_date) || (invert(\"concat_0_x\", brush_x)[0] === brush_date[0] && invert(\"concat_0_x\", brush_x)[1] === brush_date[1])) ? brush_scale_trigger : {}"
-                        }
-                    ]
+                    "update": "(!isArray(brush_date) || (invert(\"concat_0_x\", brush_x)[0] === brush_date[0] && invert(\"concat_0_x\", brush_x)[1] === brush_date[1])) ? brush_scale_trigger : {}"
                 },
                 {
                     "name": "brush_tuple",

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -61,12 +61,8 @@ const interval:SelectionCompiler = {
     if (!hasScales) {
       signals.push({
         name: name + SCALE_TRIGGER,
-        value: {},
-        on: [{
-          events: scaleTriggers.map((t) => { return {scale: t.scaleName}; }),
-          update: scaleTriggers.map((t) => t.expr).join(' && ') +
-            ` ? ${name + SCALE_TRIGGER} : {}`
-        }]
+        update: scaleTriggers.map((t) => t.expr).join(' && ') +
+          ` ? ${name + SCALE_TRIGGER} : {}`
       });
     }
 

--- a/test/compile/selection/interval.test.ts
+++ b/test/compile/selection/interval.test.ts
@@ -64,11 +64,7 @@ describe('Interval Selections', function() {
         }]
       }, {
         "name": "one_scale_trigger",
-        "value": {},
-        "on": [{
-          "events": [{"scale": "x"}],
-          "update": "(!isArray(one_Horsepower) || (invert(\"x\", one_x)[0] === one_Horsepower[0] && invert(\"x\", one_x)[1] === one_Horsepower[1])) ? one_scale_trigger : {}"
-        }]
+        "update": "(!isArray(one_Horsepower) || (invert(\"x\", one_x)[0] === one_Horsepower[0] && invert(\"x\", one_x)[1] === one_Horsepower[1])) ? one_scale_trigger : {}"
       }]);
 
       const twoSg = interval.signals(model, selCmpts['two']);
@@ -147,11 +143,7 @@ describe('Interval Selections', function() {
         },
         {
           "name": "thr_ee_scale_trigger",
-          "value": {},
-          "on": [{
-            "events": [{"scale": "x"}, {"scale": "y"}],
-            "update": "(!isArray(thr_ee_Horsepower) || (invert(\"x\", thr_ee_x)[0] === thr_ee_Horsepower[0] && invert(\"x\", thr_ee_x)[1] === thr_ee_Horsepower[1])) && (!isArray(thr_ee_Miles_per_Gallon) || (invert(\"y\", thr_ee_y)[0] === thr_ee_Miles_per_Gallon[0] && invert(\"y\", thr_ee_y)[1] === thr_ee_Miles_per_Gallon[1])) ? thr_ee_scale_trigger : {}"
-          }]
+          "update": "(!isArray(thr_ee_Horsepower) || (invert(\"x\", thr_ee_x)[0] === thr_ee_Horsepower[0] && invert(\"x\", thr_ee_x)[1] === thr_ee_Horsepower[1])) && (!isArray(thr_ee_Miles_per_Gallon) || (invert(\"y\", thr_ee_y)[0] === thr_ee_Miles_per_Gallon[0] && invert(\"y\", thr_ee_y)[1] === thr_ee_Miles_per_Gallon[1])) ? thr_ee_scale_trigger : {}"
         }
       ]);
     });


### PR DESCRIPTION
This prevents a glitch observed when brushing and panning within the same unit view. If triggers are registered as listeners to multiple scales, the brush will appear to "drift" as one scale registers and
fires an update before the other.