### PR TITLE
Time unit selections add necessary dataflow nodes

### DIFF
--- a/examples/specs/timeunit_selections.vl.json
+++ b/examples/specs/timeunit_selections.vl.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+  "data": {
+    "values": [
+      {"date": "Sun, 01 Jan 2012 23:00:01","price": 150},
+      {"date": "Sun, 02 Jan 2012 00:10:02","price": 100},
+      {"date": "Sun, 02 Jan 2012 01:20:03","price": 170},
+      {"date": "Sun, 02 Jan 2012 02:30:04","price": 165},
+      {"date": "Sun, 02 Jan 2012 03:40:05","price": 200}
+    ]
+  },
+  "hconcat": [{
+    "mark": "point",
+    "selection": {
+      "brush": {"type": "interval", "encodings": ["x"]}
+    },
+    "encoding": {
+      "x": {
+        "field": "date",
+        "type": "temporal",
+        "timeUnit": "seconds"
+      },
+      "y": {"field": "price","type": "quantitative"},
+      "color": {
+        "condition": {"selection": "brush", "value": "goldenrod"},
+        "value": "steelblue"
+      }
+    }
+  }, {
+    "transform": [{"filter": {"selection": "brush"}}],
+    "mark": "point",
+    "encoding": {
+      "x": {
+        "field": "date",
+        "type": "temporal",
+        "timeUnit": "minutes"
+      },
+      "y": {"field": "price","type": "quantitative"},
+      "color": {
+        "value": "goldenrod"
+      }
+    }
+  }]
+}

--- a/examples/vg-specs/timeunit_selections.vg.json
+++ b/examples/vg-specs/timeunit_selections.vg.json
@@ -1,0 +1,673 @@
+{
+    "$schema": "http://vega.github.io/schema/vega/v3.0.json",
+    "autosize": "pad",
+    "padding": 5,
+    "data": [
+        {
+            "name": "brush_store"
+        },
+        {
+            "name": "source_0",
+            "values": [
+                {
+                    "date": "Sun, 01 Jan 2012 23:00:01",
+                    "price": 150
+                },
+                {
+                    "date": "Sun, 02 Jan 2012 00:10:02",
+                    "price": 100
+                },
+                {
+                    "date": "Sun, 02 Jan 2012 01:20:03",
+                    "price": 170
+                },
+                {
+                    "date": "Sun, 02 Jan 2012 02:30:04",
+                    "price": 165
+                },
+                {
+                    "date": "Sun, 02 Jan 2012 03:40:05",
+                    "price": 200
+                }
+            ]
+        },
+        {
+            "name": "data_1",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "formula",
+                    "expr": "toDate(datum[\"date\"])",
+                    "as": "date"
+                },
+                {
+                    "type": "formula",
+                    "expr": "toNumber(datum[\"price\"])",
+                    "as": "price"
+                },
+                {
+                    "type": "filter",
+                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"price\"] !== null && !isNaN(datum[\"price\"])"
+                },
+                {
+                    "type": "formula",
+                    "as": "seconds_date",
+                    "expr": "datetime(0, 0, 1, 0, 0, seconds(datum[\"date\"]), 0)"
+                }
+            ]
+        },
+        {
+            "name": "data_2",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "formula",
+                    "expr": "toDate(datum[\"date\"])",
+                    "as": "date"
+                },
+                {
+                    "type": "formula",
+                    "expr": "toNumber(datum[\"price\"])",
+                    "as": "price"
+                },
+                {
+                    "type": "formula",
+                    "as": "seconds_date",
+                    "expr": "datetime(0, 0, 1, 0, 0, seconds(datum[\"date\"]), 0)"
+                },
+                {
+                    "type": "filter",
+                    "expr": "vlInterval(\"brush_store\", \"concat_1_\", datum, \"union\", \"all\")"
+                },
+                {
+                    "type": "filter",
+                    "expr": "datum[\"date\"] !== null && !isNaN(datum[\"date\"]) && datum[\"price\"] !== null && !isNaN(datum[\"price\"])"
+                },
+                {
+                    "type": "formula",
+                    "as": "minutes_date",
+                    "expr": "datetime(0, 0, 1, 0, minutes(datum[\"date\"]), 0, 0)"
+                }
+            ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "concat_0_width",
+            "update": "200"
+        },
+        {
+            "name": "concat_0_height",
+            "update": "200"
+        },
+        {
+            "name": "concat_1_width",
+            "update": "200"
+        },
+        {
+            "name": "concat_1_height",
+            "update": "200"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        }
+    ],
+    "layout": {
+        "padding": {
+            "row": 10,
+            "column": 10
+        },
+        "offset": 10,
+        "bounds": "full",
+        "align": "all"
+    },
+    "marks": [
+        {
+            "type": "group",
+            "name": "concat_0_group",
+            "encode": {
+                "update": {
+                    "width": {
+                        "signal": "concat_0_width"
+                    },
+                    "height": {
+                        "signal": "concat_0_height"
+                    },
+                    "fill": {
+                        "value": "transparent"
+                    }
+                }
+            },
+            "signals": [
+                {
+                    "name": "brush_x",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
+                                ]
+                            },
+                            "update": "[x(unit), x(unit)]"
+                        },
+                        {
+                            "events": {
+                                "source": "window",
+                                "type": "mousemove",
+                                "consume": true,
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
+                                        ]
+                                    },
+                                    {
+                                        "source": "window",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "[brush_x[0], clamp(x(unit), 0, concat_0_width)]"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_scale_trigger"
+                            },
+                            "update": "[scale(\"concat_0_x\", brush_seconds_date[0]), scale(\"concat_0_x\", brush_seconds_date[1])]"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_translate_delta"
+                            },
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, concat_0_width)"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_zoom_delta"
+                            },
+                            "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, concat_0_width)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_seconds_date",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "brush_x"
+                            },
+                            "update": "invert(\"concat_0_x\", brush_x)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "update": "(!isArray(brush_seconds_date) || (+invert(\"concat_0_x\", brush_x)[0] === +brush_seconds_date[0] && +invert(\"concat_0_x\", brush_x)[1] === +brush_seconds_date[1])) ? brush_scale_trigger : {}"
+                },
+                {
+                    "name": "brush_tuple",
+                    "update": "{unit: \"concat_0_\", intervals: [{encoding: \"x\", field: \"seconds_date\", extent: brush_seconds_date}]}"
+                },
+                {
+                    "name": "brush_translate_anchor",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousedown",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_translate_delta",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "window",
+                                    "type": "mousemove",
+                                    "consume": true,
+                                    "between": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "markname": "brush_brush"
+                                        },
+                                        {
+                                            "source": "window",
+                                            "type": "mouseup"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_anchor",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_delta",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "force": true,
+                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_modify",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "brush_tuple"
+                            },
+                            "update": "modify(\"brush_store\", brush_tuple, true)"
+                        }
+                    ]
+                }
+            ],
+            "marks": [
+                {
+                    "type": "rect",
+                    "encode": {
+                        "enter": {
+                            "fill": {
+                                "value": "#333"
+                            },
+                            "fillOpacity": {
+                                "value": 0.125
+                            }
+                        },
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
+                                    "signal": "brush_x[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
+                                    "value": 0
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
+                                    "signal": "brush_x[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
+                                    "field": {
+                                        "group": "height"
+                                    }
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "concat_0_marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "data_1"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "concat_0_x",
+                                "field": "seconds_date"
+                            },
+                            "y": {
+                                "scale": "concat_0_y",
+                                "field": "price"
+                            },
+                            "stroke": [
+                                {
+                                    "test": "vlInterval(\"brush_store\", \"concat_0_\", datum, \"union\", \"all\")",
+                                    "value": "goldenrod"
+                                },
+                                {
+                                    "value": "steelblue"
+                                }
+                            ],
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "brush_brush",
+                    "type": "rect",
+                    "encode": {
+                        "enter": {
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "white"
+                            }
+                        },
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
+                                    "signal": "brush_x[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
+                                    "value": 0
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
+                                    "signal": "brush_x[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
+                                    "field": {
+                                        "group": "height"
+                                    }
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ]
+                        }
+                    }
+                }
+            ],
+            "scales": [
+                {
+                    "name": "concat_0_x",
+                    "type": "time",
+                    "domain": {
+                        "data": "data_1",
+                        "field": "seconds_date"
+                    },
+                    "range": [
+                        0,
+                        200
+                    ],
+                    "round": true,
+                    "nice": "second"
+                },
+                {
+                    "name": "concat_0_y",
+                    "type": "linear",
+                    "domain": {
+                        "data": "data_1",
+                        "field": "price"
+                    },
+                    "range": [
+                        200,
+                        0
+                    ],
+                    "round": true,
+                    "nice": true,
+                    "zero": true
+                }
+            ],
+            "axes": [
+                {
+                    "scale": "concat_0_x",
+                    "orient": "bottom",
+                    "tickCount": 5,
+                    "title": "SECONDS(date)",
+                    "zindex": 1,
+                    "encode": {
+                        "labels": {
+                            "update": {
+                                "text": {
+                                    "signal": "timeFormat(datum.value, '%S')"
+                                },
+                                "angle": {
+                                    "value": 270
+                                },
+                                "align": {
+                                    "value": "right"
+                                },
+                                "baseline": {
+                                    "value": "middle"
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "scale": "concat_0_x",
+                    "domain": false,
+                    "grid": true,
+                    "labels": false,
+                    "orient": "bottom",
+                    "tickCount": 5,
+                    "ticks": false,
+                    "zindex": 0,
+                    "gridScale": "concat_0_y"
+                },
+                {
+                    "scale": "concat_0_y",
+                    "orient": "left",
+                    "title": "price",
+                    "zindex": 1
+                },
+                {
+                    "scale": "concat_0_y",
+                    "domain": false,
+                    "grid": true,
+                    "labels": false,
+                    "orient": "left",
+                    "ticks": false,
+                    "zindex": 0,
+                    "gridScale": "concat_0_x"
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "name": "concat_1_group",
+            "encode": {
+                "update": {
+                    "width": {
+                        "signal": "concat_1_width"
+                    },
+                    "height": {
+                        "signal": "concat_1_height"
+                    },
+                    "fill": {
+                        "value": "transparent"
+                    }
+                }
+            },
+            "marks": [
+                {
+                    "name": "concat_1_marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "data_2"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "concat_1_x",
+                                "field": "minutes_date"
+                            },
+                            "y": {
+                                "scale": "concat_1_y",
+                                "field": "price"
+                            },
+                            "stroke": {
+                                "value": "goldenrod"
+                            },
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                }
+            ],
+            "scales": [
+                {
+                    "name": "concat_1_x",
+                    "type": "time",
+                    "domain": {
+                        "data": "data_2",
+                        "field": "minutes_date"
+                    },
+                    "range": [
+                        0,
+                        200
+                    ],
+                    "round": true,
+                    "nice": "minute"
+                },
+                {
+                    "name": "concat_1_y",
+                    "type": "linear",
+                    "domain": {
+                        "data": "data_2",
+                        "field": "price"
+                    },
+                    "range": [
+                        200,
+                        0
+                    ],
+                    "round": true,
+                    "nice": true,
+                    "zero": true
+                }
+            ],
+            "axes": [
+                {
+                    "scale": "concat_1_x",
+                    "orient": "bottom",
+                    "tickCount": 5,
+                    "title": "MINUTES(date)",
+                    "zindex": 1,
+                    "encode": {
+                        "labels": {
+                            "update": {
+                                "text": {
+                                    "signal": "timeFormat(datum.value, '%M')"
+                                },
+                                "angle": {
+                                    "value": 270
+                                },
+                                "align": {
+                                    "value": "right"
+                                },
+                                "baseline": {
+                                    "value": "middle"
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "scale": "concat_1_x",
+                    "domain": false,
+                    "grid": true,
+                    "labels": false,
+                    "orient": "bottom",
+                    "tickCount": 5,
+                    "ticks": false,
+                    "zindex": 0,
+                    "gridScale": "concat_1_y"
+                },
+                {
+                    "scale": "concat_1_y",
+                    "orient": "left",
+                    "title": "price",
+                    "zindex": 1
+                },
+                {
+                    "scale": "concat_1_y",
+                    "domain": false,
+                    "grid": true,
+                    "labels": false,
+                    "orient": "left",
+                    "ticks": false,
+                    "zindex": 0,
+                    "gridScale": "concat_1_x"
+                }
+            ]
+        }
+    ]
+}

--- a/examples/vg-specs/timeunit_selections.vg.json
+++ b/examples/vg-specs/timeunit_selections.vg.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://vega.github.io/schema/vega/v3.0.json",
+    "$schema": "https://vega.github.io/schema/vega/v3.0.json",
     "autosize": "pad",
     "padding": 5,
     "data": [

--- a/src/compile/data/assemble.ts
+++ b/src/compile/data/assemble.ts
@@ -319,6 +319,7 @@ export function assembleData(dataCompomponent: DataComponent): VgData[] {
   roots = roots.filter(r => r.numChildren() > 0);
 
   getLeaves(roots).forEach(iterateFromLeaves(optimizers.moveParseUp));
+  getLeaves(roots).forEach(optimizers.removeDuplicateTimeUnits);
 
   roots.forEach(moveFacetDown);
 

--- a/src/compile/data/bin.ts
+++ b/src/compile/data/bin.ts
@@ -90,7 +90,7 @@ export class BinNode extends DataFlowNode {
     return new BinNode(bins);
   }
 
-  public static makeBinFromTransform(model: Model, t: BinTransform) {
+  public static makeFromTransform(model: Model, t: BinTransform) {
     const bins: Dict<BinComponent> = {};
 
     const bin = normalizeBin(t.bin, undefined) || {};

--- a/src/compile/data/timeunit.ts
+++ b/src/compile/data/timeunit.ts
@@ -43,7 +43,7 @@ export class TimeUnitNode extends DataFlowNode {
     return new TimeUnitNode(formula);
   }
 
-  public static makeFromTransfrom(model: Model, t: TimeUnitTransform) {
+  public static makeFromTransform(model: Model, t: TimeUnitTransform) {
     return new TimeUnitNode({
       [t.field]: {
         as: t.as,

--- a/src/compile/data/transforms.ts
+++ b/src/compile/data/transforms.ts
@@ -182,9 +182,9 @@ export function parseTransformArray(model: Model) {
 
       node = new FilterNode(model, t.filter);
     } else if (isBin(t)) {
-      node = BinNode.makeBinFromTransform(model, t);
+      node = BinNode.makeFromTransform(model, t);
     } else if (isTimeUnit(t)) {
-      node = TimeUnitNode.makeFromTransfrom(model, t);
+      node = TimeUnitNode.makeFromTransform(model, t);
     } else if (isSummarize(t)) {
       node = AggregateNode.makeFromTransform(model, t);
     } else if (isLookup(t)) {

--- a/src/compile/data/transforms.ts
+++ b/src/compile/data/transforms.ts
@@ -18,18 +18,20 @@ import {TimeUnitNode} from './timeunit';
 
 
 export class FilterNode extends DataFlowNode {
+  private expr: string;
   public clone() {
     return new FilterNode(this.model, duplicate(this.filter));
   }
 
   constructor(private readonly model: Model, private filter: LogicalOperand<Filter>) {
     super();
+    this.expr = expression(this.model, this.filter, this);
   }
 
   public assemble(): VgFilterTransform {
     return {
       type: 'filter',
-      expr: expression(this.model, this.filter)
+      expr: this.expr
     };
   }
 }
@@ -130,11 +132,24 @@ export function parseTransformArray(model: Model) {
   let previous: DataFlowNode;
   let lookupCounter = 0;
 
+  function insert(newNode: DataFlowNode) {
+    if (!first) {
+      // A parent may be inserted during node construction
+      // (e.g., selection FilterNodes may add a TimeUnitNode).
+      first = newNode.parent || newNode;
+    } else if (newNode.parent) {
+      previous.insertAsParentOf(newNode);
+    } else {
+      newNode.parent = previous;
+    }
+
+    previous = newNode;
+  }
+
   model.transforms.forEach(t => {
     if (isCalculate(t)) {
       node = new CalculateNode(t);
     } else if (isFilter(t)) {
-
       // Automatically add a parse node for filters with filter objects
       const parse = {};
       const filter = t.filter;
@@ -162,13 +177,7 @@ export function parseTransformArray(model: Model) {
 
       if (keys(parse).length > 0) {
         const parseNode = new ParseNode(parse);
-
-        if (!first) {
-          first = parseNode;
-        } else {
-          parseNode.parent = previous;
-        }
-        previous = parseNode;
+        insert(parseNode);
       }
 
       node = new FilterNode(model, t.filter);
@@ -185,12 +194,7 @@ export function parseTransformArray(model: Model) {
       return;
     }
 
-    if (!first) {
-      first = node;
-    } else {
-      node.parent = previous;
-    }
-    previous = node;
+    insert(node);
   });
 
   const last = node;

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -182,8 +182,8 @@ export abstract class Model {
     this.parseScale();
     this.parseMarkDef();
     this.parseLayoutSize(); // depends on scale
-    this.parseData(); // (pathorder) depends on markDef
     this.parseSelection();
+    this.parseData(); // (pathorder) depends on markDef
     this.parseAxisAndHeader(); // depends on scale
     this.parseLegend(); // depends on scale, markDef
     this.parseMarkGroup(); // depends on data name, scale, layoutSize, axisGroup, and children's scale, axis, legend and mark.

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -32,7 +32,7 @@ const interval:SelectionCompiler = {
     }
 
     selCmpt.project.forEach(function(p) {
-      const channel = p.encoding;
+      const channel = p.channel;
       if (channel !== X && channel !== Y) {
         warn('Interval selections only support x and y encoding channels.');
         return;
@@ -150,10 +150,10 @@ export function projections(selCmpt: SelectionComponent) {
   let yi: number = null;
 
   selCmpt.project.forEach(function(p, i) {
-    if (p.encoding === X) {
+    if (p.channel === X) {
       x  = p;
       xi = i;
-    } else if (p.encoding === Y) {
+    } else if (p.channel === Y) {
       y = p;
       yi = i;
     }

--- a/src/compile/selection/multi.ts
+++ b/src/compile/selection/multi.ts
@@ -12,10 +12,10 @@ const multi:SelectionCompiler = {
     const datum = nearest.has(selCmpt) ?
       '(item().isVoronoi ? datum.datum : datum)' : 'datum';
     const bins = {};
-    const encodings = proj.map((p) => stringValue(p.encoding)).filter((e) => e).join(', ');
+    const encodings = proj.map((p) => stringValue(p.channel)).filter((e) => e).join(', ');
     const fields = proj.map((p) => stringValue(p.field)).join(', ');
     const values = proj.map((p) => {
-      const channel = p.encoding;
+      const channel = p.channel;
       const fieldDef = model.fieldDef(channel);
       // Binned fields should capture extents, for a range test against the raw field.
       // FIXME: Arvind -- please log proper warning when the specified encoding channel has no field

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -220,6 +220,10 @@ export function predicate(model: Model, selections: LogicalOperand<string>): str
     const store = stringValue(vname + STORE);
     const op = PREDICATES_OPS[selCmpt.resolve];
 
+    if (selCmpt.timeUnit) {
+      selCmpt.timeUnit.clone().insertAsParentOf(model.component.data.main);
+    }
+
     return compiler(selCmpt.type).predicate +
       `(${store}, ${stringValue(model.getName(''))}, datum, ${op})`;
   }

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -44,7 +44,7 @@ export interface SelectionComponent {
 
 export interface ProjectComponent {
   field?: string;
-  encoding?: ScaleChannel;
+  channel?: ScaleChannel;
 }
 
 export interface SelectionCompiler {

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -6,6 +6,7 @@ import {SelectionDomain} from '../../scale';
 import {BrushConfig, SelectionDef, SelectionResolutions, SelectionTypes} from '../../selection';
 import {Dict, extend, isString, logicalExpr, stringValue, varName} from '../../util';
 import {isSignalRefDomain, VgBinding, VgData, VgDomain, VgEventStream, VgScale, VgSignalRef} from '../../vega.schema';
+import {TimeUnitNode} from '../data/timeunit';
 import {LayerModel} from '../layer';
 import {Model} from '../model';
 import {UnitModel} from '../unit';
@@ -33,6 +34,7 @@ export interface SelectionComponent {
   // Transforms
   project?: ProjectComponent[];
   fields?: any;
+  timeUnit?: TimeUnitNode;
   scales?: Channel[];
   toggle?: any;
   translate?: any;

--- a/src/compile/selection/transforms/inputs.ts
+++ b/src/compile/selection/transforms/inputs.ts
@@ -25,7 +25,7 @@ const inputBindings:TransformCompiler = {
           events: selCmpt.events,
           update: `datum && ${datum}[${stringValue(p.field)}]`
         }],
-        bind: bind[p.field] || bind[p.encoding] || bind
+        bind: bind[p.field] || bind[p.channel] || bind
       });
     });
 

--- a/src/compile/selection/transforms/project.ts
+++ b/src/compile/selection/transforms/project.ts
@@ -44,12 +44,12 @@ const project:TransformCompiler = {
     const projection = selCmpt.project || (selCmpt.project = []);
     for (const field in channels) {
       if (channels.hasOwnProperty(field)) {
-        projection.push({field: field, encoding: channels[field]});
+        projection.push({field: field, channel: channels[field]});
       }
     }
 
     const fields = selCmpt.fields || (selCmpt.fields = {});
-    projection.filter((p) => p.encoding).forEach((p) => fields[p.encoding] = p.field);
+    projection.filter((p) => p.channel).forEach((p) => fields[p.channel] = p.field);
 
     if (keys(timeUnits).length) {
       selCmpt.timeUnit = new TimeUnitNode(timeUnits);

--- a/src/compile/selection/transforms/scales.ts
+++ b/src/compile/selection/transforms/scales.ts
@@ -19,7 +19,7 @@ const scaleBindings:TransformCompiler = {
     const bound: Channel[] = selCmpt.scales = [];
 
     selCmpt.project.forEach(function(p) {
-      const channel = p.encoding;
+      const channel = p.channel;
       const scale = model.getScaleComponent(channel);
       const scaleType = scale ? scale.get('type') : undefined;
 

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -1,3 +1,4 @@
+import {DataFlowNode} from './compile/data/dataflow';
 import {Model} from './compile/model';
 import {predicate} from './compile/selection/selection';
 import {DateTime, dateTimeExpr, isDateTime} from './datetime';
@@ -108,12 +109,12 @@ export function isOneOfFilter(filter: any): filter is OneOfFilter {
  * Converts a filter into an expression.
  */
 // model is only used for selection filters.
-export function expression(model: Model, filterOp: LogicalOperand<Filter>): string {
+export function expression(model: Model, filterOp: LogicalOperand<Filter>, node?: DataFlowNode): string {
   return logicalExpr(filterOp, (filter: Filter) => {
     if (isString(filter)) {
       return filter;
     } else if (isSelectionFilter(filter)) {
-      return predicate(model, filter.selection);
+      return predicate(model, filter.selection, node);
     } else { // Filter Object
       const fieldExpr = filter.timeUnit ?
         // For timeUnit, cast into integer with time() so we can use ===, inrange, indexOf to compare values directly.

--- a/test/compile/data/bin.test.ts
+++ b/test/compile/data/bin.test.ts
@@ -13,7 +13,7 @@ function assembleFromEncoding(model: ModelWithField) {
 }
 
 function assembleFromTransform(model: Model, t: BinTransform) {
-  return BinNode.makeBinFromTransform(model, t).assemble();
+  return BinNode.makeFromTransform(model, t).assemble();
 }
 
 describe('compile/data/bin', function() {

--- a/test/compile/data/timeunit.test.ts
+++ b/test/compile/data/timeunit.test.ts
@@ -11,7 +11,7 @@ function assembleFromEncoding(model: ModelWithField) {
 }
 
 function assembleFromTransform(model: Model, t: TimeUnitTransform) {
-  return TimeUnitNode.makeFromTransfrom(model, t).assemble();
+  return TimeUnitNode.makeFromTransform(model, t).assemble();
 }
 
 describe('compile/data/timeunit', () => {

--- a/test/compile/selection/parse.test.ts
+++ b/test/compile/selection/parse.test.ts
@@ -27,20 +27,20 @@ describe('Selection', function() {
 
     assert.equal(component.one.name, 'one');
     assert.equal(component.one.type, 'single');
-    assert.sameDeepMembers(component['one'].project, [{field: '_id', encoding: null}]);
+    assert.sameDeepMembers(component['one'].project, [{field: '_id', channel: null}]);
     assert.sameDeepMembers(component['one'].events, parseSelector('click', 'scope'));
 
     assert.equal(component.two.name, 'two');
     assert.equal(component.two.type, 'multi');
     assert.equal(component.two.toggle, 'event.shiftKey');
-    assert.sameDeepMembers(component['two'].project, [{field: '_id', encoding: null}]);
+    assert.sameDeepMembers(component['two'].project, [{field: '_id', channel: null}]);
     assert.sameDeepMembers(component['two'].events, parseSelector('click', 'scope'));
 
     assert.equal(component.three.name, 'three');
     assert.equal(component.three.type, 'interval');
     assert.equal(component.three.translate, '[mousedown, window:mouseup] > window:mousemove!');
     assert.equal(component.three.zoom, 'wheel');
-    assert.sameDeepMembers<selection.ProjectComponent>(component['three'].project, [{field: 'Horsepower', encoding: 'x'}, {field: 'Miles_per_Gallon', encoding: 'y'}]);
+    assert.sameDeepMembers<selection.ProjectComponent>(component['three'].project, [{field: 'Horsepower', channel: 'x'}, {field: 'Miles_per_Gallon', channel: 'y'}]);
     assert.sameDeepMembers(component['three'].events, parseSelector('[mousedown, window:mouseup] > window:mousemove!', 'scope'));
   });
 
@@ -65,20 +65,20 @@ describe('Selection', function() {
 
     assert.equal(component.one.name, 'one');
     assert.equal(component.one.type, 'single');
-    assert.sameDeepMembers(component['one'].project, [{field: 'Cylinders', encoding: null}]);
+    assert.sameDeepMembers(component['one'].project, [{field: 'Cylinders', channel: null}]);
     assert.sameDeepMembers(component['one'].events, parseSelector('dblclick', 'scope'));
 
     assert.equal(component.two.name, 'two');
     assert.equal(component.two.type, 'multi');
     assert.equal(component.two.toggle, 'event.ctrlKey');
-    assert.sameDeepMembers<selection.ProjectComponent>(component['two'].project, [{field: 'Origin', encoding: 'color'}]);
+    assert.sameDeepMembers<selection.ProjectComponent>(component['two'].project, [{field: 'Origin', channel: 'color'}]);
     assert.sameDeepMembers(component['two'].events, parseSelector('mouseover', 'scope'));
 
     assert.equal(component.three.name, 'three');
     assert.equal(component.three.type, 'interval');
     assert.equal(component.three.translate, false);
     assert.equal(component.three.zoom, 'wheel[event.altKey]');
-    assert.sameDeepMembers<selection.ProjectComponent>(component['three'].project, [{field: 'Miles_per_Gallon', encoding: 'y'}]);
+    assert.sameDeepMembers<selection.ProjectComponent>(component['three'].project, [{field: 'Miles_per_Gallon', channel: 'y'}]);
     assert.sameDeepMembers(component['three'].events, parseSelector('[mousedown[!event.shiftKey], mouseup] > mousemove', 'scope'));
   });
 
@@ -103,20 +103,20 @@ describe('Selection', function() {
 
     assert.equal(component.one.name, 'one');
     assert.equal(component.one.type, 'single');
-    assert.sameDeepMembers(component['one'].project, [{field: 'Cylinders', encoding: null}]);
+    assert.sameDeepMembers(component['one'].project, [{field: 'Cylinders', channel: null}]);
     assert.sameDeepMembers(component['one'].events, parseSelector('dblclick', 'scope'));
 
     assert.equal(component.two.name, 'two');
     assert.equal(component.two.type, 'multi');
     assert.equal(component.two.toggle, 'event.ctrlKey');
-    assert.sameDeepMembers<selection.ProjectComponent>(component['two'].project, [{field: 'Origin', encoding: 'color'}]);
+    assert.sameDeepMembers<selection.ProjectComponent>(component['two'].project, [{field: 'Origin', channel: 'color'}]);
     assert.sameDeepMembers(component['two'].events, parseSelector('mouseover', 'scope'));
 
     assert.equal(component.three.name, 'three');
     assert.equal(component.three.type, 'interval');
     assert(!component.three.translate);
     assert.equal(component.three.zoom, 'wheel[event.altKey]');
-    assert.sameDeepMembers<selection.ProjectComponent>(component['three'].project, [{field: 'Miles_per_Gallon', encoding: 'y'}]);
+    assert.sameDeepMembers<selection.ProjectComponent>(component['three'].project, [{field: 'Miles_per_Gallon', channel: 'y'}]);
     assert.sameDeepMembers(component['three'].events, parseSelector('[mousedown[!event.shiftKey], mouseup] > mousemove', 'scope'));
   });
 });

--- a/test/compile/selection/timeunit.test.ts
+++ b/test/compile/selection/timeunit.test.ts
@@ -1,0 +1,127 @@
+/* tslint:disable:quotemark */
+
+import {assert} from 'chai';
+import {TimeUnitNode} from '../../../src/compile/data/timeunit';
+import * as selection from '../../../src/compile/selection/selection';
+import {UnitSpec} from '../../../src/spec';
+import {parseModel, parseUnitModel} from '../../util';
+
+function getModel(unit2: UnitSpec) {
+  const model = parseModel({
+    "data": {"values": [
+      {"date": "Sun, 01 Jan 2012 23:00:01","price": 150},
+      {"date": "Sun, 02 Jan 2012 00:10:02","price": 100},
+      {"date": "Sun, 02 Jan 2012 01:20:03","price": 170},
+      {"date": "Sun, 02 Jan 2012 02:30:04","price": 165},
+      {"date": "Sun, 02 Jan 2012 03:40:05","price": 200}
+    ]},
+    "hconcat": [{
+      "mark": "point",
+      "selection": {
+        "two": {"type": "single", "encodings": ["x", "y"]}
+      },
+      "encoding": {
+        "x": {
+          "field": "date",
+          "type": "temporal",
+          "timeUnit": "seconds"
+        },
+        "y": {"field": "price","type": "quantitative"}
+      }
+    }, unit2]
+  });
+  model.parse();
+  return model;
+}
+
+describe('Selection time unit', function() {
+  it('dataflow nodes are constructed', function() {
+    const model = parseUnitModel({
+      "mark": "point",
+      "encoding": {
+        "x": {"field": "date", "type": "temporal", "timeUnit": "seconds"},
+        "y": {"field": "date", "type": "temporal", "timeUnit": "minutes"}
+      }
+    });
+    const selCmpts = model.component.selection = selection.parseUnitSelection(model, {
+      "one": {"type": "single"},
+      "two": {"type": "single", "encodings": ["x", "y"]}
+    });
+
+    assert.isUndefined(selCmpts['one'].timeUnit);
+    assert.instanceOf(selCmpts['two'].timeUnit, TimeUnitNode);
+
+    const as = selCmpts['two'].timeUnit.assemble().map((tx) => tx.as);
+    assert.sameDeepMembers(as, ['seconds_date', 'minutes_date']);
+  });
+
+  it('is added with conditional encodings', function() {
+    const model = getModel({
+      "mark": "point",
+      "encoding": {
+        "x": {
+          "field": "date",
+          "type": "temporal",
+          "timeUnit": "minutes"
+        },
+        "y": {"field": "price","type": "quantitative"},
+        "color": {
+          "condition": {"selection": "two", "value": "goldenrod"},
+          "value": "steelblue"
+        }
+      }
+    });
+
+    const data2 = model.assembleData().filter((d) => d.name === 'data_2')[0].transform;
+    assert.equal(data2.filter((tx) => tx.type === 'formula' && tx.as === 'seconds_date').length, 1);
+  });
+
+  it('is added before selection filters', function() {
+    const model = getModel({
+      "transform": [{"filter": {"selection": "two"}}],
+      "mark": "point",
+      "encoding": {
+        "x": {
+          "field": "date",
+          "type": "temporal",
+          "timeUnit": "minutes"
+        },
+        "y": {"field": "price","type": "quantitative"}
+      }
+    });
+
+    const data2 = model.assembleData().filter((d) => d.name === 'data_2')[0].transform;
+    let tuIdx = -1;
+    let selIdx = -1;
+
+    data2.forEach((tx, idx) => {
+      if (tx.type === 'formula' && tx.as === 'seconds_date') {
+        tuIdx = idx;
+      } else if (tx.type === 'filter' && tx.expr.indexOf('vlPoint') >= 0) {
+        selIdx = idx;
+      }
+    });
+
+    assert.notEqual(tuIdx, -1);
+    assert.notEqual(selIdx, -1);
+    assert.isAbove(selIdx, tuIdx);
+  });
+
+  it('removes duplicate time unit formulae', function() {
+    const model = getModel({
+      "transform": [{"filter": {"selection": "two"}}],
+      "mark": "point",
+      "encoding": {
+        "x": {
+          "field": "date",
+          "type": "temporal",
+          "timeUnit": "seconds"
+        },
+        "y": {"field": "price","type": "quantitative"}
+      }
+    });
+
+    const data2 = model.assembleData().filter((d) => d.name === 'data_2')[0].transform;
+    assert.equal(data2.filter((tx) => tx.type === 'formula' && tx.as === 'seconds_date').length, 1);
+  });
+});


### PR DESCRIPTION
If a selection is projected over a time unit field, this PR adds necessary time unit calculations to the dataflows of secondary views that apply the selection.

Two example specs:

1. When applied as a `condition`:
```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "description": "Google's stock price over time.",
  "data": {
    "values": [
      {"date": "Sun, 01 Jan 2012 23:00:01","price": 150},
      {"date": "Sun, 02 Jan 2012 00:10:02","price": 100},
      {"date": "Sun, 02 Jan 2012 01:20:03","price": 170},
      {"date": "Sun, 02 Jan 2012 02:30:04","price": 165},
      {"date": "Sun, 02 Jan 2012 03:40:05","price": 200}
    ]
  },
  "hconcat": [{
    "mark": "point",
    "selection": {
      "brush": {"type": "interval", "encodings": ["x"]}
    },
    "encoding": {
      "x": {
        "field": "date",
        "type": "temporal",
        "timeUnit": "seconds"
      },
      "y": {"field": "price","type": "quantitative"},
      "color": {
        "condition": {"selection": "brush", "value": "goldenrod"},
        "value": "steelblue"
      }
    }
  }, {
    "mark": "point",
    "encoding": {
      "x": {
        "field": "date",
        "type": "temporal",
        "timeUnit": "minutes"
      },
      "y": {"field": "price","type": "quantitative"},
      "color": {
        "condition": {"selection": "brush", "value": "goldenrod"},
        "value": "steelblue"
      }
    }
  }]
}
```

2. As a selection filter:

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "description": "Google's stock price over time.",
  "data": {
    "values": [
      {"date": "Sun, 01 Jan 2012 23:00:01","price": 150},
      {"date": "Sun, 02 Jan 2012 00:10:02","price": 100},
      {"date": "Sun, 02 Jan 2012 01:20:03","price": 170},
      {"date": "Sun, 02 Jan 2012 02:30:04","price": 165},
      {"date": "Sun, 02 Jan 2012 03:40:05","price": 200}
    ]
  },
  "hconcat": [{
    "mark": "point",
    "selection": {
      "brush": {"type": "interval", "encodings": ["x"]}
    },
    "encoding": {
      "x": {
        "field": "date",
        "type": "temporal",
        "timeUnit": "seconds"
      },
      "y": {"field": "price","type": "quantitative"},
      "color": {
        "condition": {"selection": "brush", "value": "goldenrod"},
        "value": "steelblue"
      }
    }
  }, {
    "transform": [{"filter": {"selection": "brush"}}],
    "mark": "point",
    "encoding": {
      "x": {
        "field": "date",
        "type": "temporal",
        "timeUnit": "minutes"
      },
      "y": {"field": "price","type": "quantitative"},
      "color": {
        "value": "goldenrod"
      }
    }
  }]
}
```

@domoritz: I could use some help with one thing: although the second spec works, the order of operations in the output Vega transforms array is incorrect (the `seconds_date` formula appears after the selection filter). How should I reorder the nodes? What's tricky is that selections generate their TimeUnitNodes when they are parsed (which occurs after data/transforms are parsed). As a result, their TimeUnitNodes are inserted during assembly and we cannot do something analogous to the [parse nodes](https://github.com/vega/vega-lite/blob/master/src/compile/data/transforms.ts#L164).