### PR TITLE
Customize brush style using "mark" property

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -653,82 +653,6 @@
       },
       "type": "object"
     },
-    "BaseIntervalSelectionDef": {
-      "additionalProperties": false,
-      "properties": {
-        "bind": {
-          "enum": [
-            "scales"
-          ],
-          "type": "string"
-        },
-        "encodings": {
-          "items": {
-            "$ref": "#/definitions/SingleDefChannel"
-          },
-          "type": "array"
-        },
-        "fields": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "mark": {
-          "$ref": "#/definitions/BrushDef"
-        },
-        "on": {
-        },
-        "resolve": {
-          "$ref": "#/definitions/SelectionResolutions"
-        },
-        "translate": {
-          "type": [
-            "string",
-            "boolean"
-          ]
-        },
-        "zoom": {
-          "type": [
-            "string",
-            "boolean"
-          ]
-        }
-      },
-      "type": "object"
-    },
-    "BaseMultiSelectionDef": {
-      "additionalProperties": false,
-      "properties": {
-        "encodings": {
-          "items": {
-            "$ref": "#/definitions/SingleDefChannel"
-          },
-          "type": "array"
-        },
-        "fields": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "nearest": {
-          "type": "boolean"
-        },
-        "on": {
-        },
-        "resolve": {
-          "$ref": "#/definitions/SelectionResolutions"
-        },
-        "toggle": {
-          "type": [
-            "string",
-            "boolean"
-          ]
-        }
-      },
-      "type": "object"
-    },
     "BaseSelectionDef": {
       "additionalProperties": false,
       "properties": {
@@ -743,45 +667,6 @@
             "type": "string"
           },
           "type": "array"
-        },
-        "on": {
-        },
-        "resolve": {
-          "$ref": "#/definitions/SelectionResolutions"
-        }
-      },
-      "type": "object"
-    },
-    "BaseSingleSelectionDef": {
-      "additionalProperties": false,
-      "properties": {
-        "bind": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/VgBinding"
-            },
-            {
-              "additionalProperties": {
-                "$ref": "#/definitions/VgBinding"
-              },
-              "type": "object"
-            }
-          ]
-        },
-        "encodings": {
-          "items": {
-            "$ref": "#/definitions/SingleDefChannel"
-          },
-          "type": "array"
-        },
-        "fields": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "nearest": {
-          "type": "boolean"
         },
         "on": {
         },
@@ -1085,7 +970,7 @@
       ],
       "type": "object"
     },
-    "BrushDef": {
+    "BrushConfig": {
       "additionalProperties": false,
       "properties": {
         "fill": {
@@ -3149,7 +3034,7 @@
           "type": "array"
         },
         "mark": {
-          "$ref": "#/definitions/BrushDef"
+          "$ref": "#/definitions/BrushConfig"
         },
         "on": {
         },
@@ -3178,6 +3063,50 @@
       "required": [
         "type"
       ],
+      "type": "object"
+    },
+    "IntervalSelectionConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "bind": {
+          "enum": [
+            "scales"
+          ],
+          "type": "string"
+        },
+        "encodings": {
+          "items": {
+            "$ref": "#/definitions/SingleDefChannel"
+          },
+          "type": "array"
+        },
+        "fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "mark": {
+          "$ref": "#/definitions/BrushConfig"
+        },
+        "on": {
+        },
+        "resolve": {
+          "$ref": "#/definitions/SelectionResolutions"
+        },
+        "translate": {
+          "type": [
+            "string",
+            "boolean"
+          ]
+        },
+        "zoom": {
+          "type": [
+            "string",
+            "boolean"
+          ]
+        }
+      },
       "type": "object"
     },
     "LayoutSize": {
@@ -4003,6 +3932,38 @@
       ],
       "type": "object"
     },
+    "MultiSelectionConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "encodings": {
+          "items": {
+            "$ref": "#/definitions/SingleDefChannel"
+          },
+          "type": "array"
+        },
+        "fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nearest": {
+          "type": "boolean"
+        },
+        "on": {
+        },
+        "resolve": {
+          "$ref": "#/definitions/SelectionResolutions"
+        },
+        "toggle": {
+          "type": [
+            "string",
+            "boolean"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "NamedData": {
       "additionalProperties": false,
       "properties": {
@@ -4662,13 +4623,13 @@
       "additionalProperties": false,
       "properties": {
         "interval": {
-          "$ref": "#/definitions/BaseIntervalSelectionDef"
+          "$ref": "#/definitions/IntervalSelectionConfig"
         },
         "multi": {
-          "$ref": "#/definitions/BaseMultiSelectionDef"
+          "$ref": "#/definitions/MultiSelectionConfig"
         },
         "single": {
-          "$ref": "#/definitions/BaseSingleSelectionDef"
+          "$ref": "#/definitions/SingleSelectionConfig"
         }
       },
       "required": [
@@ -4814,6 +4775,45 @@
       "required": [
         "type"
       ],
+      "type": "object"
+    },
+    "SingleSelectionConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "bind": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/VgBinding"
+            },
+            {
+              "additionalProperties": {
+                "$ref": "#/definitions/VgBinding"
+              },
+              "type": "object"
+            }
+          ]
+        },
+        "encodings": {
+          "items": {
+            "$ref": "#/definitions/SingleDefChannel"
+          },
+          "type": "array"
+        },
+        "fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nearest": {
+          "type": "boolean"
+        },
+        "on": {
+        },
+        "resolve": {
+          "$ref": "#/definitions/SelectionResolutions"
+        }
+      },
       "type": "object"
     },
     "SortField": {

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -653,17 +653,107 @@
       },
       "type": "object"
     },
+    "BaseIntervalSelectionDef": {
+      "additionalProperties": false,
+      "properties": {
+        "bind": {
+          "enum": [
+            "scales"
+          ],
+          "type": "string"
+        },
+        "encodings": {
+          "items": {
+            "$ref": "#/definitions/SingleDefChannel"
+          },
+          "type": "array"
+        },
+        "fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "on": {
+        },
+        "resolve": {
+          "$ref": "#/definitions/SelectionResolutions"
+        },
+        "translate": {
+          "type": [
+            "string",
+            "boolean"
+          ]
+        },
+        "zoom": {
+          "type": [
+            "string",
+            "boolean"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "BaseMultiSelectionDef": {
+      "additionalProperties": false,
+      "properties": {
+        "encodings": {
+          "items": {
+            "$ref": "#/definitions/SingleDefChannel"
+          },
+          "type": "array"
+        },
+        "fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nearest": {
+          "type": "boolean"
+        },
+        "on": {
+        },
+        "resolve": {
+          "$ref": "#/definitions/SelectionResolutions"
+        },
+        "toggle": {
+          "type": [
+            "string",
+            "boolean"
+          ]
+        }
+      },
+      "type": "object"
+    },
     "BaseSelectionDef": {
+      "additionalProperties": false,
+      "properties": {
+        "encodings": {
+          "items": {
+            "$ref": "#/definitions/SingleDefChannel"
+          },
+          "type": "array"
+        },
+        "fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "on": {
+        },
+        "resolve": {
+          "$ref": "#/definitions/SelectionResolutions"
+        }
+      },
+      "type": "object"
+    },
+    "BaseSingleSelectionDef": {
       "additionalProperties": false,
       "properties": {
         "bind": {
           "anyOf": [
-            {
-              "enum": [
-                "scales"
-              ],
-              "type": "string"
-            },
             {
               "$ref": "#/definitions/VgBinding"
             },
@@ -694,24 +784,6 @@
         },
         "resolve": {
           "$ref": "#/definitions/SelectionResolutions"
-        },
-        "toggle": {
-          "type": [
-            "string",
-            "boolean"
-          ]
-        },
-        "translate": {
-          "type": [
-            "string",
-            "boolean"
-          ]
-        },
-        "zoom": {
-          "type": [
-            "string",
-            "boolean"
-          ]
         }
       },
       "type": "object"
@@ -3022,6 +3094,56 @@
       ],
       "type": "string"
     },
+    "IntervalSelection": {
+      "additionalProperties": false,
+      "properties": {
+        "bind": {
+          "enum": [
+            "scales"
+          ],
+          "type": "string"
+        },
+        "encodings": {
+          "items": {
+            "$ref": "#/definitions/SingleDefChannel"
+          },
+          "type": "array"
+        },
+        "fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "on": {
+        },
+        "resolve": {
+          "$ref": "#/definitions/SelectionResolutions"
+        },
+        "translate": {
+          "type": [
+            "string",
+            "boolean"
+          ]
+        },
+        "type": {
+          "enum": [
+            "interval"
+          ],
+          "type": "string"
+        },
+        "zoom": {
+          "type": [
+            "string",
+            "boolean"
+          ]
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
     "LayoutSize": {
       "additionalProperties": false,
       "properties": {
@@ -3804,6 +3926,47 @@
       "minimum": 1,
       "type": "number"
     },
+    "MultiSelection": {
+      "additionalProperties": false,
+      "properties": {
+        "encodings": {
+          "items": {
+            "$ref": "#/definitions/SingleDefChannel"
+          },
+          "type": "array"
+        },
+        "fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nearest": {
+          "type": "boolean"
+        },
+        "on": {
+        },
+        "resolve": {
+          "$ref": "#/definitions/SelectionResolutions"
+        },
+        "toggle": {
+          "type": [
+            "string",
+            "boolean"
+          ]
+        },
+        "type": {
+          "enum": [
+            "multi"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
+    },
     "NamedData": {
       "additionalProperties": false,
       "properties": {
@@ -4463,13 +4626,13 @@
       "additionalProperties": false,
       "properties": {
         "interval": {
-          "$ref": "#/definitions/BaseSelectionDef"
+          "$ref": "#/definitions/BaseIntervalSelectionDef"
         },
         "multi": {
-          "$ref": "#/definitions/BaseSelectionDef"
+          "$ref": "#/definitions/BaseMultiSelectionDef"
         },
         "single": {
-          "$ref": "#/definitions/BaseSelectionDef"
+          "$ref": "#/definitions/BaseSingleSelectionDef"
         }
       },
       "required": [
@@ -4480,73 +4643,17 @@
       "type": "object"
     },
     "SelectionDef": {
-      "additionalProperties": false,
-      "properties": {
-        "bind": {
-          "anyOf": [
-            {
-              "enum": [
-                "scales"
-              ],
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/VgBinding"
-            },
-            {
-              "additionalProperties": {
-                "$ref": "#/definitions/VgBinding"
-              },
-              "type": "object"
-            }
-          ]
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SingleSelection"
         },
-        "encodings": {
-          "items": {
-            "$ref": "#/definitions/SingleDefChannel"
-          },
-          "type": "array"
+        {
+          "$ref": "#/definitions/MultiSelection"
         },
-        "fields": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        "nearest": {
-          "type": "boolean"
-        },
-        "on": {
-        },
-        "resolve": {
-          "$ref": "#/definitions/SelectionResolutions"
-        },
-        "toggle": {
-          "type": [
-            "string",
-            "boolean"
-          ]
-        },
-        "translate": {
-          "type": [
-            "string",
-            "boolean"
-          ]
-        },
-        "type": {
-          "$ref": "#/definitions/SelectionTypes"
-        },
-        "zoom": {
-          "type": [
-            "string",
-            "boolean"
-          ]
+        {
+          "$ref": "#/definitions/IntervalSelection"
         }
-      },
-      "required": [
-        "type"
-      ],
-      "type": "object"
+      ]
     },
     "SelectionDomain": {
       "anyOf": [
@@ -4608,14 +4715,6 @@
       ],
       "type": "string"
     },
-    "SelectionTypes": {
-      "enum": [
-        "single",
-        "multi",
-        "interval"
-      ],
-      "type": "string"
-    },
     "SingleDefChannel": {
       "enum": [
         "x",
@@ -4632,6 +4731,54 @@
         "tooltip"
       ],
       "type": "string"
+    },
+    "SingleSelection": {
+      "additionalProperties": false,
+      "properties": {
+        "bind": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/VgBinding"
+            },
+            {
+              "additionalProperties": {
+                "$ref": "#/definitions/VgBinding"
+              },
+              "type": "object"
+            }
+          ]
+        },
+        "encodings": {
+          "items": {
+            "$ref": "#/definitions/SingleDefChannel"
+          },
+          "type": "array"
+        },
+        "fields": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "nearest": {
+          "type": "boolean"
+        },
+        "on": {
+        },
+        "resolve": {
+          "$ref": "#/definitions/SelectionResolutions"
+        },
+        "type": {
+          "enum": [
+            "single"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "type": "object"
     },
     "SortField": {
       "additionalProperties": false,

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -674,6 +674,9 @@
           },
           "type": "array"
         },
+        "mark": {
+          "$ref": "#/definitions/BrushDef"
+        },
         "on": {
         },
         "resolve": {
@@ -1080,6 +1083,36 @@
       "required": [
         "type"
       ],
+      "type": "object"
+    },
+    "BrushDef": {
+      "additionalProperties": false,
+      "properties": {
+        "fill": {
+          "type": "string"
+        },
+        "fillOpacity": {
+          "type": "number"
+        },
+        "stroke": {
+          "type": "string"
+        },
+        "strokeDash": {
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "strokeDashOffset": {
+          "type": "number"
+        },
+        "strokeOpacity": {
+          "type": "number"
+        },
+        "strokeWidth": {
+          "type": "number"
+        }
+      },
       "type": "object"
     },
     "CalculateTransform": {
@@ -3114,6 +3147,9 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "mark": {
+          "$ref": "#/definitions/BrushDef"
         },
         "on": {
         },

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -7,7 +7,6 @@ import {UnitModel} from '../unit';
 import {channelSignalName, ProjectComponent, SelectionCompiler, SelectionComponent, STORE, TUPLE} from './selection';
 import scales from './transforms/scales';
 
-
 export const BRUSH = '_brush';
 export const SCALE_TRIGGER = '_scale_trigger';
 
@@ -113,7 +112,10 @@ const interval:SelectionCompiler = {
     // not interefere with the core marks, but that the brushed region can still
     // be interacted with (e.g., dragging it around).
     const {fill, fillOpacity, ...stroke} = selCmpt.mark;
-    keys(stroke).forEach((k) => stroke[k] = {value: stroke[k]});
+    const vgStroke = keys(stroke).reduce((def, k) => {
+      def[k] = {value: stroke[k]};
+      return def;
+    }, {});
 
     return [{
       type: 'rect',
@@ -130,7 +132,7 @@ const interval:SelectionCompiler = {
       encode: {
         enter: {
           fill: {value: 'transparent'},
-          ...stroke
+          ...vgStroke
         },
         update: update
       }

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -112,12 +112,15 @@ const interval:SelectionCompiler = {
     // Two brush marks ensure that fill colors and other aesthetic choices do
     // not interefere with the core marks, but that the brushed region can still
     // be interacted with (e.g., dragging it around).
+    const {fill, fillOpacity, ...stroke} = selCmpt.mark;
+    keys(stroke).forEach((k) => stroke[k] = {value: stroke[k]});
+
     return [{
       type: 'rect',
       encode: {
         enter: {
-          fill: {value: '#333'},
-          fillOpacity: {value: 0.125}
+          fill: {value: fill},
+          fillOpacity: {value: fillOpacity}
         },
         update: update
       }
@@ -127,7 +130,7 @@ const interval:SelectionCompiler = {
       encode: {
         enter: {
           fill: {value: 'transparent'},
-          stroke: {value: 'white'}
+          ...stroke
         },
         update: update
       }

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -3,7 +3,7 @@ import {Channel, ScaleChannel, SingleDefChannel} from '../../channel';
 import {warn} from '../../log';
 import {LogicalOperand} from '../../logical';
 import {SelectionDomain} from '../../scale';
-import {BrushDef, SelectionDef, SelectionResolutions, SelectionTypes} from '../../selection';
+import {BrushConfig, SelectionDef, SelectionResolutions, SelectionTypes} from '../../selection';
 import {Dict, extend, isString, logicalExpr, stringValue, varName} from '../../util';
 import {isSignalRefDomain, VgBinding, VgData, VgDomain, VgEventStream, VgScale, VgSignalRef} from '../../vega.schema';
 import {LayerModel} from '../layer';
@@ -28,7 +28,7 @@ export interface SelectionComponent {
   // predicate?: string;
   bind?: 'scales' | VgBinding | {[key: string]: VgBinding};
   resolve: SelectionResolutions;
-  mark?: BrushDef;
+  mark?: BrushConfig;
 
   // Transforms
   project?: ProjectComponent[];

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -3,7 +3,7 @@ import {Channel, ScaleChannel, SingleDefChannel} from '../../channel';
 import {warn} from '../../log';
 import {LogicalOperand} from '../../logical';
 import {SelectionDomain} from '../../scale';
-import {SelectionDef, SelectionResolutions, SelectionTypes} from '../../selection';
+import {BrushDef, SelectionDef, SelectionResolutions, SelectionTypes} from '../../selection';
 import {Dict, extend, isString, logicalExpr, stringValue, varName} from '../../util';
 import {isSignalRefDomain, VgBinding, VgData, VgDomain, VgEventStream, VgScale, VgSignalRef} from '../../vega.schema';
 import {LayerModel} from '../layer';
@@ -28,6 +28,7 @@ export interface SelectionComponent {
   // predicate?: string;
   bind?: 'scales' | VgBinding | {[key: string]: VgBinding};
   resolve: SelectionResolutions;
+  mark?: BrushDef;
 
   // Transforms
   project?: ProjectComponent[];

--- a/src/compile/selection/transforms/nearest.ts
+++ b/src/compile/selection/transforms/nearest.ts
@@ -1,11 +1,11 @@
 import {TransformCompiler} from './transforms';
 
-
 const VORONOI = 'voronoi';
 
 const nearest:TransformCompiler = {
   has: function(selCmpt) {
-    return selCmpt.nearest !== undefined && selCmpt.nearest !== false;
+    return selCmpt.type !== 'interval' &&
+      selCmpt.nearest !== undefined && selCmpt.nearest !== false;
   },
 
   marks: function(model, selCmpt, marks, selMarks) {

--- a/src/compile/selection/transforms/nearest.ts
+++ b/src/compile/selection/transforms/nearest.ts
@@ -4,8 +4,7 @@ const VORONOI = 'voronoi';
 
 const nearest:TransformCompiler = {
   has: function(selCmpt) {
-    return selCmpt.type !== 'interval' &&
-      selCmpt.nearest !== undefined && selCmpt.nearest !== false;
+    return selCmpt.type !== 'interval' && selCmpt.nearest;
   },
 
   marks: function(model, selCmpt, marks, selMarks) {

--- a/src/compile/selection/transforms/toggle.ts
+++ b/src/compile/selection/transforms/toggle.ts
@@ -7,7 +7,8 @@ const TOGGLE = '_toggle';
 
 const toggle:TransformCompiler = {
   has: function(selCmpt) {
-    return selCmpt.toggle !== undefined && selCmpt.toggle !== false;
+    return selCmpt.type === 'multi' &&
+      selCmpt.toggle !== undefined && selCmpt.toggle !== false;
   },
 
   signals: function(model, selCmpt, signals) {

--- a/src/compile/selection/transforms/toggle.ts
+++ b/src/compile/selection/transforms/toggle.ts
@@ -7,8 +7,7 @@ const TOGGLE = '_toggle';
 
 const toggle:TransformCompiler = {
   has: function(selCmpt) {
-    return selCmpt.type === 'multi' &&
-      selCmpt.toggle !== undefined && selCmpt.toggle !== false;
+    return selCmpt.type === 'multi' && selCmpt.toggle;
   },
 
   signals: function(model, selCmpt, signals) {

--- a/src/compile/selection/transforms/translate.ts
+++ b/src/compile/selection/transforms/translate.ts
@@ -13,7 +13,7 @@ const DELTA  = '_translate_delta';
 
 const translate:TransformCompiler = {
   has: function(selCmpt) {
-    return selCmpt.type === 'interval' && selCmpt.translate !== undefined && selCmpt.translate !== false;
+    return selCmpt.type === 'interval' && selCmpt.translate;
   },
 
   signals: function(model, selCmpt, signals) {

--- a/src/compile/selection/transforms/zoom.ts
+++ b/src/compile/selection/transforms/zoom.ts
@@ -13,7 +13,7 @@ const DELTA  = '_zoom_delta';
 
 const zoom:TransformCompiler = {
   has: function(selCmpt) {
-    return selCmpt.type === 'interval' && selCmpt.zoom !== undefined && selCmpt.zoom !== false;
+    return selCmpt.type === 'interval' && selCmpt.zoom;
   },
 
   signals: function(model, selCmpt, signals) {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,35 +1,55 @@
 import {SingleDefChannel} from './channel';
 import {VgBinding} from './vega.schema';
 
-
 export type SelectionTypes = 'single' | 'multi' | 'interval';
 export type SelectionResolutions = 'global' | 'independent' | 'union' |
   'union_others' | 'intersect' | 'intersect_others';
 
 export interface BaseSelectionDef {
-  // domain?: SelectionDomain;
-  resolve?: SelectionResolutions;
   on?: any;
+  resolve?: SelectionResolutions;
   // predicate?: string;
-  bind?: 'scales' | VgBinding | {[key: string]: VgBinding};
+  // domain?: SelectionDomain;
 
   // Transforms
   fields?: string[];
   encodings?: SingleDefChannel[];
-  toggle?: string | boolean;
-  translate?: string | boolean;
-  zoom?: string | boolean;
+}
+
+export interface BaseSingleSelectionDef extends BaseSelectionDef {
+  bind?: VgBinding | {[key: string]: VgBinding};
   nearest?: boolean;
 }
 
-export interface SelectionDef extends BaseSelectionDef {
-  type: SelectionTypes;
+export interface BaseMultiSelectionDef extends BaseSelectionDef {
+  toggle?: string | boolean;
+  nearest?: boolean;
 }
 
+export interface BaseIntervalSelectionDef extends BaseSelectionDef {
+  translate?: string | boolean;
+  zoom?: string | boolean;
+  bind?: 'scales';
+}
+
+export interface SingleSelection extends BaseSingleSelectionDef {
+  type: 'single';
+}
+
+export interface MultiSelection extends BaseMultiSelectionDef {
+  type: 'multi';
+}
+
+export interface IntervalSelection extends BaseIntervalSelectionDef {
+  type: 'interval';
+}
+
+export type SelectionDef = SingleSelection | MultiSelection | IntervalSelection;
+
 export interface SelectionConfig {
-  single: BaseSelectionDef;
-  multi: BaseSelectionDef;
-  interval: BaseSelectionDef;
+  single: BaseSingleSelectionDef;
+  multi: BaseMultiSelectionDef;
+  interval: BaseIntervalSelectionDef;
 }
 
 export const defaultConfig:SelectionConfig = {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -8,6 +8,7 @@ export type SelectionResolutions = 'global' | 'independent' | 'union' |
 export interface BaseSelectionDef {
   on?: any;
   resolve?: SelectionResolutions;
+  // TODO(https://github.com/vega/vega-lite/issues/2596).
   // predicate?: string;
   // domain?: SelectionDomain;
 
@@ -16,17 +17,17 @@ export interface BaseSelectionDef {
   encodings?: SingleDefChannel[];
 }
 
-export interface BaseSingleSelectionDef extends BaseSelectionDef {
+export interface SingleSelectionConfig extends BaseSelectionDef {
   bind?: VgBinding | {[key: string]: VgBinding};
   nearest?: boolean;
 }
 
-export interface BaseMultiSelectionDef extends BaseSelectionDef {
+export interface MultiSelectionConfig extends BaseSelectionDef {
   toggle?: string | boolean;
   nearest?: boolean;
 }
 
-export interface BrushDef {
+export interface BrushConfig {
   fill?: string;
   fillOpacity?: number;
   stroke?: string;
@@ -36,31 +37,31 @@ export interface BrushDef {
   strokeDashOffset?: number;
 }
 
-export interface BaseIntervalSelectionDef extends BaseSelectionDef {
+export interface IntervalSelectionConfig extends BaseSelectionDef {
   translate?: string | boolean;
   zoom?: string | boolean;
   bind?: 'scales';
-  mark?: BrushDef;
+  mark?: BrushConfig;
 }
 
-export interface SingleSelection extends BaseSingleSelectionDef {
+export interface SingleSelection extends SingleSelectionConfig {
   type: 'single';
 }
 
-export interface MultiSelection extends BaseMultiSelectionDef {
+export interface MultiSelection extends MultiSelectionConfig {
   type: 'multi';
 }
 
-export interface IntervalSelection extends BaseIntervalSelectionDef {
+export interface IntervalSelection extends IntervalSelectionConfig {
   type: 'interval';
 }
 
 export type SelectionDef = SingleSelection | MultiSelection | IntervalSelection;
 
 export interface SelectionConfig {
-  single: BaseSingleSelectionDef;
-  multi: BaseMultiSelectionDef;
-  interval: BaseIntervalSelectionDef;
+  single: SingleSelectionConfig;
+  multi: MultiSelectionConfig;
+  interval: IntervalSelectionConfig;
 }
 
 export const defaultConfig:SelectionConfig = {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -26,10 +26,21 @@ export interface BaseMultiSelectionDef extends BaseSelectionDef {
   nearest?: boolean;
 }
 
+export interface BrushDef {
+  fill?: string;
+  fillOpacity?: number;
+  stroke?: string;
+  strokeOpacity?: number;
+  strokeWidth?: number;
+  strokeDash?: number[];
+  strokeDashOffset?: number;
+}
+
 export interface BaseIntervalSelectionDef extends BaseSelectionDef {
   translate?: string | boolean;
   zoom?: string | boolean;
   bind?: 'scales';
+  mark?: BrushDef;
 }
 
 export interface SingleSelection extends BaseSingleSelectionDef {
@@ -60,6 +71,7 @@ export const defaultConfig:SelectionConfig = {
     encodings: ['x', 'y'],
     translate: '[mousedown, window:mouseup] > window:mousemove!',
     zoom: 'wheel',
+    mark: {fill: '#333', fillOpacity: 0.125, stroke: 'white'},
     resolve: 'global'
   }
 };

--- a/test/compile/selection/inputs.test.ts
+++ b/test/compile/selection/inputs.test.ts
@@ -34,6 +34,9 @@ describe('Inputs Selection Transform', function() {
         "Origin": {"input": "select", "options": ["Japan", "USA", "Europe"]}
       }
     },
+    "four": {
+      "type": "single", "bind": null
+    },
     "six": {
       "type": "interval",
       "bind": "scales"
@@ -41,10 +44,11 @@ describe('Inputs Selection Transform', function() {
   });
 
   it('identifies transform invocation', function() {
-    assert.isTrue(inputs.has(selCmpts['one']));
-    assert.isTrue(inputs.has(selCmpts['two']));
-    assert.isTrue(inputs.has(selCmpts['three']));
-    assert.isFalse(inputs.has(selCmpts['six']));
+    assert.isNotFalse(inputs.has(selCmpts['one']));
+    assert.isNotFalse(inputs.has(selCmpts['two']));
+    assert.isNotFalse(inputs.has(selCmpts['three']));
+    assert.isNotTrue(inputs.has(selCmpts['four']));
+    assert.isNotTrue(inputs.has(selCmpts['six']));
   });
 
   it('adds widget binding for default projection', function() {

--- a/test/compile/selection/inputs.test.ts
+++ b/test/compile/selection/inputs.test.ts
@@ -34,20 +34,8 @@ describe('Inputs Selection Transform', function() {
         "Origin": {"input": "select", "options": ["Japan", "USA", "Europe"]}
       }
     },
-    "four": {
-      "type": "multi",
-      "bind": {"input": "range", "min": 0, "max": 10, "step": 1}
-    },
-    "five": {
-      "type": "interval",
-      "bind": {"input": "range", "min": 0, "max": 10, "step": 1}
-    },
     "six": {
       "type": "interval",
-      "bind": "scales"
-    },
-    "seven": {
-      "type": "single",
       "bind": "scales"
     }
   });
@@ -56,10 +44,7 @@ describe('Inputs Selection Transform', function() {
     assert.isTrue(inputs.has(selCmpts['one']));
     assert.isTrue(inputs.has(selCmpts['two']));
     assert.isTrue(inputs.has(selCmpts['three']));
-    assert.isFalse(inputs.has(selCmpts['four']));
-    assert.isFalse(inputs.has(selCmpts['five']));
     assert.isFalse(inputs.has(selCmpts['six']));
-    assert.isFalse(inputs.has(selCmpts['four']));
   });
 
   it('adds widget binding for default projection', function() {

--- a/test/compile/selection/interval.test.ts
+++ b/test/compile/selection/interval.test.ts
@@ -32,7 +32,16 @@ describe('Interval Selections', function() {
       "on": "[mousedown, mouseup] > mousemove, [keydown, keyup] > keypress",
       "translate": false,
       "zoom": false,
-      "resolve": "intersect"
+      "resolve": "intersect",
+      "mark": {
+        "fill": "red",
+        "fillOpacity": 0.75,
+        "stroke": "black",
+        "strokeWidth": 4,
+        "strokeDash": [10, 5],
+        "strokeDashOffset": 3,
+        "strokeOpacity": 0.25
+      }
     }
   });
 
@@ -330,8 +339,8 @@ describe('Interval Selections', function() {
         "type": "rect",
         "encode": {
           "enter": {
-            "fill": {"value": "#333"},
-            "fillOpacity": {"value": 0.125}
+            "fill": {"value": "red"},
+            "fillOpacity": {"value": 0.75}
           },
           "update": {
             "x": {
@@ -356,7 +365,11 @@ describe('Interval Selections', function() {
         "encode": {
           "enter": {
             "fill": {"value": "transparent"},
-            "stroke": {"value": "white"}
+            "stroke": {"value": "black"},
+            "strokeWidth": {"value": 4},
+            "strokeDash": {"value": [10, 5]},
+            "strokeDashOffset": {"value": 3},
+            "strokeOpacity": {"value": 0.25}
           },
           "update": {
             "x": {

--- a/test/compile/selection/nearest.test.ts
+++ b/test/compile/selection/nearest.test.ts
@@ -20,7 +20,8 @@ function getModel(markType: any) {
     "two": {"type": "multi", "nearest": true},
     "three": {"type": "interval", "nearest": true},
     "four": {"type": "single", "nearest": false},
-    "five": {"type": "multi"}
+    "five": {"type": "multi"},
+    "six": {"type": "multi", "nearest": null}
   });
 
   return model;
@@ -29,11 +30,12 @@ function getModel(markType: any) {
 describe('Nearest Selection Transform', function() {
   it('identifies transform invocation', function() {
     const selCmpts = getModel('circle').component.selection;
-    assert.isTrue(nearest.has(selCmpts['one']));
-    assert.isTrue(nearest.has(selCmpts['two']));
-    assert.isFalse(nearest.has(selCmpts['three']));
-    assert.isFalse(nearest.has(selCmpts['four']));
-    assert.isFalse(nearest.has(selCmpts['five']));
+    assert.isNotFalse(nearest.has(selCmpts['one']));
+    assert.isNotFalse(nearest.has(selCmpts['two']));
+    assert.isNotTrue(nearest.has(selCmpts['three']));
+    assert.isNotTrue(nearest.has(selCmpts['four']));
+    assert.isNotTrue(nearest.has(selCmpts['five']));
+    assert.isNotTrue(nearest.has(selCmpts['six']));
   });
 
   it('adds voronoi for non-path marks', function() {

--- a/test/compile/selection/nearest.test.ts
+++ b/test/compile/selection/nearest.test.ts
@@ -31,7 +31,7 @@ describe('Nearest Selection Transform', function() {
     const selCmpts = getModel('circle').component.selection;
     assert.isTrue(nearest.has(selCmpts['one']));
     assert.isTrue(nearest.has(selCmpts['two']));
-    assert.isTrue(nearest.has(selCmpts['three']));
+    assert.isFalse(nearest.has(selCmpts['three']));
     assert.isFalse(nearest.has(selCmpts['four']));
     assert.isFalse(nearest.has(selCmpts['five']));
   });

--- a/test/compile/selection/toggle.test.ts
+++ b/test/compile/selection/toggle.test.ts
@@ -15,12 +15,26 @@ describe('Toggle Selection Transform', function() {
     }
   });
 
+  model.parseScale();
   const selCmpts = model.component.selection = selection.parseUnitSelection(model, {
     "one": {"type": "multi"},
     "two": {
       "type": "multi", "resolve": "union",
       "on": "mouseover", "toggle": "event.ctrlKey", "encodings": ["y", "color"]
-    }
+    },
+    "three": {"type": "multi", "toggle": false},
+    "four": {"type": "multi", "toggle": null},
+    "five": {"type": "single", "toggle": true},
+    "six": {"type": "interval", "toggle": true}
+  });
+
+  it('identifies transform invocation', function() {
+    assert.isNotFalse(toggle.has(selCmpts['one']));
+    assert.isNotFalse(toggle.has(selCmpts['two']));
+    assert.isNotTrue(toggle.has(selCmpts['three']));
+    assert.isNotTrue(toggle.has(selCmpts['four']));
+    assert.isNotTrue(toggle.has(selCmpts['five']));
+    assert.isNotTrue(toggle.has(selCmpts['six']));
   });
 
   it('builds toggle signals', function() {

--- a/test/compile/selection/translate.test.ts
+++ b/test/compile/selection/translate.test.ts
@@ -40,16 +40,18 @@ describe('Translate Selection Transform', function() {
     "six": {
       "type": "interval",
       "bind": "scales"
-    }
+    },
+    "seven": {"type": "interval", "translate": null}
   });
 
   it('identifies transform invocation', function() {
-    assert.isFalse(translate.has(selCmpts['one']));
-    assert.isFalse(translate.has(selCmpts['two']));
-    assert.isFalse(translate.has(selCmpts['three']));
-    assert.isTrue(translate.has(selCmpts['four']));
-    assert.isTrue(translate.has(selCmpts['five']));
-    assert.isTrue(translate.has(selCmpts['six']));
+    assert.isNotTrue(translate.has(selCmpts['one']));
+    assert.isNotTrue(translate.has(selCmpts['two']));
+    assert.isNotTrue(translate.has(selCmpts['three']));
+    assert.isNotFalse(translate.has(selCmpts['four']));
+    assert.isNotFalse(translate.has(selCmpts['five']));
+    assert.isNotFalse(translate.has(selCmpts['six']));
+    assert.isNotTrue(translate.has(selCmpts['seven']));
   });
 
   it('builds signals for default invocation', function() {

--- a/test/compile/selection/zoom.test.ts
+++ b/test/compile/selection/zoom.test.ts
@@ -40,16 +40,18 @@ describe('Zoom Selection Transform', function() {
     "six": {
       "type": "interval",
       "bind": "scales"
-    }
+    },
+    "seven": {"type": "interval", "zoom": null}
   });
 
   it('identifies transform invocation', function() {
-    assert.isFalse(zoom.has(selCmpts['one']));
-    assert.isFalse(zoom.has(selCmpts['two']));
-    assert.isFalse(zoom.has(selCmpts['three']));
-    assert.isTrue(zoom.has(selCmpts['four']));
-    assert.isTrue(zoom.has(selCmpts['five']));
-    assert.isTrue(zoom.has(selCmpts['six']));
+    assert.isNotTrue(zoom.has(selCmpts['one']));
+    assert.isNotTrue(zoom.has(selCmpts['two']));
+    assert.isNotTrue(zoom.has(selCmpts['three']));
+    assert.isNotFalse(zoom.has(selCmpts['four']));
+    assert.isNotFalse(zoom.has(selCmpts['five']));
+    assert.isNotFalse(zoom.has(selCmpts['six']));
+    assert.isNotTrue(zoom.has(selCmpts['seven']));
   });
 
   it('builds signals for default invocation', function() {


### PR DESCRIPTION
This PR introduces a `mark` property that can be defined on interval selections (and interval selection configs) to customize the appearance of the generated brush mark. The supported style properties include `fill`, `fillOpacity`, `stroke`, `strokeWidth`, `strokeOpacity`, `strokeDash`, and `strokeDashOffset`.

(I also made the type definitions more precise, which should help make Altair's selection API cleaner).

E.g., 

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "description": "Drag out a rectangular brush to highlight points.",
  "data": {"url": "data/cars.json"},
  "selection": {
    "brush": {
      "type": "interval",
      "mark": {
        "fill": "red",
        "fillOpacity": 0.75,
        "stroke": "green",
        "strokeWidth": 4,
        "strokeDash": [10, 5],
        "strokeDashOffset": 3,
        "strokeOpacity": 1
      }
    }
  },
  "mark": "point",
  "encoding": {
    "x": {"field": "Horsepower", "type": "quantitative"},
    "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
    "color": {
      "condition": {"selection": "brush", "field": "Cylinders", "type": "ordinal"},
      "value": "grey"
    }
  }
}
```

![download 3](https://user-images.githubusercontent.com/42262/27615834-edb4427c-5b5f-11e7-9629-3831882d0d94.png)
