### PR TITLE
Fix link to mondrian-rest-ui

### DIFF
--- a/site/usage/applications.md
+++ b/site/usage/applications.md
@@ -25,7 +25,7 @@ This is an incomplete list of integrations, applications, and extensions of the 
 * [Lyra](https://github.com/vega/lyra), an interactive, graphical Visualization Design Environment (VDE)
 * [nteract](https://github.com/nteract/nteract), interactive notebook application with Vega and Vega-Lite renderer
 * [Vega-VSCode](https://github.com/vega/vega-vscode), Vega Language Plug-in for Visual Studio Code
-* [mondrian-rest-ui](https://github.com/jazzido/mondrian-rest), an experimental UI for [`mondrian-rest`](https://github.com/jazzido/mondrian-rest) inspired by [Polestar](https://github.com/vega/polestar) and [CubesViewer](https://github.com/jjmontesl/cubesviewer).
+* [mondrian-rest-ui](https://github.com/jazzido/mondrian-rest-ui), an experimental UI for [`mondrian-rest`](https://github.com/jazzido/mondrian-rest) inspired by [Polestar](https://github.com/vega/polestar) and [CubesViewer](https://github.com/jjmontesl/cubesviewer).
 * [data.world](https://data.world), upload `.vg.json` and `.vl.json` files along side your raw data, or [embed vega](https://docs.data.world/tutorials/markdown/#vega-and-vega-lite) directly into comments and summary markdown.
 
 ## Libraries


### PR DESCRIPTION
Just realized that the link to [mondrian-rest-ui](https://github.com/jazzido/mondrian-rest-ui), an application that I maintain, is wrong.

This PR corrects it.

Thanks!

