### PR TITLE
Use pan/zoom expression functions

### DIFF
--- a/examples/specs/bubble_health_income.vl.json
+++ b/examples/specs/bubble_health_income.vl.json
@@ -5,6 +5,9 @@
   "data": {
     "url": "data/gapminder-health-income.csv"
   },
+  "selection": {
+    "view": {"type": "interval", "bind": "scales"}
+  },
   "mark": "circle",
   "encoding": {
     "y": {

--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -96,13 +96,13 @@
                     "events": {
                         "signal": "brush_translate_delta"
                     },
-                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, width)"
+                    "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, width)"
                 },
                 {
                     "events": {
                         "signal": "brush_zoom_delta"
                     },
-                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, width)"
+                    "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, width)"
                 }
             ]
         },
@@ -162,13 +162,13 @@
                     "events": {
                         "signal": "brush_translate_delta"
                     },
-                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, height)"
+                    "update": "clampRange(panLinear(brush_translate_anchor.extent_y, brush_translate_delta.y / span(brush_translate_anchor.extent_y)), 0, height)"
                 },
                 {
                     "events": {
                         "signal": "brush_zoom_delta"
                     },
-                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, height)"
+                    "update": "clampRange(zoomLinear(brush_y, brush_zoom_anchor.y, brush_zoom_delta), 0, height)"
                 }
             ]
         },
@@ -230,7 +230,7 @@
                             ]
                         }
                     ],
-                    "update": "{x: x(unit) - brush_translate_anchor.x, y: y(unit) - brush_translate_anchor.y}"
+                    "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
                 }
             ]
         },

--- a/examples/vg-specs/bubble_health_income.vg.json
+++ b/examples/vg-specs/bubble_health_income.vg.json
@@ -266,7 +266,7 @@
     "axes": [
         {
             "scale": "x",
-            "labelOverlap": true,
+            "labelOverlap": "greedy",
             "orient": "bottom",
             "tickCount": 5,
             "title": "income",

--- a/examples/vg-specs/bubble_health_income.vg.json
+++ b/examples/vg-specs/bubble_health_income.vg.json
@@ -12,6 +12,9 @@
     },
     "data": [
         {
+            "name": "view_store"
+        },
+        {
             "name": "source_0",
             "url": "data/gapminder-health-income.csv",
             "format": {
@@ -42,6 +45,135 @@
         {
             "name": "height",
             "update": "300"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        },
+        {
+            "name": "view_income",
+            "on": [
+                {
+                    "events": {
+                        "signal": "view_translate_delta"
+                    },
+                    "update": "panLog(view_translate_anchor.extent_x, -view_translate_delta.x / width)"
+                },
+                {
+                    "events": {
+                        "signal": "view_zoom_delta"
+                    },
+                    "update": "zoomLog(domain(\"x\"), view_zoom_anchor.x, view_zoom_delta)"
+                }
+            ]
+        },
+        {
+            "name": "view_health",
+            "on": [
+                {
+                    "events": {
+                        "signal": "view_translate_delta"
+                    },
+                    "update": "panLinear(view_translate_anchor.extent_y, view_translate_delta.y / height)"
+                },
+                {
+                    "events": {
+                        "signal": "view_zoom_delta"
+                    },
+                    "update": "zoomLinear(domain(\"y\"), view_zoom_anchor.y, view_zoom_delta)"
+                }
+            ]
+        },
+        {
+            "name": "view_tuple",
+            "update": "{unit: \"\", intervals: [{encoding: \"x\", field: \"income\", extent: view_income}, {encoding: \"y\", field: \"health\", extent: view_health}]}"
+        },
+        {
+            "name": "view_translate_anchor",
+            "value": {},
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "mousedown"
+                        }
+                    ],
+                    "update": "{x: x(unit), y: y(unit), extent_x: domain(\"x\"), extent_y: domain(\"y\")}"
+                }
+            ]
+        },
+        {
+            "name": "view_translate_delta",
+            "value": {},
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "window",
+                            "type": "mousemove",
+                            "consume": true,
+                            "between": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousedown"
+                                },
+                                {
+                                    "source": "window",
+                                    "type": "mouseup"
+                                }
+                            ]
+                        }
+                    ],
+                    "update": "{x: view_translate_anchor.x - x(unit), y: view_translate_anchor.y - y(unit)}"
+                }
+            ]
+        },
+        {
+            "name": "view_zoom_anchor",
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "wheel"
+                        }
+                    ],
+                    "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+                }
+            ]
+        },
+        {
+            "name": "view_zoom_delta",
+            "on": [
+                {
+                    "events": [
+                        {
+                            "source": "scope",
+                            "type": "wheel"
+                        }
+                    ],
+                    "force": true,
+                    "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                }
+            ]
+        },
+        {
+            "name": "view_modify",
+            "on": [
+                {
+                    "events": {
+                        "signal": "view_tuple"
+                    },
+                    "update": "modify(\"view_store\", view_tuple, true)"
+                }
+            ]
         }
     ],
     "marks": [
@@ -76,7 +208,8 @@
                         "value": 0.7
                     }
                 }
-            }
+            },
+            "clip": true
         }
     ],
     "scales": [
@@ -86,6 +219,9 @@
             "domain": {
                 "data": "source_0",
                 "field": "income"
+            },
+            "domainRaw": {
+                "signal": "view_income"
             },
             "range": [
                 0,
@@ -100,6 +236,9 @@
             "domain": {
                 "data": "source_0",
                 "field": "health"
+            },
+            "domainRaw": {
+                "signal": "view_health"
             },
             "range": [
                 300,

--- a/examples/vg-specs/concat_selections.vg.json
+++ b/examples/vg-specs/concat_selections.vg.json
@@ -164,13 +164,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, concat_0_width)"
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, concat_0_width)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, concat_0_width)"
+                            "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, concat_0_width)"
                         }
                     ]
                 },
@@ -230,13 +230,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, concat_0_height)"
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_y, brush_translate_delta.y / span(brush_translate_anchor.extent_y)), 0, concat_0_height)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, concat_0_height)"
+                            "update": "clampRange(zoomLinear(brush_y, brush_zoom_anchor.y, brush_zoom_delta), 0, concat_0_height)"
                         }
                     ]
                 },
@@ -298,7 +298,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit) - brush_translate_anchor.x, y: y(unit) - brush_translate_anchor.y}"
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
                         }
                     ]
                 },
@@ -573,13 +573,13 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / concat_1_width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / concat_1_width]"
+                            "update": "panLinear(grid_translate_anchor.extent_x, -grid_translate_delta.x / concat_1_width)"
                         },
                         {
                             "events": {
                                 "signal": "grid_zoom_delta"
                             },
-                            "update": "[grid_zoom_anchor.x + (domain(\"concat_1_x\")[0] - grid_zoom_anchor.x) * grid_zoom_delta, grid_zoom_anchor.x + (domain(\"concat_1_x\")[1] - grid_zoom_anchor.x) * grid_zoom_delta]"
+                            "update": "zoomLinear(domain(\"concat_1_x\"), grid_zoom_anchor.x, grid_zoom_delta)"
                         }
                     ],
                     "push": "outer"
@@ -591,13 +591,13 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / concat_1_height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / concat_1_height]"
+                            "update": "panLinear(grid_translate_anchor.extent_y, grid_translate_delta.y / concat_1_height)"
                         },
                         {
                             "events": {
                                 "signal": "grid_zoom_delta"
                             },
-                            "update": "[grid_zoom_anchor.y + (domain(\"concat_1_y\")[0] - grid_zoom_anchor.y) * grid_zoom_delta, grid_zoom_anchor.y + (domain(\"concat_1_y\")[1] - grid_zoom_anchor.y) * grid_zoom_delta]"
+                            "update": "zoomLinear(domain(\"concat_1_y\"), grid_zoom_anchor.y, grid_zoom_delta)"
                         }
                     ],
                     "push": "outer"
@@ -643,7 +643,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit) - grid_translate_anchor.x, y: y(unit) - grid_translate_anchor.y}"
+                            "update": "{x: grid_translate_anchor.x - x(unit), y: grid_translate_anchor.y - y(unit)}"
                         }
                     ]
                 },

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -322,13 +322,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, child_width)"
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, child_width)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, child_width)"
+                            "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, child_width)"
                         }
                     ]
                 },
@@ -395,7 +395,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit) - brush_translate_anchor.x, y: y(unit) - brush_translate_anchor.y}"
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
                         }
                     ]
                 },
@@ -448,13 +448,13 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / child_width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / child_width]"
+                            "update": "panLinear(grid_translate_anchor.extent_x, -grid_translate_delta.x / child_width)"
                         },
                         {
                             "events": {
                                 "signal": "grid_zoom_delta"
                             },
-                            "update": "[grid_zoom_anchor.x + (domain(\"x\")[0] - grid_zoom_anchor.x) * grid_zoom_delta, grid_zoom_anchor.x + (domain(\"x\")[1] - grid_zoom_anchor.x) * grid_zoom_delta]"
+                            "update": "zoomLinear(domain(\"x\"), grid_zoom_anchor.x, grid_zoom_delta)"
                         }
                     ],
                     "push": "outer"
@@ -466,13 +466,13 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_height]"
+                            "update": "panLinear(grid_translate_anchor.extent_y, grid_translate_delta.y / child_height)"
                         },
                         {
                             "events": {
                                 "signal": "grid_zoom_delta"
                             },
-                            "update": "[grid_zoom_anchor.y + (domain(\"y\")[0] - grid_zoom_anchor.y) * grid_zoom_delta, grid_zoom_anchor.y + (domain(\"y\")[1] - grid_zoom_anchor.y) * grid_zoom_delta]"
+                            "update": "zoomLinear(domain(\"y\"), grid_zoom_anchor.y, grid_zoom_delta)"
                         }
                     ],
                     "push": "outer"
@@ -523,7 +523,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit) - grid_translate_anchor.x, y: y(unit) - grid_translate_anchor.y}"
+                            "update": "{x: grid_translate_anchor.x - x(unit), y: grid_translate_anchor.y - y(unit)}"
                         }
                     ]
                 },

--- a/examples/vg-specs/interactive_splom.vg.json
+++ b/examples/vg-specs/interactive_splom.vg.json
@@ -219,13 +219,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, child_Horsepower_Horsepower_height)"
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_y, brush_translate_delta.y / span(brush_translate_anchor.extent_y)), 0, child_Horsepower_Horsepower_height)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, child_Horsepower_Horsepower_height)"
+                            "update": "clampRange(zoomLinear(brush_y, brush_zoom_anchor.y, brush_zoom_delta), 0, child_Horsepower_Horsepower_height)"
                         }
                     ]
                 },
@@ -292,7 +292,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit) - brush_translate_anchor.x, y: y(unit) - brush_translate_anchor.y}"
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
                         }
                     ]
                 },
@@ -351,13 +351,13 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_Horsepower_Horsepower_height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_Horsepower_Horsepower_height]"
+                            "update": "panLinear(grid_translate_anchor.extent_y, grid_translate_delta.y / child_Horsepower_Horsepower_height)"
                         },
                         {
                             "events": {
                                 "signal": "grid_zoom_delta"
                             },
-                            "update": "[grid_zoom_anchor.y + (domain(\"child_Horsepower_Horsepower_y\")[0] - grid_zoom_anchor.y) * grid_zoom_delta, grid_zoom_anchor.y + (domain(\"child_Horsepower_Horsepower_y\")[1] - grid_zoom_anchor.y) * grid_zoom_delta]"
+                            "update": "zoomLinear(domain(\"child_Horsepower_Horsepower_y\"), grid_zoom_anchor.y, grid_zoom_delta)"
                         }
                     ],
                     "push": "outer"
@@ -408,7 +408,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit) - grid_translate_anchor.x, y: y(unit) - grid_translate_anchor.y}"
+                            "update": "{x: grid_translate_anchor.x - x(unit), y: grid_translate_anchor.y - y(unit)}"
                         }
                     ]
                 },
@@ -695,13 +695,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, child_Horsepower_Miles_per_Gallon_width)"
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, child_Horsepower_Miles_per_Gallon_width)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, child_Horsepower_Miles_per_Gallon_width)"
+                            "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, child_Horsepower_Miles_per_Gallon_width)"
                         }
                     ]
                 },
@@ -762,13 +762,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, child_Horsepower_Miles_per_Gallon_height)"
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_y, brush_translate_delta.y / span(brush_translate_anchor.extent_y)), 0, child_Horsepower_Miles_per_Gallon_height)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, child_Horsepower_Miles_per_Gallon_height)"
+                            "update": "clampRange(zoomLinear(brush_y, brush_zoom_anchor.y, brush_zoom_delta), 0, child_Horsepower_Miles_per_Gallon_height)"
                         }
                     ]
                 },
@@ -835,7 +835,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit) - brush_translate_anchor.x, y: y(unit) - brush_translate_anchor.y}"
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
                         }
                     ]
                 },
@@ -894,13 +894,13 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / child_Horsepower_Miles_per_Gallon_width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / child_Horsepower_Miles_per_Gallon_width]"
+                            "update": "panLinear(grid_translate_anchor.extent_x, -grid_translate_delta.x / child_Horsepower_Miles_per_Gallon_width)"
                         },
                         {
                             "events": {
                                 "signal": "grid_zoom_delta"
                             },
-                            "update": "[grid_zoom_anchor.x + (domain(\"child_Horsepower_Miles_per_Gallon_x\")[0] - grid_zoom_anchor.x) * grid_zoom_delta, grid_zoom_anchor.x + (domain(\"child_Horsepower_Miles_per_Gallon_x\")[1] - grid_zoom_anchor.x) * grid_zoom_delta]"
+                            "update": "zoomLinear(domain(\"child_Horsepower_Miles_per_Gallon_x\"), grid_zoom_anchor.x, grid_zoom_delta)"
                         }
                     ],
                     "push": "outer"
@@ -912,13 +912,13 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_Horsepower_Miles_per_Gallon_height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_Horsepower_Miles_per_Gallon_height]"
+                            "update": "panLinear(grid_translate_anchor.extent_y, grid_translate_delta.y / child_Horsepower_Miles_per_Gallon_height)"
                         },
                         {
                             "events": {
                                 "signal": "grid_zoom_delta"
                             },
-                            "update": "[grid_zoom_anchor.y + (domain(\"child_Horsepower_Miles_per_Gallon_y\")[0] - grid_zoom_anchor.y) * grid_zoom_delta, grid_zoom_anchor.y + (domain(\"child_Horsepower_Miles_per_Gallon_y\")[1] - grid_zoom_anchor.y) * grid_zoom_delta]"
+                            "update": "zoomLinear(domain(\"child_Horsepower_Miles_per_Gallon_y\"), grid_zoom_anchor.y, grid_zoom_delta)"
                         }
                     ],
                     "push": "outer"
@@ -969,7 +969,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit) - grid_translate_anchor.x, y: y(unit) - grid_translate_anchor.y}"
+                            "update": "{x: grid_translate_anchor.x - x(unit), y: grid_translate_anchor.y - y(unit)}"
                         }
                     ]
                 },
@@ -1255,13 +1255,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, child_Acceleration_Horsepower_width)"
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, child_Acceleration_Horsepower_width)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, child_Acceleration_Horsepower_width)"
+                            "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, child_Acceleration_Horsepower_width)"
                         }
                     ]
                 },
@@ -1322,13 +1322,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, child_Acceleration_Horsepower_height)"
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_y, brush_translate_delta.y / span(brush_translate_anchor.extent_y)), 0, child_Acceleration_Horsepower_height)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, child_Acceleration_Horsepower_height)"
+                            "update": "clampRange(zoomLinear(brush_y, brush_zoom_anchor.y, brush_zoom_delta), 0, child_Acceleration_Horsepower_height)"
                         }
                     ]
                 },
@@ -1395,7 +1395,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit) - brush_translate_anchor.x, y: y(unit) - brush_translate_anchor.y}"
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
                         }
                     ]
                 },
@@ -1454,13 +1454,13 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / child_Acceleration_Horsepower_width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / child_Acceleration_Horsepower_width]"
+                            "update": "panLinear(grid_translate_anchor.extent_x, -grid_translate_delta.x / child_Acceleration_Horsepower_width)"
                         },
                         {
                             "events": {
                                 "signal": "grid_zoom_delta"
                             },
-                            "update": "[grid_zoom_anchor.x + (domain(\"child_Acceleration_Horsepower_x\")[0] - grid_zoom_anchor.x) * grid_zoom_delta, grid_zoom_anchor.x + (domain(\"child_Acceleration_Horsepower_x\")[1] - grid_zoom_anchor.x) * grid_zoom_delta]"
+                            "update": "zoomLinear(domain(\"child_Acceleration_Horsepower_x\"), grid_zoom_anchor.x, grid_zoom_delta)"
                         }
                     ],
                     "push": "outer"
@@ -1472,13 +1472,13 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_Acceleration_Horsepower_height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_Acceleration_Horsepower_height]"
+                            "update": "panLinear(grid_translate_anchor.extent_y, grid_translate_delta.y / child_Acceleration_Horsepower_height)"
                         },
                         {
                             "events": {
                                 "signal": "grid_zoom_delta"
                             },
-                            "update": "[grid_zoom_anchor.y + (domain(\"child_Acceleration_Horsepower_y\")[0] - grid_zoom_anchor.y) * grid_zoom_delta, grid_zoom_anchor.y + (domain(\"child_Acceleration_Horsepower_y\")[1] - grid_zoom_anchor.y) * grid_zoom_delta]"
+                            "update": "zoomLinear(domain(\"child_Acceleration_Horsepower_y\"), grid_zoom_anchor.y, grid_zoom_delta)"
                         }
                     ],
                     "push": "outer"
@@ -1529,7 +1529,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit) - grid_translate_anchor.x, y: y(unit) - grid_translate_anchor.y}"
+                            "update": "{x: grid_translate_anchor.x - x(unit), y: grid_translate_anchor.y - y(unit)}"
                         }
                     ]
                 },
@@ -1815,13 +1815,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, child_Acceleration_Miles_per_Gallon_width)"
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, child_Acceleration_Miles_per_Gallon_width)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, child_Acceleration_Miles_per_Gallon_width)"
+                            "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, child_Acceleration_Miles_per_Gallon_width)"
                         }
                     ]
                 },
@@ -1882,13 +1882,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, child_Acceleration_Miles_per_Gallon_height)"
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_y, brush_translate_delta.y / span(brush_translate_anchor.extent_y)), 0, child_Acceleration_Miles_per_Gallon_height)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, child_Acceleration_Miles_per_Gallon_height)"
+                            "update": "clampRange(zoomLinear(brush_y, brush_zoom_anchor.y, brush_zoom_delta), 0, child_Acceleration_Miles_per_Gallon_height)"
                         }
                     ]
                 },
@@ -1955,7 +1955,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit) - brush_translate_anchor.x, y: y(unit) - brush_translate_anchor.y}"
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
                         }
                     ]
                 },
@@ -2014,13 +2014,13 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / child_Acceleration_Miles_per_Gallon_width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / child_Acceleration_Miles_per_Gallon_width]"
+                            "update": "panLinear(grid_translate_anchor.extent_x, -grid_translate_delta.x / child_Acceleration_Miles_per_Gallon_width)"
                         },
                         {
                             "events": {
                                 "signal": "grid_zoom_delta"
                             },
-                            "update": "[grid_zoom_anchor.x + (domain(\"child_Acceleration_Miles_per_Gallon_x\")[0] - grid_zoom_anchor.x) * grid_zoom_delta, grid_zoom_anchor.x + (domain(\"child_Acceleration_Miles_per_Gallon_x\")[1] - grid_zoom_anchor.x) * grid_zoom_delta]"
+                            "update": "zoomLinear(domain(\"child_Acceleration_Miles_per_Gallon_x\"), grid_zoom_anchor.x, grid_zoom_delta)"
                         }
                     ],
                     "push": "outer"
@@ -2032,13 +2032,13 @@
                             "events": {
                                 "signal": "grid_translate_delta"
                             },
-                            "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_Acceleration_Miles_per_Gallon_height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / child_Acceleration_Miles_per_Gallon_height]"
+                            "update": "panLinear(grid_translate_anchor.extent_y, grid_translate_delta.y / child_Acceleration_Miles_per_Gallon_height)"
                         },
                         {
                             "events": {
                                 "signal": "grid_zoom_delta"
                             },
-                            "update": "[grid_zoom_anchor.y + (domain(\"child_Acceleration_Miles_per_Gallon_y\")[0] - grid_zoom_anchor.y) * grid_zoom_delta, grid_zoom_anchor.y + (domain(\"child_Acceleration_Miles_per_Gallon_y\")[1] - grid_zoom_anchor.y) * grid_zoom_delta]"
+                            "update": "zoomLinear(domain(\"child_Acceleration_Miles_per_Gallon_y\"), grid_zoom_anchor.y, grid_zoom_delta)"
                         }
                     ],
                     "push": "outer"
@@ -2089,7 +2089,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit) - grid_translate_anchor.x, y: y(unit) - grid_translate_anchor.y}"
+                            "update": "{x: grid_translate_anchor.x - x(unit), y: grid_translate_anchor.y - y(unit)}"
                         }
                     ]
                 },

--- a/examples/vg-specs/layered_crossfilter.vg.json
+++ b/examples/vg-specs/layered_crossfilter.vg.json
@@ -487,13 +487,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, child_distance_layer_0_width)"
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, child_distance_layer_0_width)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, child_distance_layer_0_width)"
+                            "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, child_distance_layer_0_width)"
                         }
                     ]
                 },
@@ -555,7 +555,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit) - brush_translate_anchor.x, y: y(unit) - brush_translate_anchor.y}"
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
                         }
                     ]
                 },
@@ -941,13 +941,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, child_delay_layer_0_width)"
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, child_delay_layer_0_width)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, child_delay_layer_0_width)"
+                            "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, child_delay_layer_0_width)"
                         }
                     ]
                 },
@@ -1009,7 +1009,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit) - brush_translate_anchor.x, y: y(unit) - brush_translate_anchor.y}"
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
                         }
                     ]
                 },
@@ -1395,13 +1395,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, child_time_layer_0_width)"
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, child_time_layer_0_width)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, child_time_layer_0_width)"
+                            "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, child_time_layer_0_width)"
                         }
                     ]
                 },
@@ -1463,7 +1463,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit) - brush_translate_anchor.x, y: y(unit) - brush_translate_anchor.y}"
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
                         }
                     ]
                 },

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -141,13 +141,13 @@
                     "events": {
                         "signal": "grid_translate_delta"
                     },
-                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / layer_0_width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / layer_0_width]"
+                    "update": "panLinear(grid_translate_anchor.extent_x, -grid_translate_delta.x / layer_0_width)"
                 },
                 {
                     "events": {
                         "signal": "grid_zoom_delta"
                     },
-                    "update": "[grid_zoom_anchor.x + (domain(\"x\")[0] - grid_zoom_anchor.x) * grid_zoom_delta, grid_zoom_anchor.x + (domain(\"x\")[1] - grid_zoom_anchor.x) * grid_zoom_delta]"
+                    "update": "zoomLinear(domain(\"x\"), grid_zoom_anchor.x, grid_zoom_delta)"
                 }
             ],
             "push": "outer"
@@ -159,13 +159,13 @@
                     "events": {
                         "signal": "grid_translate_delta"
                     },
-                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / layer_0_height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / layer_0_height]"
+                    "update": "panLinear(grid_translate_anchor.extent_y, grid_translate_delta.y / layer_0_height)"
                 },
                 {
                     "events": {
                         "signal": "grid_zoom_delta"
                     },
-                    "update": "[grid_zoom_anchor.y + (domain(\"y\")[0] - grid_zoom_anchor.y) * grid_zoom_delta, grid_zoom_anchor.y + (domain(\"y\")[1] - grid_zoom_anchor.y) * grid_zoom_delta]"
+                    "update": "zoomLinear(domain(\"y\"), grid_zoom_anchor.y, grid_zoom_delta)"
                 }
             ],
             "push": "outer"
@@ -216,7 +216,7 @@
                             ]
                         }
                     ],
-                    "update": "{x: x(unit) - grid_translate_anchor.x, y: y(unit) - grid_translate_anchor.y}"
+                    "update": "{x: grid_translate_anchor.x - x(unit), y: grid_translate_anchor.y - y(unit)}"
                 }
             ]
         },
@@ -321,13 +321,13 @@
                     "events": {
                         "signal": "brush_translate_delta"
                     },
-                    "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, layer_1_width)"
+                    "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, layer_1_width)"
                 },
                 {
                     "events": {
                         "signal": "brush_zoom_delta"
                     },
-                    "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, layer_1_width)"
+                    "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, layer_1_width)"
                 }
             ]
         },
@@ -388,13 +388,13 @@
                     "events": {
                         "signal": "brush_translate_delta"
                     },
-                    "update": "clampRange([brush_translate_anchor.extent_y[0] + brush_translate_delta.y, brush_translate_anchor.extent_y[1] + brush_translate_delta.y], 0, layer_1_height)"
+                    "update": "clampRange(panLinear(brush_translate_anchor.extent_y, brush_translate_delta.y / span(brush_translate_anchor.extent_y)), 0, layer_1_height)"
                 },
                 {
                     "events": {
                         "signal": "brush_zoom_delta"
                     },
-                    "update": "clampRange([brush_zoom_anchor.y + (brush_y[0] - brush_zoom_anchor.y) * brush_zoom_delta, brush_zoom_anchor.y + (brush_y[1] - brush_zoom_anchor.y) * brush_zoom_delta], 0, layer_1_height)"
+                    "update": "clampRange(zoomLinear(brush_y, brush_zoom_anchor.y, brush_zoom_delta), 0, layer_1_height)"
                 }
             ]
         },
@@ -461,7 +461,7 @@
                             ]
                         }
                     ],
-                    "update": "{x: x(unit) - brush_translate_anchor.x, y: y(unit) - brush_translate_anchor.y}"
+                    "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
                 }
             ]
         },

--- a/examples/vg-specs/overview_detail.vg.json
+++ b/examples/vg-specs/overview_detail.vg.json
@@ -169,13 +169,13 @@
                             "events": {
                                 "signal": "brush_translate_delta"
                             },
-                            "update": "clampRange([brush_translate_anchor.extent_x[0] + brush_translate_delta.x, brush_translate_anchor.extent_x[1] + brush_translate_delta.x], 0, concat_0_width)"
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, concat_0_width)"
                         },
                         {
                             "events": {
                                 "signal": "brush_zoom_delta"
                             },
-                            "update": "clampRange([brush_zoom_anchor.x + (brush_x[0] - brush_zoom_anchor.x) * brush_zoom_delta, brush_zoom_anchor.x + (brush_x[1] - brush_zoom_anchor.x) * brush_zoom_delta], 0, concat_0_width)"
+                            "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, concat_0_width)"
                         }
                     ]
                 },
@@ -237,7 +237,7 @@
                                     ]
                                 }
                             ],
-                            "update": "{x: x(unit) - brush_translate_anchor.x, y: y(unit) - brush_translate_anchor.y}"
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
                         }
                     ]
                 },

--- a/examples/vg-specs/panzoom_scatter.vg.json
+++ b/examples/vg-specs/panzoom_scatter.vg.json
@@ -58,13 +58,13 @@
                     "events": {
                         "signal": "grid_translate_delta"
                     },
-                    "update": "[grid_translate_anchor.extent_x[0] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / width, grid_translate_anchor.extent_x[1] - span(grid_translate_anchor.extent_x) * grid_translate_delta.x / width]"
+                    "update": "panLinear(grid_translate_anchor.extent_x, -grid_translate_delta.x / width)"
                 },
                 {
                     "events": {
                         "signal": "grid_zoom_delta"
                     },
-                    "update": "[grid_zoom_anchor.x + (domain(\"x\")[0] - grid_zoom_anchor.x) * grid_zoom_delta, grid_zoom_anchor.x + (domain(\"x\")[1] - grid_zoom_anchor.x) * grid_zoom_delta]"
+                    "update": "zoomLinear(domain(\"x\"), grid_zoom_anchor.x, grid_zoom_delta)"
                 }
             ]
         },
@@ -75,13 +75,13 @@
                     "events": {
                         "signal": "grid_translate_delta"
                     },
-                    "update": "[grid_translate_anchor.extent_y[0] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / height, grid_translate_anchor.extent_y[1] + span(grid_translate_anchor.extent_y) * grid_translate_delta.y / height]"
+                    "update": "panLinear(grid_translate_anchor.extent_y, grid_translate_delta.y / height)"
                 },
                 {
                     "events": {
                         "signal": "grid_zoom_delta"
                     },
-                    "update": "[grid_zoom_anchor.y + (domain(\"y\")[0] - grid_zoom_anchor.y) * grid_zoom_delta, grid_zoom_anchor.y + (domain(\"y\")[1] - grid_zoom_anchor.y) * grid_zoom_delta]"
+                    "update": "zoomLinear(domain(\"y\"), grid_zoom_anchor.y, grid_zoom_delta)"
                 }
             ]
         },
@@ -126,7 +126,7 @@
                             ]
                         }
                     ],
-                    "update": "{x: x(unit) - grid_translate_anchor.x, y: y(unit) - grid_translate_anchor.y}"
+                    "update": "{x: grid_translate_anchor.x - x(unit), y: grid_translate_anchor.y - y(unit)}"
                 }
             ]
         },

--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -1,12 +1,12 @@
 import {Axis, AXIS_PROPERTIES, AxisEncoding, VG_AXIS_PROPERTIES} from '../../axis';
-import {Channel, SPATIAL_SCALE_CHANNELS, SpatialScaleChannel} from '../../channel';
+import {SPATIAL_SCALE_CHANNELS, SpatialScaleChannel} from '../../channel';
 import {ResolveMode} from '../../resolve';
-import {Dict, keys, some} from '../../util';
+import {keys, some} from '../../util';
 import {AxisOrient} from '../../vega.schema';
 import {VgAxis, VgAxisEncode} from '../../vega.schema';
 import {titleMerger} from '../common';
 import {LayerModel} from '../layer';
-import {defaultTieBreaker, Explicit, mergeValuesWithExplicit, Split} from '../split';
+import {defaultTieBreaker, Explicit, mergeValuesWithExplicit} from '../split';
 import {UnitModel} from '../unit';
 import {AxisComponent, AxisComponentIndex, AxisComponentPart} from './component';
 import * as encode from './encode';
@@ -276,7 +276,8 @@ function getSpecifiedOrDefaultValue<K extends keyof (Axis|VgAxis)>(property: K, 
     case 'labels':
       return isGridAxis ? false : specifiedAxis.labels;
     case 'labelOverlap':
-      return rules.labelOverlap(fieldDef, specifiedAxis, channel, isGridAxis);  // TODO: scaleType
+      const scaleType = model.component.scales[channel].get('type');
+      return rules.labelOverlap(fieldDef, specifiedAxis, channel, isGridAxis, scaleType);
     case 'domain':
       return rules.domain(property, specifiedAxis, isGridAxis, channel);
     case 'ticks':

--- a/src/compile/axis/rules.ts
+++ b/src/compile/axis/rules.ts
@@ -5,6 +5,7 @@ import {Config} from '../../config';
 import {DateTime, dateTimeExpr, isDateTime} from '../../datetime';
 import {FieldDef, title as fieldDefTitle} from '../../fielddef';
 import * as log from '../../log';
+import {ScaleType} from '../../scale';
 import {truncate} from '../../util';
 import {VgAxis} from '../../vega.schema';
 import {numberFormat} from '../common';
@@ -136,9 +137,11 @@ export function domainAndTicks(property: keyof VgAxis, specifiedAxis: Axis, isGr
   return specifiedAxis[property];
 }
 
-export function labelOverlap(fieldDef: FieldDef<string>, specifiedAxis: Axis, channel: Channel, isGridAxis: boolean) {
-  // TODO: use true for non-log continuous scales, and use "greedy" for log scales
+export function labelOverlap(fieldDef: FieldDef<string>, specifiedAxis: Axis, channel: Channel, isGridAxis: boolean, scaleType: ScaleType) {
   if (!isGridAxis && channel === 'x' && !labelAngle(specifiedAxis, channel, fieldDef)) {
+    if (scaleType === 'log') {
+      return 'greedy';
+    }
     return true;
   }
   return undefined;

--- a/src/compile/selection/transforms/translate.ts
+++ b/src/compile/selection/transforms/translate.ts
@@ -1,5 +1,5 @@
 import {selector as parseSelector} from 'vega-event-selector';
-import {Channel, X, Y} from '../../../channel';
+import {Channel, ScaleChannel, X, Y} from '../../../channel';
 import {stringValue} from '../../../util';
 import {BRUSH as INTERVAL_BRUSH, projections as intervalProjections} from '../interval';
 import {channelSignalName, SelectionComponent} from '../selection';
@@ -64,29 +64,31 @@ export {translate as default};
 
 function getSign(selCmpt: SelectionComponent, channel: Channel) {
   if (scalesCompiler.has(selCmpt)) {
-    return channel === Y ? '+' : '-';
+    return channel === Y ? '-' : '+';
   }
-  return '+';
+  return '-';
 }
 
-function onDelta(model: UnitModel, selCmpt: SelectionComponent, channel: Channel, size: 'width' | 'height', signals: any[]) {
+function onDelta(model: UnitModel, selCmpt: SelectionComponent, channel: ScaleChannel, size: 'width' | 'height', signals: any[]) {
   const name = selCmpt.name;
   const hasScales = scalesCompiler.has(selCmpt);
   const signal:any = signals.filter((s:any) => {
     return s.name === channelSignalName(selCmpt, channel, hasScales ? 'data' : 'visual');
   })[0];
-  const sizeSg = model.getSizeSignalRef(size).signal;
   const anchor = name + ANCHOR;
   const delta  = name + DELTA;
+  const sizeSg = model.getSizeSignalRef(size).signal;
+  const scaleType = model.getScaleComponent(channel).get('type');
   const sign = getSign(selCmpt, channel);
-  const offset = sign + (hasScales ?
-    ` span(${anchor}.extent_${channel}) * ${delta}.${channel} / ${sizeSg}` :
-    ` ${delta}.${channel}`);
   const extent = `${anchor}.extent_${channel}`;
-  const range = `[${extent}[0] ${offset}, ${extent}[1] ${offset}]`;
+  const offset = `${sign}${delta}.${channel} / ` + (hasScales ? `${sizeSg}` : `span(${extent})`);
+  const panFn = !hasScales ? 'panLinear' :
+    scaleType === 'log' ? 'panLog' :
+    scaleType === 'pow' ? 'panPow' : 'panLinear';
+  const update = `${panFn}(${extent}, ${offset})`;
 
   signal.on.push({
     events: {signal: delta},
-    update: hasScales ? range : `clampRange(${range}, 0, ${sizeSg})`
+    update: hasScales ? update : `clampRange(${update}, 0, ${sizeSg})`
   });
 }

--- a/src/compile/selection/transforms/translate.ts
+++ b/src/compile/selection/transforms/translate.ts
@@ -44,7 +44,7 @@ const translate:TransformCompiler = {
       value: {},
       on: [{
         events: events,
-        update: `{x: x(unit) - ${anchor}.x, y: y(unit) - ${anchor}.y}`
+        update: `{x: ${anchor}.x - x(unit), y: ${anchor}.y - y(unit)}`
       }]
     });
 
@@ -62,13 +62,6 @@ const translate:TransformCompiler = {
 
 export {translate as default};
 
-function getSign(selCmpt: SelectionComponent, channel: Channel) {
-  if (scalesCompiler.has(selCmpt)) {
-    return channel === Y ? '-' : '+';
-  }
-  return '-';
-}
-
 function onDelta(model: UnitModel, selCmpt: SelectionComponent, channel: ScaleChannel, size: 'width' | 'height', signals: any[]) {
   const name = selCmpt.name;
   const hasScales = scalesCompiler.has(selCmpt);
@@ -79,7 +72,7 @@ function onDelta(model: UnitModel, selCmpt: SelectionComponent, channel: ScaleCh
   const delta  = name + DELTA;
   const sizeSg = model.getSizeSignalRef(size).signal;
   const scaleType = model.getScaleComponent(channel).get('type');
-  const sign = getSign(selCmpt, channel);
+  const sign = hasScales && channel === X ? '-' : ''; // Invert delta when panning x-scales.
   const extent = `${anchor}.extent_${channel}`;
   const offset = `${sign}${delta}.${channel} / ` + (hasScales ? `${sizeSg}` : `span(${extent})`);
   const panFn = !hasScales ? 'panLinear' :

--- a/test/compile/selection/zoom.test.ts
+++ b/test/compile/selection/zoom.test.ts
@@ -4,14 +4,15 @@ import {assert} from 'chai';
 import {selector as parseSelector} from 'vega-event-selector';
 import * as selection from '../../../src/compile/selection/selection';
 import zoom from '../../../src/compile/selection/transforms/zoom';
+import {ScaleType} from '../../../src/scale';
 import {parseUnitModel} from '../../util';
 
-describe('Zoom Selection Transform', function() {
+function getModel(xscale?: ScaleType, yscale?: ScaleType) {
   const model = parseUnitModel({
     "mark": "circle",
     "encoding": {
-      "x": {"field": "Horsepower","type": "quantitative"},
-      "y": {"field": "Miles_per_Gallon","type": "quantitative"},
+      "x": {"field": "Horsepower","type": "quantitative", "scale": {"type": xscale || "linear"}},
+      "y": {"field": "Miles_per_Gallon","type": "quantitative", "scale": {"type": yscale || "linear"}},
       "color": {"field": "Origin", "type": "nominal"}
     }
   });
@@ -44,7 +45,13 @@ describe('Zoom Selection Transform', function() {
     "seven": {"type": "interval", "zoom": null}
   });
 
+  return {model, selCmpts};
+}
+
+describe('Zoom Selection Transform', function() {
+
   it('identifies transform invocation', function() {
+    const {model, selCmpts} = getModel();
     assert.isNotTrue(zoom.has(selCmpts['one']));
     assert.isNotTrue(zoom.has(selCmpts['two']));
     assert.isNotTrue(zoom.has(selCmpts['three']));
@@ -54,123 +61,165 @@ describe('Zoom Selection Transform', function() {
     assert.isNotTrue(zoom.has(selCmpts['seven']));
   });
 
-  it('builds signals for default invocation', function() {
-    model.component.selection = {four: selCmpts['four']};
-    const signals = selection.assembleUnitSelectionSignals(model, []);
-    assert.includeDeepMembers(signals, [
-      {
-        "name": "four_zoom_anchor",
-        "on": [
-          {
-            "events": parseSelector('@four_brush:wheel', 'scope'),
-            "update": "{x: x(unit), y: y(unit)}"
-          }
-        ]
-      },
-      {
-        "name": "four_zoom_delta",
-        "on": [
-          {
-            "events": parseSelector('@four_brush:wheel', 'scope'),
-            "force": true,
-            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-          }
-        ]
-      }
-    ]);
+  describe('Anchor/Delta signals', function() {
+    it('builds then for default invocation', function() {
+      const {model, selCmpts} = getModel();
+      model.component.selection = {four: selCmpts['four']};
+      const signals = selection.assembleUnitSelectionSignals(model, []);
+      assert.includeDeepMembers(signals, [
+        {
+          "name": "four_zoom_anchor",
+          "on": [
+            {
+              "events": parseSelector('@four_brush:wheel', 'scope'),
+              "update": "{x: x(unit), y: y(unit)}"
+            }
+          ]
+        },
+        {
+          "name": "four_zoom_delta",
+          "on": [
+            {
+              "events": parseSelector('@four_brush:wheel', 'scope'),
+              "force": true,
+              "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+            }
+          ]
+        }
+      ]);
+    });
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_x')[0].on, [
-      {
-        "events": {"signal": "four_zoom_delta"},
-        "update": "clampRange([four_zoom_anchor.x + (four_x[0] - four_zoom_anchor.x) * four_zoom_delta, four_zoom_anchor.x + (four_x[1] - four_zoom_anchor.x) * four_zoom_delta], 0, width)"
-      }
-    ]);
+    it('builds them for custom events', function() {
+      const {model, selCmpts} = getModel();
+      model.component.selection = {five: selCmpts['five']};
+      const signals = selection.assembleUnitSelectionSignals(model, []);
+      assert.includeDeepMembers(signals, [
+        {
+          "name": "five_zoom_anchor",
+          "on": [
+            {
+              "events": parseSelector('@five_brush:wheel, @five_brush:pinch', 'scope'),
+              "update": "{x: x(unit), y: y(unit)}"
+            }
+          ]
+        },
+        {
+          "name": "five_zoom_delta",
+          "on": [
+            {
+              "events": parseSelector('@five_brush:wheel, @five_brush:pinch', 'scope'),
+              "force": true,
+              "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+            }
+          ]
+        }
+      ]);
+    });
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'four_y')[0].on, [
-      {
-        "events": {"signal": "four_zoom_delta"},
-        "update": "clampRange([four_zoom_anchor.y + (four_y[0] - four_zoom_anchor.y) * four_zoom_delta, four_zoom_anchor.y + (four_y[1] - four_zoom_anchor.y) * four_zoom_delta], 0, height)"
-      }
-    ]);
+    it('builds them for scale-bound zoom', function() {
+      const {model, selCmpts} = getModel();
+      model.component.selection = {six: selCmpts['six']};
+      const signals = selection.assembleUnitSelectionSignals(model, []);
+      assert.includeDeepMembers(signals, [
+        {
+          "name": "six_zoom_anchor",
+          "on": [
+            {
+              "events": parseSelector('wheel', 'scope'),
+              "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
+            }
+          ]
+        },
+        {
+          "name": "six_zoom_delta",
+          "on": [
+            {
+              "events": parseSelector('wheel', 'scope'),
+              "force": true,
+              "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+            }
+          ]
+        }
+      ]);
+    });
   });
 
-  it('builds signals for custom events', function() {
-    model.component.selection = {five: selCmpts['five']};
-    const signals = selection.assembleUnitSelectionSignals(model, []);
-    assert.includeDeepMembers(signals, [
-      {
-        "name": "five_zoom_anchor",
-        "on": [
-          {
-            "events": parseSelector('@five_brush:wheel, @five_brush:pinch', 'scope'),
-            "update": "{x: x(unit), y: y(unit)}"
-          }
-        ]
-      },
-      {
-        "name": "five_zoom_delta",
-        "on": [
-          {
-            "events": parseSelector('@five_brush:wheel, @five_brush:pinch', 'scope'),
-            "force": true,
-            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-          }
-        ]
-      }
-    ]);
+  describe('Zoom Signal', function() {
+    it('always builds zoomLinear exprs for brushes', function() {
+      const {model, selCmpts} = getModel();
+      model.component.selection = {four: selCmpts['four']};
+      let signals = selection.assembleUnitSelectionSignals(model, []);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_x')[0].on, [
-      {
-        "events": {"signal": "five_zoom_delta"},
-        "update": "clampRange([five_zoom_anchor.x + (five_x[0] - five_zoom_anchor.x) * five_zoom_delta, five_zoom_anchor.x + (five_x[1] - five_zoom_anchor.x) * five_zoom_delta], 0, width)"
-      }
-    ]);
+      assert.includeDeepMembers(signals.filter((s) => s.name === 'four_x')[0].on, [
+        {
+          "events": {"signal": "four_zoom_delta"},
+          "update": "clampRange(zoomLinear(four_x, four_zoom_anchor.x, four_zoom_delta), 0, width)"
+        }
+      ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'five_y')[0].on, [
-      {
-        "events": {"signal": "five_zoom_delta"},
-        "update": "clampRange([five_zoom_anchor.y + (five_y[0] - five_zoom_anchor.y) * five_zoom_delta, five_zoom_anchor.y + (five_y[1] - five_zoom_anchor.y) * five_zoom_delta], 0, height)"
-      }
-    ]);
-  });
+      assert.includeDeepMembers(signals.filter((s) => s.name === 'four_y')[0].on, [
+        {
+          "events": {"signal": "four_zoom_delta"},
+          "update": "clampRange(zoomLinear(four_y, four_zoom_anchor.y, four_zoom_delta), 0, height)"
+        }
+      ]);
 
-  it('builds signals for scale-bound zoom', function() {
-    model.component.selection = {six: selCmpts['six']};
-    const signals = selection.assembleUnitSelectionSignals(model, []);
-    assert.includeDeepMembers(signals, [
-      {
-        "name": "six_zoom_anchor",
-        "on": [
-          {
-            "events": parseSelector('wheel', 'scope'),
-            "update": "{x: invert(\"x\", x(unit)), y: invert(\"y\", y(unit))}"
-          }
-        ]
-      },
-      {
-        "name": "six_zoom_delta",
-        "on": [
-          {
-            "events": parseSelector('wheel', 'scope'),
-            "force": true,
-            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
-          }
-        ]
-      }
-    ]);
+      const model2 = getModel('log', 'pow').model;
+      model2.component.selection = {four: selCmpts['four']};
+      signals = selection.assembleUnitSelectionSignals(model2, []);
+      assert.includeDeepMembers(signals.filter((s) => s.name === 'four_x')[0].on, [
+        {
+          "events": {"signal": "four_zoom_delta"},
+          "update": "clampRange(zoomLinear(four_x, four_zoom_anchor.x, four_zoom_delta), 0, width)"
+        }
+      ]);
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'six_Horsepower')[0].on, [
-      {
-        "events": {"signal": "six_zoom_delta"},
-        "update": "[six_zoom_anchor.x + (domain(\"x\")[0] - six_zoom_anchor.x) * six_zoom_delta, six_zoom_anchor.x + (domain(\"x\")[1] - six_zoom_anchor.x) * six_zoom_delta]"
-      }
-    ]);
+      assert.includeDeepMembers(signals.filter((s) => s.name === 'four_y')[0].on, [
+        {
+          "events": {"signal": "four_zoom_delta"},
+          "update": "clampRange(zoomLinear(four_y, four_zoom_anchor.y, four_zoom_delta), 0, height)"
+        }
+      ]);
+    });
 
-    assert.includeDeepMembers(signals.filter((s) => s.name === 'six_Miles_per_Gallon')[0].on, [
-      {
-        "events": {"signal": "six_zoom_delta"},
-        "update": "[six_zoom_anchor.y + (domain(\"y\")[0] - six_zoom_anchor.y) * six_zoom_delta, six_zoom_anchor.y + (domain(\"y\")[1] - six_zoom_anchor.y) * six_zoom_delta]"
-      }
-    ]);
+    it('builds zoomLinear exprs for scale-bound zoom', function() {
+      const {model, selCmpts} = getModel();
+      model.component.selection = {six: selCmpts['six']};
+      const signals = selection.assembleUnitSelectionSignals(model, []);
+
+      assert.includeDeepMembers(signals.filter((s) => s.name === 'six_Horsepower')[0].on, [
+        {
+          "events": {"signal": "six_zoom_delta"},
+          "update": "zoomLinear(domain(\"x\"), six_zoom_anchor.x, six_zoom_delta)"
+        }
+      ]);
+
+      assert.includeDeepMembers(signals.filter((s) => s.name === 'six_Miles_per_Gallon')[0].on, [
+        {
+          "events": {"signal": "six_zoom_delta"},
+          "update": "zoomLinear(domain(\"y\"), six_zoom_anchor.y, six_zoom_delta)"
+        }
+      ]);
+    });
+
+    it('builds zoomLog/Pow exprs for scale-bound zoom', function() {
+      const {model, selCmpts} = getModel('log', 'pow');
+      model.component.selection = {six: selCmpts['six']};
+      const signals = selection.assembleUnitSelectionSignals(model, []);
+
+      assert.includeDeepMembers(signals.filter((s) => s.name === 'six_Horsepower')[0].on, [
+        {
+          "events": {"signal": "six_zoom_delta"},
+          "update": "zoomLog(domain(\"x\"), six_zoom_anchor.x, six_zoom_delta)"
+        }
+      ]);
+
+      assert.includeDeepMembers(signals.filter((s) => s.name === 'six_Miles_per_Gallon')[0].on, [
+        {
+          "events": {"signal": "six_zoom_delta"},
+          "update": "zoomPow(domain(\"y\"), six_zoom_anchor.y, six_zoom_delta)"
+        }
+      ]);
+    });
   });
 });


### PR DESCRIPTION
This PR updates the translate and zoom selection transforms to use corresponding expression functions (rather than embed the necessary calculation within the signal update function). We added these functions in vega/vega-parser@4d82d86 to support smoother panning/zooming of log and pow scales. Consequently, I've also added pan/zooming to the gapminder example!