### PR TITLE
Add identifier transform for default point selections.

### DIFF
--- a/examples/vg-specs/paintbrush.vg.json
+++ b/examples/vg-specs/paintbrush.vg.json
@@ -26,6 +26,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -62,7 +66,7 @@
                             "type": "mouseover"
                         }
                     ],
-                    "update": "datum && {unit: \"\", encodings: [], fields: [\"_id\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_id\"]]}"
+                    "update": "datum && {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]}"
                 }
             ]
         },

--- a/src/compile/concat.ts
+++ b/src/compile/concat.ts
@@ -76,7 +76,7 @@ export class ConcatModel extends Model {
   public assembleData(): VgData[] {
      if (!this.parent) {
       // only assemble data in the root
-      return assembleData(this.component.data);
+      return assembleData(this, this.component.data);
     }
 
     return [];

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -213,7 +213,7 @@ export class FacetModel extends ModelWithField {
   public assembleData(): VgData[] {
     if (!this.parent) {
       // only assemble data in the root
-      return assembleData(this.component.data);
+      return assembleData(this, this.component.data);
     }
 
     return [];

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -122,7 +122,7 @@ export class LayerModel extends Model {
   public assembleData(): VgData[] {
      if (!this.parent) {
       // only assemble data in the root
-      return assembleData(this.component.data);
+      return assembleData(this, this.component.data);
     }
     return [];
   }

--- a/src/compile/repeat.ts
+++ b/src/compile/repeat.ts
@@ -150,7 +150,7 @@ export class RepeatModel extends Model {
   public assembleData(): VgData[] {
      if (!this.parent) {
       // only assemble data in the root
-      return assembleData(this.component.data);
+      return assembleData(this, this.component.data);
     }
 
     return [];

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -215,7 +215,7 @@ export class UnitModel extends ModelWithField {
   public assembleData(): VgData[] {
      if (!this.parent) {
       // only assemble data in the root
-      return assembleData(this.component.data);
+      return assembleData(this, this.component.data);
     }
     return [];
   }

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,6 +1,8 @@
 import {SingleDefChannel} from './channel';
 import {VgBinding} from './vega.schema';
 
+export const SELECTION_ID = '_vgsid_';
+
 export type SelectionTypes = 'single' | 'multi' | 'interval';
 export type SelectionResolutions = 'global' | 'independent' | 'union' |
   'union_others' | 'intersect' | 'intersect_others';
@@ -65,8 +67,8 @@ export interface SelectionConfig {
 }
 
 export const defaultConfig:SelectionConfig = {
-  single: {on: 'click', fields: ['_id'], resolve: 'global'},
-  multi: {on: 'click', fields: ['_id'], toggle: 'event.shiftKey', resolve: 'global'},
+  single: {on: 'click', fields: [SELECTION_ID], resolve: 'global'},
+  multi: {on: 'click', fields: [SELECTION_ID], toggle: 'event.shiftKey', resolve: 'global'},
   interval: {
     on: '[mousedown, window:mouseup] > window:mousemove!',
     encodings: ['x', 'y'],

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -283,6 +283,20 @@ export interface VgLookupTransform {
   default?: string;
 }
 
+export interface VgStackTransform {
+  type: 'stack';
+  offset?: StackOffset;
+  groupby: string[];
+  field: string;
+  sort: VgSort;
+  as: string[];
+}
+
+export interface VgIdentifierTransform {
+  type: 'identifier';
+  as: string;
+}
+
 export interface VgAxisEncode {
   ticks?: VgGuideEncode;
   labels?: VgGuideEncode;
@@ -301,16 +315,7 @@ export interface VgLegendEncode {
 
 export type VgGuideEncode = any; // TODO: replace this (See guideEncode in Vega Schema)
 
-export type VgTransform = VgBinTransform | VgExtentTransform | VgFormulaTransform | VgAggregateTransform | VgFilterTransform | VgImputeTransform | VgStackTransform | VgCollectTransform | VgLookupTransform;
-
-export interface VgStackTransform {
-  type: 'stack';
-  offset?: StackOffset;
-  groupby: string[];
-  field: string;
-  sort: VgSort;
-  as: string[];
-}
+export type VgTransform = VgBinTransform | VgExtentTransform | VgFormulaTransform | VgAggregateTransform | VgFilterTransform | VgImputeTransform | VgStackTransform | VgCollectTransform | VgLookupTransform | VgIdentifierTransform;
 
 export type VgSort = {
   field: string;

--- a/test/compile/data/assemble.test.ts
+++ b/test/compile/data/assemble.test.ts
@@ -7,6 +7,16 @@ import {OutputNode} from '../../../src/compile/data/dataflow';
 import {SourceNode} from '../../../src/compile/data/source';
 import {Data} from '../../../src/data';
 import {VgData} from '../../../src/vega.schema';
+import {parseUnitModel} from '../../util';
+
+const model = parseUnitModel({
+  "mark": "circle",
+    "encoding": {
+      "x": {"field": "Horsepower","type": "quantitative"},
+      "y": {"field": "Miles-per-Gallon","type": "quantitative"},
+      "color": {"field": "Origin", "type": "nominal"}
+    }
+});
 
 describe('compile/data/assemble', () => {
   describe('assembleData', () => {
@@ -18,7 +28,7 @@ describe('compile/data/assemble', () => {
 
       assert.equal(main.getSource(), 'mainOut');
 
-      const data = assembleData({
+      const data = assembleData(model, {
         sources: {named: src},
         outputNodes: {out: main},
         outputNodeRefCounts,
@@ -43,7 +53,7 @@ describe('compile/data/assemble', () => {
       assert.equal(raw.getSource(), 'rawOut');
       assert.equal(main.getSource(), 'mainOut');
 
-      const data = assembleData({
+      const data = assembleData(model, {
         sources: {named: src},
         outputNodes: {out: main},
         outputNodeRefCounts,

--- a/test/compile/selection/identifier.test.ts
+++ b/test/compile/selection/identifier.test.ts
@@ -1,0 +1,122 @@
+/* tslint:disable:quotemark */
+
+import {assert} from 'chai';
+import {parseModel} from '../../util';
+
+describe('Identifier transform', function() {
+  it('is not unnecessarily added', function() {
+    let model = parseModel({
+      "data": {"values": [1, 2, 3]},
+      "mark": "circle",
+      "encoding": {
+        "x": {"field": "Horsepower","type": "quantitative"},
+        "y": {"field": "Miles-per-Gallon","type": "quantitative"},
+        "color": {"field": "Origin", "type": "nominal"}
+      }
+    });
+    model.parse();
+
+    let data = model.assembleData();
+    assert.isNotTrue(data[0].transform &&
+      data[0].transform.some((t) => t.type === 'identifier'));
+
+    model = parseModel({
+      "data": {"values": [1, 2, 3]},
+      "selection": {
+        "pt": {"type": "single", "encodings": ["x"]}
+      },
+      "mark": "circle",
+      "encoding": {
+        "x": {"field": "Horsepower","type": "quantitative"},
+        "y": {"field": "Miles-per-Gallon","type": "quantitative"},
+        "color": {"field": "Origin", "type": "nominal"}
+      }
+    });
+    model.parse();
+    data = model.assembleData();
+    assert.isNotTrue(data[0].transform &&
+      data[0].transform.some((t) => t.type === 'identifier'));
+  });
+
+  it('is added for default point selections', function() {
+    let model = parseModel({
+      "data": {"values": [1, 2, 3]},
+      "selection": {
+        "pt": {"type": "single"}
+      },
+      "mark": "circle",
+      "encoding": {
+        "x": {"field": "Horsepower","type": "quantitative"},
+        "y": {"field": "Miles-per-Gallon","type": "quantitative"},
+        "color": {"field": "Origin", "type": "nominal"}
+      }
+    });
+    model.parse();
+    let data = model.assembleData();
+    assert.equal(data[0].transform[0].type, 'identifier');
+
+    model = parseModel({
+      "data": {"values": [1, 2, 3]},
+      "selection": {
+        "pt": {"type": "multi"}
+      },
+      "mark": "circle",
+      "encoding": {
+        "x": {"field": "Horsepower","type": "quantitative"},
+        "y": {"field": "Miles-per-Gallon","type": "quantitative"},
+        "color": {"field": "Origin", "type": "nominal"}
+      }
+    });
+    model.parse();
+    data = model.assembleData();
+    assert.equal(data[0].transform[0].type, 'identifier');
+  });
+
+  it('is added after aggregate transforms', function() {
+    let model = parseModel({
+      "data": {"values": [1, 2, 3]},
+      "selection": {
+        "pt": {"type": "single"}
+      },
+      "mark": "circle",
+      "encoding": {
+        "x": {
+          "bin": {"maxbins": 10},
+          "field": "IMDB_Rating",
+          "type": "quantitative"
+        },
+        "y": {
+          "aggregate": "count",
+          "type": "quantitative"
+        }
+      }
+    });
+    model.parse();
+    let data = model.assembleData();
+    const transforms = data[0].transform;
+    assert.equal(transforms[transforms.length-1].type, 'identifier');
+
+    model = parseModel({
+      "data": {"values": [1, 2, 3]},
+      "mark": "bar",
+      "selection": {
+        "pt": {"type": "single"}
+      },
+      "encoding": {
+        "column": {"field": "year","type": "ordinal"},
+        "x": {"field": "yield","type": "quantitative","aggregate": "sum"},
+        "y": {"field": "variety","type": "nominal"},
+        "color": {"field": "site","type": "nominal"}
+      }
+    });
+
+    model.parse();
+    data = model.assembleData();
+    data.forEach((d) => {
+      let idx = -1;
+      const aggr = d.transform.some((t, i) => (idx = i, t.type === 'aggregate'));
+      const pos = aggr ? idx + 1 : d.transform.length - 1;
+      assert.equal(d.transform[pos].type, 'identifier');
+    });
+  });
+});

--- a/test/compile/selection/inputs.test.ts
+++ b/test/compile/selection/inputs.test.ts
@@ -56,18 +56,18 @@ describe('Inputs Selection Transform', function() {
     assert.includeDeepMembers(selection.assembleUnitSelectionSignals(model, []), [
       {
         "name": "one_tuple",
-        "update": "{fields: [\"_id\"], values: [one__id]}"
+        "update": "{fields: [\"_vgsid_\"], values: [one__vgsid_]}"
       }
     ]);
 
     assert.includeDeepMembers(selection.assembleTopLevelSignals(model, []), [
       {
-        "name": "one__id",
+        "name": "one__vgsid_",
         "value": "",
         "on": [
           {
             "events": [{"source": "scope","type": "click"}],
-            "update": "datum && datum[\"_id\"]"
+            "update": "datum && datum[\"_vgsid_\"]"
           }
         ],
         "bind": {"input": "range","min": 0,"max": 10,"step": 1}

--- a/test/compile/selection/multi.test.ts
+++ b/test/compile/selection/multi.test.ts
@@ -30,7 +30,7 @@ describe('Multi Selection', function() {
       value: {},
       on: [{
         events: selCmpts['one'].events,
-        update: "datum && {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]}"
+        update: "datum && {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]}"
       }]
     }]);
 

--- a/test/compile/selection/parse.test.ts
+++ b/test/compile/selection/parse.test.ts
@@ -27,13 +27,13 @@ describe('Selection', function() {
 
     assert.equal(component.one.name, 'one');
     assert.equal(component.one.type, 'single');
-    assert.sameDeepMembers(component['one'].project, [{field: '_id', encoding: null}]);
+    assert.sameDeepMembers(component['one'].project, [{field: '_vgsid_', encoding: null}]);
     assert.sameDeepMembers(component['one'].events, parseSelector('click', 'scope'));
 
     assert.equal(component.two.name, 'two');
     assert.equal(component.two.type, 'multi');
     assert.equal(component.two.toggle, 'event.shiftKey');
-    assert.sameDeepMembers(component['two'].project, [{field: '_id', encoding: null}]);
+    assert.sameDeepMembers(component['two'].project, [{field: '_vgsid_', encoding: null}]);
     assert.sameDeepMembers(component['two'].events, parseSelector('click', 'scope'));
 
     assert.equal(component.three.name, 'three');

--- a/test/compile/selection/single.test.ts
+++ b/test/compile/selection/single.test.ts
@@ -30,7 +30,7 @@ describe('Single Selection', function() {
       value: {},
       on: [{
         events: selCmpts['one'].events,
-        update: "datum && {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]}"
+        update: "datum && {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]}"
       }]
     }]);
 
@@ -81,7 +81,7 @@ describe('Single Selection', function() {
   it('builds top-level signals', function() {
     const oneSg = single.topLevelSignals(model, selCmpts['one'], []);
     assert.sameDeepMembers(oneSg, [{
-      name: 'one', update: 'data(\"one_store\").length && {_id: data(\"one_store\")[0].values[0]}'
+      name: 'one', update: 'data(\"one_store\").length && {_vgsid_: data(\"one_store\")[0].values[0]}'
     }]);
 
     const twoSg = single.topLevelSignals(model, selCmpts['two'], []);


### PR DESCRIPTION
Fixes #2221. Default point selections are projected over an ID field. However, the default `_id` is volatile -- if the spec is parsed again, different IDs may be generated based on global Vega state. As a result, breaks the ability to snapshot state via view.getState/setState.

With vega/vega-view#10, an identifier transform was introduced which persists its state in an internal signal. This transform is added whenever new tuples are derived (i.e., at the source and post-aggregation).