### PR TITLE
Fix scale trigger coercion to only occur for continuous scales.

### DIFF
--- a/examples/specs/dashboard_europe_pop.vl.json
+++ b/examples/specs/dashboard_europe_pop.vl.json
@@ -1,0 +1,383 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+  "data": {
+    "values": [
+      {
+        "Code": "ALB",
+        "Country": "Albania",
+        "Population_ages_15_64_of_total": 69.0574620108062,
+        "Population_ages_65_and_above_of_total": 12.3963338706153
+      },
+      {
+        "Code": "ARM",
+        "Country": "Armenia",
+        "Population_ages_15_64_of_total": 70.7901217876325,
+        "Population_ages_65_and_above_of_total": 10.8259833940416
+      },
+      {
+        "Code": "AUT",
+        "Country": "Austria",
+        "Population_ages_15_64_of_total": 67.0332301646914,
+        "Population_ages_65_and_above_of_total": 18.7591300503032
+      },
+      {
+        "Code": "AZE",
+        "Country": "Azerbaijan",
+        "Population_ages_15_64_of_total": 72.4553638068118,
+        "Population_ages_65_and_above_of_total": 5.62608981288436
+      },
+      {
+        "Code": "BLR",
+        "Country": "Belarus",
+        "Population_ages_15_64_of_total": 69.9508710458679,
+        "Population_ages_65_and_above_of_total": 13.9809217228707
+      },
+      {
+        "Code": "BEL",
+        "Country": "Belgium",
+        "Population_ages_15_64_of_total": 64.8307418795963,
+        "Population_ages_65_and_above_of_total": 18.2248164293518
+      },
+      {
+        "Code": "BIH",
+        "Country": "Bosnia and Herzegovina",
+        "Population_ages_15_64_of_total": 71.0579632250127,
+        "Population_ages_65_and_above_of_total": 15.4439567753232
+      },
+      {
+        "Code": "BGR",
+        "Country": "Bulgaria",
+        "Population_ages_15_64_of_total": 65.8285064995643,
+        "Population_ages_65_and_above_of_total": 20.0274777416446
+      },
+      {
+        "Code": "CHI",
+        "Country": "Channel Islands",
+        "Population_ages_15_64_of_total": 68.022872223444,
+        "Population_ages_65_and_above_of_total": 17.2684065195611
+      },
+      {
+        "Code": "HRV",
+        "Country": "Croatia",
+        "Population_ages_15_64_of_total": 66.1722696675744,
+        "Population_ages_65_and_above_of_total": 18.9370747517226
+      },
+      {
+        "Code": "CYP",
+        "Country": "Cyprus",
+        "Population_ages_15_64_of_total": 70.6035355702394,
+        "Population_ages_65_and_above_of_total": 12.8454475242427
+      },
+      {
+        "Code": "CZE",
+        "Country": "Czech Republic",
+        "Population_ages_15_64_of_total": 66.8821170374875,
+        "Population_ages_65_and_above_of_total": 18.075987656862
+      },
+      {
+        "Code": "DNK",
+        "Country": "Denmark",
+        "Population_ages_15_64_of_total": 64.1595524918413,
+        "Population_ages_65_and_above_of_total": 18.9594398104384
+      },
+      {
+        "Code": "EST",
+        "Country": "Estonia",
+        "Population_ages_15_64_of_total": 65.1524732621339,
+        "Population_ages_65_and_above_of_total": 18.7597043330657
+      },
+      {
+        "Code": "FIN",
+        "Country": "Finland",
+        "Population_ages_15_64_of_total": 63.1844856787288,
+        "Population_ages_65_and_above_of_total": 20.4771837047151
+      },
+      {
+        "Code": "FRA",
+        "Country": "France",
+        "Population_ages_15_64_of_total": 62.3959557946308,
+        "Population_ages_65_and_above_of_total": 19.1205109623995
+      },
+      {
+        "Code": "GEO",
+        "Country": "Georgia",
+        "Population_ages_15_64_of_total": 68.6468764031909,
+        "Population_ages_65_and_above_of_total": 14.0256592059827
+      },
+      {
+        "Code": "DEU",
+        "Country": "Germany",
+        "Population_ages_15_64_of_total": 65.8735239308132,
+        "Population_ages_65_and_above_of_total": 21.2406519413629
+      },
+      {
+        "Code": "GRC",
+        "Country": "Greece",
+        "Population_ages_15_64_of_total": 64.001114781101,
+        "Population_ages_65_and_above_of_total": 21.396558181815
+      },
+      {
+        "Code": "HUN",
+        "Country": "Hungary",
+        "Population_ages_15_64_of_total": 67.6233936744744,
+        "Population_ages_65_and_above_of_total": 17.8178985477761
+      },
+      {
+        "Code": "ISL",
+        "Country": "Iceland",
+        "Population_ages_15_64_of_total": 65.9664567048645,
+        "Population_ages_65_and_above_of_total": 13.7138954238446
+      },
+      {
+        "Code": "IRL",
+        "Country": "Ireland",
+        "Population_ages_15_64_of_total": 65.079935543936,
+        "Population_ages_65_and_above_of_total": 13.1395030143128
+      },
+      {
+        "Code": "ITA",
+        "Country": "Italy",
+        "Population_ages_15_64_of_total": 63.8797421672762,
+        "Population_ages_65_and_above_of_total": 22.4098759007142
+      },
+      {
+        "Code": "KAZ",
+        "Country": "Kazakhstan",
+        "Population_ages_15_64_of_total": 66.5468630019269,
+        "Population_ages_65_and_above_of_total": 6.73573774316427
+      },
+      {
+        "Code": "XKX",
+        "Country": "Kosovo",
+        "Population_ages_15_64_of_total": 67.5956284153006,
+        "Population_ages_65_and_above_of_total": 6.77595628415301
+      },
+      {
+        "Code": "KGZ",
+        "Country": "Kyrgyz Republic",
+        "Population_ages_15_64_of_total": 64.3715060803419,
+        "Population_ages_65_and_above_of_total": 4.22684522224216
+      },
+      {
+        "Code": "LVA",
+        "Country": "Latvia",
+        "Population_ages_15_64_of_total": 65.7100750417533,
+        "Population_ages_65_and_above_of_total": 19.3677959383975
+      },
+      {
+        "Code": "LTU",
+        "Country": "Lithuania",
+        "Population_ages_15_64_of_total": 66.637321711156,
+        "Population_ages_65_and_above_of_total": 18.8477993888977
+      },
+      {
+        "Code": "LUX",
+        "Country": "Luxembourg",
+        "Population_ages_15_64_of_total": 69.5849129798452,
+        "Population_ages_65_and_above_of_total": 13.981414540389
+      },
+      {
+        "Code": "MDA",
+        "Country": "Moldova",
+        "Population_ages_15_64_of_total": 74.3086639941979,
+        "Population_ages_65_and_above_of_total": 9.95793208822932
+      },
+      {
+        "Code": "MNE",
+        "Country": "Montenegro",
+        "Population_ages_15_64_of_total": 67.7000420274825,
+        "Population_ages_65_and_above_of_total": 13.6450291715472
+      },
+      {
+        "Code": "NLD",
+        "Country": "Netherlands",
+        "Population_ages_15_64_of_total": 65.2462589355619,
+        "Population_ages_65_and_above_of_total": 18.2304693863117
+      },
+      {
+        "Code": "NOR",
+        "Country": "Norway",
+        "Population_ages_15_64_of_total": 65.6985354157875,
+        "Population_ages_65_and_above_of_total": 16.3329186310334
+      },
+      {
+        "Code": "POL",
+        "Country": "Poland",
+        "Population_ages_15_64_of_total": 69.5203957630148,
+        "Population_ages_65_and_above_of_total": 15.5333238336452
+      },
+      {
+        "Code": "PRT",
+        "Country": "Portugal",
+        "Population_ages_15_64_of_total": 65.1552111668212,
+        "Population_ages_65_and_above_of_total": 20.7914682047571
+      },
+      {
+        "Code": "ROU",
+        "Country": "Romania",
+        "Population_ages_15_64_of_total": 67.1654214752418,
+        "Population_ages_65_and_above_of_total": 17.3139967333842
+      },
+      {
+        "Code": "RUS",
+        "Country": "Russian Federation",
+        "Population_ages_15_64_of_total": 69.8822387917186,
+        "Population_ages_65_and_above_of_total": 13.3658426985027
+      },
+      {
+        "Code": "SRB",
+        "Country": "Serbia",
+        "Population_ages_15_64_of_total": 66.6173161713822,
+        "Population_ages_65_and_above_of_total": 17.0823666319247
+      },
+      {
+        "Code": "SVK",
+        "Country": "Slovak Republic",
+        "Population_ages_15_64_of_total": 71.0312889656187,
+        "Population_ages_65_and_above_of_total": 13.8450659736415
+      },
+      {
+        "Code": "SVN",
+        "Country": "Slovenia",
+        "Population_ages_15_64_of_total": 67.2471833486012,
+        "Population_ages_65_and_above_of_total": 17.9683834689382
+      },
+      {
+        "Code": "ESP",
+        "Country": "Spain",
+        "Population_ages_15_64_of_total": 66.3288553181877,
+        "Population_ages_65_and_above_of_total": 18.7894661035796
+      },
+      {
+        "Code": "SWE",
+        "Country": "Sweden",
+        "Population_ages_15_64_of_total": 62.7731014069742,
+        "Population_ages_65_and_above_of_total": 19.9420190919181
+      },
+      {
+        "Code": "CHE",
+        "Country": "Switzerland",
+        "Population_ages_15_64_of_total": 67.1827980001116,
+        "Population_ages_65_and_above_of_total": 18.0418460178465
+      },
+      {
+        "Code": "TJK",
+        "Country": "Tajikistan",
+        "Population_ages_15_64_of_total": 62.1561674893051,
+        "Population_ages_65_and_above_of_total": 3.00628812918872
+      },
+      {
+        "Code": "TUR",
+        "Country": "Turkey",
+        "Population_ages_15_64_of_total": 66.790794681757,
+        "Population_ages_65_and_above_of_total": 7.53869755140193
+      },
+      {
+        "Code": "TKM",
+        "Country": "Turkmenistan",
+        "Population_ages_15_64_of_total": 67.6209109068909,
+        "Population_ages_65_and_above_of_total": 4.15507428861104
+      },
+      {
+        "Code": "UKR",
+        "Country": "Ukraine",
+        "Population_ages_15_64_of_total": 69.7661921081373,
+        "Population_ages_65_and_above_of_total": 15.3061908119499
+      },
+      {
+        "Code": "GBR",
+        "Country": "United Kingdom",
+        "Population_ages_15_64_of_total": 64.4654096116544,
+        "Population_ages_65_and_above_of_total": 17.7603695294859
+      },
+      {
+        "Code": "UZB",
+        "Country": "Uzbekistan",
+        "Population_ages_15_64_of_total": 66.8223460574423,
+        "Population_ages_65_and_above_of_total": 4.6577368288371
+      },
+      {
+        "Code": "MKD",
+        "Country": "Macedonia",
+        "Population_ages_15_64_of_total": 70.7240914276147,
+        "Population_ages_65_and_above_of_total": 12.3228189427425
+      }
+    ]
+  },
+  "hconcat": [
+    {
+      "mark": "bar",
+      "height": 700,
+       "selection": {
+        "brush": {"type": "interval", "encodings": ["y"]}
+      },
+      "encoding": {
+        "y": {
+          "field": "Country",
+          "type": "ordinal",
+          "sort": {
+            "op": "min",
+            "field": "Population_ages_15_64_of_total",
+            "order": "descending"
+          }
+        },
+        "x": {
+          "field": "Population_ages_15_64_of_total",
+          "type": "quantitative"
+        },
+        "color": {
+          "condition": {"selection": {"not": "brush"}, "value": "steelblue"},
+          "value": "goldenrod"
+        }
+      }
+    },
+    {
+      "mark": "bar",
+      "height": 700,
+      "selection": {
+        "brush": {"type": "interval", "encodings": ["y"]}
+      },
+      "encoding": {
+        "y": {
+          "field": "Country",
+          "type": "ordinal",
+          "sort": {
+            "op": "min",
+            "field": "Population_ages_65_and_above_of_total",
+            "order": "descending"
+          }
+        },
+        "x": {
+          "field": "Population_ages_65_and_above_of_total",
+          "type": "quantitative"
+        },
+        "color": {
+          "condition": {"selection": {"not": "brush"}, "value": "steelblue"},
+          "value": "goldenrod"
+        }
+      }
+    },
+    {
+      "mark": "point",
+      "width": 260,
+      "height": 260,
+      "selection": {"brush": {"type": "interval"}},
+      "encoding": {
+        "y": {
+          "field": "Population_ages_15_64_of_total",
+          "type": "quantitative",
+          "scale": {"zero": false}
+        },
+        "x": {
+          "field": "Population_ages_65_and_above_of_total",
+          "type": "quantitative",
+          "scale": {"zero": false}
+        },
+        "color": {
+          "condition": {"selection": {"not": "brush"}, "value": "steelblue"},
+          "value": "goldenrod"
+        }
+      }
+    }
+  ]
+}

--- a/examples/vg-specs/dashboard_europe_pop.vg.json
+++ b/examples/vg-specs/dashboard_europe_pop.vg.json
@@ -1,0 +1,1641 @@
+{
+    "$schema": "http://vega.github.io/schema/vega/v3.0.json",
+    "autosize": "pad",
+    "padding": 5,
+    "data": [
+        {
+            "name": "brush_store"
+        },
+        {
+            "name": "source_0",
+            "values": [
+                {
+                    "Code": "ALB",
+                    "Country": "Albania",
+                    "Population_ages_15_64_of_total": 69.0574620108062,
+                    "Population_ages_65_and_above_of_total": 12.3963338706153
+                },
+                {
+                    "Code": "ARM",
+                    "Country": "Armenia",
+                    "Population_ages_15_64_of_total": 70.7901217876325,
+                    "Population_ages_65_and_above_of_total": 10.8259833940416
+                },
+                {
+                    "Code": "AUT",
+                    "Country": "Austria",
+                    "Population_ages_15_64_of_total": 67.0332301646914,
+                    "Population_ages_65_and_above_of_total": 18.7591300503032
+                },
+                {
+                    "Code": "AZE",
+                    "Country": "Azerbaijan",
+                    "Population_ages_15_64_of_total": 72.4553638068118,
+                    "Population_ages_65_and_above_of_total": 5.62608981288436
+                },
+                {
+                    "Code": "BLR",
+                    "Country": "Belarus",
+                    "Population_ages_15_64_of_total": 69.9508710458679,
+                    "Population_ages_65_and_above_of_total": 13.9809217228707
+                },
+                {
+                    "Code": "BEL",
+                    "Country": "Belgium",
+                    "Population_ages_15_64_of_total": 64.8307418795963,
+                    "Population_ages_65_and_above_of_total": 18.2248164293518
+                },
+                {
+                    "Code": "BIH",
+                    "Country": "Bosnia and Herzegovina",
+                    "Population_ages_15_64_of_total": 71.0579632250127,
+                    "Population_ages_65_and_above_of_total": 15.4439567753232
+                },
+                {
+                    "Code": "BGR",
+                    "Country": "Bulgaria",
+                    "Population_ages_15_64_of_total": 65.8285064995643,
+                    "Population_ages_65_and_above_of_total": 20.0274777416446
+                },
+                {
+                    "Code": "CHI",
+                    "Country": "Channel Islands",
+                    "Population_ages_15_64_of_total": 68.022872223444,
+                    "Population_ages_65_and_above_of_total": 17.2684065195611
+                },
+                {
+                    "Code": "HRV",
+                    "Country": "Croatia",
+                    "Population_ages_15_64_of_total": 66.1722696675744,
+                    "Population_ages_65_and_above_of_total": 18.9370747517226
+                },
+                {
+                    "Code": "CYP",
+                    "Country": "Cyprus",
+                    "Population_ages_15_64_of_total": 70.6035355702394,
+                    "Population_ages_65_and_above_of_total": 12.8454475242427
+                },
+                {
+                    "Code": "CZE",
+                    "Country": "Czech Republic",
+                    "Population_ages_15_64_of_total": 66.8821170374875,
+                    "Population_ages_65_and_above_of_total": 18.075987656862
+                },
+                {
+                    "Code": "DNK",
+                    "Country": "Denmark",
+                    "Population_ages_15_64_of_total": 64.1595524918413,
+                    "Population_ages_65_and_above_of_total": 18.9594398104384
+                },
+                {
+                    "Code": "EST",
+                    "Country": "Estonia",
+                    "Population_ages_15_64_of_total": 65.1524732621339,
+                    "Population_ages_65_and_above_of_total": 18.7597043330657
+                },
+                {
+                    "Code": "FIN",
+                    "Country": "Finland",
+                    "Population_ages_15_64_of_total": 63.1844856787288,
+                    "Population_ages_65_and_above_of_total": 20.4771837047151
+                },
+                {
+                    "Code": "FRA",
+                    "Country": "France",
+                    "Population_ages_15_64_of_total": 62.3959557946308,
+                    "Population_ages_65_and_above_of_total": 19.1205109623995
+                },
+                {
+                    "Code": "GEO",
+                    "Country": "Georgia",
+                    "Population_ages_15_64_of_total": 68.6468764031909,
+                    "Population_ages_65_and_above_of_total": 14.0256592059827
+                },
+                {
+                    "Code": "DEU",
+                    "Country": "Germany",
+                    "Population_ages_15_64_of_total": 65.8735239308132,
+                    "Population_ages_65_and_above_of_total": 21.2406519413629
+                },
+                {
+                    "Code": "GRC",
+                    "Country": "Greece",
+                    "Population_ages_15_64_of_total": 64.001114781101,
+                    "Population_ages_65_and_above_of_total": 21.396558181815
+                },
+                {
+                    "Code": "HUN",
+                    "Country": "Hungary",
+                    "Population_ages_15_64_of_total": 67.6233936744744,
+                    "Population_ages_65_and_above_of_total": 17.8178985477761
+                },
+                {
+                    "Code": "ISL",
+                    "Country": "Iceland",
+                    "Population_ages_15_64_of_total": 65.9664567048645,
+                    "Population_ages_65_and_above_of_total": 13.7138954238446
+                },
+                {
+                    "Code": "IRL",
+                    "Country": "Ireland",
+                    "Population_ages_15_64_of_total": 65.079935543936,
+                    "Population_ages_65_and_above_of_total": 13.1395030143128
+                },
+                {
+                    "Code": "ITA",
+                    "Country": "Italy",
+                    "Population_ages_15_64_of_total": 63.8797421672762,
+                    "Population_ages_65_and_above_of_total": 22.4098759007142
+                },
+                {
+                    "Code": "KAZ",
+                    "Country": "Kazakhstan",
+                    "Population_ages_15_64_of_total": 66.5468630019269,
+                    "Population_ages_65_and_above_of_total": 6.73573774316427
+                },
+                {
+                    "Code": "XKX",
+                    "Country": "Kosovo",
+                    "Population_ages_15_64_of_total": 67.5956284153006,
+                    "Population_ages_65_and_above_of_total": 6.77595628415301
+                },
+                {
+                    "Code": "KGZ",
+                    "Country": "Kyrgyz Republic",
+                    "Population_ages_15_64_of_total": 64.3715060803419,
+                    "Population_ages_65_and_above_of_total": 4.22684522224216
+                },
+                {
+                    "Code": "LVA",
+                    "Country": "Latvia",
+                    "Population_ages_15_64_of_total": 65.7100750417533,
+                    "Population_ages_65_and_above_of_total": 19.3677959383975
+                },
+                {
+                    "Code": "LTU",
+                    "Country": "Lithuania",
+                    "Population_ages_15_64_of_total": 66.637321711156,
+                    "Population_ages_65_and_above_of_total": 18.8477993888977
+                },
+                {
+                    "Code": "LUX",
+                    "Country": "Luxembourg",
+                    "Population_ages_15_64_of_total": 69.5849129798452,
+                    "Population_ages_65_and_above_of_total": 13.981414540389
+                },
+                {
+                    "Code": "MDA",
+                    "Country": "Moldova",
+                    "Population_ages_15_64_of_total": 74.3086639941979,
+                    "Population_ages_65_and_above_of_total": 9.95793208822932
+                },
+                {
+                    "Code": "MNE",
+                    "Country": "Montenegro",
+                    "Population_ages_15_64_of_total": 67.7000420274825,
+                    "Population_ages_65_and_above_of_total": 13.6450291715472
+                },
+                {
+                    "Code": "NLD",
+                    "Country": "Netherlands",
+                    "Population_ages_15_64_of_total": 65.2462589355619,
+                    "Population_ages_65_and_above_of_total": 18.2304693863117
+                },
+                {
+                    "Code": "NOR",
+                    "Country": "Norway",
+                    "Population_ages_15_64_of_total": 65.6985354157875,
+                    "Population_ages_65_and_above_of_total": 16.3329186310334
+                },
+                {
+                    "Code": "POL",
+                    "Country": "Poland",
+                    "Population_ages_15_64_of_total": 69.5203957630148,
+                    "Population_ages_65_and_above_of_total": 15.5333238336452
+                },
+                {
+                    "Code": "PRT",
+                    "Country": "Portugal",
+                    "Population_ages_15_64_of_total": 65.1552111668212,
+                    "Population_ages_65_and_above_of_total": 20.7914682047571
+                },
+                {
+                    "Code": "ROU",
+                    "Country": "Romania",
+                    "Population_ages_15_64_of_total": 67.1654214752418,
+                    "Population_ages_65_and_above_of_total": 17.3139967333842
+                },
+                {
+                    "Code": "RUS",
+                    "Country": "Russian Federation",
+                    "Population_ages_15_64_of_total": 69.8822387917186,
+                    "Population_ages_65_and_above_of_total": 13.3658426985027
+                },
+                {
+                    "Code": "SRB",
+                    "Country": "Serbia",
+                    "Population_ages_15_64_of_total": 66.6173161713822,
+                    "Population_ages_65_and_above_of_total": 17.0823666319247
+                },
+                {
+                    "Code": "SVK",
+                    "Country": "Slovak Republic",
+                    "Population_ages_15_64_of_total": 71.0312889656187,
+                    "Population_ages_65_and_above_of_total": 13.8450659736415
+                },
+                {
+                    "Code": "SVN",
+                    "Country": "Slovenia",
+                    "Population_ages_15_64_of_total": 67.2471833486012,
+                    "Population_ages_65_and_above_of_total": 17.9683834689382
+                },
+                {
+                    "Code": "ESP",
+                    "Country": "Spain",
+                    "Population_ages_15_64_of_total": 66.3288553181877,
+                    "Population_ages_65_and_above_of_total": 18.7894661035796
+                },
+                {
+                    "Code": "SWE",
+                    "Country": "Sweden",
+                    "Population_ages_15_64_of_total": 62.7731014069742,
+                    "Population_ages_65_and_above_of_total": 19.9420190919181
+                },
+                {
+                    "Code": "CHE",
+                    "Country": "Switzerland",
+                    "Population_ages_15_64_of_total": 67.1827980001116,
+                    "Population_ages_65_and_above_of_total": 18.0418460178465
+                },
+                {
+                    "Code": "TJK",
+                    "Country": "Tajikistan",
+                    "Population_ages_15_64_of_total": 62.1561674893051,
+                    "Population_ages_65_and_above_of_total": 3.00628812918872
+                },
+                {
+                    "Code": "TUR",
+                    "Country": "Turkey",
+                    "Population_ages_15_64_of_total": 66.790794681757,
+                    "Population_ages_65_and_above_of_total": 7.53869755140193
+                },
+                {
+                    "Code": "TKM",
+                    "Country": "Turkmenistan",
+                    "Population_ages_15_64_of_total": 67.6209109068909,
+                    "Population_ages_65_and_above_of_total": 4.15507428861104
+                },
+                {
+                    "Code": "UKR",
+                    "Country": "Ukraine",
+                    "Population_ages_15_64_of_total": 69.7661921081373,
+                    "Population_ages_65_and_above_of_total": 15.3061908119499
+                },
+                {
+                    "Code": "GBR",
+                    "Country": "United Kingdom",
+                    "Population_ages_15_64_of_total": 64.4654096116544,
+                    "Population_ages_65_and_above_of_total": 17.7603695294859
+                },
+                {
+                    "Code": "UZB",
+                    "Country": "Uzbekistan",
+                    "Population_ages_15_64_of_total": 66.8223460574423,
+                    "Population_ages_65_and_above_of_total": 4.6577368288371
+                },
+                {
+                    "Code": "MKD",
+                    "Country": "Macedonia",
+                    "Population_ages_15_64_of_total": 70.7240914276147,
+                    "Population_ages_65_and_above_of_total": 12.3228189427425
+                }
+            ]
+        },
+        {
+            "name": "data_1",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "formula",
+                    "expr": "toNumber(datum[\"Population_ages_15_64_of_total\"])",
+                    "as": "Population_ages_15_64_of_total"
+                },
+                {
+                    "type": "filter",
+                    "expr": "datum[\"Population_ages_15_64_of_total\"] !== null && !isNaN(datum[\"Population_ages_15_64_of_total\"])"
+                }
+            ]
+        },
+        {
+            "name": "data_2",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "formula",
+                    "expr": "toNumber(datum[\"Population_ages_65_and_above_of_total\"])",
+                    "as": "Population_ages_65_and_above_of_total"
+                },
+                {
+                    "type": "filter",
+                    "expr": "datum[\"Population_ages_65_and_above_of_total\"] !== null && !isNaN(datum[\"Population_ages_65_and_above_of_total\"])"
+                }
+            ]
+        },
+        {
+            "name": "data_3",
+            "source": "source_0",
+            "transform": [
+                {
+                    "type": "formula",
+                    "expr": "toNumber(datum[\"Population_ages_15_64_of_total\"])",
+                    "as": "Population_ages_15_64_of_total"
+                },
+                {
+                    "type": "formula",
+                    "expr": "toNumber(datum[\"Population_ages_65_and_above_of_total\"])",
+                    "as": "Population_ages_65_and_above_of_total"
+                },
+                {
+                    "type": "filter",
+                    "expr": "datum[\"Population_ages_15_64_of_total\"] !== null && !isNaN(datum[\"Population_ages_15_64_of_total\"]) && datum[\"Population_ages_65_and_above_of_total\"] !== null && !isNaN(datum[\"Population_ages_65_and_above_of_total\"])"
+                }
+            ]
+        }
+    ],
+    "signals": [
+        {
+            "name": "concat_0_width",
+            "update": "200"
+        },
+        {
+            "name": "concat_0_height",
+            "update": "700"
+        },
+        {
+            "name": "concat_1_width",
+            "update": "200"
+        },
+        {
+            "name": "concat_1_height",
+            "update": "700"
+        },
+        {
+            "name": "concat_2_width",
+            "update": "260"
+        },
+        {
+            "name": "concat_2_height",
+            "update": "260"
+        },
+        {
+            "name": "unit",
+            "value": {},
+            "on": [
+                {
+                    "events": "mousemove",
+                    "update": "group()._id ? group() : unit"
+                }
+            ]
+        }
+    ],
+    "layout": {
+        "padding": {
+            "row": 10,
+            "column": 10
+        },
+        "offset": 10,
+        "bounds": "full",
+        "align": "all"
+    },
+    "marks": [
+        {
+            "type": "group",
+            "name": "concat_0_group",
+            "encode": {
+                "update": {
+                    "width": {
+                        "signal": "concat_0_width"
+                    },
+                    "height": {
+                        "signal": "concat_0_height"
+                    },
+                    "fill": {
+                        "value": "transparent"
+                    }
+                }
+            },
+            "signals": [
+                {
+                    "name": "brush_y",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
+                                ]
+                            },
+                            "update": "[y(unit), y(unit)]"
+                        },
+                        {
+                            "events": {
+                                "source": "window",
+                                "type": "mousemove",
+                                "consume": true,
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
+                                        ]
+                                    },
+                                    {
+                                        "source": "window",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "[brush_y[0], clamp(y(unit), 0, concat_0_height)]"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_scale_trigger"
+                            },
+                            "update": "[0, 0]"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_translate_delta"
+                            },
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_y, brush_translate_delta.y / span(brush_translate_anchor.extent_y)), 0, concat_0_height)"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_zoom_delta"
+                            },
+                            "update": "clampRange(zoomLinear(brush_y, brush_zoom_anchor.y, brush_zoom_delta), 0, concat_0_height)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_Country",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "brush_y"
+                            },
+                            "update": "invert(\"concat_0_y\", brush_y)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "update": "(!isArray(brush_Country) || (invert(\"concat_0_y\", brush_y)[0] === brush_Country[0] && invert(\"concat_0_y\", brush_y)[1] === brush_Country[1])) ? brush_scale_trigger : {}"
+                },
+                {
+                    "name": "brush_tuple",
+                    "update": "{unit: \"concat_0_\", intervals: [{encoding: \"y\", field: \"Country\", extent: brush_Country}]}"
+                },
+                {
+                    "name": "brush_translate_anchor",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousedown",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit), extent_y: slice(brush_y)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_translate_delta",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "window",
+                                    "type": "mousemove",
+                                    "consume": true,
+                                    "between": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "markname": "brush_brush"
+                                        },
+                                        {
+                                            "source": "window",
+                                            "type": "mouseup"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_anchor",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_delta",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "force": true,
+                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_modify",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "brush_tuple"
+                            },
+                            "update": "modify(\"brush_store\", brush_tuple, true)"
+                        }
+                    ]
+                }
+            ],
+            "marks": [
+                {
+                    "type": "rect",
+                    "encode": {
+                        "enter": {
+                            "fill": {
+                                "value": "#333"
+                            },
+                            "fillOpacity": {
+                                "value": 0.125
+                            }
+                        },
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
+                                    "value": 0
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
+                                    "signal": "brush_y[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
+                                    "field": {
+                                        "group": "width"
+                                    }
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
+                                    "signal": "brush_y[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "concat_0_marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "data_1"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "concat_0_x",
+                                "field": "Population_ages_15_64_of_total"
+                            },
+                            "x2": {
+                                "scale": "concat_0_x",
+                                "value": 0
+                            },
+                            "y": {
+                                "scale": "concat_0_y",
+                                "field": "Country"
+                            },
+                            "height": {
+                                "scale": "concat_0_y",
+                                "band": true
+                            },
+                            "fill": [
+                                {
+                                    "test": "!(vlInterval(\"brush_store\", \"concat_0_\", datum, \"union\", \"all\"))",
+                                    "value": "steelblue"
+                                },
+                                {
+                                    "value": "goldenrod"
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "brush_brush",
+                    "type": "rect",
+                    "encode": {
+                        "enter": {
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "white"
+                            }
+                        },
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
+                                    "value": 0
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
+                                    "signal": "brush_y[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
+                                    "field": {
+                                        "group": "width"
+                                    }
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_0_\"",
+                                    "signal": "brush_y[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ]
+                        }
+                    }
+                }
+            ],
+            "scales": [
+                {
+                    "name": "concat_0_x",
+                    "type": "linear",
+                    "domain": {
+                        "data": "data_1",
+                        "field": "Population_ages_15_64_of_total"
+                    },
+                    "range": [
+                        0,
+                        200
+                    ],
+                    "round": true,
+                    "nice": true,
+                    "zero": true
+                },
+                {
+                    "name": "concat_0_y",
+                    "type": "band",
+                    "domain": {
+                        "data": "data_1",
+                        "field": "Country",
+                        "sort": {
+                            "op": "min",
+                            "field": "Population_ages_15_64_of_total",
+                            "order": "descending"
+                        }
+                    },
+                    "range": [
+                        700,
+                        0
+                    ],
+                    "round": true,
+                    "paddingInner": 0.1,
+                    "paddingOuter": 0.05
+                }
+            ],
+            "axes": [
+                {
+                    "scale": "concat_0_x",
+                    "labelOverlap": true,
+                    "orient": "bottom",
+                    "tickCount": 5,
+                    "title": "Population_ages_15_64_of_total",
+                    "zindex": 1
+                },
+                {
+                    "scale": "concat_0_x",
+                    "domain": false,
+                    "grid": true,
+                    "labels": false,
+                    "orient": "bottom",
+                    "tickCount": 5,
+                    "ticks": false,
+                    "zindex": 0,
+                    "gridScale": "concat_0_y"
+                },
+                {
+                    "scale": "concat_0_y",
+                    "orient": "left",
+                    "title": "Country",
+                    "zindex": 1
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "name": "concat_1_group",
+            "encode": {
+                "update": {
+                    "width": {
+                        "signal": "concat_1_width"
+                    },
+                    "height": {
+                        "signal": "concat_1_height"
+                    },
+                    "fill": {
+                        "value": "transparent"
+                    }
+                }
+            },
+            "signals": [
+                {
+                    "name": "brush_y",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
+                                ]
+                            },
+                            "update": "[y(unit), y(unit)]"
+                        },
+                        {
+                            "events": {
+                                "source": "window",
+                                "type": "mousemove",
+                                "consume": true,
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
+                                        ]
+                                    },
+                                    {
+                                        "source": "window",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "[brush_y[0], clamp(y(unit), 0, concat_1_height)]"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_scale_trigger"
+                            },
+                            "update": "[0, 0]"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_translate_delta"
+                            },
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_y, brush_translate_delta.y / span(brush_translate_anchor.extent_y)), 0, concat_1_height)"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_zoom_delta"
+                            },
+                            "update": "clampRange(zoomLinear(brush_y, brush_zoom_anchor.y, brush_zoom_delta), 0, concat_1_height)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_Country",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "brush_y"
+                            },
+                            "update": "invert(\"concat_1_y\", brush_y)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "update": "(!isArray(brush_Country) || (invert(\"concat_1_y\", brush_y)[0] === brush_Country[0] && invert(\"concat_1_y\", brush_y)[1] === brush_Country[1])) ? brush_scale_trigger : {}"
+                },
+                {
+                    "name": "brush_tuple",
+                    "update": "{unit: \"concat_1_\", intervals: [{encoding: \"y\", field: \"Country\", extent: brush_Country}]}"
+                },
+                {
+                    "name": "brush_translate_anchor",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousedown",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit), extent_y: slice(brush_y)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_translate_delta",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "window",
+                                    "type": "mousemove",
+                                    "consume": true,
+                                    "between": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "markname": "brush_brush"
+                                        },
+                                        {
+                                            "source": "window",
+                                            "type": "mouseup"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_anchor",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_delta",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "force": true,
+                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_modify",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "brush_tuple"
+                            },
+                            "update": "modify(\"brush_store\", brush_tuple, true)"
+                        }
+                    ]
+                }
+            ],
+            "marks": [
+                {
+                    "type": "rect",
+                    "encode": {
+                        "enter": {
+                            "fill": {
+                                "value": "#333"
+                            },
+                            "fillOpacity": {
+                                "value": 0.125
+                            }
+                        },
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_1_\"",
+                                    "value": 0
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_1_\"",
+                                    "signal": "brush_y[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_1_\"",
+                                    "field": {
+                                        "group": "width"
+                                    }
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_1_\"",
+                                    "signal": "brush_y[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "concat_1_marks",
+                    "type": "rect",
+                    "role": "bar",
+                    "from": {
+                        "data": "data_2"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "concat_1_x",
+                                "field": "Population_ages_65_and_above_of_total"
+                            },
+                            "x2": {
+                                "scale": "concat_1_x",
+                                "value": 0
+                            },
+                            "y": {
+                                "scale": "concat_1_y",
+                                "field": "Country"
+                            },
+                            "height": {
+                                "scale": "concat_1_y",
+                                "band": true
+                            },
+                            "fill": [
+                                {
+                                    "test": "!(vlInterval(\"brush_store\", \"concat_1_\", datum, \"union\", \"all\"))",
+                                    "value": "steelblue"
+                                },
+                                {
+                                    "value": "goldenrod"
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "brush_brush",
+                    "type": "rect",
+                    "encode": {
+                        "enter": {
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "white"
+                            }
+                        },
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_1_\"",
+                                    "value": 0
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_1_\"",
+                                    "signal": "brush_y[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_1_\"",
+                                    "field": {
+                                        "group": "width"
+                                    }
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_1_\"",
+                                    "signal": "brush_y[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ]
+                        }
+                    }
+                }
+            ],
+            "scales": [
+                {
+                    "name": "concat_1_x",
+                    "type": "linear",
+                    "domain": {
+                        "data": "data_2",
+                        "field": "Population_ages_65_and_above_of_total"
+                    },
+                    "range": [
+                        0,
+                        200
+                    ],
+                    "round": true,
+                    "nice": true,
+                    "zero": true
+                },
+                {
+                    "name": "concat_1_y",
+                    "type": "band",
+                    "domain": {
+                        "data": "data_2",
+                        "field": "Country",
+                        "sort": {
+                            "op": "min",
+                            "field": "Population_ages_65_and_above_of_total",
+                            "order": "descending"
+                        }
+                    },
+                    "range": [
+                        700,
+                        0
+                    ],
+                    "round": true,
+                    "paddingInner": 0.1,
+                    "paddingOuter": 0.05
+                }
+            ],
+            "axes": [
+                {
+                    "scale": "concat_1_x",
+                    "labelOverlap": true,
+                    "orient": "bottom",
+                    "tickCount": 5,
+                    "title": "Population_ages_65_and_above_of_total",
+                    "zindex": 1
+                },
+                {
+                    "scale": "concat_1_x",
+                    "domain": false,
+                    "grid": true,
+                    "labels": false,
+                    "orient": "bottom",
+                    "tickCount": 5,
+                    "ticks": false,
+                    "zindex": 0,
+                    "gridScale": "concat_1_y"
+                },
+                {
+                    "scale": "concat_1_y",
+                    "orient": "left",
+                    "title": "Country",
+                    "zindex": 1
+                }
+            ]
+        },
+        {
+            "type": "group",
+            "name": "concat_2_group",
+            "encode": {
+                "update": {
+                    "width": {
+                        "signal": "concat_2_width"
+                    },
+                    "height": {
+                        "signal": "concat_2_height"
+                    },
+                    "fill": {
+                        "value": "transparent"
+                    }
+                }
+            },
+            "signals": [
+                {
+                    "name": "brush_x",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
+                                ]
+                            },
+                            "update": "[x(unit), x(unit)]"
+                        },
+                        {
+                            "events": {
+                                "source": "window",
+                                "type": "mousemove",
+                                "consume": true,
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
+                                        ]
+                                    },
+                                    {
+                                        "source": "window",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "[brush_x[0], clamp(x(unit), 0, concat_2_width)]"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_scale_trigger"
+                            },
+                            "update": "[scale(\"concat_2_x\", brush_Population_ages_65_and_above_of_total[0]), scale(\"concat_2_x\", brush_Population_ages_65_and_above_of_total[1])]"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_translate_delta"
+                            },
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_x, brush_translate_delta.x / span(brush_translate_anchor.extent_x)), 0, concat_2_width)"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_zoom_delta"
+                            },
+                            "update": "clampRange(zoomLinear(brush_x, brush_zoom_anchor.x, brush_zoom_delta), 0, concat_2_width)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_Population_ages_65_and_above_of_total",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "brush_x"
+                            },
+                            "update": "invert(\"concat_2_x\", brush_x)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_y",
+                    "value": [],
+                    "on": [
+                        {
+                            "events": {
+                                "source": "scope",
+                                "type": "mousedown",
+                                "filter": [
+                                    "!event.item || event.item.mark.name !== \"brush_brush\""
+                                ]
+                            },
+                            "update": "[y(unit), y(unit)]"
+                        },
+                        {
+                            "events": {
+                                "source": "window",
+                                "type": "mousemove",
+                                "consume": true,
+                                "between": [
+                                    {
+                                        "source": "scope",
+                                        "type": "mousedown",
+                                        "filter": [
+                                            "!event.item || event.item.mark.name !== \"brush_brush\""
+                                        ]
+                                    },
+                                    {
+                                        "source": "window",
+                                        "type": "mouseup"
+                                    }
+                                ]
+                            },
+                            "update": "[brush_y[0], clamp(y(unit), 0, concat_2_height)]"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_scale_trigger"
+                            },
+                            "update": "[scale(\"concat_2_y\", brush_Population_ages_15_64_of_total[0]), scale(\"concat_2_y\", brush_Population_ages_15_64_of_total[1])]"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_translate_delta"
+                            },
+                            "update": "clampRange(panLinear(brush_translate_anchor.extent_y, brush_translate_delta.y / span(brush_translate_anchor.extent_y)), 0, concat_2_height)"
+                        },
+                        {
+                            "events": {
+                                "signal": "brush_zoom_delta"
+                            },
+                            "update": "clampRange(zoomLinear(brush_y, brush_zoom_anchor.y, brush_zoom_delta), 0, concat_2_height)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_Population_ages_15_64_of_total",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "brush_y"
+                            },
+                            "update": "invert(\"concat_2_y\", brush_y)"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_scale_trigger",
+                    "update": "(!isArray(brush_Population_ages_65_and_above_of_total) || (+invert(\"concat_2_x\", brush_x)[0] === +brush_Population_ages_65_and_above_of_total[0] && +invert(\"concat_2_x\", brush_x)[1] === +brush_Population_ages_65_and_above_of_total[1])) && (!isArray(brush_Population_ages_15_64_of_total) || (+invert(\"concat_2_y\", brush_y)[0] === +brush_Population_ages_15_64_of_total[0] && +invert(\"concat_2_y\", brush_y)[1] === +brush_Population_ages_15_64_of_total[1])) ? brush_scale_trigger : {}"
+                },
+                {
+                    "name": "brush_tuple",
+                    "update": "{unit: \"concat_2_\", intervals: [{encoding: \"x\", field: \"Population_ages_65_and_above_of_total\", extent: brush_Population_ages_65_and_above_of_total}, {encoding: \"y\", field: \"Population_ages_15_64_of_total\", extent: brush_Population_ages_15_64_of_total}]}"
+                },
+                {
+                    "name": "brush_translate_anchor",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "mousedown",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit), extent_x: slice(brush_x), extent_y: slice(brush_y)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_translate_delta",
+                    "value": {},
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "window",
+                                    "type": "mousemove",
+                                    "consume": true,
+                                    "between": [
+                                        {
+                                            "source": "scope",
+                                            "type": "mousedown",
+                                            "markname": "brush_brush"
+                                        },
+                                        {
+                                            "source": "window",
+                                            "type": "mouseup"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "update": "{x: brush_translate_anchor.x - x(unit), y: brush_translate_anchor.y - y(unit)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_anchor",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "update": "{x: x(unit), y: y(unit)}"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_zoom_delta",
+                    "on": [
+                        {
+                            "events": [
+                                {
+                                    "source": "scope",
+                                    "type": "wheel",
+                                    "markname": "brush_brush"
+                                }
+                            ],
+                            "force": true,
+                            "update": "pow(1.001, event.deltaY * pow(16, event.deltaMode))"
+                        }
+                    ]
+                },
+                {
+                    "name": "brush_modify",
+                    "on": [
+                        {
+                            "events": {
+                                "signal": "brush_tuple"
+                            },
+                            "update": "modify(\"brush_store\", brush_tuple, true)"
+                        }
+                    ]
+                }
+            ],
+            "marks": [
+                {
+                    "type": "rect",
+                    "encode": {
+                        "enter": {
+                            "fill": {
+                                "value": "#333"
+                            },
+                            "fillOpacity": {
+                                "value": 0.125
+                            }
+                        },
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_2_\"",
+                                    "signal": "brush_x[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_2_\"",
+                                    "signal": "brush_y[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_2_\"",
+                                    "signal": "brush_x[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_2_\"",
+                                    "signal": "brush_y[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ]
+                        }
+                    }
+                },
+                {
+                    "name": "concat_2_marks",
+                    "type": "symbol",
+                    "role": "point",
+                    "from": {
+                        "data": "data_3"
+                    },
+                    "encode": {
+                        "update": {
+                            "x": {
+                                "scale": "concat_2_x",
+                                "field": "Population_ages_65_and_above_of_total"
+                            },
+                            "y": {
+                                "scale": "concat_2_y",
+                                "field": "Population_ages_15_64_of_total"
+                            },
+                            "stroke": [
+                                {
+                                    "test": "!(vlInterval(\"brush_store\", \"concat_2_\", datum, \"union\", \"all\"))",
+                                    "value": "steelblue"
+                                },
+                                {
+                                    "value": "goldenrod"
+                                }
+                            ],
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "opacity": {
+                                "value": 0.7
+                            }
+                        }
+                    }
+                },
+                {
+                    "name": "brush_brush",
+                    "type": "rect",
+                    "encode": {
+                        "enter": {
+                            "fill": {
+                                "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "white"
+                            }
+                        },
+                        "update": {
+                            "x": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_2_\"",
+                                    "signal": "brush_x[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_2_\"",
+                                    "signal": "brush_y[0]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "x2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_2_\"",
+                                    "signal": "brush_x[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ],
+                            "y2": [
+                                {
+                                    "test": "data(\"brush_store\").length && data(\"brush_store\")[0].unit === \"concat_2_\"",
+                                    "signal": "brush_y[1]"
+                                },
+                                {
+                                    "value": 0
+                                }
+                            ]
+                        }
+                    }
+                }
+            ],
+            "scales": [
+                {
+                    "name": "concat_2_x",
+                    "type": "linear",
+                    "domain": {
+                        "data": "data_3",
+                        "field": "Population_ages_65_and_above_of_total"
+                    },
+                    "range": [
+                        0,
+                        260
+                    ],
+                    "zero": false,
+                    "round": true,
+                    "nice": true
+                },
+                {
+                    "name": "concat_2_y",
+                    "type": "linear",
+                    "domain": {
+                        "data": "data_3",
+                        "field": "Population_ages_15_64_of_total"
+                    },
+                    "range": [
+                        260,
+                        0
+                    ],
+                    "zero": false,
+                    "round": true,
+                    "nice": true
+                }
+            ],
+            "axes": [
+                {
+                    "scale": "concat_2_x",
+                    "labelOverlap": true,
+                    "orient": "bottom",
+                    "tickCount": 5,
+                    "title": "Population_ages_65_and_above_of_total",
+                    "zindex": 1
+                },
+                {
+                    "scale": "concat_2_x",
+                    "domain": false,
+                    "grid": true,
+                    "labels": false,
+                    "orient": "bottom",
+                    "tickCount": 5,
+                    "ticks": false,
+                    "zindex": 0,
+                    "gridScale": "concat_2_y"
+                },
+                {
+                    "scale": "concat_2_y",
+                    "orient": "left",
+                    "title": "Population_ages_15_64_of_total",
+                    "zindex": 1
+                },
+                {
+                    "scale": "concat_2_y",
+                    "domain": false,
+                    "grid": true,
+                    "labels": false,
+                    "orient": "left",
+                    "ticks": false,
+                    "zindex": 0,
+                    "gridScale": "concat_2_x"
+                }
+            ]
+        }
+    ]
+}

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -42,6 +42,8 @@ const interval:SelectionCompiler = {
       const dname = channelSignalName(selCmpt, channel, 'data');
       const vname = channelSignalName(selCmpt, channel, 'visual');
       const scaleStr = stringValue(model.scaleName(channel));
+      const scaleType = model.getScaleComponent(channel).get('type');
+      const toNum = hasContinuousDomain(scaleType) ? '+' : '';
 
       signals.push.apply(signals, cs);
       intervals.push(`{encoding: ${stringValue(channel)}, ` +
@@ -50,8 +52,8 @@ const interval:SelectionCompiler = {
       scaleTriggers.push({
         scaleName: model.scaleName(channel),
         expr: `(!isArray(${dname}) || ` +
-          `(+invert(${scaleStr}, ${vname})[0] === +${dname}[0] && ` +
-            `+invert(${scaleStr}, ${vname})[1] === +${dname}[1]))`
+          `(${toNum}invert(${scaleStr}, ${vname})[0] === ${toNum}${dname}[0] && ` +
+            `${toNum}invert(${scaleStr}, ${vname})[1] === ${toNum}${dname}[1]))`
       });
     });
 


### PR DESCRIPTION
#2589 coerced interval extents to numbers to support time scales. However, this [breaks with `band`](https://github.com/vega/vega-lite/issues/2635#issuecomment-313534244) (and presumably other discrete scale types). Thus, this PR only coerces for continuous scale types.