### PR TITLE
Add identifier transform for default point selections.

### DIFF
--- a/examples/vg-specs/paintbrush.vg.json
+++ b/examples/vg-specs/paintbrush.vg.json
@@ -29,6 +29,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -65,7 +69,7 @@
                             "type": "mouseover"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/paintbrush_color.vg.json
+++ b/examples/vg-specs/paintbrush_color.vg.json
@@ -29,6 +29,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -65,7 +69,7 @@
                             "type": "mouseover"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/paintbrush_color_nearest.vg.json
+++ b/examples/vg-specs/paintbrush_color_nearest.vg.json
@@ -29,6 +29,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -65,7 +69,7 @@
                             "type": "mouseover"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/paintbrush_simple.vg.json
+++ b/examples/vg-specs/paintbrush_simple.vg.json
@@ -28,6 +28,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -64,7 +68,7 @@
                             "type": "mouseover"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/rect_binned_heatmap.vg.json
+++ b/examples/vg-specs/rect_binned_heatmap.vg.json
@@ -137,7 +137,8 @@
                 "fields": [
                     "bin_maxbins_60_IMDB_Rating_start",
                     "bin_maxbins_60_IMDB_Rating_end"
-                ]
+                ],
+                "sort": true
             },
             "range": [
                 0,
@@ -156,7 +157,8 @@
                 "fields": [
                     "bin_maxbins_40_Rotten_Tomatoes_Rating_start",
                     "bin_maxbins_40_Rotten_Tomatoes_Rating_end"
-                ]
+                ],
+                "sort": true
             },
             "range": [
                 {

--- a/examples/vg-specs/selection_insert.vg.json
+++ b/examples/vg-specs/selection_insert.vg.json
@@ -28,6 +28,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -64,7 +68,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_multi.vg.json
+++ b/examples/vg-specs/selection_project_multi.vg.json
@@ -28,6 +28,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -64,7 +68,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_single.vg.json
+++ b/examples/vg-specs/selection_project_single.vg.json
@@ -28,6 +28,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -55,7 +59,7 @@
         },
         {
             "name": "pts",
-            "update": "data(\"pts_store\").length && {_id: data(\"pts_store\")[0].values[0]}"
+            "update": "data(\"pts_store\").length && {_vgsid_: data(\"pts_store\")[0].values[0]}"
         },
         {
             "name": "pts_tuple",
@@ -68,7 +72,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_toggle_altKey.vg.json
+++ b/examples/vg-specs/selection_toggle_altKey.vg.json
@@ -28,6 +28,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -64,7 +68,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_toggle_altKey_shiftKey.vg.json
+++ b/examples/vg-specs/selection_toggle_altKey_shiftKey.vg.json
@@ -28,6 +28,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -64,7 +68,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_toggle_shiftKey.vg.json
+++ b/examples/vg-specs/selection_toggle_shiftKey.vg.json
@@ -28,6 +28,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -64,7 +68,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_type_multi.vg.json
+++ b/examples/vg-specs/selection_type_multi.vg.json
@@ -24,6 +24,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "aggregate",
                     "groupby": [
                         "Origin",
@@ -38,6 +42,10 @@
                     "as": [
                         "count_*"
                     ]
+                },
+                {
+                    "type": "identifier",
+                    "as": "_vgsid_"
                 }
             ]
         }
@@ -80,7 +88,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_type_single.vg.json
+++ b/examples/vg-specs/selection_type_single.vg.json
@@ -24,6 +24,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "aggregate",
                     "groupby": [
                         "Origin",
@@ -38,6 +42,10 @@
                     "as": [
                         "count_*"
                     ]
+                },
+                {
+                    "type": "identifier",
+                    "as": "_vgsid_"
                 }
             ]
         }
@@ -71,7 +79,7 @@
         },
         {
             "name": "pts",
-            "update": "data(\"pts_store\").length && {_id: data(\"pts_store\")[0].values[0]}"
+            "update": "data(\"pts_store\").length && {_vgsid_: data(\"pts_store\")[0].values[0]}"
         },
         {
             "name": "pts_tuple",
@@ -84,7 +92,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_type_single_dblclick.vg.json
+++ b/examples/vg-specs/selection_type_single_dblclick.vg.json
@@ -24,6 +24,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "aggregate",
                     "groupby": [
                         "Origin",
@@ -38,6 +42,10 @@
                     "as": [
                         "count_*"
                     ]
+                },
+                {
+                    "type": "identifier",
+                    "as": "_vgsid_"
                 }
             ]
         }
@@ -71,7 +79,7 @@
         },
         {
             "name": "pts",
-            "update": "data(\"pts_store\").length && {_id: data(\"pts_store\")[0].values[0]}"
+            "update": "data(\"pts_store\").length && {_vgsid_: data(\"pts_store\")[0].values[0]}"
         },
         {
             "name": "pts_tuple",
@@ -84,7 +92,7 @@
                             "type": "dblclick"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/src/compile/data/assemble.ts
+++ b/src/compile/data/assemble.ts
@@ -15,7 +15,7 @@ import {OrderNode} from './pathorder';
 import {SourceNode} from './source';
 import {StackNode} from './stack';
 import {TimeUnitNode} from './timeunit';
-import {CalculateNode, FilterNode, LookupNode} from './transforms';
+import {CalculateNode, FilterNode, IdentifierNode, LookupNode} from './transforms';
 
 
 export const FACET_SCALE_PREFIX = 'scale_';
@@ -200,7 +200,8 @@ function makeWalkTree(data: VgData[]) {
       node instanceof CalculateNode ||
       node instanceof AggregateNode ||
       node instanceof OrderNode ||
-      node instanceof LookupNode) {
+      node instanceof LookupNode ||
+      node instanceof IdentifierNode) {
       dataSource.transform.push(node.assemble());
     }
 

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -3,7 +3,7 @@ import {Channel, ScaleChannel, SingleDefChannel, X, Y} from '../../channel';
 import {warn} from '../../log';
 import {LogicalOperand} from '../../logical';
 import {SelectionDomain} from '../../scale';
-import {BrushConfig, SelectionDef, SelectionResolution, SelectionType} from '../../selection';
+import {BrushConfig, SELECTION_ID, SelectionDef, SelectionResolution, SelectionType} from '../../selection';
 import {Dict, extend, isString, logicalExpr, stringValue, varName} from '../../util';
 import {isSignalRefDomain, VgBinding, VgData, VgDomain, VgEventStream, VgScale, VgSignalRef} from '../../vega.schema';
 import {DataFlowNode} from '../data/dataflow';
@@ -318,8 +318,15 @@ export function unitName(model: Model) {
     name += (facet.facet.row ? ` + '_' + facet[${stringValue(facet.field('row'))}]` : '')
       + (facet.facet.column ? ` + '_' + facet[${stringValue(facet.field('column'))}]` : '');
   }
-
   return name;
+}
+
+export function requiresSelectionId(model: Model) {
+  let identifier = false;
+  forEachSelection(model, (selCmpt) => {
+    identifier = identifier || selCmpt.project.some((proj) => proj.field === SELECTION_ID);
+  });
+  return identifier;
 }
 
 export function channelSignalName(selCmpt: SelectionComponent, channel: Channel, range: 'visual' | 'data') {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,6 +1,7 @@
 import {SingleDefChannel} from './channel';
 import {VgBinding} from './vega.schema';
 
+export const SELECTION_ID = '_vgsid_';
 export type SelectionType = 'single' | 'multi' | 'interval';
 export type SelectionResolution = 'global' | 'union' | 'intersect';
 
@@ -182,8 +183,8 @@ export interface SelectionConfig {
 }
 
 export const defaultConfig:SelectionConfig = {
-  single: {on: 'click', fields: ['_id'], resolve: 'global'},
-  multi: {on: 'click', fields: ['_id'], toggle: 'event.shiftKey', resolve: 'global'},
+  single: {on: 'click', fields: [SELECTION_ID], resolve: 'global'},
+  multi: {on: 'click', fields: [SELECTION_ID], toggle: 'event.shiftKey', resolve: 'global'},
   interval: {
     on: '[mousedown, window:mouseup] > window:mousemove!',
     encodings: ['x', 'y'],

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -295,6 +295,22 @@ export interface VgLookupTransform {
   default?: string;
 }
 
+export interface VgStackTransform {
+  type: 'stack';
+  offset?: StackOffset;
+  groupby: string[];
+  field: string;
+  sort: VgSort;
+  as: string[];
+}
+
+export interface VgIdentifierTransform {
+  type: 'identifier';
+  as: string;
+}
+
+export type VgTransform = VgBinTransform | VgExtentTransform | VgFormulaTransform | VgAggregateTransform | VgFilterTransform | VgImputeTransform | VgStackTransform | VgCollectTransform | VgLookupTransform | VgIdentifierTransform;
+
 export interface VgAxisEncode {
   ticks?: VgGuideEncode;
   labels?: VgGuideEncode;
@@ -312,17 +328,6 @@ export interface VgLegendEncode {
 }
 
 export type VgGuideEncode = any; // TODO: replace this (See guideEncode in Vega Schema)
-
-export type VgTransform = VgBinTransform | VgExtentTransform | VgFormulaTransform | VgAggregateTransform | VgFilterTransform | VgImputeTransform | VgStackTransform | VgCollectTransform | VgLookupTransform;
-
-export interface VgStackTransform {
-  type: 'stack';
-  offset?: StackOffset;
-  groupby: string[];
-  field: string;
-  sort: VgSort;
-  as: string[];
-}
 
 export type VgSort = {
   field: string;

--- a/test/compile/selection/identifier.test.ts
+++ b/test/compile/selection/identifier.test.ts
@@ -1,0 +1,75 @@
+import {Mark} from '../../../src/mark';
+import {VgTransform} from '../../../src/vega.schema';
+/* tslint:disable:quotemark */
+
+import {assert} from 'chai';
+import {parseModel} from '../../util';
+
+function getVgData(selection: any, x?: any, y?: any, mark?: Mark, enc?: any, transform?: any) {
+  const model = parseModel({
+    data: {url: 'data/cars.json'},
+    transform,
+    selection,
+    mark: mark || 'circle',
+    encoding: {
+      x: {field: 'Horsepower', type: 'quantitative', ...x},
+      y: {field: 'Miles-per-Gallon', type: 'quantitative', ...y},
+      color: {field: 'Origin', type: 'nominal'},
+      ...enc
+    }
+  });
+  model.parse();
+  return model.assembleData();
+}
+
+describe('Identifier transform', function() {
+  it('is not unnecessarily added', function() {
+    function test(selDef?: any) {
+      const data = getVgData(selDef);
+      for (const d of data) {
+        assert.isNotTrue(d.transform && d.transform.some((t) => t.type === 'identifier'));
+      }
+    }
+
+    test();
+    for (const type of ['single', 'multi']) {
+      test({pt: {type, encodings: ['x']}});
+    }
+  });
+
+  it('is added for default point selections', function() {
+    for (const type of ['single', 'multi']) {
+      const url = getVgData({pt: {type}});
+      assert.equal(url[0].transform[0].type, 'identifier');
+    }
+  });
+
+  it('is added immediately after aggregate transforms', function() {
+    function test(transform: VgTransform[]) {
+      let aggr = -1;
+      transform.some((t, i) => (aggr = i, t.type === 'aggregate'));
+      assert.isAtLeast(aggr, 0);
+      assert.equal(transform[aggr + 1].type, 'identifier');
+    }
+
+    for (const type of ['single', 'multi']) {
+      const sel = {pt: {type}};
+      let data = getVgData(sel, {bin: true}, {aggregate: 'count'});
+      test(data[0].transform);
+
+      data = getVgData(sel, {aggregate: 'sum'}, null, 'bar',
+        {column: {field: 'Cylinders', type: 'ordinal'}});
+      test(data[0].transform);
+    }
+  });
+
+  it('is added before any user-specified transforms', function() {
+    for (const type of ['single', 'multi']) {
+      const data = getVgData({pt: {type}}, null, null, null, null,
+        [{calculate: 'datum.Horsepower * 2', as: 'foo'}]);
+      let calc = -1;
+      data[0].transform.some((t, i) => (calc = i, t.type === 'formula' && t.as === 'foo'));
+      assert.equal(data[0].transform[calc - 1].type, 'identifier');
+    }
+  });
+});

--- a/test/compile/selection/inputs.test.ts
+++ b/test/compile/selection/inputs.test.ts
@@ -56,18 +56,18 @@ describe('Inputs Selection Transform', function() {
     assert.includeDeepMembers(selection.assembleUnitSelectionSignals(model, []), [
       {
         "name": "one_tuple",
-        "update": "{fields: [\"_id\"], values: [one__id]}"
+        "update": "{fields: [\"_vgsid_\"], values: [one__vgsid_]}"
       }
     ]);
 
     assert.includeDeepMembers(selection.assembleTopLevelSignals(model, []), [
       {
-        "name": "one__id",
+        "name": "one__vgsid_",
         "value": "",
         "on": [
           {
             "events": [{"source": "scope","type": "click"}],
-            "update": "datum && datum[\"_id\"]"
+            "update": "datum && datum[\"_vgsid_\"]"
           }
         ],
         "bind": {"input": "range","min": 0,"max": 10,"step": 1}

--- a/test/compile/selection/multi.test.ts
+++ b/test/compile/selection/multi.test.ts
@@ -30,7 +30,7 @@ describe('Multi Selection', function() {
       value: {},
       on: [{
         events: selCmpts['one'].events,
-        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
       }]
     }]);
 

--- a/test/compile/selection/parse.test.ts
+++ b/test/compile/selection/parse.test.ts
@@ -27,13 +27,13 @@ describe('Selection', function() {
 
     assert.equal(component.one.name, 'one');
     assert.equal(component.one.type, 'single');
-    assert.sameDeepMembers(component['one'].project, [{field: '_id', channel: null}]);
+    assert.sameDeepMembers(component['one'].project, [{field: '_vgsid_', channel: null}]);
     assert.sameDeepMembers(component['one'].events, parseSelector('click', 'scope'));
 
     assert.equal(component.two.name, 'two');
     assert.equal(component.two.type, 'multi');
     assert.equal(component.two.toggle, 'event.shiftKey');
-    assert.sameDeepMembers(component['two'].project, [{field: '_id', channel: null}]);
+    assert.sameDeepMembers(component['two'].project, [{field: '_vgsid_', channel: null}]);
     assert.sameDeepMembers(component['two'].events, parseSelector('click', 'scope'));
 
     assert.equal(component.three.name, 'three');

--- a/test/compile/selection/single.test.ts
+++ b/test/compile/selection/single.test.ts
@@ -30,7 +30,7 @@ describe('Single Selection', function() {
       value: {},
       on: [{
         events: selCmpts['one'].events,
-        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
       }]
     }]);
 
@@ -81,7 +81,7 @@ describe('Single Selection', function() {
   it('builds top-level signals', function() {
     const oneSg = single.topLevelSignals(model, selCmpts['one'], []);
     assert.sameDeepMembers(oneSg, [{
-      name: 'one', update: 'data(\"one_store\").length && {_id: data(\"one_store\")[0].values[0]}'
+      name: 'one', update: 'data(\"one_store\").length && {_vgsid_: data(\"one_store\")[0].values[0]}'
     }]);
 
     const twoSg = single.topLevelSignals(model, selCmpts['two'], []);


### PR DESCRIPTION
This PR replaces #2636, adding the identifier transform via the dataflow architecture instead. 

#2636 describes our desired outcome: an identifier node added every time new tuples are derived -- i.e., at the source and after an aggregate transform (and if the two happen within the same dataset, only one identifier transform is added to reduce unnecessary computation).

Here's a simple unit spec to start testing with:

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "description": "Select multiple points with the shift key.",
  "data": {"url": "data/cars.json"},
  "selection": {
    "paintbrush": {
      "type": "single"
    }
  },
  "mark": "point",
  "encoding": {
    "x": {"field": "Horsepower", "type": "quantitative"},
    "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
    "size": {
      "condition": {"selection": "paintbrush", "value": 300},
      "value": 50
    }
  }
}
```

Currently, while the identifier node is currently added, a number of things seem to happen during assembly/optimization that yield buggy or less ideal output:
1. When raw data values are embedded directly in the spec, the identifier transform is added to a new derived dataset from which all other datasets (e.g., in a layered or concatenated view) are then subsequently derived. The identifier transform should instead be merged up into the source dataset.
2. With a concatenated display, an identifier transform is correctly added to the `source` dataset, but also appears after parse transforms in last derived dataset.
3. D'oh, obvious error in the "problematic" spec. Once the selection is moved to the aggregate spec, the identifier transform appears correctly. ~~Aggregate plots, I'm unsure if identifier transforms are being dropped somewhere in the logic or whether there are just additional locations there are created from that I haven't tracked down.~~ 

    ~~For instance, with a simple aggregate plot, the identifier transform is appended correctly..~~

    ```json
    {
      "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
      "data": {"url": "data/movies.json"},
      "mark": "circle",
      "selection": {
        "pt": {"type": "single"}
      },
      "encoding": {
        "x": {"field": "IMDB_Rating", "type": "Q", "bin": true},
        "y": {"field": "Rotten_Tomatoes_Rating", "type": "Q", "bin": true},
        "size": {"aggregate": "count", "type": "Q"}
      }
    }
    ```

    ~~However, with a concatenated plot, the post-aggregate identifier disappears. Initially, I suspected this may be related to point (2) above (e.g., perhaps the identifier from the first dataset is being lifted to the source). But, you see it even when concatenating arbitrary numbers of normal plots and aggregated plots. I've been having trouble debugging further due to the unexpected ordering of datasets/concatenations.~~

    ```json
    {
      "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
      "data": {"url": "data/cars.json"},
      "hconcat": [{
        "selection": {
          "pt": {"type": "single"}
        },
        "mark": "point",
        "encoding": {
          "x": {"field": "Horsepower", "type": "quantitative"},
          "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
          "size": {
            "condition": {"selection": "pt", "value": 300},
            "value": 50
          }
        }
      }, {
        "mark": "point",
        "encoding": {
          "x": {"field": "Horsepower", "type": "quantitative"},
          "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
          "size": {
            "condition": {"selection": "pt", "value": 300},
            "value": 50
          }
        }
      }, {
        "mark": "point",
        "encoding": {
          "x": {"field": "Horsepower", "type": "quantitative", "bin": true},
          "y": {"field": "Miles_per_Gallon", "type": "quantitative", "aggregate": "count"},
          "size": {
            "condition": {"selection": "pt", "value": 300},
            "value": 50
          }
        }
      }]
    }
    ```
   
@domoritz: Given your deeper familiarity with the Vega-Lite dataflow architecture, I'm wondering whether you could take over? I'm a little worried about being a bull in a china shop here!