### PR TITLE
Nearest/voronoi should align with spatial projections.

### DIFF
--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -4,7 +4,15 @@ import {hasContinuousDomain, isBinScale} from '../../scale';
 import {extend, keys, stringValue} from '../../util';
 import {VgEventStream} from '../../vega.schema';
 import {UnitModel} from '../unit';
-import {channelSignalName, ProjectComponent, SelectionCompiler, SelectionComponent, STORE, TUPLE} from './selection';
+import {
+  channelSignalName,
+  ProjectComponent,
+  SelectionCompiler,
+  SelectionComponent,
+  spatialProjections,
+  STORE,
+  TUPLE,
+} from './selection';
 import scales from './transforms/scales';
 
 export const BRUSH = '_brush';
@@ -81,7 +89,7 @@ const interval:SelectionCompiler = {
 
   marks: function(model, selCmpt, marks) {
     const name = selCmpt.name;
-    const {xi, yi} = projections(selCmpt);
+    const {xi, yi} = spatialProjections(selCmpt);
     const tpl = name + TUPLE;
     const store = `data(${stringValue(selCmpt.name + STORE)})`;
 
@@ -142,24 +150,6 @@ const interval:SelectionCompiler = {
   }
 };
 export {interval as default};
-
-export function projections(selCmpt: SelectionComponent) {
-  let x:ProjectComponent = null;
-  let xi:number = null;
-  let y:ProjectComponent = null;
-  let yi: number = null;
-
-  selCmpt.project.forEach(function(p, i) {
-    if (p.channel === X) {
-      x  = p;
-      xi = i;
-    } else if (p.channel === Y) {
-      y = p;
-      yi = i;
-    }
-  });
-  return {x, xi, y, yi};
-}
 
 /**
  * Returns the visual and data signals for an interval selection.

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -1,5 +1,5 @@
 import {selector as parseSelector} from 'vega-event-selector';
-import {Channel, ScaleChannel, SingleDefChannel} from '../../channel';
+import {Channel, ScaleChannel, SingleDefChannel, X, Y} from '../../channel';
 import {warn} from '../../log';
 import {LogicalOperand} from '../../logical';
 import {SelectionDomain} from '../../scale';
@@ -298,4 +298,22 @@ export function channelSignalName(selCmpt: SelectionComponent, channel: Channel,
 
 function clipMarks(marks: any[]): any[] {
   return marks.map((m) => (m.clip = true, m));
+}
+
+export function spatialProjections(selCmpt: SelectionComponent) {
+  let x:ProjectComponent = null;
+  let xi:number = null;
+  let y:ProjectComponent = null;
+  let yi: number = null;
+
+  selCmpt.project.forEach((p, i) => {
+    if (p.channel === X) {
+      x  = p;
+      xi = i;
+    } else if (p.channel === Y) {
+      y = p;
+      yi = i;
+    }
+  });
+  return {x, xi, y, yi};
 }

--- a/src/compile/selection/transforms/nearest.ts
+++ b/src/compile/selection/transforms/nearest.ts
@@ -1,3 +1,4 @@
+import {spatialProjections} from '../selection';
 import {TransformCompiler} from './transforms';
 
 const VORONOI = 'voronoi';
@@ -8,6 +9,7 @@ const nearest:TransformCompiler = {
   },
 
   marks: function(model, selCmpt, marks, selMarks) {
+    const {x, y} = spatialProjections(selCmpt);
     const mark = marks[0];
     const index = selMarks.indexOf(mark);
     const isPathgroup = mark.name === model.getName('pathgroup');
@@ -26,8 +28,8 @@ const nearest:TransformCompiler = {
       },
       transform: [{
         type: 'voronoi',
-        x: 'datum.x',
-        y: 'datum.y',
+        x: (x || (!x && !y)) ? 'datum.x' : {expr: '0'},
+        y: (y || (!x && !y)) ? 'datum.y' : {expr: '0'},
         size: [model.getSizeSignalRef('width'), model.getSizeSignalRef('height')]
       }]
     };

--- a/src/compile/selection/transforms/translate.ts
+++ b/src/compile/selection/transforms/translate.ts
@@ -1,8 +1,8 @@
 import {selector as parseSelector} from 'vega-event-selector';
 import {Channel, ScaleChannel, X, Y} from '../../../channel';
 import {stringValue} from '../../../util';
-import {BRUSH as INTERVAL_BRUSH, projections as intervalProjections} from '../interval';
-import {channelSignalName, SelectionComponent} from '../selection';
+import {BRUSH as INTERVAL_BRUSH} from '../interval';
+import {channelSignalName, SelectionComponent, spatialProjections} from '../selection';
 import {UnitModel} from './../../unit';
 import {default as scalesCompiler, domain} from './scales';
 import {TransformCompiler} from './transforms';
@@ -20,7 +20,7 @@ const translate:TransformCompiler = {
     const name = selCmpt.name;
     const hasScales = scalesCompiler.has(selCmpt);
     const anchor = name + ANCHOR;
-    const {x, y} = intervalProjections(selCmpt);
+    const {x, y} = spatialProjections(selCmpt);
     let events = parseSelector(selCmpt.translate, 'scope');
 
     if (!hasScales) {

--- a/src/compile/selection/transforms/zoom.ts
+++ b/src/compile/selection/transforms/zoom.ts
@@ -1,8 +1,8 @@
 import {selector as parseSelector} from 'vega-event-selector';
 import {Channel, ScaleChannel, X, Y} from '../../../channel';
 import {stringValue} from '../../../util';
-import {BRUSH as INTERVAL_BRUSH, projections as intervalProjections} from '../interval';
-import {channelSignalName, SelectionComponent} from '../selection';
+import {BRUSH as INTERVAL_BRUSH} from '../interval';
+import {channelSignalName, SelectionComponent, spatialProjections} from '../selection';
 import {UnitModel} from './../../unit';
 import {default as scalesCompiler, domain} from './scales';
 import {TransformCompiler} from './transforms';
@@ -20,7 +20,7 @@ const zoom:TransformCompiler = {
     const name = selCmpt.name;
     const hasScales = scalesCompiler.has(selCmpt);
     const delta = name + DELTA;
-    const {x, y} = intervalProjections(selCmpt);
+    const {x, y} = spatialProjections(selCmpt);
     const sx = stringValue(model.scaleName(X));
     const sy = stringValue(model.scaleName(Y));
     let events = parseSelector(selCmpt.zoom, 'scope');


### PR DESCRIPTION
This PR ensures that if a selection is projected over the x or y channels, the voronoi is appropriately aligned (see vega/vega#799). For all other projections, the voronoi continues to be computed in both dimensions. Resolves #2657. 