### PR TITLE
Update inrange Vega Expression to match the new version

### DIFF
--- a/src/filter.ts
+++ b/src/filter.ts
@@ -136,9 +136,9 @@ export function expression(model: Model, filterOp: LogicalOperand<Filter>, node?
         const upper = filter.range[1];
 
         if (lower !== null &&  upper !== null) {
-          return 'inrange(' + fieldExpr + ', ' +
+          return 'inrange(' + fieldExpr + ', [' +
             valueExpr(lower, filter.timeUnit) + ', ' +
-            valueExpr(upper, filter.timeUnit) + ')';
+            valueExpr(upper, filter.timeUnit) + '])';
         } else if (lower !== null) {
           return fieldExpr + ' >= ' + lower;
         } else if (upper !== null) {

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -87,7 +87,7 @@ describe('filter', () => {
 
     it('should return a correct expression for a RangeFilter', () => {
       const expr = expression(null, {field: 'x', range: [0, 5]});
-      assert.equal(expr, 'inrange(datum["x"], 0, 5)');
+      assert.equal(expr, 'inrange(datum["x"], [0, 5])');
     });
 
     it('should return a correct expression for a RangeFilter with no lower bound', () => {
@@ -121,7 +121,7 @@ describe('filter', () => {
       {field: 'x', range: [0, 5]}
     ]});
 
-    assert.equal(expr, '(datum["color"]==="red") && (inrange(datum["x"], 0, 5))');
+    assert.equal(expr, '(datum["color"]==="red") && (inrange(datum["x"], [0, 5]))');
 
     expr = expression(null, {and: [
       {field: 'color', oneOf: ['red', 'yellow']},


### PR DESCRIPTION
(From `inrange(datum, min, max)` to `inrange(datum, [min, max])`. )

Fix #2648

cc: @willium

