### PR TITLE
Always clip marks.

### DIFF
--- a/examples/vg-specs/area.vg.json
+++ b/examples/vg-specs/area.vg.json
@@ -72,6 +72,7 @@
         {
             "name": "marks",
             "type": "area",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/area_vertical.vg.json
+++ b/examples/vg-specs/area_vertical.vg.json
@@ -73,6 +73,7 @@
         {
             "name": "marks",
             "type": "area",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/bar.vg.json
+++ b/examples/vg-specs/bar.vg.json
@@ -89,6 +89,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/bar_1d.vg.json
+++ b/examples/vg-specs/bar_1d.vg.json
@@ -57,6 +57,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/bar_1d_rangestep_config.vg.json
+++ b/examples/vg-specs/bar_1d_rangestep_config.vg.json
@@ -57,6 +57,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/bar_aggregate.vg.json
+++ b/examples/vg-specs/bar_aggregate.vg.json
@@ -64,6 +64,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/bar_aggregate_count.vg.json
+++ b/examples/vg-specs/bar_aggregate_count.vg.json
@@ -78,6 +78,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/bar_aggregate_size.vg.json
+++ b/examples/vg-specs/bar_aggregate_size.vg.json
@@ -64,6 +64,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/bar_aggregate_vertical.vg.json
+++ b/examples/vg-specs/bar_aggregate_vertical.vg.json
@@ -59,6 +59,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/bar_array_aggregate.vg.json
+++ b/examples/vg-specs/bar_array_aggregate.vg.json
@@ -99,6 +99,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/bar_distinct.vg.json
+++ b/examples/vg-specs/bar_distinct.vg.json
@@ -56,6 +56,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/bar_filter_calc.vg.json
+++ b/examples/vg-specs/bar_filter_calc.vg.json
@@ -93,6 +93,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/bar_grouped.vg.json
+++ b/examples/vg-specs/bar_grouped.vg.json
@@ -289,6 +289,7 @@
                 {
                     "name": "child_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "facet"

--- a/examples/vg-specs/bar_grouped_horizontal.vg.json
+++ b/examples/vg-specs/bar_grouped_horizontal.vg.json
@@ -240,6 +240,7 @@
                 {
                     "name": "child_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "facet"

--- a/examples/vg-specs/bar_layered_transparent.vg.json
+++ b/examples/vg-specs/bar_layered_transparent.vg.json
@@ -70,6 +70,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/bar_month.vg.json
+++ b/examples/vg-specs/bar_month.vg.json
@@ -65,6 +65,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/bar_size_default.vg.json
+++ b/examples/vg-specs/bar_size_default.vg.json
@@ -56,6 +56,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/bar_size_explicit.vg.json
+++ b/examples/vg-specs/bar_size_explicit.vg.json
@@ -52,6 +52,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/bar_size_explicit_bad.vg.json
+++ b/examples/vg-specs/bar_size_explicit_bad.vg.json
@@ -52,6 +52,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/bar_size_fit.vg.json
+++ b/examples/vg-specs/bar_size_fit.vg.json
@@ -52,6 +52,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/bar_size_rangestep_small.vg.json
+++ b/examples/vg-specs/bar_size_rangestep_small.vg.json
@@ -89,6 +89,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/bar_sort_by_count.vg.json
+++ b/examples/vg-specs/bar_sort_by_count.vg.json
@@ -61,6 +61,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/bar_swap_axes.vg.json
+++ b/examples/vg-specs/bar_swap_axes.vg.json
@@ -99,6 +99,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/bar_swap_custom.vg.json
+++ b/examples/vg-specs/bar_swap_custom.vg.json
@@ -99,6 +99,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/bar_tooltip.vg.json
+++ b/examples/vg-specs/bar_tooltip.vg.json
@@ -89,6 +89,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/bar_yearmonth.vg.json
+++ b/examples/vg-specs/bar_yearmonth.vg.json
@@ -66,6 +66,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/box-plot_minmax_1D_horizontal.vg.json
+++ b/examples/vg-specs/box-plot_minmax_1D_horizontal.vg.json
@@ -138,6 +138,7 @@
         {
             "name": "layer_0_marks",
             "type": "rule",
+            "clip": true,
             "role": "boxWhisker",
             "from": {
                 "data": "data_0"
@@ -160,12 +161,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "rule",
+            "clip": true,
             "role": "boxWhisker",
             "from": {
                 "data": "data_1"
@@ -188,12 +189,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_2_marks",
             "type": "rect",
+            "clip": true,
             "role": "box",
             "from": {
                 "data": "data_2"
@@ -219,12 +220,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_3_marks",
             "type": "rect",
+            "clip": true,
             "role": "boxMid",
             "from": {
                 "data": "data_3"
@@ -252,8 +253,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/box-plot_minmax_1D_vertical.vg.json
+++ b/examples/vg-specs/box-plot_minmax_1D_vertical.vg.json
@@ -138,6 +138,7 @@
         {
             "name": "layer_0_marks",
             "type": "rule",
+            "clip": true,
             "role": "boxWhisker",
             "from": {
                 "data": "data_0"
@@ -160,12 +161,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "rule",
+            "clip": true,
             "role": "boxWhisker",
             "from": {
                 "data": "data_1"
@@ -188,12 +189,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_2_marks",
             "type": "rect",
+            "clip": true,
             "role": "box",
             "from": {
                 "data": "data_2"
@@ -219,12 +220,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_3_marks",
             "type": "rect",
+            "clip": true,
             "role": "boxMid",
             "from": {
                 "data": "data_3"
@@ -252,8 +253,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/box-plot_minmax_2D_horizontal.vg.json
+++ b/examples/vg-specs/box-plot_minmax_2D_horizontal.vg.json
@@ -144,6 +144,7 @@
         {
             "name": "layer_0_marks",
             "type": "rule",
+            "clip": true,
             "role": "boxWhisker",
             "from": {
                 "data": "data_0"
@@ -167,12 +168,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "rule",
+            "clip": true,
             "role": "boxWhisker",
             "from": {
                 "data": "data_1"
@@ -196,12 +197,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_2_marks",
             "type": "rect",
+            "clip": true,
             "role": "box",
             "from": {
                 "data": "data_2"
@@ -228,12 +229,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_3_marks",
             "type": "rect",
+            "clip": true,
             "role": "boxMid",
             "from": {
                 "data": "data_3"
@@ -262,8 +263,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/box-plot_minmax_2D_vertical.vg.json
+++ b/examples/vg-specs/box-plot_minmax_2D_vertical.vg.json
@@ -144,6 +144,7 @@
         {
             "name": "layer_0_marks",
             "type": "rule",
+            "clip": true,
             "role": "boxWhisker",
             "from": {
                 "data": "data_0"
@@ -167,12 +168,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "rule",
+            "clip": true,
             "role": "boxWhisker",
             "from": {
                 "data": "data_1"
@@ -196,12 +197,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_2_marks",
             "type": "rect",
+            "clip": true,
             "role": "box",
             "from": {
                 "data": "data_2"
@@ -228,12 +229,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_3_marks",
             "type": "rect",
+            "clip": true,
             "role": "boxMid",
             "from": {
                 "data": "data_3"
@@ -262,8 +263,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -285,6 +285,7 @@
     "marks": [
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -337,6 +338,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"
@@ -373,6 +375,7 @@
         {
             "name": "brush_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {

--- a/examples/vg-specs/bubble_health_income.vg.json
+++ b/examples/vg-specs/bubble_health_income.vg.json
@@ -185,6 +185,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"
@@ -213,8 +214,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/circle.vg.json
+++ b/examples/vg-specs/circle.vg.json
@@ -45,6 +45,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/concat_selections.vg.json
+++ b/examples/vg-specs/concat_selections.vg.json
@@ -349,6 +349,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -401,6 +402,7 @@
                 {
                     "name": "concat_0_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_0"
@@ -430,6 +432,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -706,6 +709,7 @@
                 {
                     "name": "concat_1_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_1"
@@ -736,8 +740,7 @@
                                 "value": 0.7
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [

--- a/examples/vg-specs/dashboard_europe_pop.vg.json
+++ b/examples/vg-specs/dashboard_europe_pop.vg.json
@@ -593,6 +593,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -647,6 +648,7 @@
                 {
                     "name": "concat_0_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "data_1"
@@ -684,6 +686,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -992,6 +995,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1046,6 +1050,7 @@
                 {
                     "name": "concat_1_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "data_2"
@@ -1083,6 +1088,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1457,6 +1463,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1509,6 +1516,7 @@
                 {
                     "name": "concat_2_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_3"
@@ -1544,6 +1552,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {

--- a/examples/vg-specs/diverging_color_points.vg.json
+++ b/examples/vg-specs/diverging_color_points.vg.json
@@ -47,6 +47,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/errorbar_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_aggregate.vg.json
@@ -153,6 +153,7 @@
         {
             "name": "layer_0_marks",
             "type": "rule",
+            "clip": true,
             "from": {
                 "data": "data_0"
             },
@@ -174,12 +175,12 @@
                         "value": "black"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "rect",
+            "clip": true,
             "role": "tick",
             "from": {
                 "data": "data_1"
@@ -204,12 +205,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_2_marks",
             "type": "rect",
+            "clip": true,
             "role": "tick",
             "from": {
                 "data": "data_2"
@@ -234,12 +235,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_3_marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "data_3"
@@ -264,8 +265,7 @@
                         "value": 2
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
@@ -153,6 +153,7 @@
         {
             "name": "layer_0_marks",
             "type": "rule",
+            "clip": true,
             "from": {
                 "data": "data_0"
             },
@@ -174,12 +175,12 @@
                         "value": "black"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "rect",
+            "clip": true,
             "role": "tick",
             "from": {
                 "data": "data_1"
@@ -204,12 +205,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_2_marks",
             "type": "rect",
+            "clip": true,
             "role": "tick",
             "from": {
                 "data": "data_2"
@@ -234,12 +235,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_3_marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "data_3"
@@ -264,8 +265,7 @@
                         "value": 2
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -591,6 +591,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -616,12 +617,12 @@
                                 }
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "child_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "circle",
                     "from": {
                         "data": "facet"
@@ -661,8 +662,7 @@
                                 "value": 1
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "child_voronoi",
@@ -700,12 +700,12 @@
                                 }
                             ]
                         }
-                    ],
-                    "clip": true
+                    ]
                 },
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -731,8 +731,7 @@
                                 }
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "axes": [

--- a/examples/vg-specs/field_spaces.vg.json
+++ b/examples/vg-specs/field_spaces.vg.json
@@ -93,6 +93,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/github_punchcard.vg.json
+++ b/examples/vg-specs/github_punchcard.vg.json
@@ -75,6 +75,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/histogram.vg.json
+++ b/examples/vg-specs/histogram.vg.json
@@ -78,6 +78,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/histogram_bin_change.vg.json
+++ b/examples/vg-specs/histogram_bin_change.vg.json
@@ -78,6 +78,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/histogram_no_spacing.vg.json
+++ b/examples/vg-specs/histogram_no_spacing.vg.json
@@ -78,6 +78,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/histogram_sort_mean.vg.json
+++ b/examples/vg-specs/histogram_sort_mean.vg.json
@@ -63,6 +63,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/interactive_splom.vg.json
+++ b/examples/vg-specs/interactive_splom.vg.json
@@ -448,6 +448,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -473,12 +474,12 @@
                                 "signal": "brush_y[1]"
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "child_Horsepower_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_0"
@@ -510,12 +511,12 @@
                                 "value": 0.7
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -541,8 +542,7 @@
                                 "signal": "brush_y[1]"
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [
@@ -1028,6 +1028,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1051,12 +1052,12 @@
                                 "signal": "brush_y[1]"
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "child_Horsepower_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_1"
@@ -1088,12 +1089,12 @@
                                 "value": 0.7
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1117,8 +1118,7 @@
                                 "signal": "brush_y[1]"
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [
@@ -1607,6 +1607,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1630,12 +1631,12 @@
                                 "signal": "brush_y[1]"
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "child_Acceleration_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_2"
@@ -1667,12 +1668,12 @@
                                 "value": 0.7
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1696,8 +1697,7 @@
                                 "signal": "brush_y[1]"
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [
@@ -2186,6 +2186,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2209,12 +2210,12 @@
                                 "signal": "brush_y[1]"
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "child_Acceleration_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_3"
@@ -2246,12 +2247,12 @@
                                 "value": 0.7
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2275,8 +2276,7 @@
                                 "signal": "brush_y[1]"
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [

--- a/examples/vg-specs/interval_mark_style.vg.json
+++ b/examples/vg-specs/interval_mark_style.vg.json
@@ -534,6 +534,7 @@
     "marks": [
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -585,6 +586,7 @@
         },
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -637,6 +639,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },
@@ -668,6 +671,7 @@
         {
             "name": "alex_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -720,6 +724,7 @@
         {
             "name": "morgan_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {

--- a/examples/vg-specs/layer_bar_dual_axis.vg.json
+++ b/examples/vg-specs/layer_bar_dual_axis.vg.json
@@ -118,6 +118,7 @@
         {
             "name": "layer_0_marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_0"
@@ -144,12 +145,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "data_1"
             },
@@ -168,8 +169,7 @@
                         "value": "firebrick"
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/layer_bar_dual_axis_minmax.vg.json
+++ b/examples/vg-specs/layer_bar_dual_axis_minmax.vg.json
@@ -162,6 +162,7 @@
         {
             "name": "layer_0_marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_0"
@@ -188,12 +189,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_layer_0_marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "data_1"
             },
@@ -212,12 +213,12 @@
                         "value": "firebrick"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_layer_1_marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "data_2"
             },
@@ -236,8 +237,7 @@
                         "value": "firebrick"
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/layer_bar_line.vg.json
+++ b/examples/vg-specs/layer_bar_line.vg.json
@@ -110,6 +110,7 @@
         {
             "name": "layer_0_marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_1"
@@ -136,12 +137,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "data_2"
             },
@@ -160,8 +161,7 @@
                         "value": "red"
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/layer_bar_line_union.vg.json
+++ b/examples/vg-specs/layer_bar_line_union.vg.json
@@ -119,6 +119,7 @@
         {
             "name": "layer_0_marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_1"
@@ -145,12 +146,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "data_2"
             },
@@ -169,8 +170,7 @@
                         "value": "red"
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/layer_box_plot_circle.vg.json
+++ b/examples/vg-specs/layer_box_plot_circle.vg.json
@@ -163,6 +163,7 @@
         {
             "name": "layer_0_layer_0_marks",
             "type": "rule",
+            "clip": true,
             "role": "boxWhisker",
             "from": {
                 "data": "data_1"
@@ -186,12 +187,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_0_layer_1_marks",
             "type": "rule",
+            "clip": true,
             "role": "boxWhisker",
             "from": {
                 "data": "data_2"
@@ -215,12 +216,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_0_layer_2_marks",
             "type": "rect",
+            "clip": true,
             "role": "box",
             "from": {
                 "data": "data_3"
@@ -247,12 +248,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_0_layer_3_marks",
             "type": "rect",
+            "clip": true,
             "role": "boxMid",
             "from": {
                 "data": "data_4"
@@ -281,12 +282,12 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "data_5"
@@ -312,8 +313,7 @@
                         "value": 0.1
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/layer_histogram.vg.json
+++ b/examples/vg-specs/layer_histogram.vg.json
@@ -137,6 +137,7 @@
         {
             "name": "layer_0_marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_0"
@@ -164,12 +165,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_1"
@@ -197,8 +198,7 @@
                         "value": "goldenrod"
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/layer_line_color_rule.vg.json
+++ b/examples/vg-specs/layer_line_color_rule.vg.json
@@ -116,6 +116,7 @@
                 {
                     "name": "layer_0_marks",
                     "type": "line",
+                    "clip": true,
                     "from": {
                         "data": "faceted_path_layer_0_main"
                     },
@@ -136,12 +137,12 @@
                         }
                     }
                 }
-            ],
-            "clip": true
+            ]
         },
         {
             "name": "layer_1_marks",
             "type": "rule",
+            "clip": true,
             "from": {
                 "data": "data_1"
             },
@@ -167,8 +168,7 @@
                         "value": 2
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/layer_overlay.vg.json
+++ b/examples/vg-specs/layer_overlay.vg.json
@@ -169,6 +169,7 @@
         {
             "name": "layer_0_layer_0_marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "data_5"
             },
@@ -186,12 +187,12 @@
                         "value": "darkred"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_0_layer_1_marks",
             "type": "symbol",
+            "clip": true,
             "role": "pointOverlay",
             "from": {
                 "data": "data_6"
@@ -210,12 +211,12 @@
                         "value": "darkred"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_layer_0_marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "data_2"
             },
@@ -233,12 +234,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_layer_1_marks",
             "type": "symbol",
+            "clip": true,
             "role": "pointOverlay",
             "from": {
                 "data": "data_4"
@@ -257,8 +258,7 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/layer_precipitation_mean.vg.json
+++ b/examples/vg-specs/layer_precipitation_mean.vg.json
@@ -99,6 +99,7 @@
         {
             "name": "layer_0_marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_0"
@@ -125,12 +126,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "rule",
+            "clip": true,
             "from": {
                 "data": "data_1"
             },
@@ -155,8 +156,7 @@
                         "value": 3
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/layer_single_color.vg.json
+++ b/examples/vg-specs/layer_single_color.vg.json
@@ -79,6 +79,7 @@
                 {
                     "name": "layer_0_marks",
                     "type": "line",
+                    "clip": true,
                     "from": {
                         "data": "faceted_path_layer_0_main"
                     },
@@ -99,8 +100,7 @@
                         }
                     }
                 }
-            ],
-            "clip": true
+            ]
         }
     ],
     "scales": [

--- a/examples/vg-specs/layer_text_heatmap.vg.json
+++ b/examples/vg-specs/layer_text_heatmap.vg.json
@@ -87,6 +87,7 @@
         {
             "name": "layer_0_marks",
             "type": "rect",
+            "clip": true,
             "from": {
                 "data": "data_0"
             },
@@ -113,12 +114,12 @@
                         "field": "count_*"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "text",
+            "clip": true,
             "from": {
                 "data": "data_1"
             },
@@ -144,8 +145,7 @@
                         "value": "center"
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/layered_color_legend_left.vg.json
+++ b/examples/vg-specs/layered_color_legend_left.vg.json
@@ -110,6 +110,7 @@
                 {
                     "name": "layer_0_marks",
                     "type": "line",
+                    "clip": true,
                     "from": {
                         "data": "faceted_path_layer_0_main"
                     },
@@ -130,12 +131,12 @@
                         }
                     }
                 }
-            ],
-            "clip": true
+            ]
         },
         {
             "name": "layer_1_marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "data_1"
@@ -158,8 +159,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/layered_crossfilter.vg.json
+++ b/examples/vg-specs/layered_crossfilter.vg.json
@@ -546,6 +546,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -595,12 +596,12 @@
                                 }
                             ]
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "child_distance_layer_0_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "data_0"
@@ -628,12 +629,12 @@
                                 "value": "#4c78a8"
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "child_distance_layer_1_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "data_1"
@@ -661,12 +662,12 @@
                                 "value": "goldenrod"
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -716,8 +717,7 @@
                                 }
                             ]
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [
@@ -1013,6 +1013,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1062,12 +1063,12 @@
                                 }
                             ]
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "child_delay_layer_0_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "data_2"
@@ -1095,12 +1096,12 @@
                                 "value": "#4c78a8"
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "child_delay_layer_1_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "data_3"
@@ -1128,12 +1129,12 @@
                                 "value": "goldenrod"
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1183,8 +1184,7 @@
                                 }
                             ]
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [
@@ -1480,6 +1480,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1529,12 +1530,12 @@
                                 }
                             ]
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "child_time_layer_0_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "data_4"
@@ -1562,12 +1563,12 @@
                                 "value": "#4c78a8"
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "child_time_layer_1_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "data_5"
@@ -1595,12 +1596,12 @@
                                 "value": "goldenrod"
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 },
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1650,8 +1651,7 @@
                                 }
                             ]
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [

--- a/examples/vg-specs/layered_falkensee.vg.json
+++ b/examples/vg-specs/layered_falkensee.vg.json
@@ -299,6 +299,7 @@
         {
             "name": "layer_0_marks",
             "type": "rect",
+            "clip": true,
             "from": {
                 "data": "data_3"
             },
@@ -325,12 +326,12 @@
                         "field": "event"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_layer_0_marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "data_1"
             },
@@ -348,12 +349,12 @@
                         "value": "#333"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_layer_1_marks",
             "type": "symbol",
+            "clip": true,
             "role": "pointOverlay",
             "from": {
                 "data": "data_2"
@@ -375,8 +376,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -502,6 +502,7 @@
     "marks": [
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -549,12 +550,12 @@
                         }
                     ]
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_0_marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "data_0"
@@ -589,12 +590,12 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "symbol",
+            "clip": true,
             "role": "square",
             "from": {
                 "data": "data_1"
@@ -635,12 +636,12 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "brush_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -688,8 +689,7 @@
                         }
                     ]
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/line.vg.json
+++ b/examples/vg-specs/line.vg.json
@@ -57,6 +57,7 @@
         {
             "name": "marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/line_calculate.vg.json
+++ b/examples/vg-specs/line_calculate.vg.json
@@ -76,6 +76,7 @@
         {
             "name": "marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/line_color.vg.json
+++ b/examples/vg-specs/line_color.vg.json
@@ -80,6 +80,7 @@
                 {
                     "name": "marks",
                     "type": "line",
+                    "clip": true,
                     "from": {
                         "data": "faceted_path_main"
                     },

--- a/examples/vg-specs/line_color_binned.vg.json
+++ b/examples/vg-specs/line_color_binned.vg.json
@@ -121,6 +121,7 @@
                 {
                     "name": "marks",
                     "type": "line",
+                    "clip": true,
                     "from": {
                         "data": "faceted_path_main"
                     },

--- a/examples/vg-specs/line_detail.vg.json
+++ b/examples/vg-specs/line_detail.vg.json
@@ -80,6 +80,7 @@
                 {
                     "name": "marks",
                     "type": "line",
+                    "clip": true,
                     "from": {
                         "data": "faceted_path_main"
                     },

--- a/examples/vg-specs/line_max_year.vg.json
+++ b/examples/vg-specs/line_max_year.vg.json
@@ -72,6 +72,7 @@
         {
             "name": "marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/line_mean_month.vg.json
+++ b/examples/vg-specs/line_mean_month.vg.json
@@ -72,6 +72,7 @@
         {
             "name": "marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/line_mean_year.vg.json
+++ b/examples/vg-specs/line_mean_year.vg.json
@@ -72,6 +72,7 @@
         {
             "name": "marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/line_monotone.vg.json
+++ b/examples/vg-specs/line_monotone.vg.json
@@ -56,6 +56,7 @@
         {
             "name": "marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/line_month.vg.json
+++ b/examples/vg-specs/line_month.vg.json
@@ -72,6 +72,7 @@
         {
             "name": "marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/line_quarter.vg.json
+++ b/examples/vg-specs/line_quarter.vg.json
@@ -275,6 +275,7 @@
                 {
                     "name": "child_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "facet"

--- a/examples/vg-specs/line_quarter_legend.vg.json
+++ b/examples/vg-specs/line_quarter_legend.vg.json
@@ -106,6 +106,7 @@
                 {
                     "name": "marks",
                     "type": "line",
+                    "clip": true,
                     "from": {
                         "data": "faceted_path_main"
                     },

--- a/examples/vg-specs/line_slope.vg.json
+++ b/examples/vg-specs/line_slope.vg.json
@@ -95,6 +95,7 @@
                 {
                     "name": "marks",
                     "type": "line",
+                    "clip": true,
                     "from": {
                         "data": "faceted_path_main"
                     },

--- a/examples/vg-specs/line_step.vg.json
+++ b/examples/vg-specs/line_step.vg.json
@@ -57,6 +57,7 @@
         {
             "name": "marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/lookup.vg.json
+++ b/examples/vg-specs/lookup.vg.json
@@ -80,6 +80,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/minimal.vg.json
+++ b/examples/vg-specs/minimal.vg.json
@@ -34,6 +34,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/output_utc_scale.vg.json
+++ b/examples/vg-specs/output_utc_scale.vg.json
@@ -86,6 +86,7 @@
         {
             "name": "marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "data_0"
             },

--- a/examples/vg-specs/output_utc_timeunit.vg.json
+++ b/examples/vg-specs/output_utc_timeunit.vg.json
@@ -86,6 +86,7 @@
         {
             "name": "marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "data_0"
             },

--- a/examples/vg-specs/overlay_area_full.vg.json
+++ b/examples/vg-specs/overlay_area_full.vg.json
@@ -116,6 +116,7 @@
         {
             "name": "layer_0_marks",
             "type": "area",
+            "clip": true,
             "from": {
                 "data": "data_0"
             },
@@ -140,12 +141,12 @@
                         "value": "vertical"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "data_1"
             },
@@ -163,12 +164,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_2_marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "data_2"
@@ -190,8 +191,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/overlay_area_short.vg.json
+++ b/examples/vg-specs/overlay_area_short.vg.json
@@ -116,6 +116,7 @@
         {
             "name": "layer_0_marks",
             "type": "area",
+            "clip": true,
             "from": {
                 "data": "data_0"
             },
@@ -140,12 +141,12 @@
                         "value": "vertical"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "line",
+            "clip": true,
             "role": "lineOverlay",
             "from": {
                 "data": "data_1"
@@ -164,12 +165,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_2_marks",
             "type": "symbol",
+            "clip": true,
             "role": "pointOverlay",
             "from": {
                 "data": "data_2"
@@ -191,8 +192,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/overlay_line_full.vg.json
+++ b/examples/vg-specs/overlay_line_full.vg.json
@@ -88,6 +88,7 @@
         {
             "name": "layer_0_marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "data_0"
             },
@@ -105,12 +106,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "data_1"
@@ -132,8 +133,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/overlay_line_short.vg.json
+++ b/examples/vg-specs/overlay_line_short.vg.json
@@ -89,6 +89,7 @@
         {
             "name": "layer_0_marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "data_0"
             },
@@ -106,12 +107,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "symbol",
+            "clip": true,
             "role": "pointOverlay",
             "from": {
                 "data": "data_1"
@@ -133,8 +134,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/overview_detail.vg.json
+++ b/examples/vg-specs/overview_detail.vg.json
@@ -425,6 +425,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -479,6 +480,7 @@
                 {
                     "name": "concat_1_marks",
                     "type": "area",
+                    "clip": true,
                     "from": {
                         "data": "data_1"
                     },
@@ -508,6 +510,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {

--- a/examples/vg-specs/paintbrush.vg.json
+++ b/examples/vg-specs/paintbrush.vg.json
@@ -100,6 +100,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/paintbrush_color.vg.json
+++ b/examples/vg-specs/paintbrush_color.vg.json
@@ -100,6 +100,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/paintbrush_color_nearest.vg.json
+++ b/examples/vg-specs/paintbrush_color_nearest.vg.json
@@ -100,6 +100,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/paintbrush_simple.vg.json
+++ b/examples/vg-specs/paintbrush_simple.vg.json
@@ -99,6 +99,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/panzoom_splom.vg.json
+++ b/examples/vg-specs/panzoom_splom.vg.json
@@ -349,6 +349,7 @@
                 {
                     "name": "child_Horsepower_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_0"
@@ -374,8 +375,7 @@
                                 "value": 0.7
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [
@@ -607,6 +607,7 @@
                 {
                     "name": "child_Horsepower_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_1"
@@ -632,8 +633,7 @@
                                 "value": 0.7
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [
@@ -868,6 +868,7 @@
                 {
                     "name": "child_Horsepower_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_2"
@@ -893,8 +894,7 @@
                                 "value": 0.7
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [
@@ -1129,6 +1129,7 @@
                 {
                     "name": "child_Acceleration_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_3"
@@ -1154,8 +1155,7 @@
                                 "value": 0.7
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [
@@ -1372,6 +1372,7 @@
                 {
                     "name": "child_Acceleration_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_4"
@@ -1397,8 +1398,7 @@
                                 "value": 0.7
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [
@@ -1630,6 +1630,7 @@
                 {
                     "name": "child_Acceleration_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_5"
@@ -1655,8 +1656,7 @@
                                 "value": 0.7
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [
@@ -1891,6 +1891,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_6"
@@ -1916,8 +1917,7 @@
                                 "value": 0.7
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [
@@ -2152,6 +2152,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_7"
@@ -2177,8 +2178,7 @@
                                 "value": 0.7
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [
@@ -2395,6 +2395,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_8"
@@ -2420,8 +2421,7 @@
                                 "value": 0.7
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [

--- a/examples/vg-specs/panzoom_vconcat_shared.vg.json
+++ b/examples/vg-specs/panzoom_vconcat_shared.vg.json
@@ -243,6 +243,7 @@
                 {
                     "name": "concat_0_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_0"
@@ -267,8 +268,7 @@
                                 "value": 0.7
                             }
                         }
-                    },
-                    "clip": true
+                    }
                 }
             ],
             "scales": [
@@ -358,6 +358,7 @@
                 {
                     "name": "concat_1_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_1"

--- a/examples/vg-specs/parse_local_time.vg.json
+++ b/examples/vg-specs/parse_local_time.vg.json
@@ -60,6 +60,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/parse_utc_time.vg.json
+++ b/examples/vg-specs/parse_utc_time.vg.json
@@ -66,6 +66,7 @@
         {
             "name": "marks",
             "type": "text",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/parse_utc_time_format.vg.json
+++ b/examples/vg-specs/parse_utc_time_format.vg.json
@@ -60,6 +60,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/point_1d.vg.json
+++ b/examples/vg-specs/point_1d.vg.json
@@ -44,6 +44,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/point_1d_array.vg.json
+++ b/examples/vg-specs/point_1d_array.vg.json
@@ -73,6 +73,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/point_1d_bin.vg.json
+++ b/examples/vg-specs/point_1d_bin.vg.json
@@ -62,6 +62,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/point_2d_aggregate.vg.json
+++ b/examples/vg-specs/point_2d_aggregate.vg.json
@@ -99,6 +99,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/point_2d_array.vg.json
+++ b/examples/vg-specs/point_2d_array.vg.json
@@ -88,6 +88,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/point_2d_array_named.vg.json
+++ b/examples/vg-specs/point_2d_array_named.vg.json
@@ -88,6 +88,7 @@
         {
             "name": "plotname_marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/point_color.vg.json
+++ b/examples/vg-specs/point_color.vg.json
@@ -36,6 +36,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/point_colorramp_size.vg.json
+++ b/examples/vg-specs/point_colorramp_size.vg.json
@@ -46,6 +46,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/point_dot_timeunit_color.vg.json
+++ b/examples/vg-specs/point_dot_timeunit_color.vg.json
@@ -65,6 +65,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/point_filled.vg.json
+++ b/examples/vg-specs/point_filled.vg.json
@@ -45,6 +45,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/point_ordinal_color.vg.json
+++ b/examples/vg-specs/point_ordinal_color.vg.json
@@ -83,6 +83,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/point_overlap.vg.json
+++ b/examples/vg-specs/point_overlap.vg.json
@@ -69,6 +69,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/query_widgets.vg.json
+++ b/examples/vg-specs/query_widgets.vg.json
@@ -161,6 +161,7 @@
         {
             "name": "layer_0_marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "data_0"
@@ -192,12 +193,12 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "data_1"
@@ -226,8 +227,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/rect_heatmap.vg.json
+++ b/examples/vg-specs/rect_heatmap.vg.json
@@ -64,6 +64,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/repeat_histogram.vg.json
+++ b/examples/vg-specs/repeat_histogram.vg.json
@@ -268,6 +268,7 @@
                 {
                     "name": "child_Horsepower_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "data_0"
@@ -410,6 +411,7 @@
                 {
                     "name": "child_Miles_per_Gallon_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "data_1"
@@ -552,6 +554,7 @@
                 {
                     "name": "child_Acceleration_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "data_2"

--- a/examples/vg-specs/repeat_histogram_flights.vg.json
+++ b/examples/vg-specs/repeat_histogram_flights.vg.json
@@ -212,6 +212,7 @@
                 {
                     "name": "child_distance_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "data_0"
@@ -350,6 +351,7 @@
                 {
                     "name": "child_delay_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "data_1"
@@ -488,6 +490,7 @@
                 {
                     "name": "child_time_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "data_2"

--- a/examples/vg-specs/repeat_independent_colors.vg.json
+++ b/examples/vg-specs/repeat_independent_colors.vg.json
@@ -95,6 +95,7 @@
                 {
                     "name": "child_Origin_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_0"
@@ -240,6 +241,7 @@
                 {
                     "name": "child_Cylinders_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_1"

--- a/examples/vg-specs/repeat_splom_cars.vg.json
+++ b/examples/vg-specs/repeat_splom_cars.vg.json
@@ -130,6 +130,7 @@
                 {
                     "name": "child_Displacement_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_0"
@@ -259,6 +260,7 @@
                 {
                     "name": "child_Displacement_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_1"
@@ -388,6 +390,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_2"
@@ -517,6 +520,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_3"

--- a/examples/vg-specs/repeat_splom_iris.vg.json
+++ b/examples/vg-specs/repeat_splom_iris.vg.json
@@ -355,6 +355,7 @@
                 {
                     "name": "child_petalWidth_sepalLength_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_0"
@@ -484,6 +485,7 @@
                 {
                     "name": "child_petalWidth_sepalWidth_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_1"
@@ -613,6 +615,7 @@
                 {
                     "name": "child_petalWidth_petalLength_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_2"
@@ -742,6 +745,7 @@
                 {
                     "name": "child_petalWidth_petalWidth_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_3"
@@ -871,6 +875,7 @@
                 {
                     "name": "child_petalLength_sepalLength_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_4"
@@ -1000,6 +1005,7 @@
                 {
                     "name": "child_petalLength_sepalWidth_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_5"
@@ -1129,6 +1135,7 @@
                 {
                     "name": "child_petalLength_petalLength_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_6"
@@ -1258,6 +1265,7 @@
                 {
                     "name": "child_petalLength_petalWidth_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_7"
@@ -1387,6 +1395,7 @@
                 {
                     "name": "child_sepalWidth_sepalLength_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_8"
@@ -1516,6 +1525,7 @@
                 {
                     "name": "child_sepalWidth_sepalWidth_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_9"
@@ -1645,6 +1655,7 @@
                 {
                     "name": "child_sepalWidth_petalLength_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_10"
@@ -1774,6 +1785,7 @@
                 {
                     "name": "child_sepalWidth_petalWidth_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_11"
@@ -1903,6 +1915,7 @@
                 {
                     "name": "child_sepalLength_sepalLength_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_12"
@@ -2032,6 +2045,7 @@
                 {
                     "name": "child_sepalLength_sepalWidth_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_13"
@@ -2161,6 +2175,7 @@
                 {
                     "name": "child_sepalLength_petalLength_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_14"
@@ -2290,6 +2305,7 @@
                 {
                     "name": "child_sepalLength_petalWidth_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_15"

--- a/examples/vg-specs/rule_color_mean.vg.json
+++ b/examples/vg-specs/rule_color_mean.vg.json
@@ -56,6 +56,7 @@
         {
             "name": "marks",
             "type": "rule",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/scatter.vg.json
+++ b/examples/vg-specs/scatter.vg.json
@@ -46,6 +46,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/scatter_aggregate_detail.vg.json
+++ b/examples/vg-specs/scatter_aggregate_detail.vg.json
@@ -60,6 +60,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/scatter_binned.vg.json
+++ b/examples/vg-specs/scatter_binned.vg.json
@@ -99,6 +99,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/scatter_binned_color.vg.json
+++ b/examples/vg-specs/scatter_binned_color.vg.json
@@ -70,6 +70,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/scatter_binned_opacity.vg.json
+++ b/examples/vg-specs/scatter_binned_opacity.vg.json
@@ -65,6 +65,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/scatter_binned_size.vg.json
+++ b/examples/vg-specs/scatter_binned_size.vg.json
@@ -65,6 +65,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/scatter_bubble.vg.json
+++ b/examples/vg-specs/scatter_bubble.vg.json
@@ -47,6 +47,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/scatter_color.vg.json
+++ b/examples/vg-specs/scatter_color.vg.json
@@ -45,6 +45,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/scatter_color_custom.vg.json
+++ b/examples/vg-specs/scatter_color_custom.vg.json
@@ -45,6 +45,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/scatter_color_ordinal.vg.json
+++ b/examples/vg-specs/scatter_color_ordinal.vg.json
@@ -45,6 +45,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/scatter_color_ordinal_custom.vg.json
+++ b/examples/vg-specs/scatter_color_ordinal_custom.vg.json
@@ -45,6 +45,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/scatter_color_quantitative.vg.json
+++ b/examples/vg-specs/scatter_color_quantitative.vg.json
@@ -46,6 +46,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/scatter_color_shape_constant.vg.json
+++ b/examples/vg-specs/scatter_color_shape_constant.vg.json
@@ -45,6 +45,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/scatter_colored_with_shape.vg.json
+++ b/examples/vg-specs/scatter_colored_with_shape.vg.json
@@ -46,6 +46,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/scatter_connected.vg.json
+++ b/examples/vg-specs/scatter_connected.vg.json
@@ -96,6 +96,7 @@
         {
             "name": "layer_0_marks",
             "type": "line",
+            "clip": true,
             "from": {
                 "data": "data_0"
             },
@@ -113,12 +114,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "symbol",
+            "clip": true,
             "role": "pointOverlay",
             "from": {
                 "data": "data_1"
@@ -140,8 +141,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/scatter_log.vg.json
+++ b/examples/vg-specs/scatter_log.vg.json
@@ -89,6 +89,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "data_0"

--- a/examples/vg-specs/scatter_opacity.vg.json
+++ b/examples/vg-specs/scatter_opacity.vg.json
@@ -45,6 +45,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/scatter_shape_custom.vg.json
+++ b/examples/vg-specs/scatter_shape_custom.vg.json
@@ -47,6 +47,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/scatter_tooltip.vg.json
+++ b/examples/vg-specs/scatter_tooltip.vg.json
@@ -46,6 +46,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/selection_bind_cylyr.vg.json
+++ b/examples/vg-specs/selection_bind_cylyr.vg.json
@@ -124,6 +124,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/selection_bind_origin.vg.json
+++ b/examples/vg-specs/selection_bind_origin.vg.json
@@ -100,6 +100,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/selection_composition_and.vg.json
+++ b/examples/vg-specs/selection_composition_and.vg.json
@@ -534,6 +534,7 @@
     "marks": [
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -585,6 +586,7 @@
         },
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -637,6 +639,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },
@@ -674,6 +677,7 @@
         {
             "name": "alex_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -726,6 +730,7 @@
         {
             "name": "morgan_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {

--- a/examples/vg-specs/selection_composition_or.vg.json
+++ b/examples/vg-specs/selection_composition_or.vg.json
@@ -534,6 +534,7 @@
     "marks": [
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -585,6 +586,7 @@
         },
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -637,6 +639,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },
@@ -674,6 +677,7 @@
         {
             "name": "alex_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -726,6 +730,7 @@
         {
             "name": "morgan_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {

--- a/examples/vg-specs/selection_filter.vg.json
+++ b/examples/vg-specs/selection_filter.vg.json
@@ -344,6 +344,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -396,6 +397,7 @@
                 {
                     "name": "concat_0_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_0"
@@ -425,6 +427,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -576,6 +579,7 @@
                 {
                     "name": "concat_1_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_1"

--- a/examples/vg-specs/selection_filter_composition.vg.json
+++ b/examples/vg-specs/selection_filter_composition.vg.json
@@ -344,6 +344,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -396,6 +397,7 @@
                 {
                     "name": "concat_0_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_0"
@@ -425,6 +427,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -576,6 +579,7 @@
                 {
                     "name": "concat_1_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_1"

--- a/examples/vg-specs/selection_insert.vg.json
+++ b/examples/vg-specs/selection_insert.vg.json
@@ -84,6 +84,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/selection_project_binned_interval.vg.json
+++ b/examples/vg-specs/selection_project_binned_interval.vg.json
@@ -310,6 +310,7 @@
     "marks": [
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -359,12 +360,12 @@
                         }
                     ]
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_0_marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_0"
@@ -392,12 +393,12 @@
                         "value": "#4c78a8"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_1_marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "data_1"
@@ -425,12 +426,12 @@
                         "value": "goldenrod"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "brush_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -480,8 +481,7 @@
                         }
                     ]
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/selection_project_interval.vg.json
+++ b/examples/vg-specs/selection_project_interval.vg.json
@@ -300,6 +300,7 @@
     "marks": [
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -352,6 +353,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },
@@ -389,6 +391,7 @@
         {
             "name": "pts_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {

--- a/examples/vg-specs/selection_project_interval_x.vg.json
+++ b/examples/vg-specs/selection_project_interval_x.vg.json
@@ -234,6 +234,7 @@
     "marks": [
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -288,6 +289,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },
@@ -325,6 +327,7 @@
         {
             "name": "pts_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {

--- a/examples/vg-specs/selection_project_interval_x_y.vg.json
+++ b/examples/vg-specs/selection_project_interval_x_y.vg.json
@@ -300,6 +300,7 @@
     "marks": [
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -352,6 +353,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },
@@ -389,6 +391,7 @@
         {
             "name": "pts_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {

--- a/examples/vg-specs/selection_project_interval_y.vg.json
+++ b/examples/vg-specs/selection_project_interval_y.vg.json
@@ -234,6 +234,7 @@
     "marks": [
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -288,6 +289,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },
@@ -325,6 +327,7 @@
         {
             "name": "pts_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {

--- a/examples/vg-specs/selection_project_multi.vg.json
+++ b/examples/vg-specs/selection_project_multi.vg.json
@@ -99,6 +99,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/selection_project_multi_cylinders.vg.json
+++ b/examples/vg-specs/selection_project_multi_cylinders.vg.json
@@ -99,6 +99,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/selection_project_multi_cylinders_origin.vg.json
+++ b/examples/vg-specs/selection_project_multi_cylinders_origin.vg.json
@@ -99,6 +99,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/selection_project_multi_origin.vg.json
+++ b/examples/vg-specs/selection_project_multi_origin.vg.json
@@ -99,6 +99,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/selection_project_single.vg.json
+++ b/examples/vg-specs/selection_project_single.vg.json
@@ -88,6 +88,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/selection_project_single_cylinders.vg.json
+++ b/examples/vg-specs/selection_project_single_cylinders.vg.json
@@ -88,6 +88,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/selection_project_single_cylinders_origin.vg.json
+++ b/examples/vg-specs/selection_project_single_cylinders_origin.vg.json
@@ -88,6 +88,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/selection_project_single_origin.vg.json
+++ b/examples/vg-specs/selection_project_single_origin.vg.json
@@ -88,6 +88,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "point",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/selection_resolution_global.vg.json
+++ b/examples/vg-specs/selection_resolution_global.vg.json
@@ -395,6 +395,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -449,6 +450,7 @@
                 {
                     "name": "child_Horsepower_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_0"
@@ -485,6 +487,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -866,6 +869,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -918,6 +922,7 @@
                 {
                     "name": "child_Horsepower_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_1"
@@ -954,6 +959,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1333,6 +1339,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1385,6 +1392,7 @@
                 {
                     "name": "child_Horsepower_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_2"
@@ -1421,6 +1429,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1800,6 +1809,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1852,6 +1862,7 @@
                 {
                     "name": "child_Acceleration_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_3"
@@ -1888,6 +1899,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2201,6 +2213,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2255,6 +2268,7 @@
                 {
                     "name": "child_Acceleration_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_4"
@@ -2291,6 +2305,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2672,6 +2687,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2724,6 +2740,7 @@
                 {
                     "name": "child_Acceleration_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_5"
@@ -2760,6 +2777,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3139,6 +3157,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3191,6 +3210,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_6"
@@ -3227,6 +3247,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3606,6 +3627,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3658,6 +3680,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_7"
@@ -3694,6 +3717,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -4007,6 +4031,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -4061,6 +4086,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_8"
@@ -4097,6 +4123,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {

--- a/examples/vg-specs/selection_resolution_intersect.vg.json
+++ b/examples/vg-specs/selection_resolution_intersect.vg.json
@@ -395,6 +395,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -425,6 +426,7 @@
                 {
                     "name": "child_Horsepower_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_0"
@@ -461,6 +463,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -818,6 +821,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -846,6 +850,7 @@
                 {
                     "name": "child_Horsepower_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_1"
@@ -882,6 +887,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1237,6 +1243,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1265,6 +1272,7 @@
                 {
                     "name": "child_Horsepower_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_2"
@@ -1301,6 +1309,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1656,6 +1665,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1684,6 +1694,7 @@
                 {
                     "name": "child_Acceleration_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_3"
@@ -1720,6 +1731,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2009,6 +2021,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2039,6 +2052,7 @@
                 {
                     "name": "child_Acceleration_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_4"
@@ -2075,6 +2089,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2432,6 +2447,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2460,6 +2476,7 @@
                 {
                     "name": "child_Acceleration_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_5"
@@ -2496,6 +2513,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2851,6 +2869,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2879,6 +2898,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_6"
@@ -2915,6 +2935,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3270,6 +3291,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3298,6 +3320,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_7"
@@ -3334,6 +3357,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3623,6 +3647,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3653,6 +3678,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_8"
@@ -3689,6 +3715,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {

--- a/examples/vg-specs/selection_resolution_intersect_others.vg.json
+++ b/examples/vg-specs/selection_resolution_intersect_others.vg.json
@@ -395,6 +395,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -425,6 +426,7 @@
                 {
                     "name": "child_Horsepower_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_0"
@@ -461,6 +463,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -818,6 +821,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -846,6 +850,7 @@
                 {
                     "name": "child_Horsepower_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_1"
@@ -882,6 +887,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1237,6 +1243,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1265,6 +1272,7 @@
                 {
                     "name": "child_Horsepower_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_2"
@@ -1301,6 +1309,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1656,6 +1665,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1684,6 +1694,7 @@
                 {
                     "name": "child_Acceleration_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_3"
@@ -1720,6 +1731,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2009,6 +2021,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2039,6 +2052,7 @@
                 {
                     "name": "child_Acceleration_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_4"
@@ -2075,6 +2089,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2432,6 +2447,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2460,6 +2476,7 @@
                 {
                     "name": "child_Acceleration_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_5"
@@ -2496,6 +2513,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2851,6 +2869,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2879,6 +2898,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_6"
@@ -2915,6 +2935,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3270,6 +3291,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3298,6 +3320,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_7"
@@ -3334,6 +3357,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3623,6 +3647,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3653,6 +3678,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_8"
@@ -3689,6 +3715,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {

--- a/examples/vg-specs/selection_resolution_union.vg.json
+++ b/examples/vg-specs/selection_resolution_union.vg.json
@@ -395,6 +395,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -425,6 +426,7 @@
                 {
                     "name": "child_Horsepower_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_0"
@@ -461,6 +463,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -818,6 +821,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -846,6 +850,7 @@
                 {
                     "name": "child_Horsepower_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_1"
@@ -882,6 +887,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1237,6 +1243,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1265,6 +1272,7 @@
                 {
                     "name": "child_Horsepower_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_2"
@@ -1301,6 +1309,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1656,6 +1665,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1684,6 +1694,7 @@
                 {
                     "name": "child_Acceleration_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_3"
@@ -1720,6 +1731,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2009,6 +2021,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2039,6 +2052,7 @@
                 {
                     "name": "child_Acceleration_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_4"
@@ -2075,6 +2089,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2432,6 +2447,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2460,6 +2476,7 @@
                 {
                     "name": "child_Acceleration_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_5"
@@ -2496,6 +2513,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2851,6 +2869,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2879,6 +2898,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_6"
@@ -2915,6 +2935,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3270,6 +3291,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3298,6 +3320,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_7"
@@ -3334,6 +3357,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3623,6 +3647,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3653,6 +3678,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_8"
@@ -3689,6 +3715,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {

--- a/examples/vg-specs/selection_resolution_union_others.vg.json
+++ b/examples/vg-specs/selection_resolution_union_others.vg.json
@@ -395,6 +395,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -425,6 +426,7 @@
                 {
                     "name": "child_Horsepower_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_0"
@@ -461,6 +463,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -818,6 +821,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -846,6 +850,7 @@
                 {
                     "name": "child_Horsepower_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_1"
@@ -882,6 +887,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1237,6 +1243,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1265,6 +1272,7 @@
                 {
                     "name": "child_Horsepower_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_2"
@@ -1301,6 +1309,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1656,6 +1665,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -1684,6 +1694,7 @@
                 {
                     "name": "child_Acceleration_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_3"
@@ -1720,6 +1731,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2009,6 +2021,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2039,6 +2052,7 @@
                 {
                     "name": "child_Acceleration_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_4"
@@ -2075,6 +2089,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2432,6 +2447,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2460,6 +2476,7 @@
                 {
                     "name": "child_Acceleration_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_5"
@@ -2496,6 +2513,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2851,6 +2869,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -2879,6 +2898,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Horsepower_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_6"
@@ -2915,6 +2935,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3270,6 +3291,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3298,6 +3320,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Acceleration_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_7"
@@ -3334,6 +3357,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3623,6 +3647,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -3653,6 +3678,7 @@
                 {
                     "name": "child_Miles_per_Gallon_Miles_per_Gallon_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_8"
@@ -3689,6 +3715,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {

--- a/examples/vg-specs/selection_toggle_altKey.vg.json
+++ b/examples/vg-specs/selection_toggle_altKey.vg.json
@@ -99,6 +99,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/selection_toggle_altKey_shiftKey.vg.json
+++ b/examples/vg-specs/selection_toggle_altKey_shiftKey.vg.json
@@ -99,6 +99,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/selection_toggle_shiftKey.vg.json
+++ b/examples/vg-specs/selection_toggle_shiftKey.vg.json
@@ -99,6 +99,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/selection_translate_brush_drag.vg.json
+++ b/examples/vg-specs/selection_translate_brush_drag.vg.json
@@ -285,6 +285,7 @@
     "marks": [
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -337,6 +338,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"
@@ -377,6 +379,7 @@
         {
             "name": "brush_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {

--- a/examples/vg-specs/selection_translate_brush_shift-drag.vg.json
+++ b/examples/vg-specs/selection_translate_brush_shift-drag.vg.json
@@ -291,6 +291,7 @@
     "marks": [
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -343,6 +344,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"
@@ -383,6 +385,7 @@
         {
             "name": "brush_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {

--- a/examples/vg-specs/selection_translate_scatterplot_drag.vg.json
+++ b/examples/vg-specs/selection_translate_scatterplot_drag.vg.json
@@ -180,6 +180,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"
@@ -208,8 +209,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/selection_translate_scatterplot_shift-drag.vg.json
+++ b/examples/vg-specs/selection_translate_scatterplot_shift-drag.vg.json
@@ -186,6 +186,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"
@@ -214,8 +215,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/selection_type_interval.vg.json
+++ b/examples/vg-specs/selection_type_interval.vg.json
@@ -300,6 +300,7 @@
     "marks": [
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -352,6 +353,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },
@@ -389,6 +391,7 @@
         {
             "name": "pts_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {

--- a/examples/vg-specs/selection_type_multi.vg.json
+++ b/examples/vg-specs/selection_type_multi.vg.json
@@ -115,6 +115,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/selection_type_single.vg.json
+++ b/examples/vg-specs/selection_type_single.vg.json
@@ -104,6 +104,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/selection_type_single_dblclick.vg.json
+++ b/examples/vg-specs/selection_type_single_dblclick.vg.json
@@ -104,6 +104,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/selection_zoom_brush_shift-wheel.vg.json
+++ b/examples/vg-specs/selection_zoom_brush_shift-wheel.vg.json
@@ -291,6 +291,7 @@
     "marks": [
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -343,6 +344,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"
@@ -383,6 +385,7 @@
         {
             "name": "brush_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {

--- a/examples/vg-specs/selection_zoom_brush_wheel.vg.json
+++ b/examples/vg-specs/selection_zoom_brush_wheel.vg.json
@@ -285,6 +285,7 @@
     "marks": [
         {
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {
@@ -337,6 +338,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"
@@ -377,6 +379,7 @@
         {
             "name": "brush_brush",
             "type": "rect",
+            "clip": true,
             "encode": {
                 "enter": {
                     "fill": {

--- a/examples/vg-specs/selection_zoom_scatterplot_shift-wheel.vg.json
+++ b/examples/vg-specs/selection_zoom_scatterplot_shift-wheel.vg.json
@@ -186,6 +186,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"
@@ -214,8 +215,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/selection_zoom_scatterplot_wheel.vg.json
+++ b/examples/vg-specs/selection_zoom_scatterplot_wheel.vg.json
@@ -180,6 +180,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "circle",
             "from": {
                 "data": "source_0"
@@ -208,8 +209,7 @@
                         "value": 0.7
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/square.vg.json
+++ b/examples/vg-specs/square.vg.json
@@ -45,6 +45,7 @@
         {
             "name": "marks",
             "type": "symbol",
+            "clip": true,
             "role": "square",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/stacked_area.vg.json
+++ b/examples/vg-specs/stacked_area.vg.json
@@ -131,6 +131,7 @@
                 {
                     "name": "marks",
                     "type": "area",
+                    "clip": true,
                     "from": {
                         "data": "faceted_path_main"
                     },

--- a/examples/vg-specs/stacked_area_binned.vg.json
+++ b/examples/vg-specs/stacked_area_binned.vg.json
@@ -150,6 +150,7 @@
                 {
                     "name": "marks",
                     "type": "area",
+                    "clip": true,
                     "from": {
                         "data": "faceted_path_main"
                     },

--- a/examples/vg-specs/stacked_area_normalize.vg.json
+++ b/examples/vg-specs/stacked_area_normalize.vg.json
@@ -130,6 +130,7 @@
                 {
                     "name": "marks",
                     "type": "area",
+                    "clip": true,
                     "from": {
                         "data": "faceted_path_main"
                     },

--- a/examples/vg-specs/stacked_area_ordinal.vg.json
+++ b/examples/vg-specs/stacked_area_ordinal.vg.json
@@ -130,6 +130,7 @@
                 {
                     "name": "marks",
                     "type": "area",
+                    "clip": true,
                     "from": {
                         "data": "faceted_path_main"
                     },

--- a/examples/vg-specs/stacked_area_stream.vg.json
+++ b/examples/vg-specs/stacked_area_stream.vg.json
@@ -130,6 +130,7 @@
                 {
                     "name": "marks",
                     "type": "area",
+                    "clip": true,
                     "from": {
                         "data": "faceted_path_main"
                     },

--- a/examples/vg-specs/stacked_bar_1d.vg.json
+++ b/examples/vg-specs/stacked_bar_1d.vg.json
@@ -73,6 +73,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/stacked_bar_count.vg.json
+++ b/examples/vg-specs/stacked_bar_count.vg.json
@@ -85,6 +85,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/stacked_bar_h.vg.json
+++ b/examples/vg-specs/stacked_bar_h.vg.json
@@ -80,6 +80,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/stacked_bar_h_order.vg.json
+++ b/examples/vg-specs/stacked_bar_h_order.vg.json
@@ -80,6 +80,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/stacked_bar_normalize.vg.json
+++ b/examples/vg-specs/stacked_bar_normalize.vg.json
@@ -89,6 +89,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/stacked_bar_population.vg.json
+++ b/examples/vg-specs/stacked_bar_population.vg.json
@@ -90,6 +90,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/stacked_bar_size.vg.json
+++ b/examples/vg-specs/stacked_bar_size.vg.json
@@ -85,6 +85,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/stacked_bar_sum_opacity.vg.json
+++ b/examples/vg-specs/stacked_bar_sum_opacity.vg.json
@@ -94,6 +94,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/stacked_bar_v.vg.json
+++ b/examples/vg-specs/stacked_bar_v.vg.json
@@ -80,6 +80,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/stacked_bar_weather.vg.json
+++ b/examples/vg-specs/stacked_bar_weather.vg.json
@@ -85,6 +85,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "bar",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/stocks_nearest_index.vg.json
+++ b/examples/vg-specs/stocks_nearest_index.vg.json
@@ -170,6 +170,7 @@
                 {
                     "name": "layer_0_marks",
                     "type": "line",
+                    "clip": true,
                     "from": {
                         "data": "faceted_path_layer_0_main"
                     },
@@ -230,12 +231,12 @@
                         }
                     ]
                 }
-            ],
-            "clip": true
+            ]
         },
         {
             "name": "layer_1_marks",
             "type": "rule",
+            "clip": true,
             "from": {
                 "data": "data_1"
             },
@@ -257,12 +258,12 @@
                         "value": "black"
                     }
                 }
-            },
-            "clip": true
+            }
         },
         {
             "name": "layer_2_marks",
             "type": "text",
+            "clip": true,
             "from": {
                 "data": "data_2"
             },
@@ -282,8 +283,7 @@
                         "value": "black"
                     }
                 }
-            },
-            "clip": true
+            }
         }
     ],
     "scales": [

--- a/examples/vg-specs/text_scatter_colored.vg.json
+++ b/examples/vg-specs/text_scatter_colored.vg.json
@@ -50,6 +50,7 @@
         {
             "name": "marks",
             "type": "text",
+            "clip": true,
             "from": {
                 "data": "source_0"
             },

--- a/examples/vg-specs/tick_dot.vg.json
+++ b/examples/vg-specs/tick_dot.vg.json
@@ -44,6 +44,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "tick",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/tick_dot_thickness.vg.json
+++ b/examples/vg-specs/tick_dot_thickness.vg.json
@@ -44,6 +44,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "tick",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/tick_sort.vg.json
+++ b/examples/vg-specs/tick_sort.vg.json
@@ -44,6 +44,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "tick",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/tick_strip.vg.json
+++ b/examples/vg-specs/tick_strip.vg.json
@@ -49,6 +49,7 @@
         {
             "name": "marks",
             "type": "rect",
+            "clip": true,
             "role": "tick",
             "from": {
                 "data": "source_0"

--- a/examples/vg-specs/timeunit_selections.vg.json
+++ b/examples/vg-specs/timeunit_selections.vg.json
@@ -310,6 +310,7 @@
             "marks": [
                 {
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -364,6 +365,7 @@
                 {
                     "name": "concat_0_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_1"
@@ -399,6 +401,7 @@
                 {
                     "name": "brush_brush",
                     "type": "rect",
+                    "clip": true,
                     "encode": {
                         "enter": {
                             "fill": {
@@ -566,6 +569,7 @@
                 {
                     "name": "concat_1_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_2"

--- a/examples/vg-specs/trellis_anscombe.vg.json
+++ b/examples/vg-specs/trellis_anscombe.vg.json
@@ -233,6 +233,7 @@
                 {
                     "name": "child_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "circle",
                     "from": {
                         "data": "facet"

--- a/examples/vg-specs/trellis_bar.vg.json
+++ b/examples/vg-specs/trellis_bar.vg.json
@@ -263,6 +263,7 @@
                 {
                     "name": "child_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "facet"

--- a/examples/vg-specs/trellis_bar_histogram.vg.json
+++ b/examples/vg-specs/trellis_bar_histogram.vg.json
@@ -255,6 +255,7 @@
                 {
                     "name": "child_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "facet"

--- a/examples/vg-specs/trellis_barley.vg.json
+++ b/examples/vg-specs/trellis_barley.vg.json
@@ -248,6 +248,7 @@
                 {
                     "name": "trellis_barley_child_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "data_0"

--- a/examples/vg-specs/trellis_column_year.vg.json
+++ b/examples/vg-specs/trellis_column_year.vg.json
@@ -309,6 +309,7 @@
                         {
                             "name": "child_marks",
                             "type": "line",
+                            "clip": true,
                             "from": {
                                 "data": "faceted_path_child_main"
                             },

--- a/examples/vg-specs/trellis_row_column.vg.json
+++ b/examples/vg-specs/trellis_row_column.vg.json
@@ -316,6 +316,7 @@
                 {
                     "name": "child_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "facet"

--- a/examples/vg-specs/trellis_scatter.vg.json
+++ b/examples/vg-specs/trellis_scatter.vg.json
@@ -232,6 +232,7 @@
                 {
                     "name": "child_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "facet"

--- a/examples/vg-specs/trellis_scatter_binned_row.vg.json
+++ b/examples/vg-specs/trellis_scatter_binned_row.vg.json
@@ -230,6 +230,7 @@
                 {
                     "name": "child_marks",
                     "type": "symbol",
+                    "clip": true,
                     "role": "point",
                     "from": {
                         "data": "facet"

--- a/examples/vg-specs/trellis_stacked_bar.vg.json
+++ b/examples/vg-specs/trellis_stacked_bar.vg.json
@@ -267,6 +267,7 @@
                 {
                     "name": "child_marks",
                     "type": "rect",
+                    "clip": true,
                     "role": "bar",
                     "from": {
                         "data": "facet"

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -65,7 +65,7 @@ function parsePathMark(model: UnitModel) {
     {
       name: model.getName('marks'),
       type: markCompiler[mark].vgMark,
-      ...(clip(model)),
+      clip: true,
       ...(role? {role} : {}),
       // If has subfacet for line/area group, need to use faceted data from below.
       // FIXME: support sorting path order (in connected scatterplot)
@@ -112,7 +112,7 @@ function parseNonPathMark(model: UnitModel) {
   marks.push({
     name: model.getName('marks'),
     type: markCompiler[mark].vgMark,
-    ...(clip(model)),
+    clip: true,
     ...(role? {role} : {}),
     from: {data: model.requestDataName(MAIN)},
     encode: {update: markCompiler[mark].encodeEntry(model)}
@@ -147,11 +147,4 @@ function detailFields(model: UnitModel): string[] {
     }
     return details;
   }, []);
-}
-
-function clip(model: UnitModel) {
-  const xScaleDomain = model.scaleDomain(X);
-  const yScaleDomain = model.scaleDomain(Y);
-  return (xScaleDomain && isSelectionDomain(xScaleDomain)) ||
-    (yScaleDomain && isSelectionDomain(yScaleDomain)) ? {clip: true} : {};
 }

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -129,6 +129,7 @@ const interval:SelectionCompiler = {
 
     return [{
       type: 'rect',
+      clip: true,
       encode: {
         enter: {
           fill: {value: fill},
@@ -139,6 +140,7 @@ const interval:SelectionCompiler = {
     } as any].concat(marks, {
       name: name + BRUSH,
       type: 'rect',
+      clip: true,
       encode: {
         enter: {
           fill: {value: 'transparent'},

--- a/src/compile/selection/transforms/scales.ts
+++ b/src/compile/selection/transforms/scales.ts
@@ -8,8 +8,6 @@ import {TransformCompiler} from './transforms';
 
 
 const scaleBindings:TransformCompiler = {
-  clipGroup: true,
-
   has: function(selCmpt) {
     return selCmpt.type === 'interval' && selCmpt.resolve === 'global' &&
       selCmpt.bind && selCmpt.bind === 'scales';

--- a/test/compile/selection/interval.test.ts
+++ b/test/compile/selection/interval.test.ts
@@ -231,6 +231,7 @@ describe('Interval Selections', function() {
     assert.sameDeepMembers(interval.marks(model, selCmpts['one'], marks), [
       {
         "type": "rect",
+        "clip": true,
         "encode": {
           "enter": {
             "fill": {"value": "#333"},
@@ -282,6 +283,7 @@ describe('Interval Selections', function() {
       {
         "name": "one_brush",
         "type": "rect",
+        "clip": true,
         "encode": {
           "enter": {
             "fill": {"value": "transparent"},
@@ -337,6 +339,7 @@ describe('Interval Selections', function() {
     assert.sameDeepMembers(interval.marks(model, selCmpts['thr_ee'], marks), [
       {
         "type": "rect",
+        "clip": true,
         "encode": {
           "enter": {
             "fill": {"value": "red"},
@@ -362,6 +365,7 @@ describe('Interval Selections', function() {
       {
         "name": "thr_ee_brush",
         "type": "rect",
+        "clip": true,
         "encode": {
           "enter": {
             "fill": {"value": "transparent"},

--- a/test/compile/selection/layers.test.ts
+++ b/test/compile/selection/layers.test.ts
@@ -48,6 +48,7 @@ describe('Layered Selections', function() {
       "from": {
         "data": "layer_0_main"
       },
+      "clip": true,
       "encode": {
         "update": {
           "x": {
@@ -79,6 +80,7 @@ describe('Layered Selections', function() {
       "from": {
         "data": "layer_1_main"
       },
+      "clip": true,
       "encode": {
         "update": {
           "x": {


### PR DESCRIPTION
This may be a little controversial but this PR proposes to always clip marks. This handles the case where marks would overflow if the user explicitly sets scale domains with a smaller extent than [min, max] (example spec below). Moreover, if we always clip marks, we also simplify selection code paths, which no longer need to test whether clipping is required + propagate it up the model hierarchy (e.g., a source of a bug with [panning concatenated displays](https://vega.github.io/vega-lite/docs/selection-bind.html#scale-binding)).

This change touches every example, but looking through the gallery I don't see anything adversely affected (since the default _is_ a [min, max] extent).

```json
{
  "data": {"url": "data/cars.json"},
  "mark": "circle",
  "encoding": {
    "x": {
      "field": "Horsepower",
      "type": "quantitative",
      "scale": {"domain": [75,150]}
    },
    "y": {
      "field": "Miles_per_Gallon",
      "type": "quantitative",
      "scale": {"domain": [20,40]}
    },
    "size": {"field": "Cylinders","type": "quantitative"},
    "color": {"field": "Origin","type": "nominal"}
  }
}
```

Before:
![download 6](https://user-images.githubusercontent.com/42262/28396679-d3545954-6cb1-11e7-9cfe-b5cc4cd4ad14.png)

After:
![download 7](https://user-images.githubusercontent.com/42262/28396684-d7f4a04a-6cb1-11e7-8d7e-667fd5112e49.png)

