### PR TITLE
Decouple selection empty check from inclusion check.

### DIFF
--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -367,7 +367,7 @@
                     },
                     "stroke": [
                         {
-                            "test": "vlInterval(\"brush_store\", datum)",
+                            "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },

--- a/examples/vg-specs/concat_selections.vg.json
+++ b/examples/vg-specs/concat_selections.vg.json
@@ -714,7 +714,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum)",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                                     "value": "steelblue"
                                 },
                                 {

--- a/examples/vg-specs/dashboard_europe_pop.vg.json
+++ b/examples/vg-specs/dashboard_europe_pop.vg.json
@@ -682,7 +682,7 @@
                             },
                             "fill": [
                                 {
-                                    "test": "!(vlInterval(\"brush_store\", datum))",
+                                    "test": "!(length(data(\"brush_store\"))) || (!(vlInterval(\"brush_store\", datum)))",
                                     "value": "steelblue"
                                 },
                                 {
@@ -1052,7 +1052,7 @@
                             },
                             "fill": [
                                 {
-                                    "test": "!(vlInterval(\"brush_store\", datum))",
+                                    "test": "!(length(data(\"brush_store\"))) || (!(vlInterval(\"brush_store\", datum)))",
                                     "value": "steelblue"
                                 },
                                 {
@@ -1481,7 +1481,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "!(vlInterval(\"brush_store\", datum))",
+                                    "test": "!(length(data(\"brush_store\"))) || (!(vlInterval(\"brush_store\", datum)))",
                                     "value": "steelblue"
                                 },
                                 {

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -672,7 +672,7 @@
                             },
                             "fill": [
                                 {
-                                    "test": "vlPoint(\"xenc_store\", datum)",
+                                    "test": "!(length(data(\"xenc_store\"))) || (vlPoint(\"xenc_store\", datum))",
                                     "value": "red"
                                 },
                                 {
@@ -681,7 +681,7 @@
                             ],
                             "size": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"intersect\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
                                     "value": 250
                                 },
                                 {

--- a/examples/vg-specs/interactive_splom.vg.json
+++ b/examples/vg-specs/interactive_splom.vg.json
@@ -515,7 +515,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"union\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -1079,7 +1079,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"union\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -1641,7 +1641,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"union\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -2203,7 +2203,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"union\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },

--- a/examples/vg-specs/layered_crossfilter.vg.json
+++ b/examples/vg-specs/layered_crossfilter.vg.json
@@ -101,7 +101,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "vlInterval(\"brush_store\", datum)"
+                    "expr": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))"
                 },
                 {
                     "type": "filter",
@@ -203,7 +203,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "vlInterval(\"brush_store\", datum)"
+                    "expr": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))"
                 },
                 {
                     "type": "filter",
@@ -305,7 +305,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "vlInterval(\"brush_store\", datum)"
+                    "expr": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))"
                 },
                 {
                     "type": "filter",

--- a/examples/vg-specs/layered_crossfilter_discrete.vg.json
+++ b/examples/vg-specs/layered_crossfilter_discrete.vg.json
@@ -101,7 +101,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "vlPoint(\"brush_store\", datum)"
+                    "expr": "!(length(data(\"brush_store\"))) || (vlPoint(\"brush_store\", datum))"
                 },
                 {
                     "type": "filter",
@@ -203,7 +203,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "vlPoint(\"brush_store\", datum)"
+                    "expr": "!(length(data(\"brush_store\"))) || (vlPoint(\"brush_store\", datum))"
                 },
                 {
                     "type": "filter",
@@ -305,7 +305,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "vlPoint(\"brush_store\", datum)"
+                    "expr": "!(length(data(\"brush_store\"))) || (vlPoint(\"brush_store\", datum))"
                 },
                 {
                     "type": "filter",

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -597,7 +597,7 @@
                     },
                     "stroke": [
                         {
-                            "test": "vlInterval(\"brush_store\", datum)",
+                            "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                             "value": "grey"
                         },
                         {
@@ -637,7 +637,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlInterval(\"brush_store\", datum)",
+                            "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },
@@ -647,7 +647,7 @@
                     ],
                     "size": [
                         {
-                            "test": "vlPoint(\"cyl_store\", datum)",
+                            "test": "!(length(data(\"cyl_store\"))) || (vlPoint(\"cyl_store\", datum))",
                             "value": 150
                         },
                         {

--- a/examples/vg-specs/paintbrush.vg.json
+++ b/examples/vg-specs/paintbrush.vg.json
@@ -122,7 +122,7 @@
                     },
                     "size": [
                         {
-                            "test": "vlPoint(\"paintbrush_store\", datum)",
+                            "test": "!(length(data(\"paintbrush_store\"))) || (vlPoint(\"paintbrush_store\", datum))",
                             "value": 300
                         },
                         {

--- a/examples/vg-specs/paintbrush_color.vg.json
+++ b/examples/vg-specs/paintbrush_color.vg.json
@@ -116,7 +116,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlPoint(\"paintbrush_store\", datum)",
+                            "test": "!(length(data(\"paintbrush_store\"))) || (vlPoint(\"paintbrush_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },

--- a/examples/vg-specs/paintbrush_color_nearest.vg.json
+++ b/examples/vg-specs/paintbrush_color_nearest.vg.json
@@ -116,7 +116,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlPoint(\"paintbrush_store\", datum)",
+                            "test": "!(length(data(\"paintbrush_store\"))) || (vlPoint(\"paintbrush_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },

--- a/examples/vg-specs/paintbrush_simple.vg.json
+++ b/examples/vg-specs/paintbrush_simple.vg.json
@@ -121,7 +121,7 @@
                     },
                     "size": [
                         {
-                            "test": "vlPoint(\"paintbrush_store\", datum)",
+                            "test": "!(length(data(\"paintbrush_store\"))) || (vlPoint(\"paintbrush_store\", datum))",
                             "value": 300
                         },
                         {

--- a/examples/vg-specs/query_widgets.vg.json
+++ b/examples/vg-specs/query_widgets.vg.json
@@ -67,7 +67,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "vlPoint(\"CylYr_store\", datum)"
+                    "expr": "!(length(data(\"CylYr_store\"))) || (vlPoint(\"CylYr_store\", datum))"
                 },
                 {
                     "type": "filter",
@@ -177,7 +177,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlPoint(\"CylYr_store\", datum)",
+                            "test": "!(length(data(\"CylYr_store\"))) || (vlPoint(\"CylYr_store\", datum))",
                             "scale": "color",
                             "field": "Origin"
                         },

--- a/examples/vg-specs/selection_bind_cylyr.vg.json
+++ b/examples/vg-specs/selection_bind_cylyr.vg.json
@@ -140,7 +140,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlPoint(\"CylYr_store\", datum)",
+                            "test": "!(length(data(\"CylYr_store\"))) || (vlPoint(\"CylYr_store\", datum))",
                             "scale": "color",
                             "field": "Origin"
                         },
@@ -150,7 +150,7 @@
                     ],
                     "size": [
                         {
-                            "test": "vlPoint(\"CylYr_store\", datum)",
+                            "test": "!(length(data(\"CylYr_store\"))) || (vlPoint(\"CylYr_store\", datum))",
                             "value": 100
                         },
                         {

--- a/examples/vg-specs/selection_bind_origin.vg.json
+++ b/examples/vg-specs/selection_bind_origin.vg.json
@@ -116,7 +116,7 @@
                     },
                     "stroke": [
                         {
-                            "test": "vlPoint(\"org_store\", datum)",
+                            "test": "!(length(data(\"org_store\"))) || (vlPoint(\"org_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },

--- a/examples/vg-specs/selection_composition_and.vg.json
+++ b/examples/vg-specs/selection_composition_and.vg.json
@@ -688,7 +688,7 @@
                     },
                     "fill": [
                         {
-                            "test": "(vlInterval(\"alex_store\", datum)) && (vlInterval(\"morgan_store\", datum))",
+                            "test": "!(length(data(\"alex_store\")) || length(data(\"morgan_store\"))) || ((vlInterval(\"alex_store\", datum)) && (vlInterval(\"morgan_store\", datum)))",
                             "scale": "color",
                             "field": "count_*"
                         },

--- a/examples/vg-specs/selection_composition_or.vg.json
+++ b/examples/vg-specs/selection_composition_or.vg.json
@@ -688,7 +688,7 @@
                     },
                     "fill": [
                         {
-                            "test": "(vlInterval(\"alex_store\", datum)) || (vlInterval(\"morgan_store\", datum))",
+                            "test": "!(length(data(\"alex_store\")) || length(data(\"morgan_store\"))) || ((vlInterval(\"alex_store\", datum)) || (vlInterval(\"morgan_store\", datum)))",
                             "scale": "color",
                             "field": "count_*"
                         },

--- a/examples/vg-specs/selection_filter.vg.json
+++ b/examples/vg-specs/selection_filter.vg.json
@@ -49,7 +49,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "vlInterval(\"brush_store\", datum)"
+                    "expr": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))"
                 },
                 {
                     "type": "filter",

--- a/examples/vg-specs/selection_filter_composition.vg.json
+++ b/examples/vg-specs/selection_filter_composition.vg.json
@@ -49,7 +49,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "(datum.Weight_in_lbs > 3000) && (vlInterval(\"brush_store\", datum))"
+                    "expr": "(datum.Weight_in_lbs > 3000) && (!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum)))"
                 },
                 {
                     "type": "filter",

--- a/examples/vg-specs/selection_insert.vg.json
+++ b/examples/vg-specs/selection_insert.vg.json
@@ -100,7 +100,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlPoint(\"paintbrush_store\", datum)",
+                            "test": "!(length(data(\"paintbrush_store\"))) || (vlPoint(\"paintbrush_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },

--- a/examples/vg-specs/selection_project_binned_interval.vg.json
+++ b/examples/vg-specs/selection_project_binned_interval.vg.json
@@ -101,7 +101,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "vlInterval(\"brush_store\", datum)"
+                    "expr": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))"
                 },
                 {
                     "type": "filter",

--- a/examples/vg-specs/selection_project_interval.vg.json
+++ b/examples/vg-specs/selection_project_interval.vg.json
@@ -389,7 +389,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlInterval(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlInterval(\"pts_store\", datum))",
                             "scale": "color",
                             "field": "count_*"
                         },

--- a/examples/vg-specs/selection_project_interval_x.vg.json
+++ b/examples/vg-specs/selection_project_interval_x.vg.json
@@ -322,7 +322,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlInterval(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlInterval(\"pts_store\", datum))",
                             "scale": "color",
                             "field": "count_*"
                         },

--- a/examples/vg-specs/selection_project_interval_x_y.vg.json
+++ b/examples/vg-specs/selection_project_interval_x_y.vg.json
@@ -389,7 +389,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlInterval(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlInterval(\"pts_store\", datum))",
                             "scale": "color",
                             "field": "count_*"
                         },

--- a/examples/vg-specs/selection_project_interval_y.vg.json
+++ b/examples/vg-specs/selection_project_interval_y.vg.json
@@ -322,7 +322,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlInterval(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlInterval(\"pts_store\", datum))",
                             "scale": "color",
                             "field": "count_*"
                         },

--- a/examples/vg-specs/selection_project_multi.vg.json
+++ b/examples/vg-specs/selection_project_multi.vg.json
@@ -115,7 +115,7 @@
                     },
                     "stroke": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },
@@ -128,7 +128,7 @@
                     },
                     "size": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "value": 200
                         },
                         {

--- a/examples/vg-specs/selection_project_multi_cylinders.vg.json
+++ b/examples/vg-specs/selection_project_multi_cylinders.vg.json
@@ -115,7 +115,7 @@
                     },
                     "stroke": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },
@@ -128,7 +128,7 @@
                     },
                     "size": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "value": 200
                         },
                         {

--- a/examples/vg-specs/selection_project_multi_cylinders_origin.vg.json
+++ b/examples/vg-specs/selection_project_multi_cylinders_origin.vg.json
@@ -115,7 +115,7 @@
                     },
                     "stroke": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },
@@ -128,7 +128,7 @@
                     },
                     "size": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "value": 200
                         },
                         {
@@ -137,7 +137,7 @@
                     ],
                     "shape": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "scale": "shape",
                             "field": "Origin"
                         },
@@ -277,7 +277,7 @@
                     "update": {
                         "stroke": [
                             {
-                                "test": "vlPoint(\"pts_store\", datum)",
+                                "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                                 "scale": "color",
                                 "field": "Cylinders"
                             },

--- a/examples/vg-specs/selection_project_multi_origin.vg.json
+++ b/examples/vg-specs/selection_project_multi_origin.vg.json
@@ -115,7 +115,7 @@
                     },
                     "stroke": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },
@@ -128,7 +128,7 @@
                     },
                     "size": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "value": 200
                         },
                         {
@@ -137,7 +137,7 @@
                     ],
                     "shape": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "scale": "shape",
                             "field": "Origin"
                         },
@@ -277,7 +277,7 @@
                     "update": {
                         "stroke": [
                             {
-                                "test": "vlPoint(\"pts_store\", datum)",
+                                "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                                 "scale": "color",
                                 "field": "Cylinders"
                             },

--- a/examples/vg-specs/selection_project_single.vg.json
+++ b/examples/vg-specs/selection_project_single.vg.json
@@ -104,7 +104,7 @@
                     },
                     "stroke": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },
@@ -117,7 +117,7 @@
                     },
                     "size": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "value": 200
                         },
                         {

--- a/examples/vg-specs/selection_project_single_cylinders.vg.json
+++ b/examples/vg-specs/selection_project_single_cylinders.vg.json
@@ -104,7 +104,7 @@
                     },
                     "stroke": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },
@@ -117,7 +117,7 @@
                     },
                     "size": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "value": 200
                         },
                         {

--- a/examples/vg-specs/selection_project_single_cylinders_origin.vg.json
+++ b/examples/vg-specs/selection_project_single_cylinders_origin.vg.json
@@ -104,7 +104,7 @@
                     },
                     "stroke": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },
@@ -117,7 +117,7 @@
                     },
                     "size": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "value": 200
                         },
                         {
@@ -126,7 +126,7 @@
                     ],
                     "shape": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "scale": "shape",
                             "field": "Origin"
                         },
@@ -266,7 +266,7 @@
                     "update": {
                         "stroke": [
                             {
-                                "test": "vlPoint(\"pts_store\", datum)",
+                                "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                                 "scale": "color",
                                 "field": "Cylinders"
                             },

--- a/examples/vg-specs/selection_project_single_origin.vg.json
+++ b/examples/vg-specs/selection_project_single_origin.vg.json
@@ -104,7 +104,7 @@
                     },
                     "stroke": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },
@@ -117,7 +117,7 @@
                     },
                     "size": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "value": 200
                         },
                         {
@@ -126,7 +126,7 @@
                     ],
                     "shape": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "scale": "shape",
                             "field": "Origin"
                         },
@@ -266,7 +266,7 @@
                     "update": {
                         "stroke": [
                             {
-                                "test": "vlPoint(\"pts_store\", datum)",
+                                "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                                 "scale": "color",
                                 "field": "Cylinders"
                             },

--- a/examples/vg-specs/selection_resolution_global.vg.json
+++ b/examples/vg-specs/selection_resolution_global.vg.json
@@ -476,7 +476,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum)",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -924,7 +924,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum)",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -1370,7 +1370,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum)",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -1816,7 +1816,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum)",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -2195,7 +2195,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum)",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -2643,7 +2643,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum)",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -3089,7 +3089,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum)",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -3535,7 +3535,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum)",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -3914,7 +3914,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum)",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },

--- a/examples/vg-specs/selection_resolution_intersect.vg.json
+++ b/examples/vg-specs/selection_resolution_intersect.vg.json
@@ -452,7 +452,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"intersect\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -852,7 +852,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"intersect\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -1250,7 +1250,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"intersect\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -1648,7 +1648,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"intersect\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -1979,7 +1979,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"intersect\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -2379,7 +2379,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"intersect\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -2777,7 +2777,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"intersect\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -3175,7 +3175,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"intersect\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -3506,7 +3506,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"intersect\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },

--- a/examples/vg-specs/selection_resolution_union.vg.json
+++ b/examples/vg-specs/selection_resolution_union.vg.json
@@ -452,7 +452,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"union\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -852,7 +852,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"union\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -1250,7 +1250,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"union\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -1648,7 +1648,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"union\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -1979,7 +1979,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"union\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -2379,7 +2379,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"union\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -2777,7 +2777,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"union\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -3175,7 +3175,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"union\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },
@@ -3506,7 +3506,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum, \"union\")",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
                                     "scale": "color",
                                     "field": "Origin"
                                 },

--- a/examples/vg-specs/selection_toggle_altKey.vg.json
+++ b/examples/vg-specs/selection_toggle_altKey.vg.json
@@ -115,7 +115,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlPoint(\"paintbrush_store\", datum)",
+                            "test": "!(length(data(\"paintbrush_store\"))) || (vlPoint(\"paintbrush_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },

--- a/examples/vg-specs/selection_toggle_altKey_shiftKey.vg.json
+++ b/examples/vg-specs/selection_toggle_altKey_shiftKey.vg.json
@@ -115,7 +115,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlPoint(\"paintbrush_store\", datum)",
+                            "test": "!(length(data(\"paintbrush_store\"))) || (vlPoint(\"paintbrush_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },

--- a/examples/vg-specs/selection_toggle_shiftKey.vg.json
+++ b/examples/vg-specs/selection_toggle_shiftKey.vg.json
@@ -115,7 +115,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlPoint(\"paintbrush_store\", datum)",
+                            "test": "!(length(data(\"paintbrush_store\"))) || (vlPoint(\"paintbrush_store\", datum))",
                             "scale": "color",
                             "field": "Cylinders"
                         },

--- a/examples/vg-specs/selection_translate_brush_drag.vg.json
+++ b/examples/vg-specs/selection_translate_brush_drag.vg.json
@@ -368,7 +368,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlInterval(\"brush_store\", datum)",
+                            "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                             "scale": "color",
                             "field": "Origin"
                         },
@@ -569,7 +569,7 @@
                         },
                         "fill": [
                             {
-                                "test": "vlInterval(\"brush_store\", datum)",
+                                "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                                 "scale": "color",
                                 "field": "Origin"
                             },

--- a/examples/vg-specs/selection_translate_brush_shift-drag.vg.json
+++ b/examples/vg-specs/selection_translate_brush_shift-drag.vg.json
@@ -374,7 +374,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlInterval(\"brush_store\", datum)",
+                            "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                             "scale": "color",
                             "field": "Origin"
                         },
@@ -575,7 +575,7 @@
                         },
                         "fill": [
                             {
-                                "test": "vlInterval(\"brush_store\", datum)",
+                                "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                                 "scale": "color",
                                 "field": "Origin"
                             },

--- a/examples/vg-specs/selection_type_interval.vg.json
+++ b/examples/vg-specs/selection_type_interval.vg.json
@@ -389,7 +389,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlInterval(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlInterval(\"pts_store\", datum))",
                             "scale": "color",
                             "field": "count_*"
                         },

--- a/examples/vg-specs/selection_type_multi.vg.json
+++ b/examples/vg-specs/selection_type_multi.vg.json
@@ -138,7 +138,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "scale": "color",
                             "field": "count_*"
                         },

--- a/examples/vg-specs/selection_type_single.vg.json
+++ b/examples/vg-specs/selection_type_single.vg.json
@@ -127,7 +127,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "scale": "color",
                             "field": "count_*"
                         },

--- a/examples/vg-specs/selection_type_single_dblclick.vg.json
+++ b/examples/vg-specs/selection_type_single_dblclick.vg.json
@@ -127,7 +127,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlPoint(\"pts_store\", datum)",
+                            "test": "!(length(data(\"pts_store\"))) || (vlPoint(\"pts_store\", datum))",
                             "scale": "color",
                             "field": "count_*"
                         },

--- a/examples/vg-specs/selection_zoom_brush_shift-wheel.vg.json
+++ b/examples/vg-specs/selection_zoom_brush_shift-wheel.vg.json
@@ -374,7 +374,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlInterval(\"brush_store\", datum)",
+                            "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                             "scale": "color",
                             "field": "Origin"
                         },
@@ -575,7 +575,7 @@
                         },
                         "fill": [
                             {
-                                "test": "vlInterval(\"brush_store\", datum)",
+                                "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                                 "scale": "color",
                                 "field": "Origin"
                             },

--- a/examples/vg-specs/selection_zoom_brush_wheel.vg.json
+++ b/examples/vg-specs/selection_zoom_brush_wheel.vg.json
@@ -368,7 +368,7 @@
                     },
                     "fill": [
                         {
-                            "test": "vlInterval(\"brush_store\", datum)",
+                            "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                             "scale": "color",
                             "field": "Origin"
                         },
@@ -569,7 +569,7 @@
                         },
                         "fill": [
                             {
-                                "test": "vlInterval(\"brush_store\", datum)",
+                                "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                                 "scale": "color",
                                 "field": "Origin"
                             },

--- a/examples/vg-specs/stocks_nearest_index.vg.json
+++ b/examples/vg-specs/stocks_nearest_index.vg.json
@@ -61,7 +61,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "(index.date) && (vlPoint(\"index_store\", datum))"
+                    "expr": "(index.date) && (!(length(data(\"index_store\"))) || (vlPoint(\"index_store\", datum)))"
                 },
                 {
                     "type": "filter",
@@ -80,7 +80,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "(index.date) && (vlPoint(\"index_store\", datum))"
+                    "expr": "(index.date) && (!(length(data(\"index_store\"))) || (vlPoint(\"index_store\", datum)))"
                 },
                 {
                     "type": "filter",

--- a/examples/vg-specs/timeunit_selections.vg.json
+++ b/examples/vg-specs/timeunit_selections.vg.json
@@ -77,7 +77,7 @@
                 },
                 {
                     "type": "filter",
-                    "expr": "vlInterval(\"brush_store\", datum)"
+                    "expr": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))"
                 },
                 {
                     "type": "filter",
@@ -391,7 +391,7 @@
                             },
                             "stroke": [
                                 {
-                                    "test": "vlInterval(\"brush_store\", datum)",
+                                    "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
                                     "value": "goldenrod"
                                 },
                                 {

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -213,6 +213,7 @@ export function assembleLayerSelectionMarks(model: LayerModel, marks: any[]): an
 }
 
 export function predicate(model: Model, selections: LogicalOperand<string>, dfnode?: DataFlowNode): string {
+  const stores: string[] = [];
   function expr(name: string): string {
     const vname = varName(name);
     const selCmpt = model.getSelectionComponent(vname, name);
@@ -228,11 +229,14 @@ export function predicate(model: Model, selections: LogicalOperand<string>, dfno
       }
     }
 
+    stores.push(store);
     return compiler(selCmpt.type).predicate + `(${store}, datum` +
       (selCmpt.resolve === 'global' ? ')' : `, ${stringValue(selCmpt.resolve)})`);
   }
 
-  return logicalExpr(selections, expr);
+  const predicateStr = logicalExpr(selections, expr);
+  return '!(' + stores.map((s) => `length(data(${s}))`).join(' || ') +
+    `) || (${predicateStr})`;
 }
 
 // Selections are parsed _after_ scales. If a scale domain is set to

--- a/test/compile/selection/predicate.test.ts
+++ b/test/compile/selection/predicate.test.ts
@@ -42,39 +42,43 @@ describe('Selection Predicate', function() {
 
   it('generates the predicate expression', function() {
     assert.equal(predicate(model, "one"),
-      'vlPoint("one_store", datum)');
+      '!(length(data("one_store"))) || (vlPoint("one_store", datum))');
 
     assert.equal(predicate(model, {"not": "one"}),
-      '!(vlPoint("one_store", datum))');
+      '!(length(data("one_store"))) || (!(vlPoint("one_store", datum)))');
 
     assert.equal(predicate(model, {"not": {"and": ["one", "two"]}}),
-      '!((vlPoint("one_store", datum)) && ' +
-      '(vlPoint("two_store", datum, "union")))');
+      '!(length(data("one_store")) || length(data("two_store"))) || ' +
+      '(!((vlPoint("one_store", datum)) && ' +
+      '(vlPoint("two_store", datum, "union"))))');
 
     assert.equal(predicate(model, {"and": ["one", "two", {"not": "thr-ee"}]}),
-      '(vlPoint("one_store", datum)) && ' +
+      '!(length(data("one_store")) || length(data("two_store")) || length(data("thr_ee_store"))) || ' +
+      '((vlPoint("one_store", datum)) && ' +
       '(vlPoint("two_store", datum, "union")) && ' +
-      '(!(vlInterval("thr_ee_store", datum, "intersect")))');
+      '(!(vlInterval("thr_ee_store", datum, "intersect"))))');
 
     assert.equal(predicate(model, {"or": ["one", {"and": ["two", {"not": "thr-ee"}]}]}),
-      '(vlPoint("one_store", datum)) || ' +
+      '!(length(data("one_store")) || length(data("two_store")) || length(data("thr_ee_store"))) || ' +
+      '((vlPoint("one_store", datum)) || ' +
       '((vlPoint("two_store", datum, "union")) && ' +
-      '(!(vlInterval("thr_ee_store", datum, "intersect"))))');
+      '(!(vlInterval("thr_ee_store", datum, "intersect")))))');
   });
 
   it('generates Vega production rules', function() {
     assert.deepEqual<VgEncodeEntry>(nonPosition('color', model, {vgChannel: 'fill'}), {
       fill: [
-        {test: 'vlPoint("one_store", datum)', value: "grey"},
+        {test: '!(length(data("one_store"))) || (vlPoint("one_store", datum))', value: "grey"},
         {scale: "color", field: "Cylinders"}
       ]
     });
 
     assert.deepEqual<VgEncodeEntry>(nonPosition('opacity', model), {
       opacity: [
-        {test: '(vlPoint("one_store", datum)) || ' +
+        {test: '!(length(data("one_store")) || length(data("two_store")) || length(data("thr_ee_store"))) || ' +
+              '((vlPoint("one_store", datum)) || ' +
               '((vlPoint("two_store", datum, "union")) && ' +
-              '(!(vlInterval("thr_ee_store", datum, "intersect"))))',
+              '(!(vlInterval("thr_ee_store", datum, "intersect")))))',
           value: 0.5},
         {scale: "opacity", field: "Origin"}
       ]
@@ -83,24 +87,27 @@ describe('Selection Predicate', function() {
 
   it('generates a selection filter', function() {
     assert.equal(expression(model, {"selection": "one"}),
-      'vlPoint("one_store", datum)');
+      '!(length(data("one_store"))) || (vlPoint("one_store", datum))');
 
     assert.equal(expression(model, {"selection": {"not": "one"}}),
-      '!(vlPoint("one_store", datum))');
+      '!(length(data("one_store"))) || (!(vlPoint("one_store", datum)))');
 
     assert.equal(expression(model, {"selection": {"not": {"and": ["one", "two"]}}}),
-      '!((vlPoint("one_store", datum)) && ' +
-      '(vlPoint("two_store", datum, "union")))');
+      '!(length(data("one_store")) || length(data("two_store"))) || ' +
+      '(!((vlPoint("one_store", datum)) && ' +
+      '(vlPoint("two_store", datum, "union"))))');
 
     assert.equal(expression(model, {"selection": {"and": ["one", "two", {"not": "thr-ee"}]}}),
-      '(vlPoint("one_store", datum)) && ' +
+      '!(length(data("one_store")) || length(data("two_store")) || length(data("thr_ee_store"))) || ' +
+      '((vlPoint("one_store", datum)) && ' +
       '(vlPoint("two_store", datum, "union")) && ' +
-      '(!(vlInterval("thr_ee_store", datum, "intersect")))');
+      '(!(vlInterval("thr_ee_store", datum, "intersect"))))');
 
     assert.equal(expression(model, {"selection": {"or": ["one", {"and": ["two", {"not": "thr-ee"}]}]}}),
-      '(vlPoint("one_store", datum)) || ' +
+      '!(length(data("one_store")) || length(data("two_store")) || length(data("thr_ee_store"))) || ' +
+      '((vlPoint("one_store", datum)) || ' +
       '((vlPoint("two_store", datum, "union")) && ' +
-      '(!(vlInterval("thr_ee_store", datum, "intersect"))))');
+      '(!(vlInterval("thr_ee_store", datum, "intersect")))))');
   });
 
   it('throws an error for unknown selections', function() {


### PR DESCRIPTION
With vega/vega-parser#49, fixes #2696. Rather than the inclusion test functions handling empty selections, we handle those separately in the generated expression string. Now, with a logically composed selection, the "select all" operation only occurs if _all_ composed selections are empty. If at least one selection is defined, the inclusion test functions are called which operate on standard set logic now (e.g., empty _and_ not empty -> null).