### PR TITLE
Dom/overlaps

### DIFF
--- a/examples/specs/rect_binned_heatmap.vl.json
+++ b/examples/specs/rect_binned_heatmap.vl.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
+  "data": {"url": "data/movies.json"},
+  "mark": "rect",
+  "width": 300,
+  "height": 200,
+  "encoding": {
+    "x": {
+      "bin": {"maxbins":60},
+      "field": "IMDB_Rating",
+      "type": "quantitative"
+    },
+    "y": {
+      "bin": {"maxbins": 40},
+      "field": "Rotten_Tomatoes_Rating",
+      "type": "quantitative"
+    },
+    "color": {
+      "aggregate": "count",
+      "type": "quantitative"
+    }
+  },
+  "config": {
+    "range": {
+      "heatmap": {
+        "scheme": "greenblue"
+      }
+    }
+  }
+}

--- a/examples/vg-specs/area.vg.json
+++ b/examples/vg-specs/area.vg.json
@@ -139,7 +139,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "YEARMONTH(date)",
             "zindex": 1,
             "encode": {
@@ -160,13 +159,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "SUM(count)",
             "zindex": 1

--- a/examples/vg-specs/area_vertical.vg.json
+++ b/examples/vg-specs/area_vertical.vg.json
@@ -143,7 +143,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "SUM(Weight_in_lbs)",
             "zindex": 1
         },
@@ -155,13 +154,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "YEAR(Year)",
             "zindex": 1,

--- a/examples/vg-specs/bar.vg.json
+++ b/examples/vg-specs/bar.vg.json
@@ -157,8 +157,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "a",
             "zindex": 1,
             "encode": {
@@ -179,6 +179,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "b",
             "zindex": 1

--- a/examples/vg-specs/bar_1d.vg.json
+++ b/examples/vg-specs/bar_1d.vg.json
@@ -109,7 +109,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "zindex": 1
         },
         {
@@ -120,7 +119,6 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0
         }

--- a/examples/vg-specs/bar_1d_rangestep_config.vg.json
+++ b/examples/vg-specs/bar_1d_rangestep_config.vg.json
@@ -109,7 +109,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "zindex": 1
         },
         {
@@ -120,7 +119,6 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0
         }

--- a/examples/vg-specs/bar_aggregate.vg.json
+++ b/examples/vg-specs/bar_aggregate.vg.json
@@ -135,7 +135,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "zindex": 1
         },
         {
@@ -146,13 +145,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "age",
             "zindex": 1

--- a/examples/vg-specs/bar_aggregate_count.vg.json
+++ b/examples/vg-specs/bar_aggregate_count.vg.json
@@ -149,6 +149,7 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
             "title": "BIN(precipitation)",
             "values": {
@@ -173,6 +174,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Number of Records",
             "zindex": 1

--- a/examples/vg-specs/bar_aggregate_size.vg.json
+++ b/examples/vg-specs/bar_aggregate_size.vg.json
@@ -132,8 +132,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "age",
             "zindex": 1,
             "encode": {
@@ -155,6 +155,7 @@
         {
             "title": "population",
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "zindex": 1
         },

--- a/examples/vg-specs/bar_aggregate_vertical.vg.json
+++ b/examples/vg-specs/bar_aggregate_vertical.vg.json
@@ -127,8 +127,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Cylinders",
             "zindex": 1,
             "encode": {
@@ -149,6 +149,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MEAN(Acceleration)",
             "zindex": 1

--- a/examples/vg-specs/bar_array_aggregate.vg.json
+++ b/examples/vg-specs/bar_array_aggregate.vg.json
@@ -168,7 +168,6 @@
         {
             "scale": "x",
             "orient": "bottom",
-            "tickCount": 5,
             "title": "a",
             "zindex": 1,
             "encode": {
@@ -189,6 +188,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "AVERAGE(b)",
             "zindex": 1

--- a/examples/vg-specs/bar_distinct.vg.json
+++ b/examples/vg-specs/bar_distinct.vg.json
@@ -125,7 +125,6 @@
         {
             "scale": "x",
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Origin",
             "zindex": 1,
             "encode": {
@@ -146,6 +145,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "DISTINCT(Name)",
             "zindex": 1

--- a/examples/vg-specs/bar_filter_calc.vg.json
+++ b/examples/vg-specs/bar_filter_calc.vg.json
@@ -161,8 +161,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "a",
             "zindex": 1,
             "encode": {
@@ -183,6 +183,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "b2",
             "zindex": 1

--- a/examples/vg-specs/bar_grouped.vg.json
+++ b/examples/vg-specs/bar_grouped.vg.json
@@ -160,6 +160,7 @@
                 {
                     "title": "population",
                     "scale": "y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "zindex": 1
                 }
@@ -227,7 +228,6 @@
                     "title": "",
                     "scale": "x",
                     "orient": "bottom",
-                    "tickCount": 5,
                     "zindex": 1,
                     "encode": {
                         "labels": {

--- a/examples/vg-specs/bar_grouped_horizontal.vg.json
+++ b/examples/vg-specs/bar_grouped_horizontal.vg.json
@@ -193,7 +193,6 @@
                     "scale": "x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "zindex": 1
                 }
             ]

--- a/examples/vg-specs/bar_layered_transparent.vg.json
+++ b/examples/vg-specs/bar_layered_transparent.vg.json
@@ -155,8 +155,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "age",
             "zindex": 1,
             "encode": {
@@ -178,6 +178,7 @@
         {
             "title": "population",
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "zindex": 1
         },

--- a/examples/vg-specs/bar_month.vg.json
+++ b/examples/vg-specs/bar_month.vg.json
@@ -133,8 +133,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "MONTH(date)",
             "zindex": 1,
             "encode": {
@@ -158,6 +158,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MEAN(temp)",
             "zindex": 1

--- a/examples/vg-specs/bar_size_default.vg.json
+++ b/examples/vg-specs/bar_size_default.vg.json
@@ -125,7 +125,6 @@
         {
             "scale": "x",
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Origin",
             "zindex": 1,
             "encode": {
@@ -146,6 +145,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Number of Records",
             "zindex": 1

--- a/examples/vg-specs/bar_size_explicit.vg.json
+++ b/examples/vg-specs/bar_size_explicit.vg.json
@@ -122,7 +122,6 @@
         {
             "scale": "x",
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Origin",
             "zindex": 1,
             "encode": {
@@ -143,6 +142,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Number of Records",
             "zindex": 1

--- a/examples/vg-specs/bar_size_explicit_bad.vg.json
+++ b/examples/vg-specs/bar_size_explicit_bad.vg.json
@@ -122,7 +122,6 @@
         {
             "scale": "x",
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Name",
             "zindex": 1,
             "encode": {
@@ -143,6 +142,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Number of Records",
             "zindex": 1

--- a/examples/vg-specs/bar_size_fit.vg.json
+++ b/examples/vg-specs/bar_size_fit.vg.json
@@ -122,7 +122,6 @@
         {
             "scale": "x",
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Origin",
             "zindex": 1,
             "encode": {
@@ -143,6 +142,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Number of Records",
             "zindex": 1

--- a/examples/vg-specs/bar_size_rangestep_small.vg.json
+++ b/examples/vg-specs/bar_size_rangestep_small.vg.json
@@ -157,8 +157,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "a",
             "zindex": 1,
             "encode": {
@@ -179,6 +179,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "b",
             "zindex": 1

--- a/examples/vg-specs/bar_sort_by_count.vg.json
+++ b/examples/vg-specs/bar_sort_by_count.vg.json
@@ -133,7 +133,6 @@
         {
             "scale": "x",
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Cylinders",
             "zindex": 1,
             "encode": {
@@ -154,6 +153,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Number of Records",
             "zindex": 1

--- a/examples/vg-specs/bar_swap_axes.vg.json
+++ b/examples/vg-specs/bar_swap_axes.vg.json
@@ -169,7 +169,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "AVERAGE(b)",
             "zindex": 1
         },
@@ -181,7 +180,6 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"

--- a/examples/vg-specs/bar_swap_custom.vg.json
+++ b/examples/vg-specs/bar_swap_custom.vg.json
@@ -170,7 +170,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "zindex": 1
         },
         {
@@ -181,7 +180,6 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"

--- a/examples/vg-specs/bar_tooltip.vg.json
+++ b/examples/vg-specs/bar_tooltip.vg.json
@@ -160,8 +160,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "a",
             "zindex": 1,
             "encode": {
@@ -182,6 +182,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "b",
             "zindex": 1

--- a/examples/vg-specs/bar_yearmonth.vg.json
+++ b/examples/vg-specs/bar_yearmonth.vg.json
@@ -132,8 +132,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "YEARMONTH(date)",
             "zindex": 1,
             "encode": {
@@ -163,13 +163,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MEAN(temp)",
             "zindex": 1

--- a/examples/vg-specs/box-plot_minmax_1D_horizontal.vg.json
+++ b/examples/vg-specs/box-plot_minmax_1D_horizontal.vg.json
@@ -306,7 +306,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "zindex": 1
         },
         {
@@ -317,7 +316,6 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0
         }

--- a/examples/vg-specs/box-plot_minmax_1D_vertical.vg.json
+++ b/examples/vg-specs/box-plot_minmax_1D_vertical.vg.json
@@ -304,6 +304,7 @@
         {
             "title": "population",
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "zindex": 1
         },

--- a/examples/vg-specs/box-plot_minmax_2D_horizontal.vg.json
+++ b/examples/vg-specs/box-plot_minmax_2D_horizontal.vg.json
@@ -349,7 +349,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "zindex": 1
         },
         {
@@ -360,13 +359,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "age",
             "zindex": 1

--- a/examples/vg-specs/box-plot_minmax_2D_vertical.vg.json
+++ b/examples/vg-specs/box-plot_minmax_2D_vertical.vg.json
@@ -346,8 +346,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "age",
             "zindex": 1,
             "encode": {
@@ -369,6 +369,7 @@
         {
             "title": "population",
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "zindex": 1
         },

--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -489,7 +489,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -501,13 +500,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/bubble_health_income.vg.json
+++ b/examples/vg-specs/bubble_health_income.vg.json
@@ -289,7 +289,6 @@
             "scale": "x",
             "labelOverlap": "greedy",
             "orient": "bottom",
-            "tickCount": 5,
             "title": "income",
             "zindex": 1
         },
@@ -301,13 +300,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "health",
             "zindex": 1

--- a/examples/vg-specs/circle.vg.json
+++ b/examples/vg-specs/circle.vg.json
@@ -113,7 +113,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -125,13 +124,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/concat_selections.vg.json
+++ b/examples/vg-specs/concat_selections.vg.json
@@ -500,7 +500,6 @@
                     "scale": "concat_0_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Miles_per_Gallon",
                     "zindex": 1
                 },
@@ -512,13 +511,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "concat_0_y"
                 },
                 {
                     "scale": "concat_0_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Horsepower",
                     "zindex": 1
@@ -736,7 +735,6 @@
                     "scale": "concat_1_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Displacement",
                     "zindex": 1
                 },
@@ -748,13 +746,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "concat_1_y"
                 },
                 {
                     "scale": "concat_1_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Acceleration",
                     "zindex": 1

--- a/examples/vg-specs/dashboard_europe_pop.vg.json
+++ b/examples/vg-specs/dashboard_europe_pop.vg.json
@@ -753,7 +753,6 @@
                     "scale": "concat_0_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Population_ages_15_64_of_total",
                     "zindex": 1
                 },
@@ -765,13 +764,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "concat_0_y"
                 },
                 {
                     "scale": "concat_0_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Country",
                     "zindex": 1
@@ -1123,7 +1122,6 @@
                     "scale": "concat_1_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Population_ages_65_and_above_of_total",
                     "zindex": 1
                 },
@@ -1135,13 +1133,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "concat_1_y"
                 },
                 {
                     "scale": "concat_1_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Country",
                     "zindex": 1
@@ -1556,7 +1554,6 @@
                     "scale": "concat_2_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Population_ages_65_and_above_of_total",
                     "zindex": 1
                 },
@@ -1568,13 +1565,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "concat_2_y"
                 },
                 {
                     "scale": "concat_2_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Population_ages_15_64_of_total",
                     "zindex": 1

--- a/examples/vg-specs/diverging_color_points.vg.json
+++ b/examples/vg-specs/diverging_color_points.vg.json
@@ -132,7 +132,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -144,13 +143,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/errorbar_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_aggregate.vg.json
@@ -339,8 +339,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "age",
             "zindex": 1,
             "encode": {
@@ -362,6 +362,7 @@
         {
             "title": "population",
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "zindex": 1
         },

--- a/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
+++ b/examples/vg-specs/errorbar_horizontal_aggregate.vg.json
@@ -342,7 +342,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "zindex": 1
         },
         {
@@ -353,13 +352,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "age",
             "zindex": 1

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -162,6 +162,7 @@
             "axes": [
                 {
                     "scale": "y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Y",
                     "zindex": 1
@@ -230,7 +231,6 @@
                     "scale": "x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "X",
                     "zindex": 1
                 }
@@ -776,7 +776,6 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "y"

--- a/examples/vg-specs/field_spaces.vg.json
+++ b/examples/vg-specs/field_spaces.vg.json
@@ -161,7 +161,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "a b",
             "zindex": 1
         },
@@ -173,13 +172,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "c d",
             "zindex": 1

--- a/examples/vg-specs/github_punchcard.vg.json
+++ b/examples/vg-specs/github_punchcard.vg.json
@@ -154,8 +154,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "HOURS(time)",
             "zindex": 1,
             "encode": {
@@ -179,6 +179,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "DAY(time)",
             "zindex": 1,

--- a/examples/vg-specs/histogram.vg.json
+++ b/examples/vg-specs/histogram.vg.json
@@ -149,6 +149,7 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
             "title": "BIN(IMDB_Rating)",
             "values": {
@@ -173,6 +174,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Number of Records",
             "zindex": 1

--- a/examples/vg-specs/histogram_no_spacing.vg.json
+++ b/examples/vg-specs/histogram_no_spacing.vg.json
@@ -148,6 +148,7 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
             "title": "BIN(IMDB_Rating)",
             "values": {
@@ -172,6 +173,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Number of Records",
             "zindex": 1

--- a/examples/vg-specs/histogram_sort_mean.vg.json
+++ b/examples/vg-specs/histogram_sort_mean.vg.json
@@ -136,7 +136,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "MEAN(Horsepower)",
             "zindex": 1
         },
@@ -148,13 +147,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Origin",
             "zindex": 1

--- a/examples/vg-specs/interactive_splom.vg.json
+++ b/examples/vg-specs/interactive_splom.vg.json
@@ -569,7 +569,6 @@
                     "scale": "child_Horsepower_Horsepower_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -581,13 +580,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Horsepower_Horsepower_y"
                 },
                 {
                     "scale": "child_Horsepower_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Horsepower",
                     "zindex": 1
@@ -1131,7 +1130,6 @@
                     "scale": "child_Horsepower_Miles_per_Gallon_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -1143,13 +1141,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Horsepower_Miles_per_Gallon_y"
                 },
                 {
                     "scale": "child_Horsepower_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1
@@ -1693,7 +1691,6 @@
                     "scale": "child_Acceleration_Horsepower_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Acceleration",
                     "zindex": 1
                 },
@@ -1705,13 +1702,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Acceleration_Horsepower_y"
                 },
                 {
                     "scale": "child_Acceleration_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Horsepower",
                     "zindex": 1
@@ -2255,7 +2252,6 @@
                     "scale": "child_Acceleration_Miles_per_Gallon_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Acceleration",
                     "zindex": 1
                 },
@@ -2267,13 +2263,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Acceleration_Miles_per_Gallon_y"
                 },
                 {
                     "scale": "child_Acceleration_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1

--- a/examples/vg-specs/interval_mark_style.vg.json
+++ b/examples/vg-specs/interval_mark_style.vg.json
@@ -850,8 +850,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Cylinders",
             "zindex": 1,
             "encode": {
@@ -872,6 +872,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Origin",
             "zindex": 1

--- a/examples/vg-specs/layer_bar_dual_axis.vg.json
+++ b/examples/vg-specs/layer_bar_dual_axis.vg.json
@@ -234,8 +234,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "MONTH(date)",
             "zindex": 1,
             "encode": {
@@ -259,12 +259,14 @@
         },
         {
             "scale": "layer_0_y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MEAN(precipitation)",
             "zindex": 1
         },
         {
             "scale": "layer_1_y",
+            "labelOverlap": true,
             "orient": "right",
             "title": "MEAN(temp_max)",
             "zindex": 1

--- a/examples/vg-specs/layer_bar_dual_axis_minmax.vg.json
+++ b/examples/vg-specs/layer_bar_dual_axis_minmax.vg.json
@@ -314,8 +314,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "MONTH(date)",
             "zindex": 1,
             "encode": {
@@ -340,12 +340,14 @@
         {
             "title": "Mean Precipitation",
             "scale": "layer_0_y",
+            "labelOverlap": true,
             "orient": "left",
             "zindex": 1
         },
         {
             "title": "Temperature (min and max)",
             "scale": "layer_1_y",
+            "labelOverlap": true,
             "orient": "right",
             "zindex": 1
         }

--- a/examples/vg-specs/layer_bar_line.vg.json
+++ b/examples/vg-specs/layer_bar_line.vg.json
@@ -218,8 +218,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "a",
             "zindex": 1,
             "encode": {
@@ -240,6 +240,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "b",
             "zindex": 1

--- a/examples/vg-specs/layer_bar_line_union.vg.json
+++ b/examples/vg-specs/layer_bar_line_union.vg.json
@@ -227,8 +227,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "a, b",
             "zindex": 1,
             "encode": {
@@ -249,6 +249,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "c",
             "zindex": 1

--- a/examples/vg-specs/layer_box_plot_circle.vg.json
+++ b/examples/vg-specs/layer_box_plot_circle.vg.json
@@ -406,7 +406,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "zindex": 1
         },
         {
@@ -417,13 +416,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "age",
             "zindex": 1

--- a/examples/vg-specs/layer_histogram.vg.json
+++ b/examples/vg-specs/layer_histogram.vg.json
@@ -263,6 +263,7 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
             "title": "BIN(distance)",
             "values": {
@@ -287,6 +288,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Number of Records",
             "zindex": 1

--- a/examples/vg-specs/layer_line_color_rule.vg.json
+++ b/examples/vg-specs/layer_line_color_rule.vg.json
@@ -233,8 +233,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "date",
             "zindex": 1,
             "encode": {
@@ -264,13 +264,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "price, MEAN(price)",
             "zindex": 1

--- a/examples/vg-specs/layer_overlay.vg.json
+++ b/examples/vg-specs/layer_overlay.vg.json
@@ -328,8 +328,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Cylinders",
             "zindex": 1,
             "encode": {
@@ -350,6 +350,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MAX(Horsepower), MIN(Horsepower)",
             "zindex": 1

--- a/examples/vg-specs/layer_precipitation_mean.vg.json
+++ b/examples/vg-specs/layer_precipitation_mean.vg.json
@@ -205,8 +205,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "MONTH(date)",
             "zindex": 1,
             "encode": {
@@ -230,6 +230,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MEAN(precipitation)",
             "zindex": 1

--- a/examples/vg-specs/layer_single_color.vg.json
+++ b/examples/vg-specs/layer_single_color.vg.json
@@ -149,8 +149,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "date",
             "zindex": 1,
             "encode": {
@@ -180,13 +180,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "price",
             "zindex": 1

--- a/examples/vg-specs/layer_text_heatmap.vg.json
+++ b/examples/vg-specs/layer_text_heatmap.vg.json
@@ -212,8 +212,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Cylinders",
             "zindex": 1,
             "encode": {
@@ -234,6 +234,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Origin",
             "zindex": 1

--- a/examples/vg-specs/layered_color_legend_left.vg.json
+++ b/examples/vg-specs/layered_color_legend_left.vg.json
@@ -233,8 +233,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "date",
             "zindex": 1,
             "encode": {
@@ -264,13 +264,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "price",
             "zindex": 1

--- a/examples/vg-specs/layered_crossfilter.vg.json
+++ b/examples/vg-specs/layered_crossfilter.vg.json
@@ -731,6 +731,7 @@
             "axes": [
                 {
                     "scale": "child_distance_x",
+                    "labelOverlap": true,
                     "orient": "bottom",
                     "title": "BIN(distance)",
                     "values": {
@@ -755,6 +756,7 @@
                 },
                 {
                     "scale": "child_distance_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Number of Records",
                     "zindex": 1
@@ -1143,6 +1145,7 @@
             "axes": [
                 {
                     "scale": "child_delay_x",
+                    "labelOverlap": true,
                     "orient": "bottom",
                     "title": "BIN(delay)",
                     "values": {
@@ -1167,6 +1170,7 @@
                 },
                 {
                     "scale": "child_delay_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Number of Records",
                     "zindex": 1
@@ -1555,6 +1559,7 @@
             "axes": [
                 {
                     "scale": "child_time_x",
+                    "labelOverlap": true,
                     "orient": "bottom",
                     "title": "BIN(time)",
                     "values": {
@@ -1579,6 +1584,7 @@
                 },
                 {
                     "scale": "child_time_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Number of Records",
                     "zindex": 1

--- a/examples/vg-specs/layered_crossfilter_discrete.vg.json
+++ b/examples/vg-specs/layered_crossfilter_discrete.vg.json
@@ -492,6 +492,7 @@
             "axes": [
                 {
                     "scale": "child_distance_x",
+                    "labelOverlap": true,
                     "orient": "bottom",
                     "title": "BIN(distance)",
                     "values": {
@@ -516,6 +517,7 @@
                 },
                 {
                     "scale": "child_distance_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Number of Records",
                     "zindex": 1
@@ -665,6 +667,7 @@
             "axes": [
                 {
                     "scale": "child_delay_x",
+                    "labelOverlap": true,
                     "orient": "bottom",
                     "title": "BIN(delay)",
                     "values": {
@@ -689,6 +692,7 @@
                 },
                 {
                     "scale": "child_delay_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Number of Records",
                     "zindex": 1
@@ -838,6 +842,7 @@
             "axes": [
                 {
                     "scale": "child_time_x",
+                    "labelOverlap": true,
                     "orient": "bottom",
                     "title": "BIN(time)",
                     "values": {
@@ -862,6 +867,7 @@
                 },
                 {
                     "scale": "child_time_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Number of Records",
                     "zindex": 1

--- a/examples/vg-specs/layered_falkensee.vg.json
+++ b/examples/vg-specs/layered_falkensee.vg.json
@@ -450,8 +450,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "YEAR(start), YEAR(year)",
             "zindex": 1,
             "encode": {
@@ -481,13 +481,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "population",
             "zindex": 1

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -800,7 +800,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -812,13 +811,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/line.vg.json
+++ b/examples/vg-specs/line.vg.json
@@ -114,8 +114,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "date",
             "zindex": 1,
             "encode": {
@@ -145,13 +145,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "price",
             "zindex": 1

--- a/examples/vg-specs/line_calculate.vg.json
+++ b/examples/vg-specs/line_calculate.vg.json
@@ -134,8 +134,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "MONTH(date)",
             "zindex": 1,
             "encode": {
@@ -159,6 +159,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MEAN(temp_range)",
             "zindex": 1

--- a/examples/vg-specs/line_color.vg.json
+++ b/examples/vg-specs/line_color.vg.json
@@ -150,8 +150,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "date",
             "zindex": 1,
             "encode": {
@@ -181,13 +181,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "price",
             "zindex": 1

--- a/examples/vg-specs/line_color_binned.vg.json
+++ b/examples/vg-specs/line_color_binned.vg.json
@@ -190,8 +190,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Year",
             "zindex": 1,
             "encode": {
@@ -221,13 +221,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MEAN(Horsepower)",
             "zindex": 1

--- a/examples/vg-specs/line_detail.vg.json
+++ b/examples/vg-specs/line_detail.vg.json
@@ -139,8 +139,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "date",
             "zindex": 1,
             "encode": {
@@ -170,13 +170,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "price",
             "zindex": 1

--- a/examples/vg-specs/line_max_year.vg.json
+++ b/examples/vg-specs/line_max_year.vg.json
@@ -130,8 +130,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "YEARMONTH(date)",
             "zindex": 1,
             "encode": {
@@ -161,13 +161,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MAX(temp_max)",
             "zindex": 1

--- a/examples/vg-specs/line_mean_month.vg.json
+++ b/examples/vg-specs/line_mean_month.vg.json
@@ -130,8 +130,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "MONTH(date)",
             "zindex": 1,
             "encode": {
@@ -155,6 +155,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MEAN(precipitation)",
             "zindex": 1

--- a/examples/vg-specs/line_mean_year.vg.json
+++ b/examples/vg-specs/line_mean_year.vg.json
@@ -130,8 +130,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "YEAR(date)",
             "zindex": 1,
             "encode": {
@@ -161,13 +161,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MEAN(temp_max)",
             "zindex": 1

--- a/examples/vg-specs/line_monotone.vg.json
+++ b/examples/vg-specs/line_monotone.vg.json
@@ -116,8 +116,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "date",
             "zindex": 1,
             "encode": {
@@ -147,13 +147,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "price",
             "zindex": 1

--- a/examples/vg-specs/line_month.vg.json
+++ b/examples/vg-specs/line_month.vg.json
@@ -133,8 +133,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "MONTH(date)",
             "zindex": 1,
             "encode": {
@@ -158,6 +158,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MEAN(temp)",
             "zindex": 1

--- a/examples/vg-specs/line_quarter.vg.json
+++ b/examples/vg-specs/line_quarter.vg.json
@@ -142,6 +142,7 @@
             "axes": [
                 {
                     "scale": "y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "MEAN(price)",
                     "zindex": 1
@@ -208,8 +209,8 @@
             "axes": [
                 {
                     "scale": "x",
+                    "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "QUARTER(date)",
                     "zindex": 1,
                     "encode": {

--- a/examples/vg-specs/line_quarter_legend.vg.json
+++ b/examples/vg-specs/line_quarter_legend.vg.json
@@ -177,8 +177,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "YEAR(date)",
             "zindex": 1,
             "encode": {
@@ -208,13 +208,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MEAN(price)",
             "zindex": 1

--- a/examples/vg-specs/line_slope.vg.json
+++ b/examples/vg-specs/line_slope.vg.json
@@ -166,8 +166,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "year",
             "zindex": 1,
             "encode": {
@@ -188,6 +188,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MEDIAN(yield)",
             "zindex": 1

--- a/examples/vg-specs/line_step.vg.json
+++ b/examples/vg-specs/line_step.vg.json
@@ -117,8 +117,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "date",
             "zindex": 1,
             "encode": {
@@ -148,13 +148,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "price",
             "zindex": 1

--- a/examples/vg-specs/lookup.vg.json
+++ b/examples/vg-specs/lookup.vg.json
@@ -148,8 +148,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "group",
             "zindex": 1,
             "encode": {
@@ -170,6 +170,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MEAN(age)",
             "zindex": 1

--- a/examples/vg-specs/output_utc_scale.vg.json
+++ b/examples/vg-specs/output_utc_scale.vg.json
@@ -144,8 +144,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "YEARMONTHDATEHOURSMINUTES(date)",
             "zindex": 1,
             "encode": {
@@ -175,13 +175,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "price",
             "zindex": 1

--- a/examples/vg-specs/output_utc_timeunit.vg.json
+++ b/examples/vg-specs/output_utc_timeunit.vg.json
@@ -144,8 +144,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "UTCYEARMONTHDATEHOURSMINUTES(date)",
             "zindex": 1,
             "encode": {
@@ -175,13 +175,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "price",
             "zindex": 1

--- a/examples/vg-specs/overlay_area_full.vg.json
+++ b/examples/vg-specs/overlay_area_full.vg.json
@@ -254,8 +254,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "date",
             "zindex": 1,
             "encode": {
@@ -285,13 +285,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "price",
             "zindex": 1

--- a/examples/vg-specs/overlay_area_short.vg.json
+++ b/examples/vg-specs/overlay_area_short.vg.json
@@ -255,8 +255,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "date",
             "zindex": 1,
             "encode": {
@@ -286,13 +286,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "price",
             "zindex": 1

--- a/examples/vg-specs/overlay_line_full.vg.json
+++ b/examples/vg-specs/overlay_line_full.vg.json
@@ -189,8 +189,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "date",
             "zindex": 1,
             "encode": {
@@ -220,13 +220,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "price",
             "zindex": 1

--- a/examples/vg-specs/overlay_line_short.vg.json
+++ b/examples/vg-specs/overlay_line_short.vg.json
@@ -190,8 +190,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "date",
             "zindex": 1,
             "encode": {
@@ -221,13 +221,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "price",
             "zindex": 1

--- a/examples/vg-specs/overview_detail.vg.json
+++ b/examples/vg-specs/overview_detail.vg.json
@@ -160,7 +160,6 @@
                     "scale": "concat_0_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "zindex": 1,
                     "encode": {
                         "labels": {
@@ -180,13 +179,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "concat_0_y"
                 },
                 {
                     "scale": "concat_0_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "price",
                     "zindex": 1
@@ -542,7 +541,6 @@
                     "scale": "concat_1_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "date",
                     "zindex": 1,
                     "encode": {
@@ -563,7 +561,6 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "concat_1_y"
@@ -571,6 +568,7 @@
                 {
                     "tickCount": 3,
                     "scale": "concat_1_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "price",
                     "zindex": 1

--- a/examples/vg-specs/paintbrush.vg.json
+++ b/examples/vg-specs/paintbrush.vg.json
@@ -215,7 +215,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -227,13 +226,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/paintbrush_color.vg.json
+++ b/examples/vg-specs/paintbrush_color.vg.json
@@ -188,7 +188,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -200,13 +199,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/paintbrush_color_nearest.vg.json
+++ b/examples/vg-specs/paintbrush_color_nearest.vg.json
@@ -226,7 +226,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -238,13 +237,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/paintbrush_simple.vg.json
+++ b/examples/vg-specs/paintbrush_simple.vg.json
@@ -176,7 +176,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -188,13 +187,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/panzoom_splom.vg.json
+++ b/examples/vg-specs/panzoom_splom.vg.json
@@ -392,7 +392,6 @@
                     "scale": "child_Horsepower_Horsepower_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -404,13 +403,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Horsepower_Horsepower_y"
                 },
                 {
                     "scale": "child_Horsepower_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Horsepower",
                     "zindex": 1
@@ -623,7 +622,6 @@
                     "scale": "child_Horsepower_Acceleration_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -635,13 +633,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Horsepower_Acceleration_y"
                 },
                 {
                     "scale": "child_Horsepower_Acceleration_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Acceleration",
                     "zindex": 1
@@ -854,7 +852,6 @@
                     "scale": "child_Horsepower_Miles_per_Gallon_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -866,13 +863,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Horsepower_Miles_per_Gallon_y"
                 },
                 {
                     "scale": "child_Horsepower_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1
@@ -1085,7 +1082,6 @@
                     "scale": "child_Acceleration_Horsepower_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Acceleration",
                     "zindex": 1
                 },
@@ -1097,13 +1093,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Acceleration_Horsepower_y"
                 },
                 {
                     "scale": "child_Acceleration_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Horsepower",
                     "zindex": 1
@@ -1295,7 +1291,6 @@
                     "scale": "child_Acceleration_Acceleration_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Acceleration",
                     "zindex": 1
                 },
@@ -1307,13 +1302,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Acceleration_Acceleration_y"
                 },
                 {
                     "scale": "child_Acceleration_Acceleration_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Acceleration",
                     "zindex": 1
@@ -1526,7 +1521,6 @@
                     "scale": "child_Acceleration_Miles_per_Gallon_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Acceleration",
                     "zindex": 1
                 },
@@ -1538,13 +1532,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Acceleration_Miles_per_Gallon_y"
                 },
                 {
                     "scale": "child_Acceleration_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1
@@ -1757,7 +1751,6 @@
                     "scale": "child_Miles_per_Gallon_Horsepower_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Miles_per_Gallon",
                     "zindex": 1
                 },
@@ -1769,13 +1762,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Miles_per_Gallon_Horsepower_y"
                 },
                 {
                     "scale": "child_Miles_per_Gallon_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Horsepower",
                     "zindex": 1
@@ -1988,7 +1981,6 @@
                     "scale": "child_Miles_per_Gallon_Acceleration_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Miles_per_Gallon",
                     "zindex": 1
                 },
@@ -2000,13 +1992,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Miles_per_Gallon_Acceleration_y"
                 },
                 {
                     "scale": "child_Miles_per_Gallon_Acceleration_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Acceleration",
                     "zindex": 1
@@ -2198,7 +2190,6 @@
                     "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Miles_per_Gallon",
                     "zindex": 1
                 },
@@ -2210,13 +2201,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Miles_per_Gallon_Miles_per_Gallon_y"
                 },
                 {
                     "scale": "child_Miles_per_Gallon_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1

--- a/examples/vg-specs/panzoom_vconcat_shared.vg.json
+++ b/examples/vg-specs/panzoom_vconcat_shared.vg.json
@@ -288,7 +288,6 @@
                     "scale": "x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -300,13 +299,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "concat_0_y"
                 },
                 {
                     "scale": "concat_0_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1
@@ -381,7 +380,6 @@
                     "scale": "x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -393,13 +391,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "concat_1_y"
                 },
                 {
                     "scale": "concat_1_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Acceleration",
                     "zindex": 1

--- a/examples/vg-specs/parse_local_time.vg.json
+++ b/examples/vg-specs/parse_local_time.vg.json
@@ -108,6 +108,7 @@
         {
             "title": "time",
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "zindex": 1,
             "encode": {

--- a/examples/vg-specs/parse_utc_time.vg.json
+++ b/examples/vg-specs/parse_utc_time.vg.json
@@ -130,8 +130,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "YEAR(Year)",
             "zindex": 1,
             "encode": {
@@ -161,13 +161,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MEAN(Horsepower)",
             "zindex": 1

--- a/examples/vg-specs/parse_utc_time_format.vg.json
+++ b/examples/vg-specs/parse_utc_time_format.vg.json
@@ -108,6 +108,7 @@
         {
             "title": "time",
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "zindex": 1,
             "encode": {

--- a/examples/vg-specs/point_1d.vg.json
+++ b/examples/vg-specs/point_1d.vg.json
@@ -94,7 +94,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "IMDB_Rating",
             "zindex": 1
         },
@@ -106,7 +105,6 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0
         }

--- a/examples/vg-specs/point_1d_array.vg.json
+++ b/examples/vg-specs/point_1d_array.vg.json
@@ -121,7 +121,6 @@
         {
             "scale": "x",
             "orient": "bottom",
-            "tickCount": 5,
             "title": "a",
             "zindex": 1,
             "encode": {

--- a/examples/vg-specs/point_1d_bin.vg.json
+++ b/examples/vg-specs/point_1d_bin.vg.json
@@ -111,6 +111,7 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
             "title": "BIN(IMDB_Rating)",
             "values": {

--- a/examples/vg-specs/point_2d_aggregate.vg.json
+++ b/examples/vg-specs/point_2d_aggregate.vg.json
@@ -162,7 +162,6 @@
         {
             "scale": "x",
             "orient": "bottom",
-            "tickCount": 5,
             "title": "a",
             "zindex": 1,
             "encode": {
@@ -183,6 +182,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "AVERAGE(b)",
             "zindex": 1

--- a/examples/vg-specs/point_2d_array.vg.json
+++ b/examples/vg-specs/point_2d_array.vg.json
@@ -154,7 +154,6 @@
         {
             "scale": "x",
             "orient": "bottom",
-            "tickCount": 5,
             "title": "a",
             "zindex": 1,
             "encode": {
@@ -175,6 +174,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "b",
             "zindex": 1

--- a/examples/vg-specs/point_2d_array_named.vg.json
+++ b/examples/vg-specs/point_2d_array_named.vg.json
@@ -154,7 +154,6 @@
         {
             "scale": "plotname_x",
             "orient": "bottom",
-            "tickCount": 5,
             "title": "a",
             "zindex": 1,
             "encode": {
@@ -175,6 +174,7 @@
         },
         {
             "scale": "plotname_y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "b",
             "zindex": 1

--- a/examples/vg-specs/point_colorramp_size.vg.json
+++ b/examples/vg-specs/point_colorramp_size.vg.json
@@ -144,7 +144,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -156,13 +155,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Acceleration",
             "zindex": 1

--- a/examples/vg-specs/point_dot_timeunit_color.vg.json
+++ b/examples/vg-specs/point_dot_timeunit_color.vg.json
@@ -124,7 +124,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "MEAN(temp)",
             "zindex": 1
         },
@@ -136,7 +135,6 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0
         }

--- a/examples/vg-specs/point_filled.vg.json
+++ b/examples/vg-specs/point_filled.vg.json
@@ -110,7 +110,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -122,13 +121,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/point_ordinal_color.vg.json
+++ b/examples/vg-specs/point_ordinal_color.vg.json
@@ -162,7 +162,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "x",
             "zindex": 1
         },
@@ -174,13 +173,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "y",
             "zindex": 1

--- a/examples/vg-specs/query_widgets.vg.json
+++ b/examples/vg-specs/query_widgets.vg.json
@@ -305,7 +305,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -317,13 +316,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/rect_binned_heatmap.vg.json
+++ b/examples/vg-specs/rect_binned_heatmap.vg.json
@@ -19,37 +19,58 @@
             "format": {
                 "type": "json",
                 "parse": {
-                    "IMDB_Rating": "number"
+                    "IMDB_Rating": "number",
+                    "Rotten_Tomatoes_Rating": "number"
                 }
             },
             "transform": [
                 {
                     "type": "filter",
-                    "expr": "datum[\"IMDB_Rating\"] !== null && !isNaN(datum[\"IMDB_Rating\"])"
+                    "expr": "datum[\"IMDB_Rating\"] !== null && !isNaN(datum[\"IMDB_Rating\"]) && datum[\"Rotten_Tomatoes_Rating\"] !== null && !isNaN(datum[\"Rotten_Tomatoes_Rating\"])"
                 },
                 {
                     "type": "extent",
                     "field": "IMDB_Rating",
-                    "signal": "bin_maxbins_30_IMDB_Rating_extent"
+                    "signal": "bin_maxbins_60_IMDB_Rating_extent"
                 },
                 {
                     "type": "bin",
                     "field": "IMDB_Rating",
                     "as": [
-                        "bin_maxbins_30_IMDB_Rating_start",
-                        "bin_maxbins_30_IMDB_Rating_end"
+                        "bin_maxbins_60_IMDB_Rating_start",
+                        "bin_maxbins_60_IMDB_Rating_end"
                     ],
-                    "signal": "bin_maxbins_30_IMDB_Rating_bins",
-                    "maxbins": 30,
+                    "signal": "bin_maxbins_60_IMDB_Rating_bins",
+                    "maxbins": 60,
                     "extent": {
-                        "signal": "bin_maxbins_30_IMDB_Rating_extent"
+                        "signal": "bin_maxbins_60_IMDB_Rating_extent"
+                    }
+                },
+                {
+                    "type": "extent",
+                    "field": "Rotten_Tomatoes_Rating",
+                    "signal": "bin_maxbins_40_Rotten_Tomatoes_Rating_extent"
+                },
+                {
+                    "type": "bin",
+                    "field": "Rotten_Tomatoes_Rating",
+                    "as": [
+                        "bin_maxbins_40_Rotten_Tomatoes_Rating_start",
+                        "bin_maxbins_40_Rotten_Tomatoes_Rating_end"
+                    ],
+                    "signal": "bin_maxbins_40_Rotten_Tomatoes_Rating_bins",
+                    "maxbins": 40,
+                    "extent": {
+                        "signal": "bin_maxbins_40_Rotten_Tomatoes_Rating_extent"
                     }
                 },
                 {
                     "type": "aggregate",
                     "groupby": [
-                        "bin_maxbins_30_IMDB_Rating_start",
-                        "bin_maxbins_30_IMDB_Rating_end"
+                        "bin_maxbins_60_IMDB_Rating_start",
+                        "bin_maxbins_60_IMDB_Rating_end",
+                        "bin_maxbins_40_Rotten_Tomatoes_Rating_start",
+                        "bin_maxbins_40_Rotten_Tomatoes_Rating_end"
                     ],
                     "ops": [
                         "count"
@@ -67,7 +88,7 @@
     "signals": [
         {
             "name": "width",
-            "update": "200"
+            "update": "300"
         },
         {
             "name": "height",
@@ -78,7 +99,6 @@
         {
             "name": "marks",
             "type": "rect",
-            "role": "bar",
             "from": {
                 "data": "source_0"
             },
@@ -86,23 +106,23 @@
                 "update": {
                     "x2": {
                         "scale": "x",
-                        "field": "bin_maxbins_30_IMDB_Rating_start",
-                        "offset": 1
+                        "field": "bin_maxbins_60_IMDB_Rating_start"
                     },
                     "x": {
                         "scale": "x",
-                        "field": "bin_maxbins_30_IMDB_Rating_end"
-                    },
-                    "y": {
-                        "scale": "y",
-                        "field": "count_*"
+                        "field": "bin_maxbins_60_IMDB_Rating_end"
                     },
                     "y2": {
                         "scale": "y",
-                        "value": 0
+                        "field": "bin_maxbins_40_Rotten_Tomatoes_Rating_start"
+                    },
+                    "y": {
+                        "scale": "y",
+                        "field": "bin_maxbins_40_Rotten_Tomatoes_Rating_end"
                     },
                     "fill": {
-                        "value": "#4c78a8"
+                        "scale": "color",
+                        "field": "count_*"
                     }
                 }
             }
@@ -115,8 +135,8 @@
             "domain": {
                 "data": "source_0",
                 "fields": [
-                    "bin_maxbins_30_IMDB_Rating_start",
-                    "bin_maxbins_30_IMDB_Rating_end"
+                    "bin_maxbins_60_IMDB_Rating_start",
+                    "bin_maxbins_60_IMDB_Rating_end"
                 ]
             },
             "range": [
@@ -133,7 +153,10 @@
             "type": "linear",
             "domain": {
                 "data": "source_0",
-                "field": "count_*"
+                "fields": [
+                    "bin_maxbins_40_Rotten_Tomatoes_Rating_start",
+                    "bin_maxbins_40_Rotten_Tomatoes_Rating_end"
+                ]
             },
             "range": [
                 {
@@ -142,8 +165,18 @@
                 0
             ],
             "round": true,
-            "nice": true,
-            "zero": true
+            "zero": false
+        },
+        {
+            "name": "color",
+            "type": "sequential",
+            "domain": {
+                "data": "source_0",
+                "field": "count_*"
+            },
+            "range": "heatmap",
+            "nice": false,
+            "zero": false
         }
     ],
     "axes": [
@@ -153,7 +186,7 @@
             "orient": "bottom",
             "title": "BIN(IMDB_Rating)",
             "values": {
-                "signal": "sequence(bin_maxbins_30_IMDB_Rating_bins.start, bin_maxbins_30_IMDB_Rating_bins.stop + bin_maxbins_30_IMDB_Rating_bins.step, bin_maxbins_30_IMDB_Rating_bins.step)"
+                "signal": "sequence(bin_maxbins_60_IMDB_Rating_bins.start, bin_maxbins_60_IMDB_Rating_bins.stop + bin_maxbins_60_IMDB_Rating_bins.step, bin_maxbins_60_IMDB_Rating_bins.step)"
             },
             "zindex": 1,
             "encode": {
@@ -176,25 +209,28 @@
             "scale": "y",
             "labelOverlap": true,
             "orient": "left",
-            "title": "Number of Records",
+            "title": "BIN(Rotten_Tomatoes_Rating)",
+            "values": {
+                "signal": "sequence(bin_maxbins_40_Rotten_Tomatoes_Rating_bins.start, bin_maxbins_40_Rotten_Tomatoes_Rating_bins.stop + bin_maxbins_40_Rotten_Tomatoes_Rating_bins.step, bin_maxbins_40_Rotten_Tomatoes_Rating_bins.step)"
+            },
             "zindex": 1
-        },
+        }
+    ],
+    "legends": [
         {
-            "scale": "y",
-            "domain": false,
-            "grid": true,
-            "labels": false,
-            "maxExtent": 0,
-            "minExtent": 0,
-            "orient": "left",
-            "ticks": false,
-            "zindex": 0,
-            "gridScale": "x"
+            "fill": "color",
+            "title": "Number of Records",
+            "type": "gradient"
         }
     ],
     "config": {
         "axis": {
             "minExtent": 30
+        },
+        "range": {
+            "heatmap": {
+                "scheme": "greenblue"
+            }
         }
     }
 }

--- a/examples/vg-specs/rect_heatmap.vg.json
+++ b/examples/vg-specs/rect_heatmap.vg.json
@@ -143,8 +143,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Cylinders",
             "zindex": 1,
             "encode": {
@@ -165,6 +165,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Origin",
             "zindex": 1

--- a/examples/vg-specs/repeat_histogram.vg.json
+++ b/examples/vg-specs/repeat_histogram.vg.json
@@ -302,6 +302,7 @@
             "axes": [
                 {
                     "scale": "child_Horsepower_x",
+                    "labelOverlap": true,
                     "orient": "bottom",
                     "title": "BIN(Horsepower)",
                     "values": {
@@ -326,6 +327,7 @@
                 },
                 {
                     "scale": "child_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Number of Records",
                     "zindex": 1
@@ -401,6 +403,7 @@
             "axes": [
                 {
                     "scale": "child_Miles_per_Gallon_x",
+                    "labelOverlap": true,
                     "orient": "bottom",
                     "title": "BIN(Miles_per_Gallon)",
                     "values": {
@@ -425,6 +428,7 @@
                 },
                 {
                     "scale": "child_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Number of Records",
                     "zindex": 1
@@ -500,6 +504,7 @@
             "axes": [
                 {
                     "scale": "child_Acceleration_x",
+                    "labelOverlap": true,
                     "orient": "bottom",
                     "title": "BIN(Acceleration)",
                     "values": {
@@ -524,6 +529,7 @@
                 },
                 {
                     "scale": "child_Acceleration_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Number of Records",
                     "zindex": 1

--- a/examples/vg-specs/repeat_histogram_flights.vg.json
+++ b/examples/vg-specs/repeat_histogram_flights.vg.json
@@ -245,6 +245,7 @@
             "axes": [
                 {
                     "scale": "child_distance_x",
+                    "labelOverlap": true,
                     "orient": "bottom",
                     "title": "BIN(distance)",
                     "values": {
@@ -269,6 +270,7 @@
                 },
                 {
                     "scale": "child_distance_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Number of Records",
                     "zindex": 1
@@ -343,6 +345,7 @@
             "axes": [
                 {
                     "scale": "child_delay_x",
+                    "labelOverlap": true,
                     "orient": "bottom",
                     "title": "BIN(delay)",
                     "values": {
@@ -367,6 +370,7 @@
                 },
                 {
                     "scale": "child_delay_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Number of Records",
                     "zindex": 1
@@ -441,6 +445,7 @@
             "axes": [
                 {
                     "scale": "child_time_x",
+                    "labelOverlap": true,
                     "orient": "bottom",
                     "title": "BIN(time)",
                     "values": {
@@ -465,6 +470,7 @@
                 },
                 {
                     "scale": "child_time_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Number of Records",
                     "zindex": 1

--- a/examples/vg-specs/repeat_independent_colors.vg.json
+++ b/examples/vg-specs/repeat_independent_colors.vg.json
@@ -128,7 +128,6 @@
                     "scale": "child_Origin_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -140,13 +139,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Origin_y"
                 },
                 {
                     "scale": "child_Origin_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1
@@ -227,7 +226,6 @@
                     "scale": "child_Cylinders_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -239,13 +237,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Cylinders_y"
                 },
                 {
                     "scale": "child_Cylinders_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1

--- a/examples/vg-specs/repeat_splom_cars.vg.json
+++ b/examples/vg-specs/repeat_splom_cars.vg.json
@@ -163,7 +163,6 @@
                     "scale": "child_Displacement_Horsepower_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -175,13 +174,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Displacement_Horsepower_y"
                 },
                 {
                     "scale": "child_Displacement_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Displacement",
                     "zindex": 1
@@ -256,7 +255,6 @@
                     "scale": "child_Displacement_Miles_per_Gallon_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Miles_per_Gallon",
                     "zindex": 1
                 },
@@ -268,13 +266,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Displacement_Miles_per_Gallon_y"
                 },
                 {
                     "scale": "child_Displacement_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Displacement",
                     "zindex": 1
@@ -349,7 +347,6 @@
                     "scale": "child_Miles_per_Gallon_Horsepower_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -361,13 +358,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Miles_per_Gallon_Horsepower_y"
                 },
                 {
                     "scale": "child_Miles_per_Gallon_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1
@@ -442,7 +439,6 @@
                     "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Miles_per_Gallon",
                     "zindex": 1
                 },
@@ -454,13 +450,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Miles_per_Gallon_Miles_per_Gallon_y"
                 },
                 {
                     "scale": "child_Miles_per_Gallon_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1

--- a/examples/vg-specs/repeat_splom_iris.vg.json
+++ b/examples/vg-specs/repeat_splom_iris.vg.json
@@ -388,7 +388,6 @@
                     "scale": "child_petalWidth_sepalLength_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "sepalLength",
                     "zindex": 1
                 },
@@ -400,13 +399,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_petalWidth_sepalLength_y"
                 },
                 {
                     "scale": "child_petalWidth_sepalLength_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "petalWidth",
                     "zindex": 1
@@ -481,7 +480,6 @@
                     "scale": "child_petalWidth_sepalWidth_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "sepalWidth",
                     "zindex": 1
                 },
@@ -493,13 +491,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_petalWidth_sepalWidth_y"
                 },
                 {
                     "scale": "child_petalWidth_sepalWidth_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "petalWidth",
                     "zindex": 1
@@ -574,7 +572,6 @@
                     "scale": "child_petalWidth_petalLength_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "petalLength",
                     "zindex": 1
                 },
@@ -586,13 +583,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_petalWidth_petalLength_y"
                 },
                 {
                     "scale": "child_petalWidth_petalLength_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "petalWidth",
                     "zindex": 1
@@ -667,7 +664,6 @@
                     "scale": "child_petalWidth_petalWidth_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "petalWidth",
                     "zindex": 1
                 },
@@ -679,13 +675,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_petalWidth_petalWidth_y"
                 },
                 {
                     "scale": "child_petalWidth_petalWidth_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "petalWidth",
                     "zindex": 1
@@ -760,7 +756,6 @@
                     "scale": "child_petalLength_sepalLength_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "sepalLength",
                     "zindex": 1
                 },
@@ -772,13 +767,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_petalLength_sepalLength_y"
                 },
                 {
                     "scale": "child_petalLength_sepalLength_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "petalLength",
                     "zindex": 1
@@ -853,7 +848,6 @@
                     "scale": "child_petalLength_sepalWidth_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "sepalWidth",
                     "zindex": 1
                 },
@@ -865,13 +859,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_petalLength_sepalWidth_y"
                 },
                 {
                     "scale": "child_petalLength_sepalWidth_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "petalLength",
                     "zindex": 1
@@ -946,7 +940,6 @@
                     "scale": "child_petalLength_petalLength_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "petalLength",
                     "zindex": 1
                 },
@@ -958,13 +951,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_petalLength_petalLength_y"
                 },
                 {
                     "scale": "child_petalLength_petalLength_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "petalLength",
                     "zindex": 1
@@ -1039,7 +1032,6 @@
                     "scale": "child_petalLength_petalWidth_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "petalWidth",
                     "zindex": 1
                 },
@@ -1051,13 +1043,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_petalLength_petalWidth_y"
                 },
                 {
                     "scale": "child_petalLength_petalWidth_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "petalLength",
                     "zindex": 1
@@ -1132,7 +1124,6 @@
                     "scale": "child_sepalWidth_sepalLength_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "sepalLength",
                     "zindex": 1
                 },
@@ -1144,13 +1135,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_sepalWidth_sepalLength_y"
                 },
                 {
                     "scale": "child_sepalWidth_sepalLength_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "sepalWidth",
                     "zindex": 1
@@ -1225,7 +1216,6 @@
                     "scale": "child_sepalWidth_sepalWidth_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "sepalWidth",
                     "zindex": 1
                 },
@@ -1237,13 +1227,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_sepalWidth_sepalWidth_y"
                 },
                 {
                     "scale": "child_sepalWidth_sepalWidth_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "sepalWidth",
                     "zindex": 1
@@ -1318,7 +1308,6 @@
                     "scale": "child_sepalWidth_petalLength_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "petalLength",
                     "zindex": 1
                 },
@@ -1330,13 +1319,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_sepalWidth_petalLength_y"
                 },
                 {
                     "scale": "child_sepalWidth_petalLength_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "sepalWidth",
                     "zindex": 1
@@ -1411,7 +1400,6 @@
                     "scale": "child_sepalWidth_petalWidth_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "petalWidth",
                     "zindex": 1
                 },
@@ -1423,13 +1411,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_sepalWidth_petalWidth_y"
                 },
                 {
                     "scale": "child_sepalWidth_petalWidth_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "sepalWidth",
                     "zindex": 1
@@ -1504,7 +1492,6 @@
                     "scale": "child_sepalLength_sepalLength_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "sepalLength",
                     "zindex": 1
                 },
@@ -1516,13 +1503,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_sepalLength_sepalLength_y"
                 },
                 {
                     "scale": "child_sepalLength_sepalLength_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "sepalLength",
                     "zindex": 1
@@ -1597,7 +1584,6 @@
                     "scale": "child_sepalLength_sepalWidth_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "sepalWidth",
                     "zindex": 1
                 },
@@ -1609,13 +1595,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_sepalLength_sepalWidth_y"
                 },
                 {
                     "scale": "child_sepalLength_sepalWidth_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "sepalLength",
                     "zindex": 1
@@ -1690,7 +1676,6 @@
                     "scale": "child_sepalLength_petalLength_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "petalLength",
                     "zindex": 1
                 },
@@ -1702,13 +1687,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_sepalLength_petalLength_y"
                 },
                 {
                     "scale": "child_sepalLength_petalLength_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "sepalLength",
                     "zindex": 1
@@ -1783,7 +1768,6 @@
                     "scale": "child_sepalLength_petalWidth_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "petalWidth",
                     "zindex": 1
                 },
@@ -1795,13 +1779,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_sepalLength_petalWidth_y"
                 },
                 {
                     "scale": "child_sepalLength_petalWidth_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "sepalLength",
                     "zindex": 1

--- a/examples/vg-specs/rule_color_mean.vg.json
+++ b/examples/vg-specs/rule_color_mean.vg.json
@@ -116,6 +116,7 @@
     "axes": [
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MEAN(price)",
             "zindex": 1

--- a/examples/vg-specs/scatter.vg.json
+++ b/examples/vg-specs/scatter.vg.json
@@ -114,7 +114,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -126,13 +125,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/scatter_aggregate_detail.vg.json
+++ b/examples/vg-specs/scatter_aggregate_detail.vg.json
@@ -125,7 +125,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "MEAN(Horsepower)",
             "zindex": 1
         },
@@ -137,13 +136,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "MEAN(Displacement)",
             "zindex": 1

--- a/examples/vg-specs/scatter_binned.vg.json
+++ b/examples/vg-specs/scatter_binned.vg.json
@@ -182,6 +182,7 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
             "title": "BIN(IMDB_Rating)",
             "values": {
@@ -206,6 +207,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "BIN(Rotten_Tomatoes_Rating)",
             "values": {

--- a/examples/vg-specs/scatter_binned_color.vg.json
+++ b/examples/vg-specs/scatter_binned_color.vg.json
@@ -148,7 +148,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -160,13 +159,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/scatter_binned_opacity.vg.json
+++ b/examples/vg-specs/scatter_binned_opacity.vg.json
@@ -145,7 +145,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -157,13 +156,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/scatter_binned_size.vg.json
+++ b/examples/vg-specs/scatter_binned_size.vg.json
@@ -148,7 +148,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -160,13 +159,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/scatter_bubble.vg.json
+++ b/examples/vg-specs/scatter_bubble.vg.json
@@ -133,7 +133,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -145,13 +144,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/scatter_color.vg.json
+++ b/examples/vg-specs/scatter_color.vg.json
@@ -124,7 +124,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -136,13 +135,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/scatter_color_custom.vg.json
+++ b/examples/vg-specs/scatter_color_custom.vg.json
@@ -128,7 +128,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -140,13 +139,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/scatter_color_ordinal.vg.json
+++ b/examples/vg-specs/scatter_color_ordinal.vg.json
@@ -124,7 +124,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -136,13 +135,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/scatter_color_ordinal_custom.vg.json
+++ b/examples/vg-specs/scatter_color_ordinal_custom.vg.json
@@ -127,7 +127,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -139,13 +138,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/scatter_color_quantitative.vg.json
+++ b/examples/vg-specs/scatter_color_quantitative.vg.json
@@ -126,7 +126,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -138,13 +137,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/scatter_color_shape_constant.vg.json
+++ b/examples/vg-specs/scatter_color_shape_constant.vg.json
@@ -116,7 +116,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -128,13 +127,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/scatter_colored_with_shape.vg.json
+++ b/examples/vg-specs/scatter_colored_with_shape.vg.json
@@ -139,7 +139,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -151,13 +150,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/scatter_connected.vg.json
+++ b/examples/vg-specs/scatter_connected.vg.json
@@ -201,7 +201,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "miles",
             "zindex": 1
         },
@@ -213,13 +212,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "gas",
             "zindex": 1

--- a/examples/vg-specs/scatter_log.vg.json
+++ b/examples/vg-specs/scatter_log.vg.json
@@ -156,7 +156,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "x",
             "zindex": 1
         },
@@ -168,13 +167,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": "greedy",
             "orient": "left",
             "title": "y",
             "zindex": 1

--- a/examples/vg-specs/scatter_opacity.vg.json
+++ b/examples/vg-specs/scatter_opacity.vg.json
@@ -128,7 +128,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -140,13 +139,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/scatter_shape_custom.vg.json
+++ b/examples/vg-specs/scatter_shape_custom.vg.json
@@ -147,7 +147,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -159,13 +158,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/scatter_tooltip.vg.json
+++ b/examples/vg-specs/scatter_tooltip.vg.json
@@ -117,7 +117,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -129,13 +128,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_bind_cylyr.vg.json
+++ b/examples/vg-specs/selection_bind_cylyr.vg.json
@@ -218,7 +218,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -230,13 +229,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_bind_origin.vg.json
+++ b/examples/vg-specs/selection_bind_origin.vg.json
@@ -185,7 +185,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -197,13 +196,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_composition_and.vg.json
+++ b/examples/vg-specs/selection_composition_and.vg.json
@@ -856,8 +856,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Cylinders",
             "zindex": 1,
             "encode": {
@@ -878,6 +878,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Origin",
             "zindex": 1

--- a/examples/vg-specs/selection_composition_or.vg.json
+++ b/examples/vg-specs/selection_composition_or.vg.json
@@ -856,8 +856,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Cylinders",
             "zindex": 1,
             "encode": {
@@ -878,6 +878,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Origin",
             "zindex": 1

--- a/examples/vg-specs/selection_filter.vg.json
+++ b/examples/vg-specs/selection_filter.vg.json
@@ -495,7 +495,6 @@
                     "scale": "concat_0_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -507,13 +506,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "concat_0_y"
                 },
                 {
                     "scale": "concat_0_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1
@@ -587,7 +586,6 @@
                     "scale": "concat_1_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Acceleration",
                     "zindex": 1
                 },
@@ -599,13 +597,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "concat_1_y"
                 },
                 {
                     "scale": "concat_1_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Displacement",
                     "zindex": 1

--- a/examples/vg-specs/selection_filter_composition.vg.json
+++ b/examples/vg-specs/selection_filter_composition.vg.json
@@ -495,7 +495,6 @@
                     "scale": "concat_0_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -507,13 +506,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "concat_0_y"
                 },
                 {
                     "scale": "concat_0_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1
@@ -587,7 +586,6 @@
                     "scale": "concat_1_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Acceleration",
                     "zindex": 1
                 },
@@ -599,13 +597,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "concat_1_y"
                 },
                 {
                     "scale": "concat_1_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Displacement",
                     "zindex": 1

--- a/examples/vg-specs/selection_insert.vg.json
+++ b/examples/vg-specs/selection_insert.vg.json
@@ -172,7 +172,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -184,13 +183,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_project_binned_interval.vg.json
+++ b/examples/vg-specs/selection_project_binned_interval.vg.json
@@ -556,6 +556,7 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
             "title": "BIN(Acceleration)",
             "values": {
@@ -580,6 +581,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Number of Records",
             "zindex": 1

--- a/examples/vg-specs/selection_project_interval.vg.json
+++ b/examples/vg-specs/selection_project_interval.vg.json
@@ -504,8 +504,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Cylinders",
             "zindex": 1,
             "encode": {
@@ -526,6 +526,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Origin",
             "zindex": 1

--- a/examples/vg-specs/selection_project_interval_x.vg.json
+++ b/examples/vg-specs/selection_project_interval_x.vg.json
@@ -439,8 +439,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Cylinders",
             "zindex": 1,
             "encode": {
@@ -461,6 +461,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Origin",
             "zindex": 1

--- a/examples/vg-specs/selection_project_interval_x_y.vg.json
+++ b/examples/vg-specs/selection_project_interval_x_y.vg.json
@@ -504,8 +504,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Cylinders",
             "zindex": 1,
             "encode": {
@@ -526,6 +526,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Origin",
             "zindex": 1

--- a/examples/vg-specs/selection_project_interval_y.vg.json
+++ b/examples/vg-specs/selection_project_interval_y.vg.json
@@ -439,8 +439,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Cylinders",
             "zindex": 1,
             "encode": {
@@ -461,6 +461,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Origin",
             "zindex": 1

--- a/examples/vg-specs/selection_project_multi.vg.json
+++ b/examples/vg-specs/selection_project_multi.vg.json
@@ -195,7 +195,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -207,13 +206,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_project_multi_cylinders.vg.json
+++ b/examples/vg-specs/selection_project_multi_cylinders.vg.json
@@ -195,7 +195,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -207,13 +206,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_project_multi_cylinders_origin.vg.json
+++ b/examples/vg-specs/selection_project_multi_cylinders_origin.vg.json
@@ -219,7 +219,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -231,13 +230,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_project_multi_origin.vg.json
+++ b/examples/vg-specs/selection_project_multi_origin.vg.json
@@ -219,7 +219,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -231,13 +230,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_project_single.vg.json
+++ b/examples/vg-specs/selection_project_single.vg.json
@@ -184,7 +184,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -196,13 +195,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_project_single_cylinders.vg.json
+++ b/examples/vg-specs/selection_project_single_cylinders.vg.json
@@ -184,7 +184,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -196,13 +195,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_project_single_cylinders_origin.vg.json
+++ b/examples/vg-specs/selection_project_single_cylinders_origin.vg.json
@@ -208,7 +208,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -220,13 +219,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_project_single_origin.vg.json
+++ b/examples/vg-specs/selection_project_single_origin.vg.json
@@ -208,7 +208,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -220,13 +219,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_resolution_global.vg.json
+++ b/examples/vg-specs/selection_resolution_global.vg.json
@@ -554,7 +554,6 @@
                     "scale": "child_Horsepower_Horsepower_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -566,13 +565,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Horsepower_Horsepower_y"
                 },
                 {
                     "scale": "child_Horsepower_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Horsepower",
                     "zindex": 1
@@ -1000,7 +999,6 @@
                     "scale": "child_Horsepower_Acceleration_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -1012,13 +1010,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Horsepower_Acceleration_y"
                 },
                 {
                     "scale": "child_Horsepower_Acceleration_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Acceleration",
                     "zindex": 1
@@ -1446,7 +1444,6 @@
                     "scale": "child_Horsepower_Miles_per_Gallon_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -1458,13 +1455,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Horsepower_Miles_per_Gallon_y"
                 },
                 {
                     "scale": "child_Horsepower_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1
@@ -1892,7 +1889,6 @@
                     "scale": "child_Acceleration_Horsepower_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Acceleration",
                     "zindex": 1
                 },
@@ -1904,13 +1900,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Acceleration_Horsepower_y"
                 },
                 {
                     "scale": "child_Acceleration_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Horsepower",
                     "zindex": 1
@@ -2273,7 +2269,6 @@
                     "scale": "child_Acceleration_Acceleration_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Acceleration",
                     "zindex": 1
                 },
@@ -2285,13 +2280,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Acceleration_Acceleration_y"
                 },
                 {
                     "scale": "child_Acceleration_Acceleration_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Acceleration",
                     "zindex": 1
@@ -2719,7 +2714,6 @@
                     "scale": "child_Acceleration_Miles_per_Gallon_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Acceleration",
                     "zindex": 1
                 },
@@ -2731,13 +2725,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Acceleration_Miles_per_Gallon_y"
                 },
                 {
                     "scale": "child_Acceleration_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1
@@ -3165,7 +3159,6 @@
                     "scale": "child_Miles_per_Gallon_Horsepower_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Miles_per_Gallon",
                     "zindex": 1
                 },
@@ -3177,13 +3170,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Miles_per_Gallon_Horsepower_y"
                 },
                 {
                     "scale": "child_Miles_per_Gallon_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Horsepower",
                     "zindex": 1
@@ -3611,7 +3604,6 @@
                     "scale": "child_Miles_per_Gallon_Acceleration_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Miles_per_Gallon",
                     "zindex": 1
                 },
@@ -3623,13 +3615,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Miles_per_Gallon_Acceleration_y"
                 },
                 {
                     "scale": "child_Miles_per_Gallon_Acceleration_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Acceleration",
                     "zindex": 1
@@ -3992,7 +3984,6 @@
                     "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Miles_per_Gallon",
                     "zindex": 1
                 },
@@ -4004,13 +3995,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Miles_per_Gallon_Miles_per_Gallon_y"
                 },
                 {
                     "scale": "child_Miles_per_Gallon_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1

--- a/examples/vg-specs/selection_resolution_intersect.vg.json
+++ b/examples/vg-specs/selection_resolution_intersect.vg.json
@@ -506,7 +506,6 @@
                     "scale": "child_Horsepower_Horsepower_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -518,13 +517,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Horsepower_Horsepower_y"
                 },
                 {
                     "scale": "child_Horsepower_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Horsepower",
                     "zindex": 1
@@ -904,7 +903,6 @@
                     "scale": "child_Horsepower_Acceleration_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -916,13 +914,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Horsepower_Acceleration_y"
                 },
                 {
                     "scale": "child_Horsepower_Acceleration_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Acceleration",
                     "zindex": 1
@@ -1302,7 +1300,6 @@
                     "scale": "child_Horsepower_Miles_per_Gallon_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -1314,13 +1311,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Horsepower_Miles_per_Gallon_y"
                 },
                 {
                     "scale": "child_Horsepower_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1
@@ -1700,7 +1697,6 @@
                     "scale": "child_Acceleration_Horsepower_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Acceleration",
                     "zindex": 1
                 },
@@ -1712,13 +1708,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Acceleration_Horsepower_y"
                 },
                 {
                     "scale": "child_Acceleration_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Horsepower",
                     "zindex": 1
@@ -2033,7 +2029,6 @@
                     "scale": "child_Acceleration_Acceleration_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Acceleration",
                     "zindex": 1
                 },
@@ -2045,13 +2040,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Acceleration_Acceleration_y"
                 },
                 {
                     "scale": "child_Acceleration_Acceleration_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Acceleration",
                     "zindex": 1
@@ -2431,7 +2426,6 @@
                     "scale": "child_Acceleration_Miles_per_Gallon_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Acceleration",
                     "zindex": 1
                 },
@@ -2443,13 +2437,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Acceleration_Miles_per_Gallon_y"
                 },
                 {
                     "scale": "child_Acceleration_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1
@@ -2829,7 +2823,6 @@
                     "scale": "child_Miles_per_Gallon_Horsepower_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Miles_per_Gallon",
                     "zindex": 1
                 },
@@ -2841,13 +2834,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Miles_per_Gallon_Horsepower_y"
                 },
                 {
                     "scale": "child_Miles_per_Gallon_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Horsepower",
                     "zindex": 1
@@ -3227,7 +3220,6 @@
                     "scale": "child_Miles_per_Gallon_Acceleration_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Miles_per_Gallon",
                     "zindex": 1
                 },
@@ -3239,13 +3231,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Miles_per_Gallon_Acceleration_y"
                 },
                 {
                     "scale": "child_Miles_per_Gallon_Acceleration_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Acceleration",
                     "zindex": 1
@@ -3560,7 +3552,6 @@
                     "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Miles_per_Gallon",
                     "zindex": 1
                 },
@@ -3572,13 +3563,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Miles_per_Gallon_Miles_per_Gallon_y"
                 },
                 {
                     "scale": "child_Miles_per_Gallon_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1

--- a/examples/vg-specs/selection_resolution_union.vg.json
+++ b/examples/vg-specs/selection_resolution_union.vg.json
@@ -506,7 +506,6 @@
                     "scale": "child_Horsepower_Horsepower_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -518,13 +517,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Horsepower_Horsepower_y"
                 },
                 {
                     "scale": "child_Horsepower_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Horsepower",
                     "zindex": 1
@@ -904,7 +903,6 @@
                     "scale": "child_Horsepower_Acceleration_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -916,13 +914,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Horsepower_Acceleration_y"
                 },
                 {
                     "scale": "child_Horsepower_Acceleration_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Acceleration",
                     "zindex": 1
@@ -1302,7 +1300,6 @@
                     "scale": "child_Horsepower_Miles_per_Gallon_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 },
@@ -1314,13 +1311,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Horsepower_Miles_per_Gallon_y"
                 },
                 {
                     "scale": "child_Horsepower_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1
@@ -1700,7 +1697,6 @@
                     "scale": "child_Acceleration_Horsepower_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Acceleration",
                     "zindex": 1
                 },
@@ -1712,13 +1708,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Acceleration_Horsepower_y"
                 },
                 {
                     "scale": "child_Acceleration_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Horsepower",
                     "zindex": 1
@@ -2033,7 +2029,6 @@
                     "scale": "child_Acceleration_Acceleration_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Acceleration",
                     "zindex": 1
                 },
@@ -2045,13 +2040,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Acceleration_Acceleration_y"
                 },
                 {
                     "scale": "child_Acceleration_Acceleration_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Acceleration",
                     "zindex": 1
@@ -2431,7 +2426,6 @@
                     "scale": "child_Acceleration_Miles_per_Gallon_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Acceleration",
                     "zindex": 1
                 },
@@ -2443,13 +2437,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Acceleration_Miles_per_Gallon_y"
                 },
                 {
                     "scale": "child_Acceleration_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1
@@ -2829,7 +2823,6 @@
                     "scale": "child_Miles_per_Gallon_Horsepower_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Miles_per_Gallon",
                     "zindex": 1
                 },
@@ -2841,13 +2834,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Miles_per_Gallon_Horsepower_y"
                 },
                 {
                     "scale": "child_Miles_per_Gallon_Horsepower_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Horsepower",
                     "zindex": 1
@@ -3227,7 +3220,6 @@
                     "scale": "child_Miles_per_Gallon_Acceleration_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Miles_per_Gallon",
                     "zindex": 1
                 },
@@ -3239,13 +3231,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Miles_per_Gallon_Acceleration_y"
                 },
                 {
                     "scale": "child_Miles_per_Gallon_Acceleration_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Acceleration",
                     "zindex": 1
@@ -3560,7 +3552,6 @@
                     "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Miles_per_Gallon",
                     "zindex": 1
                 },
@@ -3572,13 +3563,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "child_Miles_per_Gallon_Miles_per_Gallon_y"
                 },
                 {
                     "scale": "child_Miles_per_Gallon_Miles_per_Gallon_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1

--- a/examples/vg-specs/selection_toggle_altKey.vg.json
+++ b/examples/vg-specs/selection_toggle_altKey.vg.json
@@ -187,7 +187,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -199,13 +198,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_toggle_altKey_shiftKey.vg.json
+++ b/examples/vg-specs/selection_toggle_altKey_shiftKey.vg.json
@@ -187,7 +187,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -199,13 +198,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_toggle_shiftKey.vg.json
+++ b/examples/vg-specs/selection_toggle_shiftKey.vg.json
@@ -187,7 +187,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -199,13 +198,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_translate_brush_drag.vg.json
+++ b/examples/vg-specs/selection_translate_brush_drag.vg.json
@@ -508,7 +508,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -520,13 +519,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_translate_brush_shift-drag.vg.json
+++ b/examples/vg-specs/selection_translate_brush_shift-drag.vg.json
@@ -514,7 +514,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -526,13 +525,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_translate_scatterplot_drag.vg.json
+++ b/examples/vg-specs/selection_translate_scatterplot_drag.vg.json
@@ -285,7 +285,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -297,13 +296,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_translate_scatterplot_shift-drag.vg.json
+++ b/examples/vg-specs/selection_translate_scatterplot_shift-drag.vg.json
@@ -291,7 +291,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -303,13 +302,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_type_interval.vg.json
+++ b/examples/vg-specs/selection_type_interval.vg.json
@@ -504,8 +504,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Cylinders",
             "zindex": 1,
             "encode": {
@@ -526,6 +526,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Origin",
             "zindex": 1

--- a/examples/vg-specs/selection_type_multi.vg.json
+++ b/examples/vg-specs/selection_type_multi.vg.json
@@ -200,8 +200,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Cylinders",
             "zindex": 1,
             "encode": {
@@ -222,6 +222,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Origin",
             "zindex": 1

--- a/examples/vg-specs/selection_type_single.vg.json
+++ b/examples/vg-specs/selection_type_single.vg.json
@@ -189,8 +189,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Cylinders",
             "zindex": 1,
             "encode": {
@@ -211,6 +211,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Origin",
             "zindex": 1

--- a/examples/vg-specs/selection_type_single_dblclick.vg.json
+++ b/examples/vg-specs/selection_type_single_dblclick.vg.json
@@ -189,8 +189,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Cylinders",
             "zindex": 1,
             "encode": {
@@ -211,6 +211,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Origin",
             "zindex": 1

--- a/examples/vg-specs/selection_zoom_brush_shift-wheel.vg.json
+++ b/examples/vg-specs/selection_zoom_brush_shift-wheel.vg.json
@@ -514,7 +514,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -526,13 +525,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_zoom_brush_wheel.vg.json
+++ b/examples/vg-specs/selection_zoom_brush_wheel.vg.json
@@ -508,7 +508,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -520,13 +519,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_zoom_scatterplot_shift-wheel.vg.json
+++ b/examples/vg-specs/selection_zoom_scatterplot_shift-wheel.vg.json
@@ -291,7 +291,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -303,13 +302,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/selection_zoom_scatterplot_wheel.vg.json
+++ b/examples/vg-specs/selection_zoom_scatterplot_wheel.vg.json
@@ -285,7 +285,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -297,13 +296,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/square.vg.json
+++ b/examples/vg-specs/square.vg.json
@@ -113,7 +113,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -125,13 +124,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/stacked_area.vg.json
+++ b/examples/vg-specs/stacked_area.vg.json
@@ -216,7 +216,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "YEARMONTH(date)",
             "zindex": 1,
             "encode": {
@@ -237,13 +236,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "SUM(count)",
             "zindex": 1

--- a/examples/vg-specs/stacked_area_binned.vg.json
+++ b/examples/vg-specs/stacked_area_binned.vg.json
@@ -233,6 +233,7 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
             "title": "BIN(Acceleration)",
             "values": {
@@ -257,6 +258,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "SUM(Horsepower)",
             "zindex": 1

--- a/examples/vg-specs/stacked_area_normalize.vg.json
+++ b/examples/vg-specs/stacked_area_normalize.vg.json
@@ -213,7 +213,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "YEARMONTH(date)",
             "zindex": 1,
             "encode": {
@@ -234,7 +233,6 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"

--- a/examples/vg-specs/stacked_area_ordinal.vg.json
+++ b/examples/vg-specs/stacked_area_ordinal.vg.json
@@ -214,8 +214,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "YEAR(Year)",
             "zindex": 1,
             "encode": {
@@ -245,13 +245,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "SUM(Weight_in_lbs)",
             "zindex": 1

--- a/examples/vg-specs/stacked_area_stream.vg.json
+++ b/examples/vg-specs/stacked_area_stream.vg.json
@@ -217,7 +217,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "YEARMONTH(date)",
             "zindex": 1,
             "encode": {
@@ -239,7 +238,6 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"

--- a/examples/vg-specs/stacked_bar_1d.vg.json
+++ b/examples/vg-specs/stacked_bar_1d.vg.json
@@ -138,7 +138,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "SUM(Acceleration)",
             "zindex": 1
         },
@@ -150,7 +149,6 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0
         }

--- a/examples/vg-specs/stacked_bar_count.vg.json
+++ b/examples/vg-specs/stacked_bar_count.vg.json
@@ -167,8 +167,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "MONTH(date)",
             "zindex": 1,
             "encode": {
@@ -192,6 +192,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Number of Records",
             "zindex": 1

--- a/examples/vg-specs/stacked_bar_h.vg.json
+++ b/examples/vg-specs/stacked_bar_h.vg.json
@@ -164,7 +164,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "SUM(yield)",
             "zindex": 1
         },
@@ -176,7 +175,6 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"

--- a/examples/vg-specs/stacked_bar_h_order.vg.json
+++ b/examples/vg-specs/stacked_bar_h_order.vg.json
@@ -164,7 +164,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "SUM(yield)",
             "zindex": 1
         },
@@ -176,7 +175,6 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"

--- a/examples/vg-specs/stacked_bar_normalize.vg.json
+++ b/examples/vg-specs/stacked_bar_normalize.vg.json
@@ -171,8 +171,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "age",
             "zindex": 1,
             "encode": {
@@ -194,6 +194,7 @@
         {
             "title": "population",
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "zindex": 1
         },

--- a/examples/vg-specs/stacked_bar_population.vg.json
+++ b/examples/vg-specs/stacked_bar_population.vg.json
@@ -175,8 +175,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "age",
             "zindex": 1,
             "encode": {
@@ -198,6 +198,7 @@
         {
             "title": "population",
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "zindex": 1
         },

--- a/examples/vg-specs/stacked_bar_size.vg.json
+++ b/examples/vg-specs/stacked_bar_size.vg.json
@@ -172,8 +172,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "MONTH(date)",
             "zindex": 1,
             "encode": {
@@ -197,6 +197,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Number of Records",
             "zindex": 1

--- a/examples/vg-specs/stacked_bar_sum_opacity.vg.json
+++ b/examples/vg-specs/stacked_bar_sum_opacity.vg.json
@@ -183,8 +183,8 @@
     "axes": [
         {
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "age",
             "zindex": 1,
             "encode": {
@@ -206,6 +206,7 @@
         {
             "title": "population",
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "zindex": 1
         },

--- a/examples/vg-specs/stacked_bar_v.vg.json
+++ b/examples/vg-specs/stacked_bar_v.vg.json
@@ -163,7 +163,6 @@
         {
             "scale": "x",
             "orient": "bottom",
-            "tickCount": 5,
             "title": "variety",
             "zindex": 1,
             "encode": {
@@ -184,6 +183,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "SUM(yield)",
             "zindex": 1

--- a/examples/vg-specs/stacked_bar_weather.vg.json
+++ b/examples/vg-specs/stacked_bar_weather.vg.json
@@ -176,8 +176,8 @@
         {
             "title": "Month of the year",
             "scale": "x",
+            "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "zindex": 1,
             "encode": {
                 "labels": {
@@ -200,6 +200,7 @@
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Number of Records",
             "zindex": 1

--- a/examples/vg-specs/stocks_nearest_index.vg.json
+++ b/examples/vg-specs/stocks_nearest_index.vg.json
@@ -343,6 +343,7 @@
     "axes": [
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "price",
             "zindex": 1

--- a/examples/vg-specs/text_scatter_colored.vg.json
+++ b/examples/vg-specs/text_scatter_colored.vg.json
@@ -128,7 +128,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -140,13 +139,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Miles_per_Gallon",
             "zindex": 1

--- a/examples/vg-specs/tick_dot.vg.json
+++ b/examples/vg-specs/tick_dot.vg.json
@@ -97,7 +97,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "precipitation",
             "zindex": 1
         },
@@ -109,7 +108,6 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0
         }

--- a/examples/vg-specs/tick_dot_thickness.vg.json
+++ b/examples/vg-specs/tick_dot_thickness.vg.json
@@ -97,7 +97,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -109,7 +108,6 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0
         }

--- a/examples/vg-specs/tick_sort.vg.json
+++ b/examples/vg-specs/tick_sort.vg.json
@@ -97,7 +97,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -109,7 +108,6 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0
         }

--- a/examples/vg-specs/tick_strip.vg.json
+++ b/examples/vg-specs/tick_strip.vg.json
@@ -119,7 +119,6 @@
             "scale": "x",
             "labelOverlap": true,
             "orient": "bottom",
-            "tickCount": 5,
             "title": "Horsepower",
             "zindex": 1
         },
@@ -131,13 +130,13 @@
             "maxExtent": 0,
             "minExtent": 0,
             "orient": "bottom",
-            "tickCount": 5,
             "ticks": false,
             "zindex": 0,
             "gridScale": "y"
         },
         {
             "scale": "y",
+            "labelOverlap": true,
             "orient": "left",
             "title": "Cylinders",
             "zindex": 1

--- a/examples/vg-specs/timeunit_selections.vg.json
+++ b/examples/vg-specs/timeunit_selections.vg.json
@@ -466,8 +466,8 @@
             "axes": [
                 {
                     "scale": "concat_0_x",
+                    "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "SECONDS(date)",
                     "zindex": 1,
                     "encode": {
@@ -497,13 +497,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "concat_0_y"
                 },
                 {
                     "scale": "concat_0_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "price",
                     "zindex": 1
@@ -575,8 +575,8 @@
             "axes": [
                 {
                     "scale": "concat_1_x",
+                    "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "MINUTES(date)",
                     "zindex": 1,
                     "encode": {
@@ -606,13 +606,13 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "concat_1_y"
                 },
                 {
                     "scale": "concat_1_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "price",
                     "zindex": 1

--- a/examples/vg-specs/trellis_anscombe.vg.json
+++ b/examples/vg-specs/trellis_anscombe.vg.json
@@ -115,6 +115,7 @@
             "axes": [
                 {
                     "scale": "y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Y",
                     "zindex": 1
@@ -183,7 +184,6 @@
                     "scale": "x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "X",
                     "zindex": 1
                 }
@@ -265,7 +265,6 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "y"

--- a/examples/vg-specs/trellis_bar.vg.json
+++ b/examples/vg-specs/trellis_bar.vg.json
@@ -180,6 +180,7 @@
                 {
                     "title": "population",
                     "scale": "y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "zindex": 1
                 }
@@ -199,8 +200,8 @@
             "axes": [
                 {
                     "scale": "x",
+                    "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "age",
                     "zindex": 1,
                     "encode": {

--- a/examples/vg-specs/trellis_bar_histogram.vg.json
+++ b/examples/vg-specs/trellis_bar_histogram.vg.json
@@ -167,6 +167,7 @@
             "axes": [
                 {
                     "scale": "y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Number of Records",
                     "zindex": 1
@@ -187,6 +188,7 @@
             "axes": [
                 {
                     "scale": "x",
+                    "labelOverlap": true,
                     "orient": "bottom",
                     "title": "BIN(Horsepower)",
                     "values": {

--- a/examples/vg-specs/trellis_barley.vg.json
+++ b/examples/vg-specs/trellis_barley.vg.json
@@ -154,6 +154,7 @@
             "axes": [
                 {
                     "scale": "trellis_barley_y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "variety",
                     "zindex": 1
@@ -176,7 +177,6 @@
                     "scale": "trellis_barley_x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "MEDIAN(yield)",
                     "zindex": 1
                 }
@@ -280,7 +280,6 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "trellis_barley_y"

--- a/examples/vg-specs/trellis_column_year.vg.json
+++ b/examples/vg-specs/trellis_column_year.vg.json
@@ -149,6 +149,7 @@
             "axes": [
                 {
                     "scale": "y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "MEAN(price)",
                     "zindex": 1
@@ -215,8 +216,8 @@
             "axes": [
                 {
                     "scale": "x",
+                    "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "QUARTER(date)",
                     "zindex": 1,
                     "encode": {

--- a/examples/vg-specs/trellis_row_column.vg.json
+++ b/examples/vg-specs/trellis_row_column.vg.json
@@ -192,6 +192,7 @@
             "axes": [
                 {
                     "scale": "y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1
@@ -260,7 +261,6 @@
                     "scale": "x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 }
@@ -353,7 +353,6 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "y"

--- a/examples/vg-specs/trellis_scatter.vg.json
+++ b/examples/vg-specs/trellis_scatter.vg.json
@@ -114,6 +114,7 @@
             "axes": [
                 {
                     "scale": "y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "US_DVD_Sales",
                     "zindex": 1
@@ -182,7 +183,6 @@
                     "scale": "x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Worldwide_Gross",
                     "zindex": 1
                 }
@@ -264,7 +264,6 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "y"

--- a/examples/vg-specs/trellis_scatter_binned_row.vg.json
+++ b/examples/vg-specs/trellis_scatter_binned_row.vg.json
@@ -158,6 +158,7 @@
             "axes": [
                 {
                     "scale": "y",
+                    "labelOverlap": true,
                     "orient": "left",
                     "title": "Miles_per_Gallon",
                     "zindex": 1
@@ -180,7 +181,6 @@
                     "scale": "x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "Horsepower",
                     "zindex": 1
                 }
@@ -262,7 +262,6 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "y"

--- a/examples/vg-specs/trellis_stacked_bar.vg.json
+++ b/examples/vg-specs/trellis_stacked_bar.vg.json
@@ -219,7 +219,6 @@
                     "scale": "x",
                     "labelOverlap": true,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "title": "SUM(yield)",
                     "zindex": 1
                 }
@@ -304,7 +303,6 @@
                     "maxExtent": 0,
                     "minExtent": 0,
                     "orient": "bottom",
-                    "tickCount": 5,
                     "ticks": false,
                     "zindex": 0,
                     "gridScale": "y"

--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -297,7 +297,7 @@ function getProperty<K extends keyof (Axis|VgAxis)>(property: K, specifiedAxis: 
     case 'orient':
       return getSpecifiedOrDefaultValue(specifiedAxis.orient, rules.orient(channel));
     case 'tickCount':
-      return getSpecifiedOrDefaultValue(specifiedAxis.tickCount, rules.tickCount());
+      return specifiedAxis.tickCount;
     case 'ticks':
       return rules.ticks(property, specifiedAxis, isGridAxis, channel);
     case 'title':

--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -297,7 +297,7 @@ function getProperty<K extends keyof (Axis|VgAxis)>(property: K, specifiedAxis: 
     case 'orient':
       return getSpecifiedOrDefaultValue(specifiedAxis.orient, rules.orient(channel));
     case 'tickCount':
-      return getSpecifiedOrDefaultValue(specifiedAxis.tickCount, rules.tickCount(channel, fieldDef)); // TODO: scaleType
+      return getSpecifiedOrDefaultValue(specifiedAxis.tickCount, rules.tickCount());
     case 'ticks':
       return rules.ticks(property, specifiedAxis, isGridAxis, channel);
     case 'title':

--- a/src/compile/axis/rules.ts
+++ b/src/compile/axis/rules.ts
@@ -76,10 +76,6 @@ export function orient(channel: Channel) {
   throw new Error(log.message.INVALID_CHANNEL_FOR_AXIS);
 }
 
-export function tickCount(): number {
-  return undefined;
-}
-
 export function title(maxLength: number, fieldDef: FieldDef<string>, config: Config) {
   // if not defined, automatically determine axis title from field def
   const fieldTitle = fieldDefTitle(fieldDef, config);

--- a/src/compile/axis/rules.ts
+++ b/src/compile/axis/rules.ts
@@ -44,12 +44,14 @@ export function gridScale(model: UnitModel, channel: Channel, isGridAxis: boolea
 
 
 export function labelOverlap(fieldDef: FieldDef<string>, specifiedAxis: Axis, channel: Channel, scaleType: ScaleType) {
-  if (channel === 'x' && !labelAngle(specifiedAxis, channel, fieldDef)) {
+  // do not prevent overlap for nominal data because there is no way to infer what the missing labels are
+  if ((channel === 'x' || channel === 'y') && fieldDef.type !== 'nominal') {
     if (scaleType === 'log') {
       return 'greedy';
     }
     return true;
   }
+
   return undefined;
 }
 
@@ -74,13 +76,7 @@ export function orient(channel: Channel) {
   throw new Error(log.message.INVALID_CHANNEL_FOR_AXIS);
 }
 
-export function tickCount(channel: Channel, fieldDef: FieldDef<string>) {
-  // FIXME depends on scale type too
-  if (channel === X && !fieldDef.bin) {
-    // Vega's default tickCount often lead to a lot of label occlusion on X without 90 degree rotation
-    return 5;
-  }
-
+export function tickCount(): number {
   return undefined;
 }
 

--- a/test/compile/axis/rules.test.ts
+++ b/test/compile/axis/rules.test.ts
@@ -47,14 +47,9 @@ describe('compile/axis', ()=> {
   });
 
   describe('tickCount', function() {
-    it('should return undefined by default for non-x', function () {
-      const tickCount = rules.tickCount('y', {field: 'a', type: 'quantitative'});
+    it('should return undefined by default', function () {
+      const tickCount = rules.tickCount();
       assert.deepEqual(tickCount, undefined);
-    });
-
-    it('should return 5 by default for x', function () {
-      const tickCount = rules.tickCount('x', {field: 'a', type: 'quantitative'});
-      assert.deepEqual(tickCount, 5);
     });
   });
 

--- a/test/compile/axis/rules.test.ts
+++ b/test/compile/axis/rules.test.ts
@@ -46,13 +46,6 @@ describe('compile/axis', ()=> {
     });
   });
 
-  describe('tickCount', function() {
-    it('should return undefined by default', function () {
-      const tickCount = rules.tickCount();
-      assert.deepEqual(tickCount, undefined);
-    });
-  });
-
   describe('title()', function () {
     it('should add return fieldTitle by default', function () {
       const title = rules.title(3, {field: 'a', type: "quantitative"}, {});


### PR DESCRIPTION
This makes especially binned plots with many bins much nicer. 

* always prevent overlapping
* remove hack that set the tick count to 5

<img width="482" alt="screen shot 2017-07-25 at 17 37 10" src="https://user-images.githubusercontent.com/589034/28599602-b30e6636-7160-11e7-8e4b-0371b085bb34.png">
<img width="330" alt="screen shot 2017-07-25 at 17 35 09" src="https://user-images.githubusercontent.com/589034/28599604-b5f3efe2-7160-11e7-9bf1-8fb03b542348.png">
