### PR TITLE
Use the isTuple expr function rather than checking for _id field

### DIFF
--- a/examples/vg-specs/brush.vg.json
+++ b/examples/vg-specs/brush.vg.json
@@ -50,7 +50,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/bubble_health_income.vg.json
+++ b/examples/vg-specs/bubble_health_income.vg.json
@@ -55,7 +55,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/concat_selections.vg.json
+++ b/examples/vg-specs/concat_selections.vg.json
@@ -76,7 +76,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/dashboard_europe_pop.vg.json
+++ b/examples/vg-specs/dashboard_europe_pop.vg.json
@@ -393,7 +393,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         }

--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -73,7 +73,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },
@@ -284,7 +284,7 @@
                                     "type": "mousemove"
                                 }
                             ],
-                            "update": "facet._id ? facet : group(\"cell\").datum"
+                            "update": "isTuple(facet) ? facet : group(\"cell\").datum"
                         }
                     ]
                 },

--- a/examples/vg-specs/interactive_splom.vg.json
+++ b/examples/vg-specs/interactive_splom.vg.json
@@ -107,7 +107,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/interval_mark_style.vg.json
+++ b/examples/vg-specs/interval_mark_style.vg.json
@@ -68,7 +68,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/layered_crossfilter.vg.json
+++ b/examples/vg-specs/layered_crossfilter.vg.json
@@ -345,7 +345,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         }

--- a/examples/vg-specs/layered_crossfilter_discrete.vg.json
+++ b/examples/vg-specs/layered_crossfilter_discrete.vg.json
@@ -345,7 +345,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         }

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -86,7 +86,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/overview_detail.vg.json
+++ b/examples/vg-specs/overview_detail.vg.json
@@ -87,7 +87,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         }

--- a/examples/vg-specs/paintbrush.vg.json
+++ b/examples/vg-specs/paintbrush.vg.json
@@ -29,6 +29,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -65,7 +69,7 @@
                             "type": "mouseover"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/paintbrush.vg.json
+++ b/examples/vg-specs/paintbrush.vg.json
@@ -54,7 +54,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/paintbrush_color.vg.json
+++ b/examples/vg-specs/paintbrush_color.vg.json
@@ -29,6 +29,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -65,7 +69,7 @@
                             "type": "mouseover"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/paintbrush_color.vg.json
+++ b/examples/vg-specs/paintbrush_color.vg.json
@@ -54,7 +54,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/paintbrush_color_nearest.vg.json
+++ b/examples/vg-specs/paintbrush_color_nearest.vg.json
@@ -29,6 +29,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -65,7 +69,7 @@
                             "type": "mouseover"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/paintbrush_color_nearest.vg.json
+++ b/examples/vg-specs/paintbrush_color_nearest.vg.json
@@ -54,7 +54,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/paintbrush_simple.vg.json
+++ b/examples/vg-specs/paintbrush_simple.vg.json
@@ -28,6 +28,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -64,7 +68,7 @@
                             "type": "mouseover"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/paintbrush_simple.vg.json
+++ b/examples/vg-specs/paintbrush_simple.vg.json
@@ -53,7 +53,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/panzoom_splom.vg.json
+++ b/examples/vg-specs/panzoom_splom.vg.json
@@ -194,7 +194,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/panzoom_vconcat_shared.vg.json
+++ b/examples/vg-specs/panzoom_vconcat_shared.vg.json
@@ -73,7 +73,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/query_widgets.vg.json
+++ b/examples/vg-specs/query_widgets.vg.json
@@ -91,7 +91,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/rect_binned_heatmap.vg.json
+++ b/examples/vg-specs/rect_binned_heatmap.vg.json
@@ -137,7 +137,8 @@
                 "fields": [
                     "bin_maxbins_60_IMDB_Rating_start",
                     "bin_maxbins_60_IMDB_Rating_end"
-                ]
+                ],
+                "sort": true
             },
             "range": [
                 0,
@@ -156,7 +157,8 @@
                 "fields": [
                     "bin_maxbins_40_Rotten_Tomatoes_Rating_start",
                     "bin_maxbins_40_Rotten_Tomatoes_Rating_end"
-                ]
+                ],
+                "sort": true
             },
             "range": [
                 {

--- a/examples/vg-specs/selection_bind_cylyr.vg.json
+++ b/examples/vg-specs/selection_bind_cylyr.vg.json
@@ -54,7 +54,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_bind_origin.vg.json
+++ b/examples/vg-specs/selection_bind_origin.vg.json
@@ -49,7 +49,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_composition_and.vg.json
+++ b/examples/vg-specs/selection_composition_and.vg.json
@@ -68,7 +68,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_composition_or.vg.json
+++ b/examples/vg-specs/selection_composition_or.vg.json
@@ -68,7 +68,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_filter.vg.json
+++ b/examples/vg-specs/selection_filter.vg.json
@@ -77,7 +77,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         }

--- a/examples/vg-specs/selection_filter_composition.vg.json
+++ b/examples/vg-specs/selection_filter_composition.vg.json
@@ -77,7 +77,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         }

--- a/examples/vg-specs/selection_insert.vg.json
+++ b/examples/vg-specs/selection_insert.vg.json
@@ -28,6 +28,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -64,7 +68,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_insert.vg.json
+++ b/examples/vg-specs/selection_insert.vg.json
@@ -53,7 +53,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_binned_interval.vg.json
+++ b/examples/vg-specs/selection_project_binned_interval.vg.json
@@ -141,7 +141,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_interval.vg.json
+++ b/examples/vg-specs/selection_project_interval.vg.json
@@ -65,7 +65,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_interval_x.vg.json
+++ b/examples/vg-specs/selection_project_interval_x.vg.json
@@ -65,7 +65,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_interval_x_y.vg.json
+++ b/examples/vg-specs/selection_project_interval_x_y.vg.json
@@ -65,7 +65,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_interval_y.vg.json
+++ b/examples/vg-specs/selection_project_interval_y.vg.json
@@ -65,7 +65,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_multi.vg.json
+++ b/examples/vg-specs/selection_project_multi.vg.json
@@ -28,6 +28,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -64,7 +68,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_multi.vg.json
+++ b/examples/vg-specs/selection_project_multi.vg.json
@@ -53,7 +53,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_multi_cylinders.vg.json
+++ b/examples/vg-specs/selection_project_multi_cylinders.vg.json
@@ -49,7 +49,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_multi_cylinders_origin.vg.json
+++ b/examples/vg-specs/selection_project_multi_cylinders_origin.vg.json
@@ -49,7 +49,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_multi_origin.vg.json
+++ b/examples/vg-specs/selection_project_multi_origin.vg.json
@@ -49,7 +49,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_single.vg.json
+++ b/examples/vg-specs/selection_project_single.vg.json
@@ -53,7 +53,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_single.vg.json
+++ b/examples/vg-specs/selection_project_single.vg.json
@@ -28,6 +28,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -55,7 +59,7 @@
         },
         {
             "name": "pts",
-            "update": "data(\"pts_store\").length && {_id: data(\"pts_store\")[0].values[0]}"
+            "update": "data(\"pts_store\").length && {_vgsid_: data(\"pts_store\")[0].values[0]}"
         },
         {
             "name": "pts_tuple",
@@ -68,7 +72,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_single_cylinders.vg.json
+++ b/examples/vg-specs/selection_project_single_cylinders.vg.json
@@ -49,7 +49,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_single_cylinders_origin.vg.json
+++ b/examples/vg-specs/selection_project_single_cylinders_origin.vg.json
@@ -49,7 +49,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_single_origin.vg.json
+++ b/examples/vg-specs/selection_project_single_origin.vg.json
@@ -49,7 +49,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_resolution_global.vg.json
+++ b/examples/vg-specs/selection_resolution_global.vg.json
@@ -194,7 +194,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         }

--- a/examples/vg-specs/selection_resolution_intersect.vg.json
+++ b/examples/vg-specs/selection_resolution_intersect.vg.json
@@ -194,7 +194,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         }

--- a/examples/vg-specs/selection_resolution_union.vg.json
+++ b/examples/vg-specs/selection_resolution_union.vg.json
@@ -194,7 +194,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         }

--- a/examples/vg-specs/selection_toggle_altKey.vg.json
+++ b/examples/vg-specs/selection_toggle_altKey.vg.json
@@ -28,6 +28,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -64,7 +68,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_toggle_altKey.vg.json
+++ b/examples/vg-specs/selection_toggle_altKey.vg.json
@@ -53,7 +53,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_toggle_altKey_shiftKey.vg.json
+++ b/examples/vg-specs/selection_toggle_altKey_shiftKey.vg.json
@@ -28,6 +28,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -64,7 +68,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_toggle_altKey_shiftKey.vg.json
+++ b/examples/vg-specs/selection_toggle_altKey_shiftKey.vg.json
@@ -53,7 +53,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_toggle_shiftKey.vg.json
+++ b/examples/vg-specs/selection_toggle_shiftKey.vg.json
@@ -28,6 +28,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "filter",
                     "expr": "datum[\"Horsepower\"] !== null && !isNaN(datum[\"Horsepower\"]) && datum[\"Miles_per_Gallon\"] !== null && !isNaN(datum[\"Miles_per_Gallon\"])"
                 }
@@ -64,7 +68,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_toggle_shiftKey.vg.json
+++ b/examples/vg-specs/selection_toggle_shiftKey.vg.json
@@ -53,7 +53,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_translate_brush_drag.vg.json
+++ b/examples/vg-specs/selection_translate_brush_drag.vg.json
@@ -50,7 +50,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_translate_brush_shift-drag.vg.json
+++ b/examples/vg-specs/selection_translate_brush_shift-drag.vg.json
@@ -50,7 +50,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_translate_scatterplot_drag.vg.json
+++ b/examples/vg-specs/selection_translate_scatterplot_drag.vg.json
@@ -50,7 +50,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_translate_scatterplot_shift-drag.vg.json
+++ b/examples/vg-specs/selection_translate_scatterplot_shift-drag.vg.json
@@ -50,7 +50,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_type_interval.vg.json
+++ b/examples/vg-specs/selection_type_interval.vg.json
@@ -65,7 +65,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_type_multi.vg.json
+++ b/examples/vg-specs/selection_type_multi.vg.json
@@ -24,6 +24,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "aggregate",
                     "groupby": [
                         "Origin",
@@ -38,6 +42,10 @@
                     "as": [
                         "count_*"
                     ]
+                },
+                {
+                    "type": "identifier",
+                    "as": "_vgsid_"
                 }
             ]
         }
@@ -80,7 +88,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_type_multi.vg.json
+++ b/examples/vg-specs/selection_type_multi.vg.json
@@ -73,7 +73,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_type_single.vg.json
+++ b/examples/vg-specs/selection_type_single.vg.json
@@ -73,7 +73,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_type_single.vg.json
+++ b/examples/vg-specs/selection_type_single.vg.json
@@ -24,6 +24,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "aggregate",
                     "groupby": [
                         "Origin",
@@ -38,6 +42,10 @@
                     "as": [
                         "count_*"
                     ]
+                },
+                {
+                    "type": "identifier",
+                    "as": "_vgsid_"
                 }
             ]
         }
@@ -71,7 +79,7 @@
         },
         {
             "name": "pts",
-            "update": "data(\"pts_store\").length && {_id: data(\"pts_store\")[0].values[0]}"
+            "update": "data(\"pts_store\").length && {_vgsid_: data(\"pts_store\")[0].values[0]}"
         },
         {
             "name": "pts_tuple",
@@ -84,7 +92,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_type_single_dblclick.vg.json
+++ b/examples/vg-specs/selection_type_single_dblclick.vg.json
@@ -24,6 +24,10 @@
             },
             "transform": [
                 {
+                    "type": "identifier",
+                    "as": "_vgsid_"
+                },
+                {
                     "type": "aggregate",
                     "groupby": [
                         "Origin",
@@ -38,6 +42,10 @@
                     "as": [
                         "count_*"
                     ]
+                },
+                {
+                    "type": "identifier",
+                    "as": "_vgsid_"
                 }
             ]
         }
@@ -71,7 +79,7 @@
         },
         {
             "name": "pts",
-            "update": "data(\"pts_store\").length && {_id: data(\"pts_store\")[0].values[0]}"
+            "update": "data(\"pts_store\").length && {_vgsid_: data(\"pts_store\")[0].values[0]}"
         },
         {
             "name": "pts_tuple",
@@ -84,7 +92,7 @@
                             "type": "dblclick"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
                 }
             ]
         },

--- a/examples/vg-specs/selection_type_single_dblclick.vg.json
+++ b/examples/vg-specs/selection_type_single_dblclick.vg.json
@@ -73,7 +73,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_zoom_brush_shift-wheel.vg.json
+++ b/examples/vg-specs/selection_zoom_brush_shift-wheel.vg.json
@@ -50,7 +50,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_zoom_brush_wheel.vg.json
+++ b/examples/vg-specs/selection_zoom_brush_wheel.vg.json
@@ -50,7 +50,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_zoom_scatterplot_shift-wheel.vg.json
+++ b/examples/vg-specs/selection_zoom_scatterplot_shift-wheel.vg.json
@@ -50,7 +50,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/selection_zoom_scatterplot_wheel.vg.json
+++ b/examples/vg-specs/selection_zoom_scatterplot_wheel.vg.json
@@ -50,7 +50,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/stocks_nearest_index.vg.json
+++ b/examples/vg-specs/stocks_nearest_index.vg.json
@@ -104,7 +104,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         },

--- a/examples/vg-specs/timeunit_selections.vg.json
+++ b/examples/vg-specs/timeunit_selections.vg.json
@@ -110,7 +110,7 @@
             "on": [
                 {
                     "events": "mousemove",
-                    "update": "group()._id ? group() : unit"
+                    "update": "isTuple(group()) ? group() : unit"
                 }
             ]
         }

--- a/src/compile/data/assemble.ts
+++ b/src/compile/data/assemble.ts
@@ -15,7 +15,7 @@ import {OrderNode} from './pathorder';
 import {SourceNode} from './source';
 import {StackNode} from './stack';
 import {TimeUnitNode} from './timeunit';
-import {CalculateNode, FilterNode, LookupNode} from './transforms';
+import {CalculateNode, FilterNode, IdentifierNode, LookupNode} from './transforms';
 
 
 export const FACET_SCALE_PREFIX = 'scale_';
@@ -200,7 +200,8 @@ function makeWalkTree(data: VgData[]) {
       node instanceof CalculateNode ||
       node instanceof AggregateNode ||
       node instanceof OrderNode ||
-      node instanceof LookupNode) {
+      node instanceof LookupNode ||
+      node instanceof IdentifierNode) {
       dataSource.transform.push(node.assemble());
     }
 

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -139,7 +139,7 @@ export function assembleUnitSelectionSignals(model: UnitModel, signals: any[]) {
       value: {},
       on: [{
         events: parseSelector('mousemove', 'scope'),
-        update: `facet._id ? facet : group(${name}).datum`
+        update: `isTuple(facet) ? facet : group(${name}).datum`
       }]
     });
   }
@@ -169,7 +169,7 @@ export function assembleTopLevelSignals(model: UnitModel, signals: any[]) {
       signals.unshift({
         name: 'unit',
         value: {},
-        on: [{events: 'mousemove', update: 'group()._id ? group() : unit'}]
+        on: [{events: 'mousemove', update: 'isTuple(group()) ? group() : unit'}]
       });
     }
   }

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -3,7 +3,7 @@ import {Channel, ScaleChannel, SingleDefChannel, X, Y} from '../../channel';
 import {warn} from '../../log';
 import {LogicalOperand} from '../../logical';
 import {SelectionDomain} from '../../scale';
-import {BrushConfig, SelectionDef, SelectionResolution, SelectionType} from '../../selection';
+import {BrushConfig, SELECTION_ID, SelectionDef, SelectionResolution, SelectionType} from '../../selection';
 import {Dict, extend, isString, logicalExpr, stringValue, varName} from '../../util';
 import {isSignalRefDomain, VgBinding, VgData, VgDomain, VgEventStream, VgScale, VgSignalRef} from '../../vega.schema';
 import {DataFlowNode} from '../data/dataflow';
@@ -318,8 +318,15 @@ export function unitName(model: Model) {
     name += (facet.facet.row ? ` + '_' + facet[${stringValue(facet.field('row'))}]` : '')
       + (facet.facet.column ? ` + '_' + facet[${stringValue(facet.field('column'))}]` : '');
   }
-
   return name;
+}
+
+export function requiresSelectionId(model: Model) {
+  let identifier = false;
+  forEachSelection(model, (selCmpt) => {
+    identifier = identifier || selCmpt.project.some((proj) => proj.field === SELECTION_ID);
+  });
+  return identifier;
 }
 
 export function channelSignalName(selCmpt: SelectionComponent, channel: Channel, range: 'visual' | 'data') {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,6 +1,7 @@
 import {SingleDefChannel} from './channel';
 import {VgBinding} from './vega.schema';
 
+export const SELECTION_ID = '_vgsid_';
 export type SelectionType = 'single' | 'multi' | 'interval';
 export type SelectionResolution = 'global' | 'union' | 'intersect';
 
@@ -182,8 +183,8 @@ export interface SelectionConfig {
 }
 
 export const defaultConfig:SelectionConfig = {
-  single: {on: 'click', fields: ['_id'], resolve: 'global'},
-  multi: {on: 'click', fields: ['_id'], toggle: 'event.shiftKey', resolve: 'global'},
+  single: {on: 'click', fields: [SELECTION_ID], resolve: 'global'},
+  multi: {on: 'click', fields: [SELECTION_ID], toggle: 'event.shiftKey', resolve: 'global'},
   interval: {
     on: '[mousedown, window:mouseup] > window:mousemove!',
     encodings: ['x', 'y'],

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -295,6 +295,22 @@ export interface VgLookupTransform {
   default?: string;
 }
 
+export interface VgStackTransform {
+  type: 'stack';
+  offset?: StackOffset;
+  groupby: string[];
+  field: string;
+  sort: VgSort;
+  as: string[];
+}
+
+export interface VgIdentifierTransform {
+  type: 'identifier';
+  as: string;
+}
+
+export type VgTransform = VgBinTransform | VgExtentTransform | VgFormulaTransform | VgAggregateTransform | VgFilterTransform | VgImputeTransform | VgStackTransform | VgCollectTransform | VgLookupTransform | VgIdentifierTransform;
+
 export interface VgAxisEncode {
   ticks?: VgGuideEncode;
   labels?: VgGuideEncode;
@@ -312,17 +328,6 @@ export interface VgLegendEncode {
 }
 
 export type VgGuideEncode = any; // TODO: replace this (See guideEncode in Vega Schema)
-
-export type VgTransform = VgBinTransform | VgExtentTransform | VgFormulaTransform | VgAggregateTransform | VgFilterTransform | VgImputeTransform | VgStackTransform | VgCollectTransform | VgLookupTransform;
-
-export interface VgStackTransform {
-  type: 'stack';
-  offset?: StackOffset;
-  groupby: string[];
-  field: string;
-  sort: VgSort;
-  as: string[];
-}
 
 export type VgSort = {
   field: string;

--- a/test/compile/selection/facets.test.ts
+++ b/test/compile/selection/facets.test.ts
@@ -42,7 +42,7 @@ describe('Faceted Selections', function() {
         "on": [
           {
             "events": [{"source": "scope","type": "mousemove"}],
-            "update": "facet._id ? facet : group(\"cell\").datum"
+            "update": "isTuple(facet) ? facet : group(\"cell\").datum"
           }
         ]
       }

--- a/test/compile/selection/identifier.test.ts
+++ b/test/compile/selection/identifier.test.ts
@@ -1,0 +1,75 @@
+import {Mark} from '../../../src/mark';
+import {VgTransform} from '../../../src/vega.schema';
+/* tslint:disable:quotemark */
+
+import {assert} from 'chai';
+import {parseModel} from '../../util';
+
+function getVgData(selection: any, x?: any, y?: any, mark?: Mark, enc?: any, transform?: any) {
+  const model = parseModel({
+    data: {url: 'data/cars.json'},
+    transform,
+    selection,
+    mark: mark || 'circle',
+    encoding: {
+      x: {field: 'Horsepower', type: 'quantitative', ...x},
+      y: {field: 'Miles-per-Gallon', type: 'quantitative', ...y},
+      color: {field: 'Origin', type: 'nominal'},
+      ...enc
+    }
+  });
+  model.parse();
+  return model.assembleData();
+}
+
+describe('Identifier transform', function() {
+  it('is not unnecessarily added', function() {
+    function test(selDef?: any) {
+      const data = getVgData(selDef);
+      for (const d of data) {
+        assert.isNotTrue(d.transform && d.transform.some((t) => t.type === 'identifier'));
+      }
+    }
+
+    test();
+    for (const type of ['single', 'multi']) {
+      test({pt: {type, encodings: ['x']}});
+    }
+  });
+
+  it('is added for default point selections', function() {
+    for (const type of ['single', 'multi']) {
+      const url = getVgData({pt: {type}});
+      assert.equal(url[0].transform[0].type, 'identifier');
+    }
+  });
+
+  it('is added immediately after aggregate transforms', function() {
+    function test(transform: VgTransform[]) {
+      let aggr = -1;
+      transform.some((t, i) => (aggr = i, t.type === 'aggregate'));
+      assert.isAtLeast(aggr, 0);
+      assert.equal(transform[aggr + 1].type, 'identifier');
+    }
+
+    for (const type of ['single', 'multi']) {
+      const sel = {pt: {type}};
+      let data = getVgData(sel, {bin: true}, {aggregate: 'count'});
+      test(data[0].transform);
+
+      data = getVgData(sel, {aggregate: 'sum'}, null, 'bar',
+        {column: {field: 'Cylinders', type: 'ordinal'}});
+      test(data[0].transform);
+    }
+  });
+
+  it('is added before any user-specified transforms', function() {
+    for (const type of ['single', 'multi']) {
+      const data = getVgData({pt: {type}}, null, null, null, null,
+        [{calculate: 'datum.Horsepower * 2', as: 'foo'}]);
+      let calc = -1;
+      data[0].transform.some((t, i) => (calc = i, t.type === 'formula' && t.as === 'foo'));
+      assert.equal(data[0].transform[calc - 1].type, 'identifier');
+    }
+  });
+});

--- a/test/compile/selection/inputs.test.ts
+++ b/test/compile/selection/inputs.test.ts
@@ -56,18 +56,18 @@ describe('Inputs Selection Transform', function() {
     assert.includeDeepMembers(selection.assembleUnitSelectionSignals(model, []), [
       {
         "name": "one_tuple",
-        "update": "{fields: [\"_id\"], values: [one__id]}"
+        "update": "{fields: [\"_vgsid_\"], values: [one__vgsid_]}"
       }
     ]);
 
     assert.includeDeepMembers(selection.assembleTopLevelSignals(model, []), [
       {
-        "name": "one__id",
+        "name": "one__vgsid_",
         "value": "",
         "on": [
           {
             "events": [{"source": "scope","type": "click"}],
-            "update": "datum && datum[\"_id\"]"
+            "update": "datum && datum[\"_vgsid_\"]"
           }
         ],
         "bind": {"input": "range","min": 0,"max": 10,"step": 1}

--- a/test/compile/selection/multi.test.ts
+++ b/test/compile/selection/multi.test.ts
@@ -30,7 +30,7 @@ describe('Multi Selection', function() {
       value: {},
       on: [{
         events: selCmpts['one'].events,
-        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
       }]
     }]);
 

--- a/test/compile/selection/parse.test.ts
+++ b/test/compile/selection/parse.test.ts
@@ -27,13 +27,13 @@ describe('Selection', function() {
 
     assert.equal(component.one.name, 'one');
     assert.equal(component.one.type, 'single');
-    assert.sameDeepMembers(component['one'].project, [{field: '_id', channel: null}]);
+    assert.sameDeepMembers(component['one'].project, [{field: '_vgsid_', channel: null}]);
     assert.sameDeepMembers(component['one'].events, parseSelector('click', 'scope'));
 
     assert.equal(component.two.name, 'two');
     assert.equal(component.two.type, 'multi');
     assert.equal(component.two.toggle, 'event.shiftKey');
-    assert.sameDeepMembers(component['two'].project, [{field: '_id', channel: null}]);
+    assert.sameDeepMembers(component['two'].project, [{field: '_vgsid_', channel: null}]);
     assert.sameDeepMembers(component['two'].events, parseSelector('click', 'scope'));
 
     assert.equal(component.three.name, 'three');

--- a/test/compile/selection/single.test.ts
+++ b/test/compile/selection/single.test.ts
@@ -94,7 +94,7 @@ describe('Single Selection', function() {
       {
         name: 'unit',
         value: {},
-        on: [{events: 'mousemove', update: 'group()._id ? group() : unit'}]
+        on: [{events: 'mousemove', update: 'isTuple(group()) ? group() : unit'}]
       }
     ].concat(oneSg, twoSg));
   });

--- a/test/compile/selection/single.test.ts
+++ b/test/compile/selection/single.test.ts
@@ -30,7 +30,7 @@ describe('Single Selection', function() {
       value: {},
       on: [{
         events: selCmpts['one'].events,
-        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_id\"], values: [datum[\"_id\"]]} : null"
+        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
       }]
     }]);
 
@@ -81,7 +81,7 @@ describe('Single Selection', function() {
   it('builds top-level signals', function() {
     const oneSg = single.topLevelSignals(model, selCmpts['one'], []);
     assert.sameDeepMembers(oneSg, [{
-      name: 'one', update: 'data(\"one_store\").length && {_id: data(\"one_store\")[0].values[0]}'
+      name: 'one', update: 'data(\"one_store\").length && {_vgsid_: data(\"one_store\")[0].values[0]}'
     }]);
 
     const twoSg = single.topLevelSignals(model, selCmpts['two'], []);


### PR DESCRIPTION
This PR removes the last vestiges of `_id` field references in the Vega-Lite codebase! With Vega 3.0.0-rc5, the `_id` field has been replaced with an ES6 `Symbol` property. A corresponding `isTuple` expression function has been exposed to determine whether a JavaScript object is a Vega tuple or not.

Fixes #2221.