### PR TITLE
Selections fixes from runtime tests

### DIFF
--- a/examples/vg-specs/faceted_selections.vg.json
+++ b/examples/vg-specs/faceted_selections.vg.json
@@ -88,7 +88,7 @@
                             "type": "mouseover"
                         }
                     ],
-                    "update": "datum && (item().isVoronoi ? datum.datum : datum)[\"X\"]"
+                    "update": "datum && item().mark.marktype !== 'group' ? (item().isVoronoi ? datum.datum : datum)[\"X\"] : null"
                 }
             ],
             "bind": {
@@ -606,7 +606,7 @@
                 },
                 {
                     "name": "xenc_tuple",
-                    "update": "{fields: [\"X\"], values: [xenc_X]}"
+                    "update": "xenc_X ? {fields: [\"X\"], values: [xenc_X]} : null"
                 },
                 {
                     "name": "xenc_modify",

--- a/examples/vg-specs/layered_crossfilter_discrete.vg.json
+++ b/examples/vg-specs/layered_crossfilter_discrete.vg.json
@@ -392,7 +392,8 @@
                                     "type": "click"
                                 }
                             ],
-                            "update": "datum && item().mark.marktype !== 'group' ? {unit: \"child_distance_layer_0\", encodings: [\"x\"], fields: [\"distance\"], values: [[datum[\"bin_maxbins_20_distance_start\"], datum[\"bin_maxbins_20_distance_end\"]]], bins: {\"distance\":1}} : null"
+                            "update": "datum && item().mark.marktype !== 'group' ? {unit: \"child_distance_layer_0\", encodings: [\"x\"], fields: [\"distance\"], values: [[datum[\"bin_maxbins_20_distance_start\"], datum[\"bin_maxbins_20_distance_end\"]]], bins: {\"distance\":1}} : null",
+                            "force": true
                         }
                     ]
                 },
@@ -567,7 +568,8 @@
                                     "type": "click"
                                 }
                             ],
-                            "update": "datum && item().mark.marktype !== 'group' ? {unit: \"child_delay_layer_0\", encodings: [\"x\"], fields: [\"delay\"], values: [[datum[\"bin_maxbins_20_delay_start\"], datum[\"bin_maxbins_20_delay_end\"]]], bins: {\"delay\":1}} : null"
+                            "update": "datum && item().mark.marktype !== 'group' ? {unit: \"child_delay_layer_0\", encodings: [\"x\"], fields: [\"delay\"], values: [[datum[\"bin_maxbins_20_delay_start\"], datum[\"bin_maxbins_20_delay_end\"]]], bins: {\"delay\":1}} : null",
+                            "force": true
                         }
                     ]
                 },
@@ -742,7 +744,8 @@
                                     "type": "click"
                                 }
                             ],
-                            "update": "datum && item().mark.marktype !== 'group' ? {unit: \"child_time_layer_0\", encodings: [\"x\"], fields: [\"time\"], values: [[datum[\"bin_maxbins_20_time_start\"], datum[\"bin_maxbins_20_time_end\"]]], bins: {\"time\":1}} : null"
+                            "update": "datum && item().mark.marktype !== 'group' ? {unit: \"child_time_layer_0\", encodings: [\"x\"], fields: [\"time\"], values: [[datum[\"bin_maxbins_20_time_start\"], datum[\"bin_maxbins_20_time_end\"]]], bins: {\"time\":1}} : null",
+                            "force": true
                         }
                     ]
                 },

--- a/examples/vg-specs/layered_crossfilter_discrete.vg.json
+++ b/examples/vg-specs/layered_crossfilter_discrete.vg.json
@@ -392,7 +392,7 @@
                                     "type": "click"
                                 }
                             ],
-                            "update": "datum && item().mark.marktype !== 'group' ? {unit: \"child_distance_layer_0\", encodings: [\"x\"], fields: [\"distance\"], values: [[datum[\"bin_maxbins_20_distance_start\"], datum[\"bin_maxbins_20_distance_end\"]]], bins: {\"distance\":1}} : null",
+                            "update": "datum && item().mark.marktype !== 'group' ? {unit: \"child_distance_layer_0\", encodings: [\"x\"], fields: [\"distance\"], values: [[datum[\"bin_maxbins_20_distance_start\"], datum[\"bin_maxbins_20_distance_end\"]]], \"bin_distance\": 1} : null",
                             "force": true
                         }
                     ]
@@ -568,7 +568,7 @@
                                     "type": "click"
                                 }
                             ],
-                            "update": "datum && item().mark.marktype !== 'group' ? {unit: \"child_delay_layer_0\", encodings: [\"x\"], fields: [\"delay\"], values: [[datum[\"bin_maxbins_20_delay_start\"], datum[\"bin_maxbins_20_delay_end\"]]], bins: {\"delay\":1}} : null",
+                            "update": "datum && item().mark.marktype !== 'group' ? {unit: \"child_delay_layer_0\", encodings: [\"x\"], fields: [\"delay\"], values: [[datum[\"bin_maxbins_20_delay_start\"], datum[\"bin_maxbins_20_delay_end\"]]], \"bin_delay\": 1} : null",
                             "force": true
                         }
                     ]
@@ -744,7 +744,7 @@
                                     "type": "click"
                                 }
                             ],
-                            "update": "datum && item().mark.marktype !== 'group' ? {unit: \"child_time_layer_0\", encodings: [\"x\"], fields: [\"time\"], values: [[datum[\"bin_maxbins_20_time_start\"], datum[\"bin_maxbins_20_time_end\"]]], bins: {\"time\":1}} : null",
+                            "update": "datum && item().mark.marktype !== 'group' ? {unit: \"child_time_layer_0\", encodings: [\"x\"], fields: [\"time\"], values: [[datum[\"bin_maxbins_20_time_start\"], datum[\"bin_maxbins_20_time_end\"]]], \"bin_time\": 1} : null",
                             "force": true
                         }
                     ]

--- a/examples/vg-specs/layered_selections.vg.json
+++ b/examples/vg-specs/layered_selections.vg.json
@@ -101,7 +101,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && datum[\"Cylinders\"]"
+                    "update": "datum && item().mark.marktype !== 'group' ? datum[\"Cylinders\"] : null"
                 }
             ],
             "bind": {
@@ -263,7 +263,7 @@
         },
         {
             "name": "cyl_tuple",
-            "update": "{fields: [\"Cylinders\"], values: [cyl_Cylinders]}"
+            "update": "cyl_Cylinders ? {fields: [\"Cylinders\"], values: [cyl_Cylinders]} : null"
         },
         {
             "name": "cyl_modify",

--- a/examples/vg-specs/paintbrush.vg.json
+++ b/examples/vg-specs/paintbrush.vg.json
@@ -69,7 +69,8 @@
                             "type": "mouseover"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/paintbrush_color.vg.json
+++ b/examples/vg-specs/paintbrush_color.vg.json
@@ -69,7 +69,8 @@
                             "type": "mouseover"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/paintbrush_color_nearest.vg.json
+++ b/examples/vg-specs/paintbrush_color_nearest.vg.json
@@ -69,7 +69,8 @@
                             "type": "mouseover"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/paintbrush_simple.vg.json
+++ b/examples/vg-specs/paintbrush_simple.vg.json
@@ -68,7 +68,8 @@
                             "type": "mouseover"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/query_widgets.vg.json
+++ b/examples/vg-specs/query_widgets.vg.json
@@ -106,7 +106,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && datum[\"Year\"]"
+                    "update": "datum && item().mark.marktype !== 'group' ? datum[\"Year\"] : null"
                 }
             ],
             "bind": {
@@ -127,7 +127,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && datum[\"Cylinders\"]"
+                    "update": "datum && item().mark.marktype !== 'group' ? datum[\"Cylinders\"] : null"
                 }
             ],
             "bind": {
@@ -143,7 +143,7 @@
         },
         {
             "name": "CylYr_tuple",
-            "update": "{fields: [\"Cylinders\", \"Year\"], values: [CylYr_Cylinders, CylYr_Year]}"
+            "update": "CylYr_Cylinders && CylYr_Year ? {fields: [\"Cylinders\", \"Year\"], values: [CylYr_Cylinders, CylYr_Year]} : null"
         },
         {
             "name": "CylYr_modify",

--- a/examples/vg-specs/selection_bind_cylyr.vg.json
+++ b/examples/vg-specs/selection_bind_cylyr.vg.json
@@ -69,7 +69,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && datum[\"Year\"]"
+                    "update": "datum && item().mark.marktype !== 'group' ? datum[\"Year\"] : null"
                 }
             ],
             "bind": {
@@ -90,7 +90,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && datum[\"Cylinders\"]"
+                    "update": "datum && item().mark.marktype !== 'group' ? datum[\"Cylinders\"] : null"
                 }
             ],
             "bind": {
@@ -106,7 +106,7 @@
         },
         {
             "name": "CylYr_tuple",
-            "update": "{fields: [\"Cylinders\", \"Year\"], values: [CylYr_Cylinders, CylYr_Year]}"
+            "update": "CylYr_Cylinders && CylYr_Year ? {fields: [\"Cylinders\", \"Year\"], values: [CylYr_Cylinders, CylYr_Year]} : null"
         },
         {
             "name": "CylYr_modify",

--- a/examples/vg-specs/selection_bind_origin.vg.json
+++ b/examples/vg-specs/selection_bind_origin.vg.json
@@ -64,7 +64,7 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && datum[\"Origin\"]"
+                    "update": "datum && item().mark.marktype !== 'group' ? datum[\"Origin\"] : null"
                 }
             ],
             "bind": {
@@ -82,7 +82,7 @@
         },
         {
             "name": "org_tuple",
-            "update": "{fields: [\"Origin\"], values: [org_Origin]}"
+            "update": "org_Origin ? {fields: [\"Origin\"], values: [org_Origin]} : null"
         },
         {
             "name": "org_modify",

--- a/examples/vg-specs/selection_insert.vg.json
+++ b/examples/vg-specs/selection_insert.vg.json
@@ -68,7 +68,8 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_multi.vg.json
+++ b/examples/vg-specs/selection_project_multi.vg.json
@@ -68,7 +68,8 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_multi_cylinders.vg.json
+++ b/examples/vg-specs/selection_project_multi_cylinders.vg.json
@@ -64,7 +64,8 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"Cylinders\"], values: [datum[\"Cylinders\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"Cylinders\"], values: [datum[\"Cylinders\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_multi_cylinders_origin.vg.json
+++ b/examples/vg-specs/selection_project_multi_cylinders_origin.vg.json
@@ -64,7 +64,8 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"Cylinders\", \"Origin\"], values: [datum[\"Cylinders\"], datum[\"Origin\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"Cylinders\", \"Origin\"], values: [datum[\"Cylinders\"], datum[\"Origin\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_multi_origin.vg.json
+++ b/examples/vg-specs/selection_project_multi_origin.vg.json
@@ -64,7 +64,8 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"Origin\"], values: [datum[\"Origin\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"Origin\"], values: [datum[\"Origin\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_single.vg.json
+++ b/examples/vg-specs/selection_project_single.vg.json
@@ -72,7 +72,8 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_single_cylinders.vg.json
+++ b/examples/vg-specs/selection_project_single_cylinders.vg.json
@@ -68,7 +68,8 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"Cylinders\"], values: [datum[\"Cylinders\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"Cylinders\"], values: [datum[\"Cylinders\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_single_cylinders_origin.vg.json
+++ b/examples/vg-specs/selection_project_single_cylinders_origin.vg.json
@@ -68,7 +68,8 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"Cylinders\", \"Origin\"], values: [datum[\"Cylinders\"], datum[\"Origin\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"Cylinders\", \"Origin\"], values: [datum[\"Cylinders\"], datum[\"Origin\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/selection_project_single_origin.vg.json
+++ b/examples/vg-specs/selection_project_single_origin.vg.json
@@ -68,7 +68,8 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"Origin\"], values: [datum[\"Origin\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"Origin\"], values: [datum[\"Origin\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/selection_toggle_altKey.vg.json
+++ b/examples/vg-specs/selection_toggle_altKey.vg.json
@@ -68,7 +68,8 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/selection_toggle_altKey_shiftKey.vg.json
+++ b/examples/vg-specs/selection_toggle_altKey_shiftKey.vg.json
@@ -68,7 +68,8 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/selection_toggle_shiftKey.vg.json
+++ b/examples/vg-specs/selection_toggle_shiftKey.vg.json
@@ -68,7 +68,8 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/selection_type_multi.vg.json
+++ b/examples/vg-specs/selection_type_multi.vg.json
@@ -88,7 +88,8 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/selection_type_single.vg.json
+++ b/examples/vg-specs/selection_type_single.vg.json
@@ -92,7 +92,8 @@
                             "type": "click"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/selection_type_single_dblclick.vg.json
+++ b/examples/vg-specs/selection_type_single_dblclick.vg.json
@@ -92,7 +92,8 @@
                             "type": "dblclick"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/examples/vg-specs/stocks_nearest_index.vg.json
+++ b/examples/vg-specs/stocks_nearest_index.vg.json
@@ -123,7 +123,8 @@
                             "type": "mousemove"
                         }
                     ],
-                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"layer_0\", encodings: [\"x\"], fields: [\"date\"], values: [(item().isVoronoi ? datum.datum : datum)[\"date\"]]} : null"
+                    "update": "datum && item().mark.marktype !== 'group' ? {unit: \"layer_0\", encodings: [\"x\"], fields: [\"date\"], values: [(item().isVoronoi ? datum.datum : datum)[\"date\"]]} : null",
+                    "force": true
                 }
             ]
         },

--- a/src/compile/selection/multi.ts
+++ b/src/compile/selection/multi.ts
@@ -27,7 +27,10 @@ const multi:SelectionCompiler = {
     // Only add a discrete selection to the store if a datum is present _and_
     // the interaction isn't occuring on a group mark. This guards against
     // polluting interactive state with invalid values in faceted displays
-    // as the group marks are also data-driven.
+    // as the group marks are also data-driven. We force the update to account
+    // for constant null states but varying toggles (e.g., shift-click in
+    // whitespace followed by a click in whitespace; the store should only
+    // be cleared on the second click).
     return [{
       name: selCmpt.name + TUPLE,
       value: {},
@@ -37,7 +40,8 @@ const multi:SelectionCompiler = {
           `{unit: ${unitName(model)}, encodings: [${encodings}], ` +
           `fields: [${fields}], values: [${values}]` +
           (keys(bins).length ? `, bins: ${JSON.stringify(bins)}` : '') +
-          '} : null'
+          '} : null',
+        force: true
       }]
     }];
   },

--- a/src/compile/selection/multi.ts
+++ b/src/compile/selection/multi.ts
@@ -11,14 +11,14 @@ const multi:SelectionCompiler = {
     const proj = selCmpt.project;
     const datum = nearest.has(selCmpt) ?
       '(item().isVoronoi ? datum.datum : datum)' : 'datum';
-    const bins = {};
+    const bins: string[] = [];
     const encodings = proj.map((p) => stringValue(p.channel)).filter((e) => e).join(', ');
     const fields = proj.map((p) => stringValue(p.field)).join(', ');
     const values = proj.map((p) => {
       const channel = p.channel;
       const fieldDef = model.fieldDef(channel);
       // Binned fields should capture extents, for a range test against the raw field.
-      return (fieldDef && fieldDef.bin) ? (bins[p.field] = 1,
+      return (fieldDef && fieldDef.bin) ? (bins.push(p.field),
         `[${datum}[${stringValue(model.field(channel, {binSuffix: 'start'}))}], ` +
             `${datum}[${stringValue(model.field(channel, {binSuffix: 'end'}))}]]`) :
         `${datum}[${stringValue(p.field)}]`;
@@ -39,7 +39,7 @@ const multi:SelectionCompiler = {
         update: `datum && item().mark.marktype !== 'group' ? ` +
           `{unit: ${unitName(model)}, encodings: [${encodings}], ` +
           `fields: [${fields}], values: [${values}]` +
-          (keys(bins).length ? `, bins: ${JSON.stringify(bins)}` : '') +
+          (bins.length ? ', ' + bins.map((b) => `${stringValue('bin_' + b)}: 1`).join(', ') : '') +
           '} : null',
         force: true
       }]

--- a/src/compile/selection/transforms/translate.ts
+++ b/src/compile/selection/transforms/translate.ts
@@ -71,14 +71,16 @@ function onDelta(model: UnitModel, selCmpt: SelectionComponent, channel: ScaleCh
   const anchor = name + ANCHOR;
   const delta  = name + DELTA;
   const sizeSg = model.getSizeSignalRef(size).signal;
-  const scaleType = model.getScaleComponent(channel).get('type');
+  const scaleCmpt = model.getScaleComponent(channel);
+  const scaleType = scaleCmpt.get('type');
   const sign = hasScales && channel === X ? '-' : ''; // Invert delta when panning x-scales.
   const extent = `${anchor}.extent_${channel}`;
   const offset = `${sign}${delta}.${channel} / ` + (hasScales ? `${sizeSg}` : `span(${extent})`);
   const panFn = !hasScales ? 'panLinear' :
     scaleType === 'log' ? 'panLog' :
     scaleType === 'pow' ? 'panPow' : 'panLinear';
-  const update = `${panFn}(${extent}, ${offset})`;
+  const update = `${panFn}(${extent}, ${offset}` +
+    (hasScales && scaleType === 'pow' ? `, ${scaleCmpt.get('exponent') || 1}` : '') + ')';
 
   signal.on.push({
     events: {signal: delta},

--- a/src/compile/selection/transforms/zoom.ts
+++ b/src/compile/selection/transforms/zoom.ts
@@ -69,14 +69,16 @@ function onDelta(model: UnitModel, selCmpt: SelectionComponent, channel: ScaleCh
     return s.name === channelSignalName(selCmpt, channel, hasScales ? 'data' : 'visual');
   })[0];
   const sizeSg = model.getSizeSignalRef(size).signal;
-  const scaleType = model.getScaleComponent(channel).get('type');
+  const scaleCmpt = model.getScaleComponent(channel);
+  const scaleType = scaleCmpt.get('type');
   const base = hasScales ? domain(model, channel) : signal.name;
   const delta  = name + DELTA;
   const anchor = `${name}${ANCHOR}.${channel}`;
   const zoomFn = !hasScales ? 'zoomLinear' :
     scaleType === 'log' ? 'zoomLog' :
     scaleType === 'pow' ? 'zoomPow' : 'zoomLinear';
-  const update = `${zoomFn}(${base}, ${anchor}, ${delta})`;
+  const update = `${zoomFn}(${base}, ${anchor}, ${delta}` +
+    (hasScales && scaleType === 'pow' ? `, ${scaleCmpt.get('exponent') || 1}` : '') + ')';
 
   signal.on.push({
     events: {signal: delta},

--- a/test/compile/selection/inputs.test.ts
+++ b/test/compile/selection/inputs.test.ts
@@ -56,7 +56,7 @@ describe('Inputs Selection Transform', function() {
     assert.includeDeepMembers(selection.assembleUnitSelectionSignals(model, []), [
       {
         "name": "one_tuple",
-        "update": "{fields: [\"_vgsid_\"], values: [one__vgsid_]}"
+        "update": "one__vgsid_ ? {fields: [\"_vgsid_\"], values: [one__vgsid_]} : null"
       }
     ]);
 
@@ -67,7 +67,7 @@ describe('Inputs Selection Transform', function() {
         "on": [
           {
             "events": [{"source": "scope","type": "click"}],
-            "update": "datum && datum[\"_vgsid_\"]"
+            "update": "datum && item().mark.marktype !== 'group' ? datum[\"_vgsid_\"] : null"
           }
         ],
         "bind": {"input": "range","min": 0,"max": 10,"step": 1}
@@ -80,7 +80,7 @@ describe('Inputs Selection Transform', function() {
     assert.includeDeepMembers(selection.assembleUnitSelectionSignals(model, []), [
       {
         "name": "two_tuple",
-        "update": "{fields: [\"Cylinders\", \"Horsepower\"], values: [two_Cylinders, two_Horsepower]}"
+        "update": "two_Cylinders && two_Horsepower ? {fields: [\"Cylinders\", \"Horsepower\"], values: [two_Cylinders, two_Horsepower]} : null"
       }
     ]);
 
@@ -91,7 +91,7 @@ describe('Inputs Selection Transform', function() {
         "on": [
           {
             "events": [{"source": "scope","type": "click"}],
-            "update": "datum && datum[\"Horsepower\"]"
+            "update": "datum && item().mark.marktype !== 'group' ? datum[\"Horsepower\"] : null"
           }
         ],
         "bind": {"input": "range","min": 0,"max": 10,"step": 1}
@@ -102,7 +102,7 @@ describe('Inputs Selection Transform', function() {
         "on": [
           {
             "events": [{"source": "scope","type": "click"}],
-            "update": "datum && datum[\"Cylinders\"]"
+            "update": "datum && item().mark.marktype !== 'group' ? datum[\"Cylinders\"] : null"
           }
         ],
         "bind": {"input": "range","min": 0,"max": 10,"step": 1}
@@ -115,7 +115,7 @@ describe('Inputs Selection Transform', function() {
     assert.includeDeepMembers(selection.assembleUnitSelectionSignals(model, []), [
       {
         "name": "three_tuple",
-        "update": "{fields: [\"Cylinders\", \"Origin\"], values: [three_Cylinders, three_Origin]}"
+        "update": "three_Cylinders && three_Origin ? {fields: [\"Cylinders\", \"Origin\"], values: [three_Cylinders, three_Origin]} : null"
       }
     ]);
 
@@ -126,7 +126,7 @@ describe('Inputs Selection Transform', function() {
         "on": [
           {
             "events": [{"source": "scope","type": "click"}],
-            "update": "datum && (item().isVoronoi ? datum.datum : datum)[\"Origin\"]"
+            "update": "datum && item().mark.marktype !== 'group' ? (item().isVoronoi ? datum.datum : datum)[\"Origin\"] : null"
           }
         ],
         "bind": {
@@ -140,7 +140,7 @@ describe('Inputs Selection Transform', function() {
         "on": [
           {
             "events": [{"source": "scope","type": "click"}],
-            "update": "datum && (item().isVoronoi ? datum.datum : datum)[\"Cylinders\"]"
+            "update": "datum && item().mark.marktype !== 'group' ? (item().isVoronoi ? datum.datum : datum)[\"Cylinders\"] : null"
           }
         ],
         "bind": {

--- a/test/compile/selection/multi.test.ts
+++ b/test/compile/selection/multi.test.ts
@@ -41,7 +41,7 @@ describe('Multi Selection', function() {
       value: {},
       on: [{
         events: selCmpts['two'].events,
-        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [\"y\", \"color\"], fields: [\"Miles_per_Gallon\", \"Origin\"], values: [[(item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_start\"], (item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_end\"]], (item().isVoronoi ? datum.datum : datum)[\"Origin\"]], bins: {\"Miles_per_Gallon\":1}} : null",
+        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [\"y\", \"color\"], fields: [\"Miles_per_Gallon\", \"Origin\"], values: [[(item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_start\"], (item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_end\"]], (item().isVoronoi ? datum.datum : datum)[\"Origin\"]], \"bin_Miles_per_Gallon\": 1} : null",
         force: true
       }]
     }]);

--- a/test/compile/selection/multi.test.ts
+++ b/test/compile/selection/multi.test.ts
@@ -30,7 +30,8 @@ describe('Multi Selection', function() {
       value: {},
       on: [{
         events: selCmpts['one'].events,
-        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
+        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null",
+        force: true
       }]
     }]);
 
@@ -40,7 +41,8 @@ describe('Multi Selection', function() {
       value: {},
       on: [{
         events: selCmpts['two'].events,
-        "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [\"y\", \"color\"], fields: [\"Miles_per_Gallon\", \"Origin\"], values: [[(item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_start\"], (item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_end\"]], (item().isVoronoi ? datum.datum : datum)[\"Origin\"]], bins: {\"Miles_per_Gallon\":1}} : null"
+        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [\"y\", \"color\"], fields: [\"Miles_per_Gallon\", \"Origin\"], values: [[(item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_start\"], (item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_end\"]], (item().isVoronoi ? datum.datum : datum)[\"Origin\"]], bins: {\"Miles_per_Gallon\":1}} : null",
+        force: true
       }]
     }]);
 

--- a/test/compile/selection/single.test.ts
+++ b/test/compile/selection/single.test.ts
@@ -30,7 +30,8 @@ describe('Single Selection', function() {
       value: {},
       on: [{
         events: selCmpts['one'].events,
-        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null"
+        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [], fields: [\"_vgsid_\"], values: [datum[\"_vgsid_\"]]} : null",
+        force: true
       }]
     }]);
 
@@ -40,7 +41,8 @@ describe('Single Selection', function() {
       value: {},
       on: [{
         events: selCmpts['two'].events,
-        "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [\"y\", \"color\"], fields: [\"Miles_per_Gallon\", \"Origin\"], values: [[(item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_start\"], (item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_end\"]], (item().isVoronoi ? datum.datum : datum)[\"Origin\"]], bins: {\"Miles_per_Gallon\":1}} : null"
+        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [\"y\", \"color\"], fields: [\"Miles_per_Gallon\", \"Origin\"], values: [[(item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_start\"], (item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_end\"]], (item().isVoronoi ? datum.datum : datum)[\"Origin\"]], bins: {\"Miles_per_Gallon\":1}} : null",
+        force: true
       }]
     }]);
 

--- a/test/compile/selection/single.test.ts
+++ b/test/compile/selection/single.test.ts
@@ -41,7 +41,7 @@ describe('Single Selection', function() {
       value: {},
       on: [{
         events: selCmpts['two'].events,
-        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [\"y\", \"color\"], fields: [\"Miles_per_Gallon\", \"Origin\"], values: [[(item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_start\"], (item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_end\"]], (item().isVoronoi ? datum.datum : datum)[\"Origin\"]], bins: {\"Miles_per_Gallon\":1}} : null",
+        update: "datum && item().mark.marktype !== 'group' ? {unit: \"\", encodings: [\"y\", \"color\"], fields: [\"Miles_per_Gallon\", \"Origin\"], values: [[(item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_start\"], (item().isVoronoi ? datum.datum : datum)[\"bin_maxbins_10_Miles_per_Gallon_end\"]], (item().isVoronoi ? datum.datum : datum)[\"Origin\"]], \"bin_Miles_per_Gallon\": 1} : null",
         force: true
       }]
     }]);

--- a/test/compile/selection/translate.test.ts
+++ b/test/compile/selection/translate.test.ts
@@ -217,7 +217,7 @@ describe('Translate Selection Transform', function() {
       assert.includeDeepMembers(signals.filter((s) => s.name === 'six_Miles_per_Gallon')[0].on, [
         {
           "events": {"signal": "six_translate_delta"},
-          "update": "panPow(six_translate_anchor.extent_y, six_translate_delta.y / height)"
+          "update": "panPow(six_translate_anchor.extent_y, six_translate_delta.y / height, 1)"
         }
       ]);
     });

--- a/test/compile/selection/zoom.test.ts
+++ b/test/compile/selection/zoom.test.ts
@@ -217,7 +217,7 @@ describe('Zoom Selection Transform', function() {
       assert.includeDeepMembers(signals.filter((s) => s.name === 'six_Miles_per_Gallon')[0].on, [
         {
           "events": {"signal": "six_zoom_delta"},
-          "update": "zoomPow(domain(\"y\"), six_zoom_anchor.y, six_zoom_delta)"
+          "update": "zoomPow(domain(\"y\"), six_zoom_anchor.y, six_zoom_delta, 1)"
         }
       ]);
     });


### PR DESCRIPTION
The commits describe several fixes for selections unearthed during runtime testing:
* We need to force the discrete tuples through in order to account for shift-click in whitespace followed by a whitespace click (i.e., the tuple would null out but toggle would be true followed by the same null tuple but a false toggle). Without the force, the second click does not clear out the store as desired.
* Rather than nesting binned fields within an object (which would require a deep equality check for the modify call to function correctly, vega/vega-parser#52), we lift them to be properties of the tuple directly.
* Propagating the changes made in c9d1950 to the "inputs" selection transform.
* Missing `exponent` parameter to the `panPow` and `zoomPow` expression functions.