### PR TITLE
Make BaseConcat to reduce redundant code + Fix Circular Dependencies

### DIFF
--- a/src/compile/baseconcat.ts
+++ b/src/compile/baseconcat.ts
@@ -1,0 +1,107 @@
+import {Config} from '../config';
+import {ResolveMapping} from '../resolve';
+import {BaseSpec} from '../spec';
+import {keys} from '../util';
+import {VgData, VgScale, VgSignal} from '../vega.schema';
+import {assembleData} from './data/assemble';
+import {parseData} from './data/parse';
+import {assembleLayoutSignals} from './layout/assemble';
+import {parseNonUnitLegend} from './legend/parse';
+import {Model} from './model';
+import {assembleScaleForModelAndChildren} from './scale/assemble';
+
+export abstract class BaseConcatModel extends Model {
+  constructor(spec: BaseSpec, parent: Model, parentGivenName: string, config: Config, resolve: ResolveMapping) {
+    super(spec, parent, parentGivenName, config, resolve);
+  }
+
+  public parseData() {
+    this.component.data = parseData(this);
+    this.children.forEach((child) => {
+      child.parseData();
+    });
+  }
+  public parseSelection() {
+    // Merge selections up the hierarchy so that they may be referenced
+    // across unit specs. Persist their definitions within each child
+    // to assemble signals which remain within output Vega unit groups.
+    this.component.selection = {};
+    for (const child of this.children) {
+      child.parseSelection();
+      keys(child.component.selection).forEach((key) => {
+        this.component.selection[key] = child.component.selection[key];
+      });
+    }
+  }
+
+  public parseMarkGroup() {
+    for (const child of this.children) {
+      child.parseMarkGroup();
+    }
+  }
+
+  public parseAxisAndHeader() {
+    for (const child of this.children) {
+      child.parseAxisAndHeader();
+    }
+
+    // TODO(#2415): support shared axes
+  }
+  public parseLegend() {
+    parseNonUnitLegend(this);
+  }
+  public assembleData(): VgData[] {
+     if (!this.parent) {
+      // only assemble data in the root
+      return assembleData(this.component.data);
+    }
+
+    return [];
+  }
+
+  public assembleParentGroupProperties(): any {
+    return null;
+  }
+
+  public assembleScales(): VgScale[] {
+    return assembleScaleForModelAndChildren(this);
+  }
+
+  public assembleSelectionTopLevelSignals(signals: any[]): VgSignal[] {
+    return this.children.reduce((sg, child) => child.assembleSelectionTopLevelSignals(sg), signals);
+  }
+
+  public assembleSelectionSignals(): VgSignal[] {
+    this.children.forEach((child) => child.assembleSelectionSignals());
+    return [];
+  }
+
+  public assembleLayoutSignals(): VgSignal[] {
+    return this.children.reduce((signals, child) => {
+      return signals.concat(child.assembleLayoutSignals());
+    }, assembleLayoutSignals(this));
+  }
+
+  public assembleSelectionData(data: VgData[]): VgData[] {
+    return this.children.reduce((db, child) => child.assembleSelectionData(db), []);
+  }
+
+  public assembleMarks(): any[] {
+    // only children have marks
+    return this.children.map(child => {
+      const title = child.assembleTitle();
+      const encodeEntry = child.assembleParentGroupProperties();
+      return {
+        type: 'group',
+        name: child.getName('group'),
+        ...(title ? {title} : {}),
+        ...(encodeEntry ? {
+          encode: {
+            update: encodeEntry
+          }
+        } : {}),
+        ...child.assembleGroup()
+      };
+    });
+  }
+}

--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -14,7 +14,8 @@ import {ConcatModel} from './concat';
 import {FacetModel} from './facet';
 import {LayerModel} from './layer';
 import {Model} from './model';
-import {RepeaterValue, RepeatModel} from './repeat';
+import {RepeatModel} from './repeat';
+import {RepeaterValue} from './repeater';
 import {Explicit} from './split';
 import {UnitModel} from './unit';
 

--- a/src/compile/concat.ts
+++ b/src/compile/concat.ts
@@ -8,6 +8,7 @@ import {Model} from './model';
 import {RepeaterValue} from './repeat';
 
 export class ConcatModel extends BaseConcatModel {
+  public readonly type = 'concat';
 
   public readonly children: Model[];
 

--- a/src/compile/concat.ts
+++ b/src/compile/concat.ts
@@ -1,23 +1,13 @@
-import {NonspatialScaleChannel, ScaleChannel} from '../channel';
-import {CellConfig, Config} from '../config';
-import {Repeat} from '../repeat';
-import {ResolveMapping} from '../resolve';
-import {Scale} from '../scale';
-import {ConcatSpec, isVConcatSpec, RepeatSpec} from '../spec';
-import {Dict, keys, vals} from '../util';
-import {VgData, VgLayout, VgScale, VgSignal} from '../vega.schema';
+import {Config} from '../config';
+import {ConcatSpec, isVConcatSpec} from '../spec';
+import {VgLayout} from '../vega.schema';
+import {BaseConcatModel} from './baseconcat';
 import {buildModel} from './common';
-import {assembleData} from './data/assemble';
-import {parseData} from './data/parse';
-import {assembleLayoutSignals} from './layout/assemble';
 import {parseConcatLayoutSize} from './layout/parse';
-import {parseNonUnitLegend} from './legend/parse';
 import {Model} from './model';
 import {RepeaterValue} from './repeat';
-import {assembleScaleForModelAndChildren} from './scale/assemble';
-import {ScaleComponentIndex} from './scale/component';
 
-export class ConcatModel extends Model {
+export class ConcatModel extends BaseConcatModel {
 
   public readonly children: Model[];
 
@@ -33,86 +23,13 @@ export class ConcatModel extends Model {
     });
   }
 
-  public parseData() {
-    this.component.data = parseData(this);
-    this.children.forEach((child) => {
-      child.parseData();
-    });
-  }
-
   public parseLayoutSize() {
     parseConcatLayoutSize(this);
   }
 
-  public parseSelection() {
-    // Merge selections up the hierarchy so that they may be referenced
-    // across unit specs. Persist their definitions within each child
-    // to assemble signals which remain within output Vega unit groups.
-    this.component.selection = {};
-    for (const child of this.children) {
-      child.parseSelection();
-      keys(child.component.selection).forEach((key) => {
-        this.component.selection[key] = child.component.selection[key];
-      });
-    }
-  }
-
-  public parseMarkGroup() {
-    for (const child of this.children) {
-      child.parseMarkGroup();
-    }
-  }
-
-  public parseAxisAndHeader() {
-    for (const child of this.children) {
-      child.parseAxisAndHeader();
-    }
-
-    // TODO(#2415): support shared axes
-  }
 
   public parseAxisGroup(): void {
     return null;
-  }
-
-  public parseLegend() {
-    parseNonUnitLegend(this);
-  }
-
-  public assembleData(): VgData[] {
-     if (!this.parent) {
-      // only assemble data in the root
-      return assembleData(this.component.data);
-    }
-
-    return [];
-  }
-
-  public assembleParentGroupProperties(): any {
-    return null;
-  }
-
-  public assembleScales(): VgScale[] {
-    return assembleScaleForModelAndChildren(this);
-  }
-
-  public assembleSelectionTopLevelSignals(signals: any[]): VgSignal[] {
-    return this.children.reduce((sg, child) => child.assembleSelectionTopLevelSignals(sg), signals);
-  }
-
-  public assembleSelectionSignals(): VgSignal[] {
-    this.children.forEach((child) => child.assembleSelectionSignals());
-    return [];
-  }
-
-  public assembleLayoutSignals(): VgSignal[] {
-    return this.children.reduce((signals, child) => {
-      return signals.concat(child.assembleLayoutSignals());
-    }, assembleLayoutSignals(this));
-  }
-
-  public assembleSelectionData(data: VgData[]): VgData[] {
-    return this.children.reduce((db, child) => child.assembleSelectionData(db), []);
   }
 
   public assembleLayout(): VgLayout {
@@ -124,25 +41,5 @@ export class ConcatModel extends Model {
       bounds: 'full',
       align: 'all'
     };
-  }
-
-  public assembleMarks(): any[] {
-    // only children have marks
-    return this.children.map(child => {
-      const title = child.assembleTitle();
-
-      const encodeEntry = child.assembleParentGroupProperties();
-      return {
-        type: 'group',
-        name: child.getName('group'),
-        ...(title ? {title} : {}),
-        ...(encodeEntry ? {
-          encode: {
-            update: encodeEntry
-          }
-        } : {}),
-        ...child.assembleGroup()
-      };
-    });
   }
 }

--- a/src/compile/concat.ts
+++ b/src/compile/concat.ts
@@ -5,7 +5,7 @@ import {BaseConcatModel} from './baseconcat';
 import {buildModel} from './common';
 import {parseConcatLayoutSize} from './layout/parse';
 import {Model} from './model';
-import {RepeaterValue} from './repeat';
+import {RepeaterValue} from './repeater';
 
 export class ConcatModel extends BaseConcatModel {
   public readonly type = 'concat';

--- a/src/compile/data/bin.ts
+++ b/src/compile/data/bin.ts
@@ -7,7 +7,7 @@ import {BinTransform, Transform} from '../../transform';
 import {Dict, duplicate, extend, flatten, hash, isBoolean, keys, StringSet, vals} from '../../util';
 import {VgBinTransform, VgTransform} from '../../vega.schema';
 import {numberFormatExpr} from '../common';
-import {Model, ModelWithField} from '../model';
+import {isUnitModel, Model, ModelWithField} from '../model';
 import {UnitModel} from '../unit';
 import {DataFlowNode} from './dataflow';
 
@@ -17,7 +17,7 @@ function rangeFormula(model: ModelWithField, fieldDef: FieldDef<string>, channel
     if (discreteDomain) {
       // read format from axis or legend, if there is no format then use config.numberFormat
 
-      const guide = (model instanceof UnitModel) ? (model.axis(channel) || model.legend(channel) || {}) : {};
+      const guide = isUnitModel(model) ? (model.axis(channel) || model.legend(channel) || {}) : {};
 
       const startField = field(fieldDef, {expr: 'datum', binSuffix: 'start'});
       const endField = field(fieldDef, {expr: 'datum', binSuffix: 'end'});

--- a/src/compile/data/formatparse.ts
+++ b/src/compile/data/formatparse.ts
@@ -7,7 +7,7 @@ import {CalculateTransform, FilterTransform, isCalculate, isFilter} from '../../
 import {QUANTITATIVE, TEMPORAL} from '../../type';
 import {Dict, duplicate, extend, isArray, isNumber, isString, keys, stringValue, toSet} from '../../util';
 import {VgFormulaTransform} from '../../vega.schema';
-import {Model, ModelWithField} from '../model';
+import {isFacetModel, isUnitModel, Model, ModelWithField} from '../model';
 import {DataFlowNode} from './dataflow';
 
 
@@ -54,7 +54,7 @@ export class ParseNode extends DataFlowNode {
       return fieldMap;
     }, {});
 
-    if (model instanceof ModelWithField) {
+    if (isUnitModel(model) || isFacetModel(model)) {
       // Parse encoded fields
       model.forEachFieldDef(fieldDef => {
         if (fieldDef.type === TEMPORAL) {

--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -2,7 +2,7 @@ import {MAIN, RAW} from '../../data';
 import {Dict} from '../../util';
 import {FacetModel} from '../facet';
 import {LayerModel} from '../layer';
-import {Model, ModelWithField} from '../model';
+import {isFacetModel, isLayerModel, isUnitModel, Model, ModelWithField} from '../model';
 import {requiresSelectionId} from '../selection/selection';
 import {UnitModel} from '../unit';
 import {AggregateNode} from './aggregate';
@@ -116,8 +116,8 @@ export function parseData(model: Model): DataComponent {
 
   // HACK: This is equivalent for merging bin extent for union scale.
   // FIXME(https://github.com/vega/vega-lite/issues/2270): Correctly merge extent / bin node for shared bin scale
-  const parentIsLayer = model.parent && (model.parent instanceof LayerModel);
-  if (model instanceof ModelWithField) {
+  const parentIsLayer = model.parent && isLayerModel(model.parent);
+  if (isUnitModel(model) || isFacetModel(model)) {
     if (parentIsLayer) {
       const bin = BinNode.makeBinFromEncoding(model);
       if (bin) {
@@ -139,7 +139,7 @@ export function parseData(model: Model): DataComponent {
     head = parse;
   }
 
-  if (model instanceof ModelWithField) {
+  if (isUnitModel(model) || isFacetModel(model)) {
     const nullFilter = NullFilterNode.make(model);
     if (nullFilter) {
       nullFilter.parent = head;
@@ -168,7 +168,7 @@ export function parseData(model: Model): DataComponent {
   raw.parent = head;
   head = raw;
 
-  if (model instanceof UnitModel) {
+  if (isUnitModel(model)) {
     const agg = AggregateNode.makeFromEncoding(model);
     if (agg) {
       agg.parent = head;
@@ -203,7 +203,7 @@ export function parseData(model: Model): DataComponent {
 
   // add facet marker
   let facetRoot = null;
-  if (model instanceof FacetModel) {
+  if (isFacetModel(model)) {
     const facetName = model.getName('facet');
     facetRoot = new FacetNode(model, facetName, main.getSource());
     outputNodes[facetName] = facetRoot;

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -43,6 +43,7 @@ import {getFieldFromDomains} from './scale/domain';
 import {UnitModel} from './unit';
 
 export class FacetModel extends ModelWithField {
+  public readonly type = 'facet';
   public readonly facet: Facet<string>;
 
   public readonly child: Model;

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -35,7 +35,7 @@ import {parseChildrenLayoutSize} from './layout/parse';
 import {labels} from './legend/encode';
 import {parseNonUnitLegend} from './legend/parse';
 import {Model, ModelWithField} from './model';
-import {RepeaterValue, replaceRepeaterInFacet} from './repeat';
+import {RepeaterValue, replaceRepeaterInFacet} from './repeater';
 import {parseGuideResolve} from './resolve';
 import {assembleScalesForModel} from './scale/assemble';
 import {ScaleComponent, ScaleComponentIndex} from './scale/component';

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -23,6 +23,7 @@ import {UnitModel} from './unit';
 
 
 export class LayerModel extends Model {
+  public readonly type = 'layer';
 
   // HACK: This should be (LayerModel | UnitModel)[], but setting the correct type leads to weird error.
   // So I'm just putting generic Model for now.

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -15,7 +15,7 @@ import {assembleLayoutSignals} from './layout/assemble';
 import {parseLayerLayoutSize} from './layout/parse';
 import {parseNonUnitLegend} from './legend/parse';
 import {Model} from './model';
-import {RepeaterValue} from './repeat';
+import {RepeaterValue} from './repeater';
 import {assembleScaleForModelAndChildren} from './scale/assemble';
 import {ScaleComponent, ScaleComponentIndex} from './scale/component';
 import {assembleLayerSelectionMarks} from './selection/selection';

--- a/src/compile/layout/assemble.ts
+++ b/src/compile/layout/assemble.ts
@@ -5,7 +5,7 @@ import {extend, isArray, keys, StringSet} from '../../util';
 import {isVgRangeStep, VgData, VgFormulaTransform, VgRangeStep, VgSignal, VgTransform} from '../../vega.schema';
 import {FacetModel} from '../facet';
 import {LayerModel} from '../layer';
-import {Model, ModelWithField} from '../model';
+import {isFacetModel, Model, ModelWithField} from '../model';
 import {ScaleComponent} from '../scale/component';
 import {UnitModel} from '../unit';
 
@@ -36,7 +36,7 @@ export function sizeSignals(model: Model, sizeType: 'width' | 'height'): VgSigna
       if (hasDiscreteDomain(type) && isVgRangeStep(range)) {
         const scaleName = model.scaleName(channel);
 
-        if (model.parent instanceof FacetModel) {
+        if (isFacetModel(model.parent)) {
           // If parent is facet and this is an independent scale, return only signal signal
           // as the width/height will be calculated using the cardinality from
           // facet's aggregate rather than reading from scale domain

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -10,7 +10,7 @@ import {isSortField} from '../../sort';
 import {contains} from '../../util';
 import {sortParams} from '../common';
 import {FacetModel} from '../facet';
-import {Model} from '../model';
+import {isUnitModel, Model} from '../model';
 import {UnitModel} from '../unit';
 import {area} from './area';
 import {bar} from './bar';
@@ -38,7 +38,7 @@ const markCompiler: {[type: string]: MarkCompiler} = {
 };
 
 export function parseMarkDef(model: Model) {
-  if (model instanceof UnitModel) {
+  if (isUnitModel(model)) {
     normalizeMarkDef(model.markDef, model.encoding, model.component.scales, model.config);
   } else {
     for (const child of model.children) {

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -27,7 +27,6 @@ import {getHeaderGroup, getTitleGroup, HEADER_CHANNELS, HEADER_TYPES, LayoutHead
 import {assembleLegends} from './legend/assemble';
 import {LegendComponentIndex} from './legend/component';
 import {parseMarkDef} from './mark/mark';
-import {RepeaterValue} from './repeat';
 import {assembleScalesForModel} from './scale/assemble';
 import {ScaleComponent, ScaleComponentIndex} from './scale/component';
 import {getFieldFromDomains} from './scale/domain';

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -19,14 +19,17 @@ import {Dict, extend, vals, varName} from '../util';
 import {isVgRangeStep, VgAxis, VgData, VgEncodeEntry, VgLayout, VgLegend, VgMarkGroup, VgScale, VgSignal, VgSignalRef, VgTitle, VgValueRef} from '../vega.schema';
 import {assembleAxes} from './axis/assemble';
 import {AxisComponent, AxisComponentIndex} from './axis/component';
+import {ConcatModel} from './concat';
 import {DataComponent} from './data/index';
 import {FacetModel} from './facet';
+import {LayerModel} from './layer';
 import {sizeExpr} from './layout/assemble';
 import {LayoutSizeComponent, LayoutSizeIndex} from './layout/component';
 import {getHeaderGroup, getTitleGroup, HEADER_CHANNELS, HEADER_TYPES, LayoutHeaderComponent} from './layout/header';
 import {assembleLegends} from './legend/assemble';
 import {LegendComponentIndex} from './legend/component';
 import {parseMarkDef} from './mark/mark';
+import {RepeatModel} from './repeat';
 import {assembleScalesForModel} from './scale/assemble';
 import {ScaleComponent, ScaleComponentIndex} from './scale/component';
 import {getFieldFromDomains} from './scale/domain';
@@ -99,7 +102,29 @@ export class NameMap implements NameMapInterface {
   }
 }
 
+export function isUnitModel(model: Model): model is UnitModel {
+  return model && model.type === 'unit';
+}
+
+export function isFacetModel(model: Model): model is FacetModel {
+  return model && model.type === 'facet';
+}
+
+export function isRepeatModel(model: Model): model is RepeatModel {
+  return model && model.type === 'repeat';
+}
+
+export function isConcatModel(model: Model): model is ConcatModel {
+  return model && model.type === 'concat';
+}
+
+export function isLayerModel(model: Model): model is LayerModel {
+  return model && model.type === 'layer';
+}
+
 export abstract class Model {
+
+  public abstract readonly type: 'unit' | 'facet' | 'layer' | 'concat' | 'repeat';
   public readonly parent: Model;
   public readonly name: string;
 
@@ -301,7 +326,7 @@ export abstract class Model {
 
     // Only include scales if this spec is top-level or if parent is facet.
     // (Otherwise, it will be merged with upper-level's scope.)
-    const scales = (!this.parent || this.parent instanceof FacetModel) ? this.assembleScales() : [];
+    const scales = (!this.parent || isFacetModel(this.parent)) ? this.assembleScales() : [];
     if (scales.length > 0) {
       group.scales = scales;
     }
@@ -323,7 +348,7 @@ export abstract class Model {
 
   public hasDescendantWithFieldOnChannel(channel: Channel) {
     for (const child of this.children) {
-      if (child instanceof UnitModel) {
+      if (isUnitModel(child)) {
         if (child.channelHasField(channel)) {
           return true;
         }
@@ -355,7 +380,7 @@ export abstract class Model {
   }
 
   public getSizeSignalRef(sizeType: 'width' | 'height'): VgSignalRef {
-    if (this.parent instanceof FacetModel) {
+    if (isFacetModel(this.parent)) {
       const channel = sizeType === 'width' ? 'x' : 'y';
       const scaleComponent = this.component.scales[channel];
 

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -102,6 +102,16 @@ export class NameMap implements NameMapInterface {
   }
 }
 
+/*
+  We use type guards instead of `instanceof` as `instanceof` makes
+  different parts of the compiler depend on the actual implementation of
+  the model classes, which in turn depend on different parts of the compiler.
+  Thus, `instanceof` leads to circular dependency problems.
+
+  On the other hand, type guards only make different parts of the compiler
+  depend on the type of the model classes, but not the actual implementation.
+*/
+
 export function isUnitModel(model: Model): model is UnitModel {
   return model && model.type === 'unit';
 }

--- a/src/compile/repeat.ts
+++ b/src/compile/repeat.ts
@@ -12,62 +12,7 @@ import {BaseConcatModel} from './baseconcat';
 import {buildModel} from './common';
 import {parseRepeatLayoutSize} from './layout/parse';
 import {Model} from './model';
-
-export type RepeaterValue = {
-  row?: string,
-  column?: string
-};
-
-export function replaceRepeaterInFacet(facet: Facet<Field>, repeater: RepeaterValue): Facet<string> {
-  return replaceRepeater(facet, repeater) as Facet<string>;
-}
-
-export function replaceRepeaterInEncoding(encoding: Encoding<Field>, repeater: RepeaterValue): Encoding<string> {
-  return replaceRepeater(encoding, repeater) as Encoding<string>;
-}
-
-/**
- * Replace repeater values in a field def with the concrete field name.
- */
-function replaceRepeaterInFieldDef(fieldDef: FieldDef<Field>, repeater: RepeaterValue): FieldDef<string> | null {
-  const field = fieldDef.field;
-  if (isRepeatRef(field)) {
-    if (field.repeat in repeater) {
-      return {
-        ...fieldDef,
-        field: repeater[field.repeat]
-      };
-    } else {
-      log.warn(log.message.noSuchRepeatedValue(field.repeat));
-      return null;
-    }
-  } else {
-    // field is not a repeat ref so we can just return the field def
-    return fieldDef as FieldDef<string>;
-  }
-}
-
-type EncodingOrFacet<F> = Encoding<F> | Facet<F>;
-
-function replaceRepeater(mapping: EncodingOrFacet<Field>, repeater: RepeaterValue): EncodingOrFacet<string> {
-  const out: EncodingOrFacet<string> = {};
-  for (const channel in mapping) {
-    if (mapping.hasOwnProperty(channel)) {
-      const fieldDef: FieldDef<Field> | FieldDef<Field>[] = mapping[channel];
-
-      if (isArray(fieldDef)) {
-        out[channel] = fieldDef.map(fd => replaceRepeaterInFieldDef(fd, repeater))
-          .filter((fd: FieldDef<string> | null) => fd !== null);
-      } else {
-        const fd = replaceRepeaterInFieldDef(fieldDef, repeater);
-        if (fd !== null) {
-          out[channel] = fd;
-        }
-      }
-    }
-  }
-  return out;
-}
+import {RepeaterValue} from './repeater';
 
 export class RepeatModel extends BaseConcatModel {
   public readonly type = 'repeat';

--- a/src/compile/repeat.ts
+++ b/src/compile/repeat.ts
@@ -70,6 +70,7 @@ function replaceRepeater(mapping: EncodingOrFacet<Field>, repeater: RepeaterValu
 }
 
 export class RepeatModel extends BaseConcatModel {
+  public readonly type = 'repeat';
   public readonly repeat: Repeat;
 
   public readonly children: Model[];

--- a/src/compile/repeater.ts
+++ b/src/compile/repeater.ts
@@ -1,0 +1,61 @@
+import {isArray} from 'vega-util';
+import {Encoding} from '../encoding';
+import {Facet} from '../facet';
+import {Field, FieldDef, isRepeatRef} from '../fielddef';
+import * as log from '../log';
+
+export type RepeaterValue = {
+  row?: string,
+  column?: string
+};
+
+export function replaceRepeaterInFacet(facet: Facet<Field>, repeater: RepeaterValue): Facet<string> {
+  return replaceRepeater(facet, repeater) as Facet<string>;
+}
+
+export function replaceRepeaterInEncoding(encoding: Encoding<Field>, repeater: RepeaterValue): Encoding<string> {
+  return replaceRepeater(encoding, repeater) as Encoding<string>;
+}
+
+/**
+ * Replace repeater values in a field def with the concrete field name.
+ */
+function replaceRepeaterInFieldDef(fieldDef: FieldDef<Field>, repeater: RepeaterValue): FieldDef<string> | null {
+  const field = fieldDef.field;
+  if (isRepeatRef(field)) {
+    if (field.repeat in repeater) {
+      return {
+        ...fieldDef,
+        field: repeater[field.repeat]
+      };
+    } else {
+      log.warn(log.message.noSuchRepeatedValue(field.repeat));
+      return null;
+    }
+  } else {
+    // field is not a repeat ref so we can just return the field def
+    return fieldDef as FieldDef<string>;
+  }
+}
+
+type EncodingOrFacet<F> = Encoding<F> | Facet<F>;
+
+function replaceRepeater(mapping: EncodingOrFacet<Field>, repeater: RepeaterValue): EncodingOrFacet<string> {
+  const out: EncodingOrFacet<string> = {};
+  for (const channel in mapping) {
+    if (mapping.hasOwnProperty(channel)) {
+      const fieldDef: FieldDef<Field> | FieldDef<Field>[] = mapping[channel];
+
+      if (isArray(fieldDef)) {
+        out[channel] = fieldDef.map(fd => replaceRepeaterInFieldDef(fd, repeater))
+          .filter((fd: FieldDef<string> | null) => fd !== null);
+      } else {
+        const fd = replaceRepeaterInFieldDef(fieldDef, repeater);
+        if (fd !== null) {
+          out[channel] = fd;
+        }
+      }
+    }
+  }
+  return out;
+}

--- a/src/compile/resolve.ts
+++ b/src/compile/resolve.ts
@@ -5,13 +5,13 @@ import {contains} from '../util';
 import {ConcatModel} from './concat';
 import {FacetModel} from './facet';
 import {LayerModel} from './layer';
-import {Model} from './model';
+import {isConcatModel, isFacetModel, isLayerModel, isRepeatModel, Model} from './model';
 import {RepeatModel} from './repeat';
 
 export function defaultScaleResolve(channel: ScaleChannel, model: Model): ResolveMode {
-  if (model instanceof LayerModel || model instanceof FacetModel) {
+  if (isLayerModel(model) || isFacetModel(model)) {
     return 'shared';
-  } else if (model instanceof ConcatModel || model instanceof RepeatModel) {
+  } else if (isConcatModel(model) || isRepeatModel(model)) {
     return contains(SPATIAL_SCALE_CHANNELS, channel) ? 'independent' : 'shared';
   }
   /* istanbul ignore next: should never reach here. */

--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -23,13 +23,13 @@ import {
 } from '../../vega.schema';
 import {FACET_SCALE_PREFIX} from '../data/assemble';
 import {FacetModel} from '../facet';
-import {Model} from '../model';
+import {isFacetModel, isUnitModel, Model} from '../model';
 import {SELECTION_DOMAIN} from '../selection/selection';
 import {UnitModel} from '../unit';
 import {ScaleComponentIndex} from './component';
 
 export function parseScaleDomain(model: Model) {
-  if (model instanceof UnitModel) {
+  if (isUnitModel(model)) {
     parseUnitScaleDomain(model);
   } else {
     parseNonUnitScaleDomain(model);
@@ -85,7 +85,7 @@ function parseNonUnitScaleDomain(model: Model) {
       }
     }
 
-    if (model instanceof FacetModel) {
+    if (isFacetModel(model)) {
       domains.forEach((domain) => {
         // Replace the scale domain with data output from a cloned subtree after the facet.
         if (isDataRefDomain(domain)) {

--- a/src/compile/scale/parse.ts
+++ b/src/compile/scale/parse.ts
@@ -9,7 +9,7 @@ import {
 } from '../../scale';
 import {keys} from '../../util';
 import {VgScale} from '../../vega.schema';
-import {Model} from '../model';
+import {isUnitModel, Model} from '../model';
 import {defaultScaleResolve} from '../resolve';
 import {Explicit, mergeValuesWithExplicit, tieBreakByComparing} from '../split';
 import {UnitModel} from '../unit';
@@ -30,7 +30,7 @@ export function parseScale(model: Model) {
 }
 
 export function parseScaleCore(model: Model) {
-  if (model instanceof UnitModel) {
+  if (isUnitModel(model)) {
     model.component.scales = parseUnitScaleCore(model);
   } else {
     model.component.scales = parseNonUnitScaleCore(model);

--- a/src/compile/scale/properties.ts
+++ b/src/compile/scale/properties.ts
@@ -6,7 +6,7 @@ import {smallestUnit} from '../../timeunit';
 import * as util from '../../util';
 import {keys} from '../../util';
 import {VgScale} from '../../vega.schema';
-import {Model} from '../model';
+import {isUnitModel, Model} from '../model';
 import {Explicit, mergeValuesWithExplicit, Split, tieBreakByComparing} from '../split';
 import {UnitModel} from '../unit';
 import {ScaleComponent, ScaleComponentIndex, ScaleComponentProps} from './component';
@@ -14,7 +14,7 @@ import {parseScaleRange} from './range';
 
 
 export function parseScaleProperty(model: Model, property: keyof (Scale | ScaleComponentProps)) {
-  if (model instanceof UnitModel) {
+  if (isUnitModel(model)) {
     parseUnitScaleProperty(model, property);
   } else {
     parseNonUnitScaleProperty(model, property);

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -8,7 +8,7 @@ import {Type} from '../../type';
 import * as util from '../../util';
 import {isVgRangeStep, VgRange, VgRangeScheme, VgSignalRef} from '../../vega.schema';
 import {LayoutSize} from '../layout/component';
-import {Model} from '../model';
+import {isUnitModel, Model} from '../model';
 import {Explicit, makeImplicit, Split} from '../split';
 import {UnitModel} from '../unit';
 import {ScaleComponent, ScaleComponentIndex} from './component';
@@ -21,7 +21,7 @@ export const RANGE_PROPERTIES: (keyof Scale)[] = ['range', 'rangeStep', 'scheme'
 
 
 export function parseScaleRange(model: Model) {
-  if (model instanceof UnitModel) {
+  if (isUnitModel(model)) {
     parseUnitScaleRange(model);
   } else {
     parseNonUnitScaleProperty(model, 'range');

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -10,7 +10,7 @@ import {DataFlowNode} from '../data/dataflow';
 import {TimeUnitNode} from '../data/timeunit';
 import {FacetModel} from '../facet';
 import {LayerModel} from '../layer';
-import {Model} from '../model';
+import {isFacetModel, isUnitModel, Model} from '../model';
 import {UnitModel} from '../unit';
 import intervalCompiler from './interval';
 import multiCompiler from './multi';
@@ -204,7 +204,7 @@ export function assembleUnitSelectionMarks(model: UnitModel, marks: any[]): any[
 
 export function assembleLayerSelectionMarks(model: LayerModel, marks: any[]): any[] {
   model.children.forEach(child => {
-    if (child instanceof UnitModel) {
+    if (isUnitModel(child)) {
       marks = assembleUnitSelectionMarks(child, marks);
     }
   });
@@ -302,7 +302,7 @@ function compiler(type: SelectionType): SelectionCompiler {
 function getFacetModel(model: Model): FacetModel {
   let parent = model.parent;
   while (parent) {
-    if (parent instanceof FacetModel) {
+    if (isFacetModel(parent)) {
       break;
     }
     parent = parent.parent;

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -26,7 +26,7 @@ import {parseUnitLegend} from './legend/parse';
 import {initEncoding} from './mark/init';
 import {parseMarkGroup} from './mark/mark';
 import {isLayerModel, Model, ModelWithField} from './model';
-import {RepeaterValue, replaceRepeaterInEncoding} from './repeat';
+import {RepeaterValue, replaceRepeaterInEncoding} from './repeater';
 import {assembleScalesForModel} from './scale/assemble';
 import {ScaleIndex} from './scale/component';
 import {assembleTopLevelSignals, assembleUnitSelectionData, assembleUnitSelectionMarks, assembleUnitSelectionSignals, parseUnitSelection} from './selection/selection';

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -1,5 +1,5 @@
 import {Axis} from '../axis';
-import {Channel, isScaleChannel, NONSPATIAL_SCALE_CHANNELS, SCALE_CHANNELS, ScaleChannel, SingleDefChannel, UNIT_CHANNELS, X, X2, Y, Y2} from '../channel';
+import {Channel, isScaleChannel, NONSPATIAL_SCALE_CHANNELS, SCALE_CHANNELS, ScaleChannel, SingleDefChannel, X, Y} from '../channel';
 import {CellConfig, Config} from '../config';
 import * as vlEncoding from '../encoding'; // TODO: remove
 import {Encoding, normalizeEncoding} from '../encoding';
@@ -18,7 +18,6 @@ import {parseUnitAxis} from './axis/parse';
 import {applyConfig} from './common';
 import {assembleData} from './data/assemble';
 import {parseData} from './data/parse';
-import {FacetModel} from './facet';
 import {LayerModel} from './layer';
 import {assembleLayoutSignals} from './layout/assemble';
 import {parseUnitLayoutSize} from './layout/parse';
@@ -26,18 +25,18 @@ import {LegendIndex} from './legend/component';
 import {parseUnitLegend} from './legend/parse';
 import {initEncoding} from './mark/init';
 import {parseMarkGroup} from './mark/mark';
-import {Model, ModelWithField} from './model';
+import {isLayerModel, Model, ModelWithField} from './model';
 import {RepeaterValue, replaceRepeaterInEncoding} from './repeat';
 import {assembleScalesForModel} from './scale/assemble';
 import {ScaleIndex} from './scale/component';
 import {assembleTopLevelSignals, assembleUnitSelectionData, assembleUnitSelectionMarks, assembleUnitSelectionSignals, parseUnitSelection} from './selection/selection';
-import {Split} from './split';
 
 
 /**
  * Internal model of Vega-Lite specification for the compiler.
  */
 export class UnitModel extends ModelWithField {
+  public readonly type = 'unit';
   public readonly markDef: MarkDef;
   public readonly encoding: Encoding<string>;
 
@@ -237,7 +236,7 @@ export class UnitModel extends ModelWithField {
     // If this unit is part of a layer, selections should augment
     // all in concert rather than each unit individually. This
     // ensures correct interleaving of clipping and brushed marks.
-    if (!this.parent || !(this.parent instanceof LayerModel)) {
+    if (!this.parent || !isLayerModel(this.parent)) {
       marks = assembleUnitSelectionMarks(this, marks);
     }
 

--- a/test/compile/repeat.test.ts
+++ b/test/compile/repeat.test.ts
@@ -1,6 +1,6 @@
 import {assert} from 'chai';
 
-import {replaceRepeaterInEncoding} from '../../src/compile/repeat';
+import {replaceRepeaterInEncoding} from '../../src/compile/repeater';
 import {Encoding} from '../../src/encoding';
 import * as log from '../../src/log';
 import {keys} from '../../src/util';


### PR DESCRIPTION
Note: We use type guards instead of `instanceof` as `instanceof` makes
  different parts of the compiler depend on the actual implementation of
  the model classes, which in turn depend on different parts of the compiler.
  Thus, `instanceof` leads to circular dependency problems.

  On the other hand, type guards only make different parts of the compiler
  depend on the type of the model classes, but not the actual implementation.