### PR TITLE
Updated Selection Not and Paintbrush Simple example

### DIFF
--- a/examples/specs/paintbrush_simple.vl.json
+++ b/examples/specs/paintbrush_simple.vl.json
@@ -10,9 +10,10 @@
     "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
     "size": {
       "condition": {
-        "selection": "paintbrush", "value": 300
-      },
-      "value": 50
+             "selection": {"not": "paintbrush"},
+             "value": 50
+           },
+      "value": 300
     }
   }
 }

--- a/site/docs/selection.md
+++ b/site/docs/selection.md
@@ -56,7 +56,7 @@ Vega-Lite provides a number of selection _transformations_ to further customize 
 
 Selections can be used to conditionally specify visual encodings -- encode data values one way if they fall within the selection, and another if they do not. For instance, in the first two examples on this page, rectangles are colored based on whether or not their data values fall within the `pts` selection. If they do, they are colored by the number of records; and, if they do not, they are left grey.
 
-In this example, a selection (named `paintbrush`) is used to resize the points in the scatterplot on hover.
+In this example, a selection (named `paintbrush`) is used to resize the points in the scatterplot on hover. Using the `not` operator, it is possible to ensure that the initial size is small, and when the `pts` selection is made, the point is resized to the new size. 
 
 <div class="vl-example" data-name="paintbrush_simple"></div>
 


### PR DESCRIPTION
- Changed `selection.md` to explain the use of `not` operator for size encoding.
- Updated the paintbrush-simple example.
