### PR TITLE
Added Visdown.com in Tools

### DIFF
--- a/site/usage/applications.md
+++ b/site/usage/applications.md
@@ -28,6 +28,7 @@ This is an incomplete list of integrations, applications, and extensions of the 
 * [mondrian-rest-ui](https://github.com/jazzido/mondrian-rest-ui), an experimental UI for [`mondrian-rest`](https://github.com/jazzido/mondrian-rest) inspired by [Polestar](https://github.com/vega/polestar) and [CubesViewer](https://github.com/jjmontesl/cubesviewer).
 * [data.world](https://data.world), upload `.vg.json` and `.vl.json` files along side your raw data, or [embed vega](https://docs.data.world/tutorials/markdown/#vega-and-vega-lite) directly into comments and summary markdown.
 * [vega-desktop](https://github.com/kristw/vega-desktop), a desktop app that let you open `.vg.json` and `.vl.json` to see visualizations just like you open image files with an image viewer. Can also be used for [creating visualizations with vega/vega-lite locally](https://medium.com/@kristw/create-visualizations-with-vega-on-your-machine-using-your-preferred-editor-529e1be875c0).
+* [Visdown](http://visdown.com], a webapp to create your visualisations in markdown. It allows you to write `vega-lite` specs in `yaml` (not 'json') within `code` blocks in markdown.
 
 ## Libraries
 

--- a/site/usage/applications.md
+++ b/site/usage/applications.md
@@ -28,7 +28,7 @@ This is an incomplete list of integrations, applications, and extensions of the 
 * [mondrian-rest-ui](https://github.com/jazzido/mondrian-rest-ui), an experimental UI for [`mondrian-rest`](https://github.com/jazzido/mondrian-rest) inspired by [Polestar](https://github.com/vega/polestar) and [CubesViewer](https://github.com/jjmontesl/cubesviewer).
 * [data.world](https://data.world), upload `.vg.json` and `.vl.json` files along side your raw data, or [embed vega](https://docs.data.world/tutorials/markdown/#vega-and-vega-lite) directly into comments and summary markdown.
 * [vega-desktop](https://github.com/kristw/vega-desktop), a desktop app that let you open `.vg.json` and `.vl.json` to see visualizations just like you open image files with an image viewer. Can also be used for [creating visualizations with vega/vega-lite locally](https://medium.com/@kristw/create-visualizations-with-vega-on-your-machine-using-your-preferred-editor-529e1be875c0).
-* [Visdown](http://visdown.com], a webapp to create your visualisations in markdown. It allows you to write `vega-lite` specs in `yaml` (not 'json') within `code` blocks in markdown.
+* [Visdown](http://visdown.com], a web app to create Vega-Lite visualisations in Markdown. Specs are written in [YAML](http://www.yaml.org/) (not JSON) within `code` blocks.
 
 ## Libraries
 


### PR DESCRIPTION
Adding Visdown.com as one tool to explore tools. It also has starter learning documentation on how to start playing around with vega-lite: data layer, visual layer, annotation layer, interaction layer and composition. Thank you for creating this library! 