### PR TITLE
Redirect title config to `guide-title` and hard-code non-mark config to title.

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -4937,7 +4937,7 @@
     },
     "StyleConfigIndex": {
       "additionalProperties": {
-        "$ref": "#/definitions/MarkConfig"
+        "$ref": "#/definitions/VgMarkConfig"
       },
       "type": "object"
     },

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -29,6 +29,14 @@
       ],
       "type": "string"
     },
+    "Anchor": {
+      "enum": [
+        "start",
+        "middle",
+        "end"
+      ],
+      "type": "string"
+    },
     "AnyMark": {
       "anyOf": [
         {
@@ -543,6 +551,10 @@
           "$ref": "#/definitions/Interpolate",
           "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
         },
+        "limit": {
+          "description": "The maximum length of the text mark in pixels (default 0, indicating no limit). The text value will be automatically truncated if the rendered size exceeds the limit.",
+          "type": "number"
+        },
         "opacity": {
           "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
           "maximum": 1,
@@ -862,6 +874,10 @@
         "interpolate": {
           "$ref": "#/definitions/Interpolate",
           "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+        },
+        "limit": {
+          "description": "The maximum length of the text mark in pixels (default 0, indicating no limit). The text value will be automatically truncated if the rendered size exceeds the limit.",
+          "type": "number"
         },
         "opacity": {
           "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
@@ -3759,6 +3775,10 @@
           "$ref": "#/definitions/Interpolate",
           "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
         },
+        "limit": {
+          "description": "The maximum length of the text mark in pixels (default 0, indicating no limit). The text value will be automatically truncated if the rendered size exceeds the limit.",
+          "type": "number"
+        },
         "opacity": {
           "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
           "maximum": 1,
@@ -5064,6 +5084,10 @@
           "$ref": "#/definitions/Interpolate",
           "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
         },
+        "limit": {
+          "description": "The maximum length of the text mark in pixels (default 0, indicating no limit). The text value will be automatically truncated if the rendered size exceeds the limit.",
+          "type": "number"
+        },
         "opacity": {
           "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
           "maximum": 1,
@@ -5259,6 +5283,10 @@
           "$ref": "#/definitions/Interpolate",
           "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
         },
+        "limit": {
+          "description": "The maximum length of the text mark in pixels (default 0, indicating no limit). The text value will be automatically truncated if the rendered size exceeds the limit.",
+          "type": "number"
+        },
         "opacity": {
           "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
           "maximum": 1,
@@ -5402,6 +5430,15 @@
         "as"
       ],
       "type": "object"
+    },
+    "TitleOrient": {
+      "enum": [
+        "top",
+        "bottom",
+        "left",
+        "right"
+      ],
+      "type": "string"
     },
     "TopLevelFacetedUnitSpec": {
       "additionalProperties": false,
@@ -6556,6 +6593,10 @@
           "$ref": "#/definitions/Interpolate",
           "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
         },
+        "limit": {
+          "description": "The maximum length of the text mark in pixels (default 0, indicating no limit). The text value will be automatically truncated if the rendered size exceeds the limit.",
+          "type": "number"
+        },
         "opacity": {
           "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
           "maximum": 1,
@@ -6725,16 +6766,16 @@
       "additionalProperties": false,
       "properties": {
         "anchor": {
-          "description": "Title anchor position (`\"start\"`, `\"middle\"`, or `\"end\"`).",
-          "type": "string"
+          "$ref": "#/definitions/Anchor",
+          "description": "Title anchor position (`\"start\"`, `\"middle\"`, or `\"end\"`)."
         },
         "angle": {
           "description": "Angle in degrees of title text.",
           "type": "number"
         },
         "baseline": {
-          "description": "Vertical text baseline for title text.",
-          "type": "string"
+          "$ref": "#/definitions/VerticalAlign",
+          "description": "Vertical text baseline for title text."
         },
         "color": {
           "description": "Text color for title text.",
@@ -6750,11 +6791,15 @@
           "type": "number"
         },
         "fontWeight": {
-          "description": "Font weight for title text.",
-          "type": [
-            "string",
-            "number"
-          ]
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FontWeight"
+            },
+            {
+              "$ref": "#/definitions/FontWeightNumber"
+            }
+          ],
+          "description": "Font weight for title text."
         },
         "limit": {
           "description": "The maximum allowed length in pixels of legend labels.",
@@ -6766,8 +6811,8 @@
           "type": "number"
         },
         "orient": {
-          "description": "Default title orientation (\"top\", \"bottom\", \"left\", or \"right\")",
-          "type": "string"
+          "$ref": "#/definitions/TitleOrient",
+          "description": "Default title orientation (\"top\", \"bottom\", \"left\", or \"right\")"
         }
       },
       "type": "object"

--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -9,7 +9,7 @@ import {TimeUnit} from '../timeunit';
 import {formatExpression} from '../timeunit';
 import {QUANTITATIVE} from '../type';
 import {isArray} from '../util';
-import {VgEncodeEntry, VgSort} from '../vega.schema';
+import {VgEncodeEntry, VgMarkConfig, VgSort} from '../vega.schema';
 import {ConcatModel} from './concat';
 import {FacetModel} from './facet';
 import {LayerModel} from './layer';
@@ -91,8 +91,12 @@ export function getMarkConfig<P extends keyof MarkConfig>(prop: P, mark: MarkDef
   const styles = getStyles(mark);
   for (const style of styles) {
     const styleConfig = config.style[style];
-    if (styleConfig && styleConfig[prop] !== undefined) {
-      value = styleConfig[prop];
+
+    // MarkConfig extends VgMarkConfig so a prop may not be a valid property for style
+    // However here we also check if it is defined, so it is okay to cast here
+    const p = prop as keyof VgMarkConfig;
+    if (styleConfig && styleConfig[p] !== undefined) {
+      value = styleConfig[p];
     }
   }
 

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -106,13 +106,15 @@ export class LayerModel extends Model {
   }
 
   public assembleTitle(): VgTitle {
-    if (this.title) {
-      return this.title;
+    let title = super.assembleTitle();
+    if (title) {
+      return title;
     }
     // If title does not provide layer, look into children
     for (const child of this.children) {
-      if (child.title) {
-        return child.title;
+      title = child.assembleTitle();
+      if (title) {
+        return title;
       }
     }
     return undefined;

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -7,9 +7,9 @@ import * as log from '../log';
 import {ResolveMapping} from '../resolve';
 import {hasDiscreteDomain} from '../scale';
 import {BaseSpec} from '../spec';
-import {Title} from '../title';
+import {extractTitleConfig, Title} from '../title';
 import {Transform} from '../transform';
-import {Dict, extend, varName} from '../util';
+import {Dict, extend, keys, varName} from '../util';
 import {
   isVgRangeStep,
   VgAxis,
@@ -334,7 +334,12 @@ export abstract class Model {
   }
 
   public assembleTitle(): VgTitle {
-    return this.title;
+    const title: VgTitle = {
+      ...extractTitleConfig(this.config.title).nonMark,
+      ...this.title
+    };
+
+    return keys(title).length > 0 ? title : undefined;
   }
 
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@ import {defaultConfig as defaultSelectionConfig, SelectionConfig} from './select
 import {StackOffset} from './stack';
 import {TopLevelProperties} from './toplevelprops';
 import {duplicate, isObject, keys, mergeDeep} from './util';
-import {VgRangeScheme, VgTitleConfig} from './vega.schema';
+import {VgMarkConfig, VgRangeScheme, VgTitleConfig} from './vega.schema';
 
 
 export interface CellConfig {
@@ -148,7 +148,7 @@ export interface VLOnlyConfig {
 }
 
 export interface StyleConfigIndex {
-  [style: string]: MarkConfig;
+  [style: string]: VgMarkConfig;
 }
 
 export type AreaOverlay = 'line' | 'linepoint' | 'none';

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ import * as mark from './mark';
 import {defaultScaleConfig, ScaleConfig} from './scale';
 import {defaultConfig as defaultSelectionConfig, SelectionConfig} from './selection';
 import {StackOffset} from './stack';
+import {extractTitleConfig} from './title';
 import {TopLevelProperties} from './toplevelprops';
 import {duplicate, isObject, keys, mergeDeep} from './util';
 import {VgMarkConfig, VgRangeScheme, VgTitleConfig} from './vega.schema';
@@ -239,7 +240,7 @@ export function initConfig(config: Config) {
   return mergeDeep(duplicate(defaultConfig), config);
 }
 
-const MARK_STYLES = ['cell'].concat(PRIMITIVE_MARKS, COMPOSITE_MARK_STYLES) as (Mark | CompositeMarkStyle)[];
+const MARK_STYLES = ['cell'].concat(PRIMITIVE_MARKS, COMPOSITE_MARK_STYLES) as ('cell' | Mark | CompositeMarkStyle)[];
 
 
 const VL_ONLY_CONFIG_PROPERTIES: (keyof Config)[] = [
@@ -294,8 +295,15 @@ export function stripAndRedirectConfig(config: Config) {
       }
     }
 
+    // Redirect mark config to config.style so that mark config only affect its own mark type
+    // without affecting other marks that share the same underlying Vega marks.
+    // For example, config.rect should not affect bar marks.
     redirectConfig(config, mark);
   }
+
+  // Redirect config.title -- so that title config do not
+  // affect header labels, which also uses `title` directive to implement.
+  redirectConfig(config, 'title', 'group-title');
 
   // Remove empty config objects
   for (const prop in config) {
@@ -307,14 +315,16 @@ export function stripAndRedirectConfig(config: Config) {
   return keys(config).length > 0 ? config : undefined;
 }
 
-function redirectConfig(config: Config, prop: Mark | CompositeMarkStyle) {
-  const style = {
-    ...config[prop],
+function redirectConfig(config: Config, prop: Mark | CompositeMarkStyle | 'title' | 'cell', toProp?: string) {
+  const propConfig: VgMarkConfig = prop === 'title' ? extractTitleConfig(config.title).mark : config[prop];
+
+  const style: VgMarkConfig = {
+    ...propConfig,
     ...config.style[prop]
   };
   // set config.style if it is not an empty object
   if (keys(style).length > 0) {
-    config.style[prop] = style;
+    config.style[toProp || prop] = style;
   }
   delete config[prop];
 }

--- a/src/title.ts
+++ b/src/title.ts
@@ -1,11 +1,6 @@
-import {Anchor, Orient, TitleOrient} from './vega.schema';
+import {Anchor, Orient, TitleOrient, VgMarkConfig, VgTitleConfig} from './vega.schema';
 
-export interface Title {
-  /**
-   * The title text.
-   */
-  text: string;
-
+export interface TitleBase {
   /**
    * The orientation of the title relative to the chart. One of `"top"` (the default), `"bottom"`, `"left"`, or `"right"`.
    */
@@ -22,4 +17,38 @@ export interface Title {
   offset?: number;
 
   // TODO: name, encode, interactive, zindex
+}
+
+export interface Title extends TitleBase {
+  /**
+   * The title text.
+   */
+  text: string;
+}
+
+export function extractTitleConfig(titleConfig: VgTitleConfig): {
+  mark: VgMarkConfig,
+  nonMark: TitleBase
+} {
+  const {
+    // These are non-mark title config that need to be hardcoded
+    anchor, offset, orient,
+    // color needs to be redirect to fill
+    color,
+    // The rest are mark config.
+    ...titleMarkConfig
+  } = titleConfig;
+
+  const mark: VgMarkConfig = {
+    ...titleMarkConfig,
+    ...color ? {fill: color} : {}
+  };
+
+  const nonMark: TitleBase = {
+    ...anchor ? {anchor} : {},
+    ...offset ? {offset} : {},
+    ...orient ? {orient} : {}
+  };
+
+  return {mark, nonMark};
 }

--- a/src/title.ts
+++ b/src/title.ts
@@ -1,4 +1,4 @@
-import {Anchor, Orient} from './vega.schema';
+import {Anchor, Orient, TitleOrient} from './vega.schema';
 
 export interface Title {
   /**
@@ -9,7 +9,7 @@ export interface Title {
   /**
    * The orientation of the title relative to the chart. One of `"top"` (the default), `"bottom"`, `"left"`, or `"right"`.
    */
-  orient?: Orient;
+  orient?: TitleOrient;
 
   /**
    * The anchor position for placing the title. One of `"start"`, `"middle"` (the default), or `"end"`. For example, with an orientation of top these anchor positions map to a left-, center-, or right-aligned title.

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -1005,6 +1005,11 @@ export interface VgMarkConfig {
   radius?: number;
 
   /**
+   * The maximum length of the text mark in pixels (default 0, indicating no limit). The text value will be automatically truncated if the rendered size exceeds the limit.
+   */
+  limit?: number;
+
+  /**
    * Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating "north".
    */
   theta?: number;
@@ -1047,7 +1052,7 @@ export interface VgTitle {
   /**
    * The orientation of the title relative to the chart. One of `"top"` (the default), `"bottom"`, `"left"`, or `"right"`.
    */
-  orient?: Orient;
+  orient?: TitleOrient;
 
   /**
    * The anchor position for placing the title. One of `"start"`, `"middle"` (the default), or `"end"`. For example, with an orientation of top these anchor positions map to a left-, center-, or right-aligned title.
@@ -1062,11 +1067,13 @@ export interface VgTitle {
   // TODO: name, encode, interactive, zindex
 }
 
+export type TitleOrient = 'top' | 'bottom' | 'left' | 'right';
+
 export interface VgTitleConfig {
   /**
    * Title anchor position (`"start"`, `"middle"`, or `"end"`).
    */
-  anchor?: string;
+  anchor?: Anchor;
   /**
    * Angle in degrees of title text.
    */
@@ -1074,7 +1081,7 @@ export interface VgTitleConfig {
   /**
    * Vertical text baseline for title text.
    */
-  baseline?:	string;
+  baseline?: VerticalAlign;
   /**
    * Text color for title text.
    */
@@ -1094,7 +1101,7 @@ export interface VgTitleConfig {
   /**
    * Font weight for title text.
    */
-  fontWeight?:	string | number;
+  fontWeight?: FontWeight | FontWeightNumber;
   /**
    * The maximum allowed length in pixels of legend labels.
    *
@@ -1108,5 +1115,5 @@ export interface VgTitleConfig {
   /**
    * Default title orientation ("top", "bottom", "left", or "right")
    */
-  orient?:	string;
+  orient?: TitleOrient;
 }

--- a/test/compile/compile.test.ts
+++ b/test/compile/compile.test.ts
@@ -109,7 +109,7 @@ describe('Compile', function() {
       assert.deepEqual(spec.title, {text: 'test'});
     });
 
-    it('should return title for a concat spec.', () => {
+    it('should return a title for a concat spec and augment the title with non-mark title config (e.g., anchor).', () => {
       const spec = compile({
         "data": {
           "values": [{"a": "A","b": 28}]
@@ -118,9 +118,10 @@ describe('Compile', function() {
         "hconcat": [{
           "mark": "point",
           "encoding": {}
-        }]
+        }],
+        "config": {"title": {"anchor": "start"}}
       }).spec;
-      assert.deepEqual(spec.title, {text: 'test'});
+      assert.deepEqual(spec.title, {text: 'test', anchor: 'start'});
     });
   });
 });

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -18,6 +18,10 @@ describe('config', () => {
       },
       cell: {
         fill: '#eee'
+      },
+      title: {
+        color: 'red',
+        fontWeight: 'bold'
       }
     };
     const copy = duplicate(config);
@@ -43,8 +47,14 @@ describe('config', () => {
       assert.deepEqual(output.style.bar.opacity, 0.5, 'Bar config should be redirected to config.style.bar');
     });
 
+    it('should redirect config.title to config.style.group-title and rename color to fill', () => {
+      assert.deepEqual(output.title, undefined);
+      assert.deepEqual(output.style['group-title'].fontWeight, 'bold');
+      assert.deepEqual(output.style['group-title'].fill, 'red');
+    });
+
     it('should remove empty config object', () => {
-      assert.isUndefined(output.title);
+      assert.isUndefined(output.axisTop);
     });
   });
 });


### PR DESCRIPTION
We need to do this so that title config do not affect header labels, which also uses title to implement.

Part of #2763