### PR TITLE
Use "Grammar of Interactive Graphics" branding.

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -5,7 +5,7 @@ base: /
 
 <div class="page-centered title">
   <h1>
-    <strong>Vega-Lite</strong> –  A High-Level Visualization Grammar
+    <strong>Vega-Lite</strong> –  A High-Level Grammar of Interactive Graphics
   </h1>
 </div>
 

--- a/site/index.md
+++ b/site/index.md
@@ -1,7 +1,7 @@
 ---
 layout: home
 permalink: /
-title: A High-Level Visualization Grammar
+title: A High-Level Grammar of Interactive Graphics
 
 images:
  - spec: stacked_area_stream
@@ -29,12 +29,12 @@ images:
 ---
 
 {:.lead}
-**Vega-Lite** is a high-level visualization grammar. It provides a concise JSON syntax for supporting rapid generation of visualizations to support analysis. Vega-Lite specifications can be compiled to [Vega](http://vega.github.io/vega) specifications.
+**Vega-Lite** is a high-level grammar of interactive graphics. It provides a concise JSON syntax for supporting rapid generation of visualizations to support analysis. Vega-Lite specifications can be compiled to [Vega](http://vega.github.io/vega) specifications.
 
 
 <span class="lead-columns">
   <span>
-    Vega-Lite specifications describe visualizations as mappings from data to **properties of graphical marks** (e.g., points or bars). The Vega-Lite compiler **automatically produces visualization components** including axes, legends, and scales. It then determines properties of these components based on a set of **carefully designed rules**. This approach allows specifications to be succinct and expressive, but also provide user control. As Vega-Lite is designed for analysis, it supports **data transformations** such as aggregation, binning, filtering, sorting, and **visual transformations** including stacking and faceting. Moreover, Vega-Lite views can be **composed** into larger views and made **interactive with selections**.
+    Vega-Lite specifications describe visualizations as mappings from data to **properties of graphical marks** (e.g., points or bars). The Vega-Lite compiler **automatically produces visualization components** including axes, legends, and scales. It then determines properties of these components based on a set of **carefully designed rules**. This approach allows specifications to be succinct and expressive, but also provide user control. As Vega-Lite is designed for analysis, it supports **data transformations** such as aggregation, binning, filtering, sorting, and **visual transformations** including stacking and faceting. Moreover, Vega-Lite specifications can be **composed** into layered and multi-view displays, and made **interactive with selections**.
   </span>
   <span class="lead-buttons">
     [Get started<br><small>Latest Version: {{ site.data.versions.vega-lite }}</small>]({{site.baseurl}}/tutorials/getting_started.html)
@@ -42,7 +42,7 @@ images:
   </span>
 </span>
 
-Read our [introduction article to Vega-Lite 1 on Medium](https://medium.com/p/438f9215f09e), look at our [talk about the new features in Vega-Lite 2](https://www.domoritz.de/talks/VegaLite-OpenVisConf-2017.pdf), check out the [documentation]({{site.baseurl}}/docs/) and take a look at our [example gallery]({{site.baseurl}}/examples/).
+Read our [introduction article to Vega-Lite v1 on Medium](https://medium.com/p/438f9215f09e), watch our [OpenVis Conf talk about the new features in Vega-Lite v2](https://www.youtube.com/watch?v=9uaHRWj04D4), check out the [documentation]({{site.baseurl}}/docs/) and take a look at our [example gallery]({{site.baseurl}}/examples/).
 
 ## Example
 


### PR DESCRIPTION
I think that better differentiates Vega-Lite v2 from v1 (and other high-level visualization grammars, e.g., ggplot2).