### PR TITLE
Swap deploy schema and deploy github

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -71,8 +71,9 @@ git checkout master
 git push --tags
 # now the published tag contains build files which work great with bower.
 
-# 3. GITHUB PAGES PUBLISH
+# 3. SCHEMA
+scripts/deploy-schema.sh
+
+# 4. GITHUB PAGES PUBLISH
 scripts/deploy-gh.sh
 
-# 4. SCHEMA
-scripts/deploy-schema.sh


### PR DESCRIPTION
I think we should swap them because deploy github is more problematic so we better run it at the end and if it fails, we only need to re-run one thing.

