### PR TITLE
Hide title config as we still hide `title`

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -39,14 +39,6 @@
       ],
       "type": "string"
     },
-    "Anchor": {
-      "enum": [
-        "start",
-        "middle",
-        "end"
-      ],
-      "type": "string"
-    },
     "AnyMark": {
       "anyOf": [
         {
@@ -1584,10 +1576,6 @@
         "timeFormat": {
           "description": "Default datetime format for axis and legend labels. The format can be set directly on each axis and legend. [D3 time format pattern](https://github.com/mbostock/d3/wiki/Time-Formatting)).\n\n__Default value:__ `'%b %d, %Y'`.",
           "type": "string"
-        },
-        "title": {
-          "$ref": "#/definitions/VgTitleConfig",
-          "description": "Title Config "
         }
       },
       "type": "object"
@@ -5275,15 +5263,6 @@
       ],
       "type": "object"
     },
-    "TitleOrient": {
-      "enum": [
-        "top",
-        "bottom",
-        "left",
-        "right"
-      ],
-      "type": "string"
-    },
     "TopLevelFacetedUnitSpec": {
       "additionalProperties": false,
       "properties": {
@@ -6563,61 +6542,6 @@
         "input",
         "options"
       ],
-      "type": "object"
-    },
-    "VgTitleConfig": {
-      "additionalProperties": false,
-      "properties": {
-        "anchor": {
-          "$ref": "#/definitions/Anchor",
-          "description": "Title anchor position (`\"start\"`, `\"middle\"`, or `\"end\"`)."
-        },
-        "angle": {
-          "description": "Angle in degrees of title text.",
-          "type": "number"
-        },
-        "baseline": {
-          "$ref": "#/definitions/VerticalAlign",
-          "description": "Vertical text baseline for title text."
-        },
-        "color": {
-          "description": "Text color for title text.",
-          "type": "string"
-        },
-        "font": {
-          "description": "Font name for title text.",
-          "type": "string"
-        },
-        "fontSize": {
-          "description": "Font size in pixels for title text.\n\n__Default value:__ `10`.",
-          "minimum": 0,
-          "type": "number"
-        },
-        "fontWeight": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/FontWeight"
-            },
-            {
-              "$ref": "#/definitions/FontWeightNumber"
-            }
-          ],
-          "description": "Font weight for title text."
-        },
-        "limit": {
-          "description": "The maximum allowed length in pixels of legend labels.",
-          "minimum": 0,
-          "type": "number"
-        },
-        "offset": {
-          "description": "Offset in pixels of the title from the chart body and axes.",
-          "type": "number"
-        },
-        "orient": {
-          "$ref": "#/definitions/TitleOrient",
-          "description": "Default title orientation (\"top\", \"bottom\", \"left\", or \"right\")"
-        }
-      },
       "type": "object"
     },
     "VlOnlyGuideConfig": {

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -224,8 +224,8 @@ For a full list of axis configuration, please see the [Axis Config section in th
 ## Legend Configuration  (`config.legend.*`)
 
 Legend configuration determines default properties for [legends](legend.html). Please see [legend config](legend.html#legend-config) for each property name and default values.
-
+<!--
 {:#title-config}
 ## Title Configuration  (`config.title.*`)
 
-{% include table.html props="anchor,angle,baseline,color,font,fontSize,fontWeight,limit,offset,orient" source="VgTitleConfig" %}
+{% include table.html props="anchor,angle,baseline,color,font,fontSize,fontWeight,limit,offset,orient" source="VgTitleConfig" %} -->

--- a/src/config.ts
+++ b/src/config.ts
@@ -179,7 +179,10 @@ export interface Config extends TopLevelProperties, VLOnlyConfig, MarkConfigMixi
   /** Legend Config */
   legend?: LegendConfig;
 
-  /** Title Config */
+  /**
+   * Title Config
+   * @hide
+   */
   title?: VgTitleConfig;
 
   /** Style Config */


### PR DESCRIPTION
(We still hides `title` because `title` is not well supported for plots with `layout` operator.  See https://github.com/vega/vega/issues/960.)

