### PR TITLE
Get rid of `model.assembleScales()`

### DIFF
--- a/src/compile/baseconcat.ts
+++ b/src/compile/baseconcat.ts
@@ -2,11 +2,10 @@ import {Config} from '../config';
 import {Resolve} from '../resolve';
 import {BaseSpec} from '../spec';
 import {keys} from '../util';
-import {VgData, VgScale, VgSignal} from '../vega.schema';
+import {VgData, VgSignal} from '../vega.schema';
 import {parseData} from './data/parse';
 import {assembleLayoutSignals} from './layoutsize/assemble';
 import {Model} from './model';
-import {assembleScaleForModelAndChildren} from './scale/assemble';
 
 export abstract class BaseConcatModel extends Model {
   constructor(spec: BaseSpec, parent: Model, parentGivenName: string, config: Config, resolve: Resolve) {
@@ -44,10 +43,6 @@ export abstract class BaseConcatModel extends Model {
     }
 
     // TODO(#2415): support shared axes
-  }
-
-  public assembleScales(): VgScale[] {
-    return assembleScaleForModelAndChildren(this);
   }
 
   public assembleSelectionTopLevelSignals(signals: any[]): VgSignal[] {

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -17,7 +17,6 @@ import {parseChildrenLayoutSize} from './layoutsize/parse';
 import {Model, ModelWithField} from './model';
 import {RepeaterValue, replaceRepeaterInFacet} from './repeater';
 import {parseGuideResolve} from './resolve';
-import {assembleScalesForModel} from './scale/assemble';
 import {getFieldFromDomains} from './scale/domain';
 
 export class FacetModel extends ModelWithField {
@@ -160,10 +159,6 @@ export class FacetModel extends ModelWithField {
         // Otherwise do nothing for independent axes
       }
     }
-  }
-
-  public assembleScales(): VgScale[] {
-    return assembleScalesForModel(this);
   }
 
   public assembleSelectionTopLevelSignals(signals: any[]): VgSignal[] {

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -2,14 +2,13 @@ import {Config} from '../config';
 import * as log from '../log';
 import {isLayerSpec, isUnitSpec, LayerSpec, LayoutSizeMixins} from '../spec';
 import {flatten, keys} from '../util';
-import {VgData, VgLayout, VgScale, VgSignal, VgTitle} from '../vega.schema';
+import {VgData, VgLayout, VgSignal, VgTitle} from '../vega.schema';
 import {parseLayerAxis} from './axis/parse';
 import {parseData} from './data/parse';
 import {assembleLayoutSignals} from './layoutsize/assemble';
 import {parseLayerLayoutSize} from './layoutsize/parse';
 import {Model} from './model';
 import {RepeaterValue} from './repeater';
-import {assembleScaleForModelAndChildren} from './scale/assemble';
 import {assembleLayerSelectionMarks} from './selection/selection';
 import {UnitModel} from './unit';
 
@@ -118,10 +117,6 @@ export class LayerModel extends Model {
       }
     }
     return undefined;
-  }
-
-  public assembleScales(): VgScale[] {
-    return assembleScaleForModelAndChildren(this);
   }
 
   public assembleLayout(): VgLayout {

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -37,6 +37,7 @@ import {LegendComponentIndex} from './legend/component';
 import {parseLegend} from './legend/parse';
 import {parseMarkDef} from './mark/mark';
 import {RepeatModel} from './repeat';
+import {assembleScales} from './scale/assemble';
 import {ScaleComponent, ScaleComponentIndex} from './scale/component';
 import {getFieldFromDomains} from './scale/domain';
 import {parseScale} from './scale/parse';
@@ -298,8 +299,6 @@ export abstract class Model {
 
   public abstract assembleLayoutSignals(): VgSignal[];
 
-  public abstract assembleScales(): VgScale[];
-
   public assembleHeaderMarks(): VgMarkGroup[] {
     const {layoutHeaders} = this.component;
     const headerMarks = [];
@@ -368,7 +367,7 @@ export abstract class Model {
 
     // Only include scales if this spec is top-level or if parent is facet.
     // (Otherwise, it will be merged with upper-level's scope.)
-    const scales = (!this.parent || isFacetModel(this.parent)) ? this.assembleScales() : [];
+    const scales = (!this.parent || isFacetModel(this.parent)) ? assembleScales(this) : [];
     if (scales.length > 0) {
       group.scales = scales;
     }

--- a/src/compile/scale/assemble.ts
+++ b/src/compile/scale/assemble.ts
@@ -2,14 +2,21 @@ import {isArray} from 'vega-util';
 import {Channel, ScaleChannel} from '../../channel';
 import {keys} from '../../util';
 import {isDataRefDomain, isVgRangeStep, isVgSignalRef, VgRange, VgScale} from '../../vega.schema';
-import {Model} from '../model';
+import {isConcatModel, isLayerModel, isRepeatModel, Model} from '../model';
 import {isRawSelectionDomain, selectionScaleDomain} from '../selection/selection';
 import {mergeDomains} from './domain';
 
-export function assembleScaleForModelAndChildren(model: Model) {
-  return model.children.reduce((scales, child) => {
-    return scales.concat(child.assembleScales());
-  }, assembleScalesForModel(model));
+export function assembleScales(model: Model): VgScale[] {
+  if (isLayerModel(model) || isConcatModel(model) || isRepeatModel(model)) {
+    // For concat / layer / repeat, include scales of children too
+    return model.children.reduce((scales, child) => {
+      return scales.concat(assembleScales(child));
+    }, assembleScalesForModel(model));
+  } else {
+    // For facet, child scales would not be included in the parent's scope.
+    // For unit, there is no child.
+    return assembleScalesForModel(model);
+  }
 }
 
 export function assembleScalesForModel(model: Model): VgScale[] {

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -21,7 +21,7 @@ import {SortField, SortOrder} from '../sort';
 import {LayoutSizeMixins, UnitSpec} from '../spec';
 import {stack, StackProperties} from '../stack';
 import {Dict, duplicate} from '../util';
-import {VgData, VgEncodeEntry, VgLayout, VgScale, VgSignal} from '../vega.schema';
+import {VgData, VgEncodeEntry, VgLayout, VgSignal} from '../vega.schema';
 import {AxisIndex} from './axis/component';
 import {parseUnitAxis} from './axis/parse';
 import {parseData} from './data/parse';
@@ -32,7 +32,6 @@ import {initEncoding} from './mark/init';
 import {parseMarkGroup} from './mark/mark';
 import {isLayerModel, Model, ModelWithField} from './model';
 import {RepeaterValue, replaceRepeaterInEncoding} from './repeater';
-import {assembleScalesForModel} from './scale/assemble';
 import {ScaleIndex} from './scale/component';
 import {
   assembleTopLevelSignals,
@@ -203,10 +202,6 @@ export class UnitModel extends ModelWithField {
 
   public parseAxisAndHeader() {
     this.component.axes = parseUnitAxis(this);
-  }
-
-  public assembleScales(): VgScale[] {
-    return assembleScalesForModel(this);
   }
 
   public assembleSelectionTopLevelSignals(signals: any[]): VgSignal[] {

--- a/test/compile/concat.test.ts
+++ b/test/compile/concat.test.ts
@@ -3,29 +3,6 @@ import {VgLayout} from '../../src/vega.schema';
 import {parseConcatModel} from '../util';
 
 describe('Concat', function() {
-  describe('assembleScales', () => {
-    it('includes all scales', () => {
-      const model = parseConcatModel({
-        vconcat: [{
-          mark: 'point',
-          encoding: {
-            x: {field: 'a', type: 'ordinal'}
-          }
-        },{
-          mark: 'bar',
-          encoding: {
-            x: {field: 'b', type: 'ordinal'},
-            y: {field: 'c', type: 'quantitative'}
-          }
-        }]
-      });
-
-      model.parseScale();
-      const scales = model.assembleScales();
-      assert.equal(scales.length, 3);
-    });
-  });
-
   describe('merge scale domains', () => {
     it('should instantiate all children in vconcat', () => {
       const model = parseConcatModel({

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -174,30 +174,6 @@ describe('FacetModel', function() {
     });
   });
 
-  describe('assembleScales', () => {
-    it('includes shared scales, but not independent scales (as they are nested).', () => {
-      const model = parseFacetModelWithScale({
-        facet: {
-          column: {field: 'a', type: 'quantitative', format: 'd'}
-        },
-        spec: {
-          mark: 'point',
-          encoding: {
-            x: {field: 'b', type: 'quantitative'},
-            y: {field: 'c', type: 'quantitative'}
-          }
-        },
-        resolve: {
-          scale: {x: 'independent'}
-        }
-      });
-
-      const scales = model.assembleScales();
-      assert.equal(scales.length, 1);
-      assert.equal(scales[0].name, 'y');
-    });
-  });
-
   describe('assembleHeaderMarks', () => {
     it('should sort headers in ascending order', () => {
       const model = parseFacetModelWithScale({

--- a/test/compile/layer.test.ts
+++ b/test/compile/layer.test.ts
@@ -57,35 +57,6 @@ describe('Layer', function() {
     });
   });
 
-  describe('assembleScales', () => {
-    it('includes all scales from children, both shared and independent', () => {
-      const model = parseLayerModel({
-        layer: [{
-          mark: 'point',
-          encoding: {
-            x: {field: 'a', type: 'quantitative'},
-            y: {field: 'c', type: 'quantitative'}
-          }
-        },{
-          mark: 'point',
-          encoding: {
-            x: {field: 'b', type: 'quantitative'},
-            y: {field: 'c', type: 'quantitative'}
-          }
-        }],
-        resolve: {
-          scale: {
-            x: 'independent'
-          }
-        }
-      });
-
-      model.parseScale();
-      const scales = model.assembleScales();
-      assert.equal(scales.length, 3); // 2 x, 1 y
-    });
-  });
-
   describe('dual axis chart', () => {
     const model = parseLayerModel({
       layer: [{

--- a/test/compile/repeat.test.ts
+++ b/test/compile/repeat.test.ts
@@ -7,26 +7,6 @@ import {keys} from '../../src/util';
 import {parseRepeatModel} from '../util';
 
 describe('Repeat', function() {
-  describe('assembleScales', () => {
-    it('includes all scales', () => {
-      const model = parseRepeatModel({
-        repeat: {
-          row: ['Acceleration', 'Horsepower']
-        },
-        spec: {
-          mark: 'point',
-          encoding: {
-            x: {field: {repeat: 'row'}, type: 'quantitative'}
-          }
-        }
-      });
-
-      model.parseScale();
-      const scales = model.assembleScales();
-      assert.equal(scales.length, 2);
-    });
-  });
-
   describe('resolveRepeat', () => {
     it('should resolve repeated fields', () => {
       const resolved = replaceRepeaterInEncoding({

--- a/test/compile/scale/assemble.test.ts
+++ b/test/compile/scale/assemble.test.ts
@@ -1,8 +1,100 @@
 import {assert} from 'chai';
-import {assembleScaleRange} from '../../../src/compile/scale/assemble';
-import {parseUnitModel, parseUnitModelWithScale} from '../../util';
+import {assembleScaleRange, assembleScales} from '../../../src/compile/scale/assemble';
+import {parseConcatModel, parseFacetModelWithScale, parseLayerModel, parseRepeatModel, parseUnitModel, parseUnitModelWithScale} from '../../util';
 
 describe('compile/scale/assemble', () => {
+  describe('assembleScales', () => {
+    it('includes all scales for concat', () => {
+      const model = parseConcatModel({
+        vconcat: [{
+          mark: 'point',
+          encoding: {
+            x: {field: 'a', type: 'ordinal'}
+          }
+        },{
+          mark: 'bar',
+          encoding: {
+            x: {field: 'b', type: 'ordinal'},
+            y: {field: 'c', type: 'quantitative'}
+          }
+        }]
+      });
+
+      model.parseScale();
+      const scales = assembleScales(model);
+      assert.equal(scales.length, 3);
+    });
+
+
+    it('includes all scales from children for layer, both shared and independent', () => {
+      const model = parseLayerModel({
+        layer: [{
+          mark: 'point',
+          encoding: {
+            x: {field: 'a', type: 'quantitative'},
+            y: {field: 'c', type: 'quantitative'}
+          }
+        },{
+          mark: 'point',
+          encoding: {
+            x: {field: 'b', type: 'quantitative'},
+            y: {field: 'c', type: 'quantitative'}
+          }
+        }],
+        resolve: {
+          scale: {
+            x: 'independent'
+          }
+        }
+      });
+
+      model.parseScale();
+      const scales = assembleScales(model);
+      assert.equal(scales.length, 3); // 2 x, 1 y
+    });
+
+    it('includes all scales for repeat', () => {
+      const model = parseRepeatModel({
+        repeat: {
+          row: ['Acceleration', 'Horsepower']
+        },
+        spec: {
+          mark: 'point',
+          encoding: {
+            x: {field: {repeat: 'row'}, type: 'quantitative'}
+          }
+        }
+      });
+
+      model.parseScale();
+      const scales = assembleScales(model);
+      assert.equal(scales.length, 2);
+    });
+
+    it('includes shared scales, but not independent scales (as they are nested) for facet.', () => {
+      const model = parseFacetModelWithScale
+      ({
+        facet: {
+          column: {field: 'a', type: 'quantitative', format: 'd'}
+        },
+        spec: {
+          mark: 'point',
+          encoding: {
+            x: {field: 'b', type: 'quantitative'},
+            y: {field: 'c', type: 'quantitative'}
+          }
+        },
+        resolve: {
+          scale: {x: 'independent'}
+        }
+      });
+
+      const scales = assembleScales(model);
+      assert.equal(scales.length, 1);
+      assert.equal(scales[0].name, 'y');
+    });
+  });
+
   describe('assembleScaleRange', () => {
     it('replaces a range step constant with a signal', () => {
       const model = parseUnitModel({


### PR DESCRIPTION
so we have less methods in models + have all assembleScale tests in one place

(We couldn't do this earlier due to circular dependencies problem.)

