### PR TITLE
Hide first item of TOC as it will always be Documentation Overview

### DIFF
--- a/site/static/main.css
+++ b/site/static/main.css
@@ -647,3 +647,8 @@ footer .edit-page {
     margin-top: 0;
   }
 }
+
+/* Hide first item of TOC as it will always be Documentation Overview */
+ul#markdown-toc > li:first-child {
+    display: none;
+}


### PR DESCRIPTION
Fix https://github.com/vega/vega-lite/issues/2890

(Let's agree on always adding "# Documentation Overview" so we don't have floating TOC)


