### PR TITLE
Make transform nodes re-useable for external modules

### DIFF
--- a/src/compile/data/aggregate.ts
+++ b/src/compile/data/aggregate.ts
@@ -6,7 +6,6 @@ import {SummarizeTransform} from '../../transform';
 import {NOMINAL, ORDINAL} from '../../type';
 import {Dict, differ, duplicate, extend, keys, StringSet} from '../../util';
 import {VgAggregateTransform} from '../../vega.schema';
-import {Model} from '../model';
 import {UnitModel} from './../unit';
 import {DataFlowNode} from './dataflow';
 
@@ -102,7 +101,7 @@ export class AggregateNode extends DataFlowNode {
     return new AggregateNode(dims, meas);
   }
 
-  public static makeFromTransform(model: Model, t: SummarizeTransform): AggregateNode {
+  public static makeFromTransform(t: SummarizeTransform): AggregateNode {
     const dims = {};
     const meas = {};
     for(const s of t.summarize) {

--- a/src/compile/data/bin.ts
+++ b/src/compile/data/bin.ts
@@ -32,21 +32,48 @@ function binKey(bin: BinParams, field: string) {
   return `${binToString(bin)}_${field}`;
 }
 
-function createBinComponent(bin: BinParams, t: FieldDef<string>|BinTransform, model: Model, key:string) {
-  return {
+function isModelParams(p: {model: Model} | {signal?: string, extentSignal?: string}): p is {model: Model} {
+  return !!p['model'];
+}
+
+function getSignalsFromParams(
+  params: {model: Model} | {signal?: string, extentSignal?: string},
+  key: string
+) {
+  if (isModelParams(params)) {
+    const model = params.model;
+    return {
+      signal: model.getName(`${key}_bins`),
+      extentSignal: model.getName(`${key}_extent`)
+    };
+  }
+  return params;
+}
+
+function createBinComponent(
+  t: FieldDef<string>|BinTransform,
+  params: {model: Model} | {signal?: string, extentSignal?: string}
+) {
+  const bin = normalizeBin(t.bin, undefined) || {};
+  const key = binKey(bin, t.field);
+  const {signal, extentSignal} = getSignalsFromParams(params, key);
+
+  const binComponent: BinComponent = {
     bin: bin,
     field: t.field,
     as: [field(t, {}), field(t, {binSuffix: 'end'})],
-    signal: model.getName(`${key}_bins`),
-    extentSignal: model.getName(key + '_extent')
+    ...signal ? {signal} : {},
+    ...extentSignal ? {extentSignal} : {}
   };
+
+  return {key, binComponent};
 }
 
 export interface BinComponent {
   bin: BinParams;
   field: string;
-  extentSignal: string;
-  signal: string;
+  extentSignal?: string;
+  signal?: string;
   as: string[];
 
   // Range Formula
@@ -65,20 +92,17 @@ export class BinNode extends DataFlowNode {
   }
 
   public static makeBinFromEncoding(model: ModelWithField) {
-    const bins = model.reduceFieldDef((binComponent: Dict<BinComponent>, fieldDef, channel) => {
+    const bins = model.reduceFieldDef((binComponentIndex: Dict<BinComponent>, fieldDef, channel) => {
       const fieldDefBin = fieldDef.bin;
       if (fieldDefBin) {
-        const bin = normalizeBin(fieldDefBin, undefined) || {};
-        const key = binKey(bin, fieldDef.field);
-        if (!(key in binComponent)) {
-          binComponent[key] =  createBinComponent(bin, fieldDef, model, key);
-        }
-        binComponent[key] = {
-          ...binComponent[key],
+        const {key, binComponent} = createBinComponent(fieldDef, {model});
+        binComponentIndex[key] = {
+          ...binComponent,
+          ...binComponentIndex[key],
           ...rangeFormula(model, fieldDef, channel, model.config)
         };
       }
-      return binComponent;
+      return binComponentIndex;
     }, {});
 
     if (keys(bins).length === 0) {
@@ -88,13 +112,16 @@ export class BinNode extends DataFlowNode {
     return new BinNode(bins);
   }
 
-  public static makeFromTransform(model: Model, t: BinTransform) {
-    const bin = normalizeBin(t.bin, undefined) || {};
-    const key = binKey(bin, t.field);
+  /**
+   * Creates a bin node from BinTransform.
+   * The optional parameter should provide
+   */
+  public static makeFromTransform(t: BinTransform, params: {model: Model} | {signal?: string, extentSignal?: string}) {
+    const {key, binComponent} = createBinComponent(t, params);
     return new BinNode({
-      [key]: createBinComponent(bin, t, model, key)
+      [key]: binComponent
     });
-}
+  }
 
   public merge(other: BinNode) {
     this.bins = extend(other.bins);
@@ -133,7 +160,7 @@ export class BinNode extends DataFlowNode {
           ...bin.bin
       };
 
-      if (!bin.bin.extent) {
+      if (!bin.bin.extent && bin.extentSignal) {
         transform.push({
           type: 'extent',
           field: bin.field,

--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -102,7 +102,7 @@ export function parseTransformArray(model: Model) {
 
       node = new FilterNode(model, t.filter);
     } else if (isBin(t)) {
-      node = BinNode.makeFromTransform(model, t);
+      node = BinNode.makeFromTransform(t, {model});
     } else if (isTimeUnit(t)) {
       node = TimeUnitNode.makeFromTransform(t);
     } else if (isSummarize(t)) {

--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -104,9 +104,9 @@ export function parseTransformArray(model: Model) {
     } else if (isBin(t)) {
       node = BinNode.makeFromTransform(model, t);
     } else if (isTimeUnit(t)) {
-      node = TimeUnitNode.makeFromTransform(model, t);
+      node = TimeUnitNode.makeFromTransform(t);
     } else if (isSummarize(t)) {
-      node = AggregateNode.makeFromTransform(model, t);
+      node = AggregateNode.makeFromTransform(t);
 
       if (requiresSelectionId(model)) {
         insert(node);

--- a/src/compile/data/timeunit.ts
+++ b/src/compile/data/timeunit.ts
@@ -4,7 +4,7 @@ import {TimeUnitTransform} from '../../transform';
 import {TEMPORAL} from '../../type';
 import {Dict, duplicate, extend, keys, vals} from '../../util';
 import {VgFormulaTransform} from '../../vega.schema';
-import {Model, ModelWithField} from '../model';
+import {ModelWithField} from '../model';
 import {DataFlowNode} from './dataflow';
 
 
@@ -43,7 +43,7 @@ export class TimeUnitNode extends DataFlowNode {
     return new TimeUnitNode(formula);
   }
 
-  public static makeFromTransform(model: Model, t: TimeUnitTransform) {
+  public static makeFromTransform(t: TimeUnitTransform) {
     return new TimeUnitNode({
       [t.field]: {
         as: t.as,

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -8,7 +8,13 @@ import {fieldExpr as timeUnitFieldExpr, isSingleTimeUnit, normalizeTimeUnit, Tim
 import {isArray, isString, logicalExpr} from './util';
 
 
-export type Filter = EqualFilter | RangeFilter | OneOfFilter | SelectionFilter | string;
+export type Filter =
+  // FieldFilter (but we don't type FieldFilter here so the schema has no nesting
+  // and thus the documentation shows all of the types clearly)
+  EqualFilter | RangeFilter | OneOfFilter |
+  SelectionFilter | string;
+
+export type FieldFilter = EqualFilter | RangeFilter | OneOfFilter;
 
 export interface SelectionFilter {
   /**
@@ -120,38 +126,45 @@ export function expression(model: Model, filterOp: LogicalOperand<Filter>, node?
     } else if (isSelectionFilter(filter)) {
       return predicate(model, filter.selection, node);
     } else { // Filter Object
-      const fieldExpr = filter.timeUnit ?
-        // For timeUnit, cast into integer with time() so we can use ===, inrange, indexOf to compare values directly.
-          // TODO: We calculate timeUnit on the fly here. Consider if we would like to consolidate this with timeUnit pipeline
-          // TODO: support utc
-        ('time(' + timeUnitFieldExpr(filter.timeUnit, filter.field) + ')') :
-        field(filter, {expr: 'datum'});
+      return fieldFilterExpression(filter);
+    }
+  });
+}
 
-      if (isEqualFilter(filter)) {
-        return fieldExpr + '===' + valueExpr(filter.equal, filter.timeUnit);
-      } else if (isOneOfFilter(filter)) {
-        // "oneOf" was formerly "in" -- so we need to add backward compatibility
-        const oneOf: OneOfFilter[] = filter.oneOf || filter['in'];
-        return 'indexof([' +
-          oneOf.map((v) => valueExpr(v, filter.timeUnit)).join(',') +
-          '], ' + fieldExpr + ') !== -1';
-      } else if (isRangeFilter(filter)) {
-        const lower = filter.range[0];
-        const upper = filter.range[1];
+export function fieldFilterExpression(filter: FieldFilter) {
+  const fieldExpr = filter.timeUnit ?
+    // For timeUnit, cast into integer with time() so we can use ===, inrange, indexOf to compare values directly.
+      // TODO: We calculate timeUnit on the fly here. Consider if we would like to consolidate this with timeUnit pipeline
+      // TODO: support utc
+    ('time(' + timeUnitFieldExpr(filter.timeUnit, filter.field) + ')') :
+    field(filter, {expr: 'datum'});
 
-        if (lower !== null &&  upper !== null) {
-          return 'inrange(' + fieldExpr + ', [' +
-            valueExpr(lower, filter.timeUnit) + ', ' +
-            valueExpr(upper, filter.timeUnit) + '])';
-        } else if (lower !== null) {
-          return fieldExpr + ' >= ' + lower;
-        } else if (upper !== null) {
-          return fieldExpr + ' <= ' + upper;
-        }
-      }
+  if (isEqualFilter(filter)) {
+    return fieldExpr + '===' + valueExpr(filter.equal, filter.timeUnit);
+  } else if (isOneOfFilter(filter)) {
+    // "oneOf" was formerly "in" -- so we need to add backward compatibility
+    const oneOf: OneOfFilter[] = filter.oneOf || filter['in'];
+    return 'indexof([' +
+      oneOf.map((v) => valueExpr(v, filter.timeUnit)).join(',') +
+      '], ' + fieldExpr + ') !== -1';
+  } else if (isRangeFilter(filter)) {
+    const lower = filter.range[0];
+    const upper = filter.range[1];
+
+    if (lower !== null &&  upper !== null) {
+      return 'inrange(' + fieldExpr + ', [' +
+        valueExpr(lower, filter.timeUnit) + ', ' +
+        valueExpr(upper, filter.timeUnit) + '])';
+    } else if (lower !== null) {
+      return fieldExpr + ' >= ' + lower;
+    } else if (upper !== null) {
+      return fieldExpr + ' <= ' + upper;
     }
     return undefined;
-  });
+  }
+
+  /* istanbul ignore next: it should never reach here */
+  throw new Error(`Invalid field filter: ${JSON.stringify(filter)}`);
 }
 
 function valueExpr(v: any, timeUnit: TimeUnit) {

--- a/test/compile/data/aggregate.test.ts
+++ b/test/compile/data/aggregate.test.ts
@@ -157,15 +157,7 @@ describe('compile/data/summary', function () {
         ],
         groupby: ['Displacement_mean', 'Acceleration_sum']};
 
-      const model = parseUnitModel({
-        mark: "point",
-        transform: [t],
-        encoding: {
-          'x': {'field': 'Displacement', 'type': "quantitative"}
-        }
-      });
-
-      const agg = AggregateNode.makeFromTransform(model, t);
+      const agg = AggregateNode.makeFromTransform(t);
       assert.deepEqual<VgAggregateTransform>(agg.assemble(), {
         type: 'aggregate',
         groupby: ['Displacement_mean', 'Acceleration_sum'],
@@ -182,15 +174,7 @@ describe('compile/data/summary', function () {
         {aggregate: 'sum', field: 'Acceleration', as: 'Acceleration_sum'}],
         groupby: ['Displacement_mean', 'Acceleration_sum']};
 
-      const model = parseUnitModel({
-        mark: "point",
-        transform: [t],
-        encoding: {
-          'x': {'field': 'Displacement', 'type': "quantitative"}
-        }
-      });
-
-      const agg = AggregateNode.makeFromTransform(model, t);
+      const agg = AggregateNode.makeFromTransform(t);
       assert.deepEqual<VgAggregateTransform>(agg.assemble(), {
         type: 'aggregate',
         groupby: ['Displacement_mean', 'Acceleration_sum'],

--- a/test/compile/data/bin.test.ts
+++ b/test/compile/data/bin.test.ts
@@ -13,7 +13,7 @@ function assembleFromEncoding(model: ModelWithField) {
 }
 
 function assembleFromTransform(model: Model, t: BinTransform) {
-  return BinNode.makeFromTransform(model, t).assemble();
+  return BinNode.makeFromTransform(t, {model}).assemble();
 }
 
 describe('compile/data/bin', function() {

--- a/test/compile/data/timeunit.test.ts
+++ b/test/compile/data/timeunit.test.ts
@@ -2,7 +2,7 @@
 
 import {assert} from 'chai';
 import {TimeUnitNode} from '../../../src/compile/data/timeunit';
-import {Model, ModelWithField} from '../../../src/compile/model';
+import {ModelWithField} from '../../../src/compile/model';
 import {TimeUnitTransform} from '../../../src/transform';
 import {parseUnitModel} from '../../util';
 
@@ -10,8 +10,8 @@ function assembleFromEncoding(model: ModelWithField) {
   return TimeUnitNode.makeFromEncoding(model).assemble();
 }
 
-function assembleFromTransform(model: Model, t: TimeUnitTransform) {
-  return TimeUnitNode.makeFromTransform(model, t).assemble();
+function assembleFromTransform(t: TimeUnitTransform) {
+  return TimeUnitNode.makeFromTransform(t).assemble();
 }
 
 describe('compile/data/timeunit', () => {
@@ -36,16 +36,8 @@ describe('compile/data/timeunit', () => {
 
     it('should return a dictionary of formula transform from transform array', () => {
       const t: TimeUnitTransform = {field: 'date', as: 'month_date', timeUnit: 'month'};
-      const model = parseUnitModel({
-        "data": {"values": []},
-        "transform": [t],
-        "mark": "point",
-        "encoding": {
-          "x": {field: 'date', type: 'temporal', timeUnit: 'month'}
-        }
-      });
 
-      assert.deepEqual(assembleFromTransform(model, t), [{
+      assert.deepEqual(assembleFromTransform(t), [{
         type: 'formula',
         as: 'month_date',
         expr: 'datetime(0, month(datum["date"]), 1, 0, 0, 0, 0)'


### PR DESCRIPTION
This PR should makes factory methods for the transform nodes that you need re-usable for you.

As mentioned in the email, to we convert a Vega-Lite `transform` array to a Vega `transform` array,
for each transforms, you can convert a Vega-Lite transform to Vega transform(s).

1) Use a factory method to create a node
2) call node.assemble(), which will output relevant Vega transforms