### PR TITLE
Remove ROW/COLUMN from `channelSupportScaleType`

### DIFF
--- a/src/scale.ts
+++ b/src/scale.ts
@@ -625,9 +625,6 @@ export function channelScalePropertyIncompatability(channel: Channel, propName: 
 
 export function channelSupportScaleType(channel: Channel, scaleType: ScaleType): boolean {
   switch (channel) {
-    case Channel.ROW:
-    case Channel.COLUMN:
-      return scaleType === 'band'; // row / column currently supports band only
     case Channel.X:
     case Channel.Y:
     case Channel.SIZE: // TODO: size and opacity can support ordinal with more modification

--- a/test/scale.test.ts
+++ b/test/scale.test.ts
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import {Channel, SCALE_CHANNELS, ScaleChannel} from '../src/channel';
+import {SCALE_CHANNELS, ScaleChannel} from '../src/channel';
 import * as scale from '../src/scale';
 import {channelSupportScaleType, CONTINUOUS_TO_CONTINUOUS_SCALES, SCALE_TYPES, ScaleType} from '../src/scale';
 import {some, without} from '../src/util';
@@ -45,16 +45,6 @@ describe('scale', () => {
         assert(some(SCALE_CHANNELS, (channel) => {
           return channelSupportScaleType(channel, scaleType);
         }));
-      }
-    });
-
-    it('row,column should support only band', () => {
-      for (const channel of ['row', 'column'] as Channel[]) {
-        assert(channelSupportScaleType(channel, 'band'));
-        const nonBands = without<ScaleType>(SCALE_TYPES, ['band']);
-        for (const scaleType of nonBands) {
-          assert(!channelSupportScaleType(channel, scaleType));
-        }
       }
     });
 


### PR DESCRIPTION
(row/column do not have scales.)
