### PR TITLE
Don’t hide toc entries via css but instead use {:.no_toc}

### DIFF
--- a/site/docs/area.md
+++ b/site/docs/area.md
@@ -17,10 +17,6 @@ permalink: /docs/area.html
 
 `area` represent multiple data element as a single area shape. Area marks are often used to show change over time, using either a single area or stacked areas.
 
-## Documentation Overview
-
-* TOC
-{:toc}
 
 ### Area Chart
 

--- a/site/docs/axis.md
+++ b/site/docs/axis.md
@@ -41,6 +41,7 @@ Besides `axis` property of each encoding channel, the configuration object ([`co
 ```
 
 ## Documentation Overview
+{:.no_toc}
 
 * TOC
 {:toc}

--- a/site/docs/bar.md
+++ b/site/docs/bar.md
@@ -17,10 +17,6 @@ permalink: /docs/bar.html
 
 The `bar` mark encodes x and y channels with a pair of discrete and continuous fields. Bar marks are useful in a wide variety of visualizations, including bar charts and timelines.
 
-## Documentation Overview
-
-* TOC
-{:toc}
 
 ### Single Bar Chart
 

--- a/site/docs/data.md
+++ b/site/docs/data.md
@@ -10,6 +10,7 @@ Akin to [Vega](https://www.github.com/vega/vega)'s [data model](https://vega.git
 Vega-Lite's `data` property describes the visualization's data source as part of the specification, which can be either [inline data](#inline) (`values`) or [a URL from which to load the data](#url) (`url`).  Alternatively, we can create an empty, [named data source](#named) (`name`), which can be [bound at runtime](https://vega.github.io/vega/docs/api/view/#data).
 
 ## Documentation Overview
+{:.no_toc}
 
 * TOC
 {:toc}

--- a/site/docs/facet.md
+++ b/site/docs/facet.md
@@ -14,6 +14,7 @@ First, the [`facet` operator](#facet-operator) is one of Vega-Lite's [view compo
 Second, as a shortcut you can use the [`column` or `row` encoding channels](#facet-channels).
 
 ## Documentation Overview
+{:.no_toc}
 
 * TOC
 {:toc}

--- a/site/docs/line.md
+++ b/site/docs/line.md
@@ -17,10 +17,6 @@ permalink: /docs/line.html
 
 The `line` mark represents the data points stored in a field with a line connecting all of these points. Line marks are commonly used to depict trajectories or change over time. Unlike other marks that represent one data element per mark, one line mark represents multiple data element as a single line (same is true for [`area`](area.html)).
 
-## Documentation Overview
-
-* TOC
-{:toc}
 
 ### Line Chart
 

--- a/site/docs/point.md
+++ b/site/docs/point.md
@@ -17,10 +17,6 @@ permalink: /docs/point.html
 
 `point` mark represents each data point with a symbol. Point marks are commonly used in visualizations like scatterplots.
 
-## Documentation Overview
-
-* TOC
-{:toc}
 
 ### Dot Plot
 

--- a/site/docs/scale.md
+++ b/site/docs/scale.md
@@ -40,6 +40,7 @@ For more information about guides that visualize the scales, please see the [axe
 
 
 ## Documentation Overview
+{:.no_toc}
 
 * TOC
 {:toc}

--- a/site/docs/selection.md
+++ b/site/docs/selection.md
@@ -14,6 +14,7 @@ Selections are the basic building block in Vega-Lite's _grammar of interaction._
 | [resolve](#resolving-selections-in-data-driven-views) | String | A strategy for how the selection's data query should be constructed, when used within a multiview or layered display. |
 
 ## Documentation Overview
+{:.no_toc}
 
 * TOC
 {:toc}

--- a/site/docs/size.md
+++ b/site/docs/size.md
@@ -9,6 +9,7 @@ permalink: /docs/size.html
 This page describe how to adjust width and height of visualizations in Vega-lite.
 
 ## Documentation Overview
+{:.no_toc}
 
 * TOC
 {:toc}

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -11,6 +11,7 @@ Vega-Lite specifications are JSON objects that describe a diverse range of inter
 These operators include [`layer`](layer.html), [`facet`](facet.html), [`concat`](concat.html), [`repeat`](repeat.html).
 
 ## Documentation Overview
+{:.no_toc}
 
 * TOC
 {:toc}

--- a/site/docs/stack.md
+++ b/site/docs/stack.md
@@ -28,6 +28,7 @@ determines type of stacking offset if the field should be stacked.
 ```
 
 ## Documentation Overview
+{:.no_toc}
 
 * TOC
 {:toc}

--- a/site/docs/tooltip.md
+++ b/site/docs/tooltip.md
@@ -8,6 +8,7 @@ permalink: /docs/tooltip.html
 Tooltip can provide details of a particular data point on demand. There are two ways to create a tooltip in Vega-Lite.
 
 ## Documentation Overview
+{:.no_toc}
 
 * TOC
 {:toc}

--- a/site/static/main.css
+++ b/site/static/main.css
@@ -647,8 +647,3 @@ footer .edit-page {
     margin-top: 0;
   }
 }
-
-/* Hide first item of TOC as it will always be Documentation Overview */
-ul#markdown-toc > li:first-child {
-    display: none;
-}


### PR DESCRIPTION
See https://kramdown.gettalong.org/converter/html.html#toc

This has two advantages. First, it makes it more explicit what is shown. Second, we don't even output the HTML. 