### PR TITLE
Possible alternative structure for selection docs

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -704,7 +704,7 @@
           "type": "array"
         },
         "on": {
-          "description": "A Vega event stream (object or selector) that triggers the selection."
+          "description": "A Vega event stream (object or selector) that triggers the selection.\nFor interval selections, the event stream must specify a [start and end](https://vega.github.io/vega/docs/event-streams/#between-filters)"
         },
         "resolve": {
           "$ref": "#/definitions/SelectionResolution",
@@ -2962,7 +2962,7 @@
           "description": "Each (unbound) interval selection also adds a rectangle mark to depict the\nextents of the interval. The `mark` property can be used to customize the\nappearance of the mark."
         },
         "on": {
-          "description": "A Vega event stream (object or selector) that triggers the selection."
+          "description": "A Vega event stream (object or selector) that triggers the selection.\nFor interval selections, the event stream must specify a [start and end](https://vega.github.io/vega/docs/event-streams/#between-filters)"
         },
         "resolve": {
           "$ref": "#/definitions/SelectionResolution",
@@ -3023,7 +3023,7 @@
           "description": "Each (unbound) interval selection also adds a rectangle mark to depict the\nextents of the interval. The `mark` property can be used to customize the\nappearance of the mark."
         },
         "on": {
-          "description": "A Vega event stream (object or selector) that triggers the selection."
+          "description": "A Vega event stream (object or selector) that triggers the selection.\nFor interval selections, the event stream must specify a [start and end](https://vega.github.io/vega/docs/event-streams/#between-filters)"
         },
         "resolve": {
           "$ref": "#/definitions/SelectionResolution",
@@ -3925,7 +3925,7 @@
           "type": "boolean"
         },
         "on": {
-          "description": "A Vega event stream (object or selector) that triggers the selection."
+          "description": "A Vega event stream (object or selector) that triggers the selection.\nFor interval selections, the event stream must specify a [start and end](https://vega.github.io/vega/docs/event-streams/#between-filters)"
         },
         "resolve": {
           "$ref": "#/definitions/SelectionResolution",
@@ -3972,7 +3972,7 @@
           "type": "boolean"
         },
         "on": {
-          "description": "A Vega event stream (object or selector) that triggers the selection."
+          "description": "A Vega event stream (object or selector) that triggers the selection.\nFor interval selections, the event stream must specify a [start and end](https://vega.github.io/vega/docs/event-streams/#between-filters)"
         },
         "resolve": {
           "$ref": "#/definitions/SelectionResolution",
@@ -4949,7 +4949,7 @@
           "type": "boolean"
         },
         "on": {
-          "description": "A Vega event stream (object or selector) that triggers the selection."
+          "description": "A Vega event stream (object or selector) that triggers the selection.\nFor interval selections, the event stream must specify a [start and end](https://vega.github.io/vega/docs/event-streams/#between-filters)"
         },
         "resolve": {
           "$ref": "#/definitions/SelectionResolution",
@@ -5003,7 +5003,7 @@
           "type": "boolean"
         },
         "on": {
-          "description": "A Vega event stream (object or selector) that triggers the selection."
+          "description": "A Vega event stream (object or selector) that triggers the selection.\nFor interval selections, the event stream must specify a [start and end](https://vega.github.io/vega/docs/event-streams/#between-filters)"
         },
         "resolve": {
           "$ref": "#/definitions/SelectionResolution",

--- a/site/docs/selection/selection.md
+++ b/site/docs/selection/selection.md
@@ -20,14 +20,6 @@ permalink: /docs/selection.html
 
 Selections are the basic building block in Vega-Lite's _grammar of interaction._ They map user input (e.g., mouse moves and clicks, touch presses, etc.) into data queries, which can subsequently be used to drive conditional encoding rules, filter data points, or determine scale domains.
 
-{:#definition}
-| Property                 | Type                | Description    |
-| :----------------------- | :-----------------: | :------------- |
-| [type](#selection-types) | String | _**Required.**_ Determines the default event processing and data query for the selection. |
-| [on](#selection-on)      | [Vega Event Stream](https://vega.github.io/vega/docs/event-streams/) | Alternate user input events that should trigger the selection. For interval selections, the event stream must specify a [start and end](https://vega.github.io/vega/docs/event-streams/#between-filters). |
-| [resolve](#resolving-selections-in-data-driven-views) | String | A strategy for how the selection's data query should be constructed, when used within a multiview or layered display. |
-| [mark](#mark) | Object | For interval selections only, an object to customize the appearance of the rectangle mark. |
-
 ## Documentation Overview
 {:.no_toc}
 
@@ -36,11 +28,12 @@ Selections are the basic building block in Vega-Lite's _grammar of interaction._
 
 ## Selection Types
 
-Selections are defined within single views, and their simplest definition consists of a **name** and a **type**. The selection type determines the default events that trigger a selection and the resultant data query. Vega-Lite currently supports three selection types:
+Selections are defined within single views, and their simplest definition consists of a **name** and a **type**. The selection type determines the default events that trigger a selection and the resultant data query.
 
-  * `single` -- to select a single discrete data value on `click`.
-  * `multi` -- to select multiple discrete data value; the first value is selected on `click` and additional values toggled on shift-`click`.
-  * `interval` -- to select a continuous range of data values on `drag`.
+{:#definition}
+| Property                 | Type                | Description    |
+| :----------------------- | :-----------------: | :------------- |
+| [type](#selection-types) | String | _**Required.**_ Determines the default event processing and data query for the selection. Vega-Lite currently supports three selection types: <br/> - `single` -- to select a single discrete data value on `click`. <br/> - `multi` -- to select multiple discrete data value; the first value is selected on `click` and additional values toggled on shift-`click`. <br/> - `interval` -- to select a continuous range of data values on `drag`. |
 
 For example, try the different types against the example selection (named `pts`) below: <select onchange="changeSpec('selection_type', 'selection_type_' + this.value)">
   <option>single</option>
@@ -50,10 +43,32 @@ For example, try the different types against the example selection (named `pts`)
 
 <div id="selection_type" class="vl-example" data-name="selection_type_single"></div>
 
+## Selection Properties
+
 <a id="selection-on"></a>
 While selection types provide useful defaults, it can often be useful to override these properties to customize the interaction design. The `on` property can be used to specify alternate events to trigger a selection. For instance, a single rectangle in the heatmap below can now be selected on double-click instead.
 
 <div class="vl-example" data-name="selection_type_single_dblclick"></div>
+
+Moreover, Vega-Lite provides a number of selection _transformations_ to further customize the behaviour of a selection. These include: [bind](bind.html), [nearest](nearest.html), [project](project.html), [toggle](toggle.html), [translate](translate.html), and [zoom](zoom.html).
+
+All selections can contain the following properties.
+
+{% include table.html props="on,resolve" source="SingleSelection" %}
+
+### Single Selections
+
+{% include table.html props="bind,nearest" source="SingleSelection" %}
+
+### Multi Selections
+
+{% include table.html props="toggle,nearest" source="MultiSelection" %}
+
+### Interval Selections
+
+{% include table.html props="bind,mark,translate,zoom" source="IntervalSelection" %}
+
+#### Interval Selection Marks
 
 {:#mark}
 Every interval selection also adds a rectangle mark to the visualization, to depict the extents of the selected region. The appearance of this mark can be customized with the following properties, specified under `mark`.
@@ -65,8 +80,6 @@ For example, the spec below imagines two users, Alex and Morgan, who can each dr
 _Note:_ the two intervals do not have any effect on the visualization yet (we'll cover that next!).
 
 <div class="vl-example" data-name="interval_mark_style"></div>
-
-Vega-Lite provides a number of selection _transformations_ to further customize the behaviour of a selection. These include: [bind](bind.html), [nearest](nearest.html), [project](project.html), [toggle](toggle.html), [translate](translate.html), and [zoom](zoom.html).
 
 ## Using Selections
 

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -8,6 +8,7 @@ export type SelectionResolution = 'global' | 'union' | 'intersect';
 export interface BaseSelectionDef {
   /**
    * A Vega event stream (object or selector) that triggers the selection.
+   * For interval selections, the event stream must specify a [start and end](https://vega.github.io/vega/docs/event-streams/#between-filters)
    */
   on?: any;
   /**


### PR DESCRIPTION
Make selection docs have explicit section for general selection properties / subsections for single/multi/interval selections.  

I haven't fixed all the links / make glues for all sections, but just wanna propose an idea that you can take over.  

After cleaning up, this should resolve my comments in https://github.com/vega/vega-lite/pull/2968.

If you like it, please feel free to take over this.  