### PR TITLE
Rename config.cell => config.view + Add docs.

### DIFF
--- a/_data/link.yml
+++ b/_data/link.yml
@@ -89,6 +89,9 @@ TickConfig:
 VgTitleConfig:
   name: TitleConfig
   link: "title.html#config"
+ViewConfig:
+  name: ViewConfig
+  link: "spec.html#config"
 
 # Encoding
 EncodingWithFacet:

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1029,55 +1029,6 @@
       ],
       "type": "object"
     },
-    "CellConfig": {
-      "additionalProperties": false,
-      "properties": {
-        "clip": {
-          "description": "Whether the view should be clipped.",
-          "type": "boolean"
-        },
-        "fill": {
-          "description": "The fill color.\n\n__Default value:__ (none)",
-          "type": "string"
-        },
-        "fillOpacity": {
-          "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ (none)",
-          "type": "number"
-        },
-        "height": {
-          "description": "The default height of the single plot or each plot in a trellis plot when the visualization has a continuous (non-ordinal) y-scale with `rangeStep` = `null`.\n\n__Default value:__ `200`",
-          "type": "number"
-        },
-        "stroke": {
-          "description": "The stroke color.\n\n__Default value:__ (none)",
-          "type": "string"
-        },
-        "strokeDash": {
-          "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.\n\n__Default value:__ (none)",
-          "items": {
-            "type": "number"
-          },
-          "type": "array"
-        },
-        "strokeDashOffset": {
-          "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.\n\n__Default value:__ (none)",
-          "type": "number"
-        },
-        "strokeOpacity": {
-          "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ (none)",
-          "type": "number"
-        },
-        "strokeWidth": {
-          "description": "The stroke width, in pixels.\n\n__Default value:__ (none)",
-          "type": "number"
-        },
-        "width": {
-          "description": "The default width of the single plot or each plot in a trellis plot when the visualization has a continuous (non-ordinal) x-scale or ordinal x-scale with `rangeStep` = `null`.\n\n__Default value:__ `200`",
-          "type": "number"
-        }
-      },
-      "type": "object"
-    },
     "CompositeAggregate": {
       "$ref": "#/definitions/BOXPLOT"
     },
@@ -1464,10 +1415,6 @@
           "$ref": "#/definitions/BarConfig",
           "description": "Bar-Specific Config "
         },
-        "cell": {
-          "$ref": "#/definitions/CellConfig",
-          "description": "Cell Config "
-        },
         "circle": {
           "$ref": "#/definitions/MarkConfig",
           "description": "Circle-Specific Config "
@@ -1554,6 +1501,10 @@
         "title": {
           "$ref": "#/definitions/VgTitleConfig",
           "description": "Title configuration, which determines default properties for all [titles](title.html). For a full list of title configuration options, please see the [corresponding section of the title documentation](title.html#config)."
+        },
+        "view": {
+          "$ref": "#/definitions/ViewConfig",
+          "description": "Default properties for [single view plots](spec.html#single). "
         }
       },
       "type": "object"
@@ -2360,7 +2311,7 @@
           "type": "string"
         },
         "height": {
-          "description": "The height of a visualization.\n\n__Default value:__\n- For y-axis with a continuous (non-ordinal) scale, the height will be the value of [`config.cell.height`](config.html#cell-config).\n- For y-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the height is determined by the value of `rangeStep` and the cardinality of the field mapped to y-channel.   Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.cell.height`](config.html#cell-config).\n- If no field is mapped to `x` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plot with `row` and `column` channels, this represents the height of a single cell.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
+          "description": "The height of a visualization.\n\n__Default value:__\n- For y-axis with a continuous (non-ordinal) scale, the height will be the value of [`config.view.height`](spec.html#config).\n- For y-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the height is determined by the value of `rangeStep` and the cardinality of the field mapped to y-channel.   Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](spec.html#config).\n- If no field is mapped to `x` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plot with `row` and `column` channels, this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
           "type": "number"
         },
         "layer": {
@@ -2403,7 +2354,7 @@
           "type": "array"
         },
         "width": {
-          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- For x-axis with a continuous (non-ordinal) scale, the width will be the value of [`config.cell.width`](config.html#cell-config).\n- For x-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the width is determined by the value of `rangeStep` and the cardinality of the field mapped to x-channel.   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.cell.width`](config.html#cell-config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plot with `row` and `column` channels, this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- For x-axis with a continuous (non-ordinal) scale, the width will be the value of [`config.view.width`](spec.html#config).\n- For x-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the width is determined by the value of `rangeStep` and the cardinality of the field mapped to x-channel.   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plot with `row` and `column` channels, this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
           "type": "number"
         }
       },
@@ -2499,7 +2450,7 @@
           "description": "A key-value mapping between encoding channels and definition of fields."
         },
         "height": {
-          "description": "The height of a visualization.\n\n__Default value:__\n- For y-axis with a continuous (non-ordinal) scale, the height will be the value of [`config.cell.height`](config.html#cell-config).\n- For y-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the height is determined by the value of `rangeStep` and the cardinality of the field mapped to y-channel.   Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.cell.height`](config.html#cell-config).\n- If no field is mapped to `x` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plot with `row` and `column` channels, this represents the height of a single cell.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
+          "description": "The height of a visualization.\n\n__Default value:__\n- For y-axis with a continuous (non-ordinal) scale, the height will be the value of [`config.view.height`](spec.html#config).\n- For y-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the height is determined by the value of `rangeStep` and the cardinality of the field mapped to y-channel.   Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](spec.html#config).\n- If no field is mapped to `x` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plot with `row` and `column` channels, this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
           "type": "number"
         },
         "mark": {
@@ -2536,7 +2487,7 @@
           "type": "array"
         },
         "width": {
-          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- For x-axis with a continuous (non-ordinal) scale, the width will be the value of [`config.cell.width`](config.html#cell-config).\n- For x-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the width is determined by the value of `rangeStep` and the cardinality of the field mapped to x-channel.   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.cell.width`](config.html#cell-config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plot with `row` and `column` channels, this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- For x-axis with a continuous (non-ordinal) scale, the width will be the value of [`config.view.width`](spec.html#config).\n- For x-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the width is determined by the value of `rangeStep` and the cardinality of the field mapped to x-channel.   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plot with `row` and `column` channels, this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
           "type": "number"
         }
       },
@@ -2562,7 +2513,7 @@
           "description": "A key-value mapping between encoding channels and definition of fields."
         },
         "height": {
-          "description": "The height of a visualization.\n\n__Default value:__\n- For y-axis with a continuous (non-ordinal) scale, the height will be the value of [`config.cell.height`](config.html#cell-config).\n- For y-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the height is determined by the value of `rangeStep` and the cardinality of the field mapped to y-channel.   Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.cell.height`](config.html#cell-config).\n- If no field is mapped to `x` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plot with `row` and `column` channels, this represents the height of a single cell.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
+          "description": "The height of a visualization.\n\n__Default value:__\n- For y-axis with a continuous (non-ordinal) scale, the height will be the value of [`config.view.height`](spec.html#config).\n- For y-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the height is determined by the value of `rangeStep` and the cardinality of the field mapped to y-channel.   Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](spec.html#config).\n- If no field is mapped to `x` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plot with `row` and `column` channels, this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
           "type": "number"
         },
         "mark": {
@@ -2599,7 +2550,7 @@
           "type": "array"
         },
         "width": {
-          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- For x-axis with a continuous (non-ordinal) scale, the width will be the value of [`config.cell.width`](config.html#cell-config).\n- For x-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the width is determined by the value of `rangeStep` and the cardinality of the field mapped to x-channel.   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.cell.width`](config.html#cell-config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plot with `row` and `column` channels, this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- For x-axis with a continuous (non-ordinal) scale, the width will be the value of [`config.view.width`](spec.html#config).\n- For x-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the width is determined by the value of `rangeStep` and the cardinality of the field mapped to x-channel.   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plot with `row` and `column` channels, this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
           "type": "number"
         }
       },
@@ -2870,11 +2821,11 @@
       "additionalProperties": false,
       "properties": {
         "height": {
-          "description": "The height of a visualization.\n\n__Default value:__\n- For y-axis with a continuous (non-ordinal) scale, the height will be the value of [`config.cell.height`](config.html#cell-config).\n- For y-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the height is determined by the value of `rangeStep` and the cardinality of the field mapped to y-channel.   Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.cell.height`](config.html#cell-config).\n- If no field is mapped to `x` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plot with `row` and `column` channels, this represents the height of a single cell.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
+          "description": "The height of a visualization.\n\n__Default value:__\n- For y-axis with a continuous (non-ordinal) scale, the height will be the value of [`config.view.height`](spec.html#config).\n- For y-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the height is determined by the value of `rangeStep` and the cardinality of the field mapped to y-channel.   Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](spec.html#config).\n- If no field is mapped to `x` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plot with `row` and `column` channels, this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
           "type": "number"
         },
         "width": {
-          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- For x-axis with a continuous (non-ordinal) scale, the width will be the value of [`config.cell.width`](config.html#cell-config).\n- For x-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the width is determined by the value of `rangeStep` and the cardinality of the field mapped to x-channel.   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.cell.width`](config.html#cell-config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plot with `row` and `column` channels, this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- For x-axis with a continuous (non-ordinal) scale, the width will be the value of [`config.view.width`](spec.html#config).\n- For x-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the width is determined by the value of `rangeStep` and the cardinality of the field mapped to x-channel.   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plot with `row` and `column` channels, this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
           "type": "number"
         }
       },
@@ -5408,7 +5359,7 @@
           "description": "A key-value mapping between encoding channels and definition of fields."
         },
         "height": {
-          "description": "The height of a visualization.\n\n__Default value:__\n- For y-axis with a continuous (non-ordinal) scale, the height will be the value of [`config.cell.height`](config.html#cell-config).\n- For y-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the height is determined by the value of `rangeStep` and the cardinality of the field mapped to y-channel.   Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.cell.height`](config.html#cell-config).\n- If no field is mapped to `x` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plot with `row` and `column` channels, this represents the height of a single cell.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
+          "description": "The height of a visualization.\n\n__Default value:__\n- For y-axis with a continuous (non-ordinal) scale, the height will be the value of [`config.view.height`](spec.html#config).\n- For y-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the height is determined by the value of `rangeStep` and the cardinality of the field mapped to y-channel.   Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](spec.html#config).\n- If no field is mapped to `x` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plot with `row` and `column` channels, this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
           "type": "number"
         },
         "mark": {
@@ -5449,7 +5400,7 @@
           "type": "array"
         },
         "width": {
-          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- For x-axis with a continuous (non-ordinal) scale, the width will be the value of [`config.cell.width`](config.html#cell-config).\n- For x-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the width is determined by the value of `rangeStep` and the cardinality of the field mapped to x-channel.   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.cell.width`](config.html#cell-config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plot with `row` and `column` channels, this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- For x-axis with a continuous (non-ordinal) scale, the width will be the value of [`config.view.width`](spec.html#config).\n- For x-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the width is determined by the value of `rangeStep` and the cardinality of the field mapped to x-channel.   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plot with `row` and `column` channels, this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
           "type": "number"
         }
       },
@@ -5627,7 +5578,7 @@
           "type": "string"
         },
         "height": {
-          "description": "The height of a visualization.\n\n__Default value:__\n- For y-axis with a continuous (non-ordinal) scale, the height will be the value of [`config.cell.height`](config.html#cell-config).\n- For y-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the height is determined by the value of `rangeStep` and the cardinality of the field mapped to y-channel.   Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.cell.height`](config.html#cell-config).\n- If no field is mapped to `x` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plot with `row` and `column` channels, this represents the height of a single cell.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
+          "description": "The height of a visualization.\n\n__Default value:__\n- For y-axis with a continuous (non-ordinal) scale, the height will be the value of [`config.view.height`](spec.html#config).\n- For y-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the height is determined by the value of `rangeStep` and the cardinality of the field mapped to y-channel.   Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](spec.html#config).\n- If no field is mapped to `x` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plot with `row` and `column` channels, this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
           "type": "number"
         },
         "layer": {
@@ -5674,7 +5625,7 @@
           "type": "array"
         },
         "width": {
-          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- For x-axis with a continuous (non-ordinal) scale, the width will be the value of [`config.cell.width`](config.html#cell-config).\n- For x-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the width is determined by the value of `rangeStep` and the cardinality of the field mapped to x-channel.   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.cell.width`](config.html#cell-config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plot with `row` and `column` channels, this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- For x-axis with a continuous (non-ordinal) scale, the width will be the value of [`config.view.width`](spec.html#config).\n- For x-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the width is determined by the value of `rangeStep` and the cardinality of the field mapped to x-channel.   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plot with `row` and `column` channels, this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](size.html) contains more examples.",
           "type": "number"
         }
       },
@@ -5946,10 +5897,6 @@
     "VLOnlyConfig": {
       "additionalProperties": false,
       "properties": {
-        "cell": {
-          "$ref": "#/definitions/CellConfig",
-          "description": "Cell Config "
-        },
         "countTitle": {
           "description": "Default axis and legend title for count fields.\n\n__Default value:__ `'Number of Records'`.",
           "type": "string"
@@ -5980,6 +5927,10 @@
         "timeFormat": {
           "description": "Default datetime format for axis and legend labels. The format can be set directly on each axis and legend. Use [D3's time format pattern](https://github.com/d3/d3-time-format#locale_format).\n\n__Default value:__ `'%b %d, %Y'`.",
           "type": "string"
+        },
+        "view": {
+          "$ref": "#/definitions/ViewConfig",
+          "description": "Default properties for [single view plots](spec.html#single). "
         }
       },
       "type": "object"
@@ -6801,6 +6752,55 @@
         "orient": {
           "$ref": "#/definitions/TitleOrient",
           "description": "Default title orientation (\"top\", \"bottom\", \"left\", or \"right\")"
+        }
+      },
+      "type": "object"
+    },
+    "ViewConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "clip": {
+          "description": "Whether the view should be clipped.",
+          "type": "boolean"
+        },
+        "fill": {
+          "description": "The fill color.\n\n__Default value:__ (none)",
+          "type": "string"
+        },
+        "fillOpacity": {
+          "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ (none)",
+          "type": "number"
+        },
+        "height": {
+          "description": "The default height of the single plot or each plot in a trellis plot when the visualization has a continuous (non-ordinal) y-scale with `rangeStep` = `null`.\n\n__Default value:__ `200`",
+          "type": "number"
+        },
+        "stroke": {
+          "description": "The stroke color.\n\n__Default value:__ (none)",
+          "type": "string"
+        },
+        "strokeDash": {
+          "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.\n\n__Default value:__ (none)",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "strokeDashOffset": {
+          "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.\n\n__Default value:__ (none)",
+          "type": "number"
+        },
+        "strokeOpacity": {
+          "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ (none)",
+          "type": "number"
+        },
+        "strokeWidth": {
+          "description": "The stroke width, in pixels.\n\n__Default value:__ (none)",
+          "type": "number"
+        },
+        "width": {
+          "description": "The default width of the single plot or each plot in a trellis plot when the visualization has a continuous (non-ordinal) x-scale or ordinal x-scale with `rangeStep` = `null`.\n\n__Default value:__ `200`",
+          "type": "number"
         }
       },
       "type": "object"

--- a/examples/specs/bar_grouped.vl.json
+++ b/examples/specs/bar_grouped.vl.json
@@ -25,7 +25,7 @@
     }
   },
   "config": {
-    "cell": {"stroke": "transparent"},
+    "view": {"stroke": "transparent"},
     "axis": {"domainWidth": 1}
   }
 }

--- a/examples/specs/bar_grouped_horizontal.vl.json
+++ b/examples/specs/bar_grouped_horizontal.vl.json
@@ -25,7 +25,7 @@
     }
   },
   "config": {
-    "cell": {"stroke": "transparent"},
+    "view": {"stroke": "transparent"},
     "axis": {"domainWidth": 1}
   }
 }

--- a/examples/specs/facet_independent_scale.vl.json
+++ b/examples/specs/facet_independent_scale.vl.json
@@ -27,5 +27,5 @@
   "resolve": {
     "scale": {"x": "independent"}
   },
-  "config": {"cell": {"fill": "yellow"}}
+  "config": {"view": {"fill": "yellow"}}
 }

--- a/examples/specs/facet_independent_scale_layer.vl.json
+++ b/examples/specs/facet_independent_scale_layer.vl.json
@@ -47,5 +47,5 @@
   "resolve": {
     "scale": {"x": "independent"}
   },
-  "config": {"cell": {"fill": "yellow"}}
+  "config": {"view": {"fill": "yellow"}}
 }

--- a/examples/specs/normalized/bar_grouped_horizontal_normalized.vl.json
+++ b/examples/specs/normalized/bar_grouped_horizontal_normalized.vl.json
@@ -13,7 +13,7 @@
     }
   ],
   "config": {
-    "cell": {
+    "view": {
       "stroke": "transparent"
     },
     "axis": {

--- a/examples/specs/normalized/bar_grouped_normalized.vl.json
+++ b/examples/specs/normalized/bar_grouped_normalized.vl.json
@@ -13,7 +13,7 @@
     }
   ],
   "config": {
-    "cell": {
+    "view": {
       "stroke": "transparent"
     },
     "axis": {

--- a/examples/specs/rect_binned_heatmap.vl.json
+++ b/examples/specs/rect_binned_heatmap.vl.json
@@ -26,7 +26,7 @@
         "scheme": "greenblue"
       }
     },
-    "cell": {
+    "view": {
       "stroke": "transparent"
     }
   }

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -11,7 +11,6 @@ permalink: /docs/config.html
   ...,
   "config": {             // Configuration Object
     ...                   // - Top-level Configuration
-    "cell": { ... },      // - Cell Configuration
     "axis": { ... },      // - Axis Configuration
     "legend": { ... },    // - Legend Configuration
     "mark": { ... },      // - Mark Configuration
@@ -19,7 +18,8 @@ permalink: /docs/config.html
     "range": { ... },     // - Scale Range Configuration
     "scale": { ... },     // - Scale Configuration
     "selection": { ... }, // - Selection Configuration
-    "title": { ... }      // - title Configuration
+    "title": { ... },     // - title Configuration
+    "view": { ... }       // - View Configuration
   }
 }
 ```
@@ -37,36 +37,6 @@ A Vega-Lite `config` object can have the following top-level properties:
 {:#format}
 
 {% include table.html props="autoResize,background,countTitle,invalidValues,numberFormat,padding,timeFormat" source="Config" %}
-
-{:#cell-config}
-## Cell Configuration
-
-{: .suppress-error}
-```json
-{
-  ...,
-  "config": {          // Configuration Object
-    "cell": { ... },   // - Cell Configuration
-    ...
-  }
-}
-```
-
-At its core, a Vega-Lite specification describes a single plot. When a [facet channel](encoding.html#facet) is added, the visualization is faceted into a trellis plot, which contains multiple plots.
-Each plot in either a single plot or a trellis plot is called a _cell_. Cell configuration allows us to customize each single plot and each plot in a trellis plot.
-
-### Cell Size Configuration
-
-`width` and `height` property of the cell configuration determine the width of a visualization with a continuous x-scale and the height of a visualization with a continuous y-scale respectively.
-
-{% include table.html props="width,height" source="CellConfig" %}
-
-**For more information about visualization's size, please see [Customizing Size](size.html) page.**
-
-### Cell Style Configuration
-
-{% include table.html props="clip,fill,fillOpacity,stroke,strokeOpacity,strokeWidth,strokeDash,strokeDashOffset" source="CellConfig" %}
-
 
 {:#axis-config}
 ## Axis Configurations
@@ -109,3 +79,7 @@ In addition to the default mark properties above, default values can be further 
 ## Title Configuration
 
 {% include table.html props="title" source="Config" %}
+
+## View Configuration
+
+{% include table.html props="view" source="Config" %}

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -33,7 +33,7 @@ In addition to the [common properties](#common), any kind of top-level specifica
 
 
 ## Single View Specifications
-{:#single-view-spec}
+{:#single}
 
 {: .suppress-error}
 ```json
@@ -85,3 +85,34 @@ To create layered and multi-view graphics, please refer to the following pages:
 - [`facet`](facet.html)
 - [`concat`](concat.html)
 - [`repeat`](repeat.html)
+
+
+
+{:#config}
+## View Configuration
+
+{: .suppress-error}
+```json
+// Top-level View Specification
+{
+  ...,
+  "config": {          // Configuration Object
+    "view": { ... },   // - View Configuration
+    ...
+  }
+}
+```
+
+The style of a single view visualization can be customized by specifying the `view ` property of the `config` object.
+
+### Default View Size
+
+The `width` and `height` properties of the `view` configuration determine the width of a single view with a continuous x-scale and the height of a single view with a continuous y-scale respectively.
+
+{% include table.html props="width,height" source="ViewConfig" %}
+
+**For more information about view size, please see the [size](size.html) documentation.**
+
+### View Styles
+
+{% include table.html props="clip,fill,fillOpacity,stroke,strokeOpacity,strokeWidth,strokeDash,strokeDashOffset" source="ViewConfig" %}

--- a/site/docs/view/size.md
+++ b/site/docs/view/size.md
@@ -34,7 +34,7 @@ When the top-level `width` property is specified, the width of the single plot i
 
 If the top-level `width` / `height` property is not specified, the width / height of a single view is determined by the properties of the `x` / `y` channel:
 
-- If `x` / `y` axis has a continuous scale (either quantitative or time), the width/height is drawn directly from the [`config.cell.width`](config.html#cell-config) / [`config.cell.height`](config.html#cell-config) property.
+- If `x` / `y` axis has a continuous scale (either quantitative or time), the width/height is drawn directly from the [`config.view.width`](spec.html#config) / [`config.view.height`](spec.html#config) property.
 
 - If the `x` / `y` channel has a [discrete scale](scale.html#discrete) (`point` or `band`) with a numeric `rangeStep` value (default), the width / height is is determined based on the scale's `rangeStep`, `paddingInner`, `paddingOuter` and the cardinality of the encoded field (the number of possible distinct values of the field).
 
@@ -44,7 +44,7 @@ This example shows a plot with a continuous y-scale and a discrete x-scale:
 
 <span class="vl-example" data-name="bar_size_default"></span>
 
-- If the `x` / `y` channel has a discrete scale with `rangeStep` = `null`, the width / height is drawn directly from the [`config.cell.width`](config.html#cell-config) / [`config.cell.height`](config.html#cell-config) property and the band of the scale will be adjusted to fit to the width.
+- If the `x` / `y` channel has a discrete scale with `rangeStep` = `null`, the width / height is drawn directly from the [`config.view.width`](spec.html#config) / [`config.view.height`](spec.html#config) property and the band of the scale will be adjusted to fit to the width.
 
 <span class="vl-example" data-name="bar_size_fit"></span>
 

--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -1,5 +1,5 @@
 import {Channel, isScaleChannel} from '../channel';
-import {CellConfig, Config} from '../config';
+import {Config, ViewConfig} from '../config';
 import {field, FieldDef, FieldRefOption, isScaleFieldDef, isTimeFieldDef, OrderFieldDef} from '../fielddef';
 import {MarkConfig, MarkDef, TextConfig} from '../mark';
 import {ScaleType} from '../scale';
@@ -13,7 +13,7 @@ import {UnitModel} from './unit';
 
 
 export function applyConfig(e: VgEncodeEntry,
-    config: CellConfig | MarkConfig | TextConfig, // TODO(#1842): consolidate MarkConfig | TextConfig?
+    config: ViewConfig | MarkConfig | TextConfig, // TODO(#1842): consolidate MarkConfig | TextConfig?
     propsList: string[]) {
   for (const property of propsList) {
     const value = config[property];

--- a/src/compile/data/facet.ts
+++ b/src/compile/data/facet.ts
@@ -85,7 +85,7 @@ export class FacetNode extends DataFlowNode {
           if (field) {
             childIndependentFieldsWithStep[channel] = field;
           } else {
-            log.warn('Unknown field for ${channel}.  Cannot calculate cell size.');
+            log.warn('Unknown field for ${channel}.  Cannot calculate view size.');
           }
         }
       }

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -277,7 +277,7 @@ export class FacetModel extends ModelWithField {
               fields.push(field);
               ops.push('distinct');
             } else {
-              log.warn('Unknown field for ${channel}.  Cannot calculate cell size.');
+              log.warn('Unknown field for ${channel}.  Cannot calculate view size.');
             }
           }
         }

--- a/src/compile/layoutsize/parse.ts
+++ b/src/compile/layoutsize/parse.ts
@@ -103,9 +103,7 @@ function defaultUnitSize(model: UnitModel, sizeType: 'width' | 'height'): Layout
       // For discrete domain with range.step, use dynamic width/height
       return 'range-step';
     } else {
-      // FIXME(https://github.com/vega/vega-lite/issues/1975): revise config.cell name
-      // Otherwise, read this from cell config
-      return config.cell[sizeType];
+      return config.view[sizeType];
     }
   } else {
     // No scale - set default size

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -117,7 +117,6 @@ function defaultSizeRef(scaleName: string, scale: ScaleComponent, config: Config
   if (config.scale.rangeStep && config.scale.rangeStep !== null) {
     return {value: config.scale.rangeStep - 1};
   }
-  // TODO: this should depends on cell's width / height?
   return {value: 20};
 }
 

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -451,7 +451,7 @@ export abstract class Model {
               signal: sizeExpr(scaleName, scaleComponent, fieldRef)
             };
           } else {
-            log.warn('Unknown field for ${channel}.  Cannot calculate cell size.');
+            log.warn('Unknown field for ${channel}.  Cannot calculate view size.');
             return null;
           }
 

--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -424,15 +424,15 @@ export function getFieldFromDomain(domain: VgDomain): string {
         if (!field) {
           field = nonUnionDomain.field;
         } else if (field !== nonUnionDomain.field) {
-          log.warn('Detected faceted independent scales that union domain of multiple fields from different data sources.  We will use the first field.  The result cell size may be incorrect.');
+          log.warn('Detected faceted independent scales that union domain of multiple fields from different data sources.  We will use the first field.  The result view size may be incorrect.');
           return field;
         }
       }
     }
-    log.warn('Detected faceted independent scales that union domain of identical fields from different source detected.  We will assume that this is the same field from a different fork of the same data source.  However, if this is not case, the result cell size maybe incorrect.');
+    log.warn('Detected faceted independent scales that union domain of identical fields from different source detected.  We will assume that this is the same field from a different fork of the same data source.  However, if this is not case, the result view size maybe incorrect.');
     return field;
   } else if (isFieldRefUnionDomain(domain) && isString) {
-    log.warn('Detected faceted independent scales that union domain of multiple fields from the same data source.  We will use the first field.  The result cell size may be incorrect.');
+    log.warn('Detected faceted independent scales that union domain of multiple fields from the same data source.  We will use the first field.  The result view size may be incorrect.');
     const field = domain.fields[0];
     return isString(field) ? field : undefined;
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,7 +14,7 @@ import {duplicate, isObject, keys, mergeDeep} from './util';
 import {VgMarkConfig, VgScheme, VgTitleConfig} from './vega.schema';
 
 
-export interface CellConfig {
+export interface ViewConfig {
   /**
    * The default width of the single plot or each plot in a trellis plot when the visualization has a continuous (non-ordinal) x-scale or ordinal x-scale with `rangeStep` = `null`.
    *
@@ -94,7 +94,7 @@ export interface CellConfig {
   strokeDashOffset?: number;
 }
 
-export const defaultCellConfig: CellConfig = {
+export const defaultViewConfig: ViewConfig = {
   width: 200,
   height: 200
 };
@@ -166,8 +166,8 @@ export interface VLOnlyConfig {
   timeFormat?: string;
 
 
-  /** Cell Config */
-  cell?: CellConfig;
+  /** Default properties for [single view plots](spec.html#single). */
+  view?: ViewConfig;
 
   /**
    * Scale configuration determines default properties for all [scales](scale.html). For a full list of scale configuration options, please see the [corresponding section of the scale documentation](scale.html#config).
@@ -233,7 +233,7 @@ export const defaultConfig: Config = {
 
   invalidValues: 'filter',
 
-  cell: defaultCellConfig,
+  view: defaultViewConfig,
 
   mark: mark.defaultMarkConfig,
   area: {},
@@ -275,7 +275,7 @@ export function initConfig(config: Config) {
   return mergeDeep(duplicate(defaultConfig), config);
 }
 
-const MARK_STYLES = ['cell'].concat(PRIMITIVE_MARKS, COMPOSITE_MARK_STYLES) as ('cell' | Mark | CompositeMarkStyle)[];
+const MARK_STYLES = ['view'].concat(PRIMITIVE_MARKS, COMPOSITE_MARK_STYLES) as ('view' | Mark | CompositeMarkStyle)[];
 
 
 const VL_ONLY_CONFIG_PROPERTIES: (keyof Config)[] = [
@@ -285,7 +285,7 @@ const VL_ONLY_CONFIG_PROPERTIES: (keyof Config)[] = [
 ];
 
 const VL_ONLY_ALL_MARK_SPECIFIC_CONFIG_PROPERTY_INDEX = {
-  cell: ['width', 'height'],
+  view: ['width', 'height'],
   ...VL_ONLY_MARK_SPECIFIC_CONFIG_PROPERTY_INDEX,
   ...VL_ONLY_COMPOSITE_MARK_SPECIFIC_CONFIG_PROPERTY_INDEX
 };
@@ -350,8 +350,12 @@ export function stripAndRedirectConfig(config: Config) {
   return keys(config).length > 0 ? config : undefined;
 }
 
-function redirectConfig(config: Config, prop: Mark | CompositeMarkStyle | 'title' | 'cell', toProp?: string) {
+function redirectConfig(config: Config, prop: Mark | CompositeMarkStyle | 'title' | 'view', toProp?: string) {
   const propConfig: VgMarkConfig = prop === 'title' ? extractTitleConfig(config.title).mark : config[prop];
+
+  if (prop === 'view') {
+    toProp = 'cell'; // View's default style is "cell"
+  }
 
   const style: VgMarkConfig = {
     ...propConfig,

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -66,8 +66,8 @@ export interface LayoutSizeMixins {
    *
    * __Default value:__ This will be determined by the following rules:
    *
-   * - For x-axis with a continuous (non-ordinal) scale, the width will be the value of [`config.cell.width`](config.html#cell-config).
-   * - For x-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the width is determined by the value of `rangeStep` and the cardinality of the field mapped to x-channel.   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.cell.width`](config.html#cell-config).
+   * - For x-axis with a continuous (non-ordinal) scale, the width will be the value of [`config.view.width`](spec.html#config).
+   * - For x-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the width is determined by the value of `rangeStep` and the cardinality of the field mapped to x-channel.   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](spec.html#config).
    * - If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.
    *
    * __Note:__ For plot with `row` and `column` channels, this represents the width of a single view.
@@ -80,11 +80,11 @@ export interface LayoutSizeMixins {
    * The height of a visualization.
    *
    * __Default value:__
-   * - For y-axis with a continuous (non-ordinal) scale, the height will be the value of [`config.cell.height`](config.html#cell-config).
-   * - For y-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the height is determined by the value of `rangeStep` and the cardinality of the field mapped to y-channel.   Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.cell.height`](config.html#cell-config).
+   * - For y-axis with a continuous (non-ordinal) scale, the height will be the value of [`config.view.height`](spec.html#config).
+   * - For y-axis with an ordinal scale: if [`rangeStep`](scale.html#ordinal) is a numeric value (default), the height is determined by the value of `rangeStep` and the cardinality of the field mapped to y-channel.   Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](spec.html#config).
    * - If no field is mapped to `x` channel, the `height` will be the value of `rangeStep`.
    *
-   * __Note__: For plot with `row` and `column` channels, this represents the height of a single cell.
+   * __Note__: For plot with `row` and `column` channels, this represents the height of a single view.
    *
    * __See also:__ The documentation for [width and height](size.html) contains more examples.
    */

--- a/test/compile/data/facet.test.ts
+++ b/test/compile/data/facet.test.ts
@@ -30,7 +30,7 @@ describe('compile/data/facet', function() {
         'resolve': {
           'scale': {'x': 'independent'}
         },
-        'config': {'cell': {'fill': 'yellow'}}
+        'config': {'view': {'fill': 'yellow'}}
       });
 
       const node = new FacetNode(model, 'facetName', 'dataName');

--- a/test/compile/layoutsize/assemble.test.ts
+++ b/test/compile/layoutsize/assemble.test.ts
@@ -89,7 +89,7 @@ describe('compile/layout', () => {
       }]);
     });
 
-    it('should return static cell size for ordinal x-scale with null', () => {
+    it('should return static view size for ordinal x-scale with null', () => {
       const model = parseUnitModelWithScaleAndLayoutSize({
         mark: 'point',
         encoding: {
@@ -102,7 +102,7 @@ describe('compile/layout', () => {
     });
 
 
-    it('should return static cell size for ordinal y-scale with null', () => {
+    it('should return static view size for ordinal y-scale with null', () => {
       const model = parseUnitModelWithScaleAndLayoutSize({
         mark: 'point',
         encoding: {
@@ -114,7 +114,7 @@ describe('compile/layout', () => {
       assert.deepEqual(size, [{name: 'height', update: '200'}]);
     });
 
-    it('should return static cell size for ordinal scale with top-level width', () => {
+    it('should return static view size for ordinal scale with top-level width', () => {
       const model = parseUnitModelWithScaleAndLayoutSize({
         width: 205,
         mark: 'point',
@@ -127,7 +127,7 @@ describe('compile/layout', () => {
       assert.deepEqual(size, [{name: 'width', update: '205'}]);
     });
 
-    it('should return static cell size for ordinal scale with top-level width even if there is numeric rangeStep', () => {
+    it('should return static view size for ordinal scale with top-level width even if there is numeric rangeStep', () => {
       log.runLocalLogger((localLogger) => {
         const model = parseUnitModelWithScaleAndLayoutSize({
           width: 205,
@@ -143,7 +143,7 @@ describe('compile/layout', () => {
       });
     });
 
-    it('should return static cell width for non-ordinal x-scale', () => {
+    it('should return static view width for non-ordinal x-scale', () => {
       const model = parseUnitModelWithScaleAndLayoutSize({
         mark: 'point',
         encoding: {
@@ -156,7 +156,7 @@ describe('compile/layout', () => {
     });
 
 
-    it('should return static cell size for non-ordinal y-scale', () => {
+    it('should return static view size for non-ordinal y-scale', () => {
       const model = parseUnitModelWithScaleAndLayoutSize({
         mark: 'point',
         encoding: {

--- a/test/compile/layoutsize/parse.test.ts
+++ b/test/compile/layoutsize/parse.test.ts
@@ -37,28 +37,28 @@ describe('compile/layout', () => {
       assert.deepEqual(model.component.layoutSize.implicit.height, 23);
     });
 
-    it('should have width/height = config.cell.width/height for non-ordinal x,y', () => {
+    it('should have width/height = config.view.width/height for non-ordinal x,y', () => {
       const model = parseUnitModelWithScaleAndLayoutSize({
         mark: 'point',
         encoding: {
           x: {field: 'a', type: 'quantitative'},
           y: {field: 'b', type: 'quantitative'}
         },
-        config: {cell: {width: 123, height: 456}}
+        config: {view: {width: 123, height: 456}}
       });
 
       assert.deepEqual(model.component.layoutSize.implicit.width, 123);
       assert.deepEqual(model.component.layoutSize.implicit.height, 456);
     });
 
-    it('should have width/height = config.cell.width/height for non-ordinal x,y', () => {
+    it('should have width/height = config.view.width/height for non-ordinal x,y', () => {
       const model = parseUnitModelWithScaleAndLayoutSize({
         mark: 'point',
         encoding: {
           x: {field: 'a', type: 'ordinal', scale: {rangeStep: null}},
           y: {field: 'b', type: 'ordinal', scale: {rangeStep: null}}
         },
-        config: {cell: {width: 123, height: 456}}
+        config: {view: {width: 123, height: 456}}
       });
 
       assert.deepEqual(model.component.layoutSize.implicit.width, 123);
@@ -72,7 +72,7 @@ describe('compile/layout', () => {
           x: {field: 'a', type: 'ordinal'},
           y: {field: 'b', type: 'ordinal'}
         },
-        config: {cell: {width: 123, height: 456}}
+        config: {view: {width: 123, height: 456}}
       });
 
       assert.deepEqual(model.component.layoutSize.get('width'), 'range-step');

--- a/test/compile/mark/text.test.ts
+++ b/test/compile/mark/text.test.ts
@@ -141,7 +141,7 @@ describe('Mark: Text', function() {
     const childModel = model.children[0] as UnitModel;
     const props = text.encodeEntry(childModel);
 
-    it('should fit cell on x', function() {
+    it('should fit the view on x', function() {
       assert.deepEqual(props.x, {field: {group: 'width'}, offset: -5});
     });
 

--- a/test/compile/scale/range.test.ts
+++ b/test/compile/scale/range.test.ts
@@ -87,7 +87,7 @@ describe('compile/scale', () => {
       it('should return default topLevelSize if rangeStep config is null', () => {
         for (const scaleType of ['point', 'band'] as ScaleType[]) {
           assert.deepEqual(
-            parseRangeForChannel('x', scaleType, NOMINAL, {}, {cell: {width: 200}, scale: {rangeStep: null}}, undefined, 'point', undefined, 'plot_width', []).value,
+            parseRangeForChannel('x', scaleType, NOMINAL, {}, {view: {width: 200}, scale: {rangeStep: null}}, undefined, 'point', undefined, 'plot_width', []).value,
             [0, {signal: 'plot_width'}]
           );
         }
@@ -96,7 +96,7 @@ describe('compile/scale', () => {
       it('should return default topLevelSize for text if textXRangeStep config is null', () => {
         for (const scaleType of ['point', 'band'] as ScaleType[]) {
           assert.deepEqual(
-            parseRangeForChannel('x', scaleType, NOMINAL, {}, {cell: {width: 200}, scale: {textXRangeStep: null}}, undefined, 'text', undefined, 'plot_width', []).value,
+            parseRangeForChannel('x', scaleType, NOMINAL, {}, {view: {width: 200}, scale: {textXRangeStep: null}}, undefined, 'text', undefined, 'plot_width', []).value,
             [0, {signal: 'plot_width'}]
           );
         }

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -16,7 +16,7 @@ describe('config', () => {
         opacity: 0.5,
         ...defaultConfig.bar
       },
-      cell: {
+      view: {
         fill: '#eee'
       },
       title: {
@@ -43,6 +43,7 @@ describe('config', () => {
       assert.isUndefined(output.style.bar['binSpacing'], `VL only Bar config should be removed`);
       assert.isUndefined(output.style.cell['width'], `VL only cell config should be removed`);
       assert.isUndefined(output.style.cell['height'], `VL only cell config should be removed`);
+      assert.equal(output.style.cell['fill'], '#eee', `config.view should be redirect to config.style.cell`);
 
       assert.deepEqual(output.style.bar.opacity, 0.5, 'Bar config should be redirected to config.style.bar');
     });


### PR DESCRIPTION
"cell" is a weird keyword that is coming from nowhere. 

Naming it "View Config" makes it fit nicely in the View Specification page. 

This is obviously a breaking change, but I strongly think we should make it right as it is the last chance.  