### PR TITLE
Standardize naming: Use position rather than spatial

### DIFF
--- a/site/docs/composition/repeat.md
+++ b/site/docs/composition/repeat.md
@@ -41,4 +41,4 @@ Repeat can be used to create a scatterplot matrix (SPLOM), where each cell shows
 
 ## Resolve
 
-The default [resolutions](resolve.html) for repeat are independent scales and axes for spatial channels and shared scales and legends for legends.
+The default [resolutions](resolve.html) for repeat are independent scales and axes for position channels and shared scales and legends for legends.

--- a/site/docs/composition/resolve.md
+++ b/site/docs/composition/resolve.md
@@ -13,8 +13,8 @@ Vega-Lite determines whether scale domains should be unioned. If the scale domai
   "resolve": {
     CHANNEL: {
       "scale": ...,  // Scale resolution
-      "axis": ...,  // Axis resolution for spatial channels
-      "legend": ...  // Legend resolution for non-spatial channels
+      "axis": ...,  // Axis resolution for position channels
+      "legend": ...  // Legend resolution for non-position channels
     }
   }
 }

--- a/site/docs/encoding/axis.md
+++ b/site/docs/encoding/axis.md
@@ -5,7 +5,7 @@ title: Axis
 permalink: /docs/axis.html
 ---
 
-Axes provide axis lines, ticks and labels to convey how a spatial range represents a data range. Simply put, axes visualize scales.
+Axes provide axis lines, ticks and labels to convey how a positional range represents a data range. Simply put, axes visualize scales.
 
 By default, Vega-Lite automatically creates axes with default properties for `x` and `y` channels when they encode data fields.
 User can set the `axis` property of x- or y-[field definition](encoding.html#field) to an object to customize [axis properties](#axis-properties) or set `axis` to `null` to remove the axis.

--- a/site/docs/encoding/legend.md
+++ b/site/docs/encoding/legend.md
@@ -5,7 +5,7 @@ title: Legend
 permalink: /docs/legend.html
 ---
 
-Similar to [axes](axis.html), legends visualize scales. However, whereas axes aid interpretation of scales with spatial ranges, legends aid interpretation of scales with ranges such as colors, shapes and sizes.
+Similar to [axes](axis.html), legends visualize scales. However, whereas axes aid interpretation of scales with positional ranges, legends aid interpretation of scales with ranges such as colors, shapes and sizes.
 
 By default, Vega-Lite automatically creates legends with default properties for `color`, `opacity`, `size`, and `shape` channels when they encode data fields.
 User can set the `legend` property of a [mark property channel's field definition](encoding.html#mark-prop) to an object to customize [legend properties](#legend-properties) or set `legend` to `null` to remove the legend.

--- a/site/docs/selection/nearest.md
+++ b/site/docs/selection/nearest.md
@@ -13,7 +13,7 @@ In the scatterplot below, points <select onchange="changeSpec('paintbrush_neares
 
 <div id="paintbrush_nearest" class="vl-example" data-name="paintbrush_color_nearest"></div>
 
-The `nearest` transform also respects any [spatial encoding projections](project.html) applied to the selection. For instance, in the example below, moving the mouse cursor back-and-forth snaps the vertical rule and label to the nearest `date` value.
+The `nearest` transform also respects any [position encoding projections](project.html) applied to the selection. For instance, in the example below, moving the mouse cursor back-and-forth snaps the vertical rule and label to the nearest `date` value.
 
 <div id="paintbrush_nearest" class="vl-example" data-name="stocks_nearest_index"></div>
 

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -105,39 +105,39 @@ export function isChannel(str: string): str is Channel {
 export const UNIT_CHANNELS = flagKeys(UNIT_CHANNEL_INDEX);
 
 
-// NONSPATIAL_CHANNELS = UNIT_CHANNELS without X, Y, X2, Y2;
+// NONPOSITION_CHANNELS = UNIT_CHANNELS without X, Y, X2, Y2;
 const {
   x: _x, y: _y,
   // x2 and y2 share the same scale as x and y
   x2: _x2, y2: _y2,
   // The rest of unit channels then have scale
-  ...NONSPATIAL_CHANNEL_INDEX
+  ...NONPOSITION_CHANNEL_INDEX
 } = UNIT_CHANNEL_INDEX;
 
-export const NONSPATIAL_CHANNELS = flagKeys(NONSPATIAL_CHANNEL_INDEX);
-export type NonSpatialChannel = typeof NONSPATIAL_CHANNELS[0];
+export const NONPOSITION_CHANNELS = flagKeys(NONPOSITION_CHANNEL_INDEX);
+export type NonPositionChannel = typeof NONPOSITION_CHANNELS[0];
 
-// SPATIAL_SCALE_CHANNELS = X and Y;
-const SPATIAL_SCALE_CHANNEL_INDEX: {x:1, y:1} = {x:1, y:1};
-export const SPATIAL_SCALE_CHANNELS = flagKeys(SPATIAL_SCALE_CHANNEL_INDEX);
-export type SpatialScaleChannel = typeof SPATIAL_SCALE_CHANNELS[0];
+// POSITION_SCALE_CHANNELS = X and Y;
+const POSITION_SCALE_CHANNEL_INDEX: {x:1, y:1} = {x:1, y:1};
+export const POSITION_SCALE_CHANNELS = flagKeys(POSITION_SCALE_CHANNEL_INDEX);
+export type PositionScaleChannel = typeof POSITION_SCALE_CHANNELS[0];
 
-// NON_SPATIAL_SCALE_CHANNEL = SCALE_CHANNELS without X, Y
+// NON_POSITION_SCALE_CHANNEL = SCALE_CHANNELS without X, Y
 const {
     // x2 and y2 share the same scale as x and y
   // text and tooltip has format instead of scale
   text: _t, tooltip: _tt,
   // detail and order have no scale
   detail: _dd, order: _oo,
-  ...NONSPATIAL_SCALE_CHANNEL_INDEX
-} = NONSPATIAL_CHANNEL_INDEX;
-export const NONSPATIAL_SCALE_CHANNELS = flagKeys(NONSPATIAL_SCALE_CHANNEL_INDEX);
-export type NonspatialScaleChannel = typeof NONSPATIAL_SCALE_CHANNELS[0];
+  ...NONPOSITION_SCALE_CHANNEL_INDEX
+} = NONPOSITION_CHANNEL_INDEX;
+export const NONPOSITION_SCALE_CHANNELS = flagKeys(NONPOSITION_SCALE_CHANNEL_INDEX);
+export type NonPositionScaleChannel = typeof NONPOSITION_SCALE_CHANNELS[0];
 
 // Declare SCALE_CHANNEL_INDEX
 const SCALE_CHANNEL_INDEX = {
-  ...SPATIAL_SCALE_CHANNEL_INDEX,
-  ...NONSPATIAL_SCALE_CHANNEL_INDEX
+  ...POSITION_SCALE_CHANNEL_INDEX,
+  ...NONPOSITION_SCALE_CHANNEL_INDEX
 };
 
 /** List of channels with scales */

--- a/src/compile/axis/encode.ts
+++ b/src/compile/axis/encode.ts
@@ -1,5 +1,5 @@
 import {Axis} from '../../axis';
-import {Channel, SpatialScaleChannel, X} from '../../channel';
+import {Channel, PositionScaleChannel, X} from '../../channel';
 import {FieldDef, isTimeFieldDef} from '../../fielddef';
 import {ScaleType} from '../../scale';
 import {NOMINAL, ORDINAL} from '../../type';
@@ -9,7 +9,7 @@ import {timeFormatExpression} from '../common';
 import {Split} from '../split';
 import {UnitModel} from '../unit';
 
-export function labels(model: UnitModel, channel: SpatialScaleChannel, specifiedLabelsSpec: any, def: Split<Partial<VgAxis>>) {
+export function labels(model: UnitModel, channel: PositionScaleChannel, specifiedLabelsSpec: any, def: Split<Partial<VgAxis>>) {
   const fieldDef = model.fieldDef(channel) ||
     (
       channel === 'x' ? model.fieldDef('x2') :

--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -1,5 +1,5 @@
 import {Axis, AXIS_PROPERTIES, AXIS_PROPERTY_TYPE, AxisEncoding, VG_AXIS_PROPERTIES} from '../../axis';
-import {SPATIAL_SCALE_CHANNELS, SpatialScaleChannel} from '../../channel';
+import {POSITION_SCALE_CHANNELS, PositionScaleChannel} from '../../channel';
 import {keys, some} from '../../util';
 import {AxisOrient} from '../../vega.schema';
 import {VgAxis, VgAxisEncode} from '../../vega.schema';
@@ -16,7 +16,7 @@ type AxisPart = keyof AxisEncoding;
 const AXIS_PARTS: AxisPart[] = ['domain', 'grid', 'labels', 'ticks', 'title'];
 
 export function parseUnitAxis(model: UnitModel): AxisComponentIndex {
-  return SPATIAL_SCALE_CHANNELS.reduce(function(axis, channel) {
+  return POSITION_SCALE_CHANNELS.reduce(function(axis, channel) {
     if (model.axis(channel)) {
       const axisComponent: AxisComponent = {};
       // TODO: support multiple axis
@@ -53,7 +53,7 @@ export function parseLayerAxis(model: LayerModel) {
   for (const child of model.children) {
     child.parseAxisAndHeader();
 
-    keys(child.component.axes).forEach((channel: SpatialScaleChannel) => {
+    keys(child.component.axes).forEach((channel: PositionScaleChannel) => {
       resolve.axis[channel] = parseGuideResolve(model.component.resolve, channel);
       if (resolve.axis[channel] === 'shared') {
         // If the resolve says shared (and has not been overridden)
@@ -72,7 +72,7 @@ export function parseLayerAxis(model: LayerModel) {
   }
 
   // Move axes to layer's axis component and merge shared axes
-  ['x', 'y'].forEach((channel: SpatialScaleChannel) => {
+  ['x', 'y'].forEach((channel: PositionScaleChannel) => {
     for (const child of model.children) {
       if (!child.component.axes[channel]) {
         // skip if the child does not have a particular axis
@@ -202,16 +202,16 @@ function hasAxisPart(axis: AxisComponentPart, part: AxisPart) {
 /**
  * Make an inner axis for showing grid for shared axis.
  */
-export function parseGridAxis(channel: SpatialScaleChannel, model: UnitModel): AxisComponentPart {
+export function parseGridAxis(channel: PositionScaleChannel, model: UnitModel): AxisComponentPart {
   // FIXME: support adding ticks for grid axis that are inner axes of faceted plots.
   return parseAxis(channel, model, true);
 }
 
-export function parseMainAxis(channel: SpatialScaleChannel, model: UnitModel): AxisComponentPart {
+export function parseMainAxis(channel: PositionScaleChannel, model: UnitModel): AxisComponentPart {
   return parseAxis(channel, model, false);
 }
 
-function parseAxis(channel: SpatialScaleChannel, model: UnitModel, isGridAxis: boolean): AxisComponentPart {
+function parseAxis(channel: PositionScaleChannel, model: UnitModel, isGridAxis: boolean): AxisComponentPart {
   const axis = model.axis(channel);
 
   const axisComponent = new AxisComponentPart(
@@ -264,7 +264,7 @@ function parseAxis(channel: SpatialScaleChannel, model: UnitModel, isGridAxis: b
   return axisComponent;
 }
 
-function getProperty<K extends keyof (Axis|VgAxis)>(property: K, specifiedAxis: Axis, channel: SpatialScaleChannel, model: UnitModel, isGridAxis: boolean): VgAxis[K] {
+function getProperty<K extends keyof (Axis|VgAxis)>(property: K, specifiedAxis: Axis, channel: PositionScaleChannel, model: UnitModel, isGridAxis: boolean): VgAxis[K] {
   const fieldDef = model.fieldDef(channel);
 
   if ((isGridAxis && AXIS_PROPERTY_TYPE[property] === 'main') ||

--- a/src/compile/axis/properties.ts
+++ b/src/compile/axis/properties.ts
@@ -1,6 +1,6 @@
 import {Axis} from '../../axis';
 import {BinParams} from '../../bin';
-import {SpatialScaleChannel, X, Y} from '../../channel';
+import {PositionScaleChannel, X, Y} from '../../channel';
 import {Config} from '../../config';
 import {DateTime, dateTimeExpr, isDateTime} from '../../datetime';
 import {FieldDef, title as fieldDefTitle} from '../../fielddef';
@@ -11,7 +11,7 @@ import {VgSignalRef} from '../../vega.schema';
 import {UnitModel} from '../unit';
 
 
-export function domainAndTicks(property: 'domain' | 'ticks', specifiedAxis: Axis, isGridAxis: boolean, channel: SpatialScaleChannel) {
+export function domainAndTicks(property: 'domain' | 'ticks', specifiedAxis: Axis, isGridAxis: boolean, channel: PositionScaleChannel) {
   if (isGridAxis) {
     return false;
   }
@@ -30,9 +30,9 @@ export function grid(scaleType: ScaleType, fieldDef: FieldDef<string>) {
   return !hasDiscreteDomain(scaleType) && !fieldDef.bin;
 }
 
-export function gridScale(model: UnitModel, channel: SpatialScaleChannel, isGridAxis: boolean) {
+export function gridScale(model: UnitModel, channel: PositionScaleChannel, isGridAxis: boolean) {
   if (isGridAxis) {
-    const gridChannel: SpatialScaleChannel = channel === 'x' ? 'y' : 'x';
+    const gridChannel: PositionScaleChannel = channel === 'x' ? 'y' : 'x';
     if (model.getScaleComponent(gridChannel)) {
       return model.scaleName(gridChannel);
     }
@@ -41,7 +41,7 @@ export function gridScale(model: UnitModel, channel: SpatialScaleChannel, isGrid
 }
 
 
-export function labelOverlap(fieldDef: FieldDef<string>, specifiedAxis: Axis, channel: SpatialScaleChannel, scaleType: ScaleType) {
+export function labelOverlap(fieldDef: FieldDef<string>, specifiedAxis: Axis, channel: PositionScaleChannel, scaleType: ScaleType) {
   // do not prevent overlap for nominal data because there is no way to infer what the missing labels are
   if (fieldDef.type !== 'nominal') {
     if (scaleType === 'log') {
@@ -63,7 +63,7 @@ export function minMaxExtent(specifiedExtent: number, isGridAxis: boolean) {
   }
 }
 
-export function orient(channel: SpatialScaleChannel) {
+export function orient(channel: PositionScaleChannel) {
   switch (channel) {
     case X:
       return 'bottom';
@@ -74,7 +74,7 @@ export function orient(channel: SpatialScaleChannel) {
   throw new Error(log.message.INVALID_CHANNEL_FOR_AXIS);
 }
 
-export function tickCount(channel: SpatialScaleChannel, fieldDef: FieldDef<string>, scaleType: ScaleType, size: VgSignalRef) {
+export function tickCount(channel: PositionScaleChannel, fieldDef: FieldDef<string>, scaleType: ScaleType, size: VgSignalRef) {
   if (!hasDiscreteDomain(scaleType) && scaleType !== 'log' && !contains(['month', 'hours', 'day', 'quarter'], fieldDef.timeUnit)) {
 
     if (fieldDef.bin) {

--- a/src/compile/legend/assemble.ts
+++ b/src/compile/legend/assemble.ts
@@ -1,5 +1,5 @@
 import * as stringify from 'json-stable-stringify';
-import {NonspatialScaleChannel} from '../../channel';
+import {NonPositionScaleChannel} from '../../channel';
 import {flatten, keys, vals} from '../../util';
 import {VgLegend} from '../../vega.schema';
 import {Model} from '../model';
@@ -10,7 +10,7 @@ export function assembleLegends(model: Model): VgLegend[] {
   const legendComponentIndex = model.component.legends;
   const legendByDomain: {[domainHash: string]: LegendComponent[]} = {};
 
-  keys(legendComponentIndex).forEach((channel: NonspatialScaleChannel) => {
+  keys(legendComponentIndex).forEach((channel: NonPositionScaleChannel) => {
     const scaleComponent = model.getScaleComponent(channel);
     const domainHash = stringify(scaleComponent.domains);
     if (legendByDomain[domainHash]) {

--- a/src/compile/legend/component.ts
+++ b/src/compile/legend/component.ts
@@ -1,5 +1,5 @@
 import {Legend} from '../..//legend';
-import {NonspatialScaleChannel} from '../../channel';
+import {NonPositionScaleChannel} from '../../channel';
 import {VgLegend} from '../../vega.schema';
 import {Split} from '../split';
 
@@ -7,6 +7,6 @@ import {Split} from '../split';
 export class LegendComponent extends Split<Partial<VgLegend>> {}
 
 // Using Mapped Type to declare type (https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types)
-export type LegendComponentIndex = {[P in NonspatialScaleChannel]?: LegendComponent};
+export type LegendComponentIndex = {[P in NonPositionScaleChannel]?: LegendComponent};
 
-export type LegendIndex = {[P in NonspatialScaleChannel]?: Legend};
+export type LegendIndex = {[P in NonPositionScaleChannel]?: Legend};

--- a/src/compile/legend/encode.ts
+++ b/src/compile/legend/encode.ts
@@ -1,4 +1,4 @@
-import {Channel, COLOR, NonspatialScaleChannel, OPACITY, SHAPE} from '../../channel';
+import {Channel, COLOR, NonPositionScaleChannel, OPACITY, SHAPE} from '../../channel';
 import {FieldDef, isTimeFieldDef, isValueDef} from '../../fielddef';
 import {AREA, BAR, CIRCLE, FILL_STROKE_CONFIG, LINE, POINT, SQUARE, TEXT, TICK} from '../../mark';
 import {ScaleType} from '../../scale';
@@ -92,7 +92,7 @@ export function gradient(fieldDef: FieldDef<string>, gradientSpec: any, model: U
   return keys(gradient).length > 0 ? gradient : undefined;
 }
 
-export function labels(fieldDef: FieldDef<string>, labelsSpec: any, model: UnitModel, channel: NonspatialScaleChannel, legendCmpt: LegendComponent) {
+export function labels(fieldDef: FieldDef<string>, labelsSpec: any, model: UnitModel, channel: NonPositionScaleChannel, legendCmpt: LegendComponent) {
   const legend = model.legend(channel);
   const config = model.config;
 

--- a/src/compile/legend/parse.ts
+++ b/src/compile/legend/parse.ts
@@ -1,4 +1,4 @@
-import {Channel, COLOR, NonspatialScaleChannel, OPACITY, SHAPE, SIZE} from '../../channel';
+import {Channel, COLOR, NonPositionScaleChannel, OPACITY, SHAPE, SIZE} from '../../channel';
 import {title as fieldDefTitle} from '../../fielddef';
 import {Legend, LEGEND_PROPERTIES, VG_LEGEND_PROPERTIES} from '../../legend';
 import {deleteNestedProperty, keys} from '../../util';
@@ -47,7 +47,7 @@ function getLegendDefWithScale(model: UnitModel, channel: Channel): VgLegend {
   return null;
 }
 
-export function parseLegendForChannel(model: UnitModel, channel: NonspatialScaleChannel): LegendComponent {
+export function parseLegendForChannel(model: UnitModel, channel: NonPositionScaleChannel): LegendComponent {
   const fieldDef = model.fieldDef(channel);
   const legend = model.legend(channel);
 
@@ -82,7 +82,7 @@ export function parseLegendForChannel(model: UnitModel, channel: NonspatialScale
   return legendCmpt;
 }
 
-function getProperty(property: keyof (Legend | VgLegend), specifiedLegend: Legend, channel: NonspatialScaleChannel, model: UnitModel) {
+function getProperty(property: keyof (Legend | VgLegend), specifiedLegend: Legend, channel: NonPositionScaleChannel, model: UnitModel) {
   const fieldDef = model.fieldDef(channel);
 
   switch (property) {
@@ -107,7 +107,7 @@ function parseNonUnitLegend(model: Model) {
   for (const child of model.children) {
     parseLegend(child);
 
-    keys(child.component.legends).forEach((channel: NonspatialScaleChannel) => {
+    keys(child.component.legends).forEach((channel: NonPositionScaleChannel) => {
       resolve.legend[channel] = parseGuideResolve(model.component.resolve, channel);
 
       if (resolve.legend[channel] === 'shared') {
@@ -126,7 +126,7 @@ function parseNonUnitLegend(model: Model) {
     });
   }
 
-  keys(legends).forEach((channel: NonspatialScaleChannel) => {
+  keys(legends).forEach((channel: NonPositionScaleChannel) => {
     for (const child of model.children) {
       if (!child.component.legends[channel]) {
         // skip if the child does not have a particular legend

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -1,5 +1,5 @@
 import {isArray} from 'vega-util';
-import {NONSPATIAL_CHANNELS} from '../../channel';
+import {NONPOSITION_CHANNELS} from '../../channel';
 import {MAIN} from '../../data';
 import {isAggregate} from '../../encoding';
 import {field, getFieldDef} from '../../fielddef';
@@ -160,7 +160,7 @@ function parseNonPathMark(model: UnitModel) {
  * that the model's spec contains.
  */
 function detailFields(model: UnitModel): string[] {
-  return NONSPATIAL_CHANNELS.reduce(function(details, channel) {
+  return NONPOSITION_CHANNELS.reduce(function(details, channel) {
     const {encoding} = model;
     if (channel === 'order') {
       return details;

--- a/src/compile/mark/mixins.ts
+++ b/src/compile/mark/mixins.ts
@@ -1,4 +1,4 @@
-import {NONSPATIAL_SCALE_CHANNELS} from '../../channel';
+import {NONPOSITION_SCALE_CHANNELS} from '../../channel';
 import {ChannelDef, FieldDef, getFieldDef, isValueDef} from '../../fielddef';
 import * as log from '../../log';
 import {MarkDef} from '../../mark';
@@ -48,7 +48,7 @@ export function valueIfDefined(prop: string, value: string | number | boolean): 
 /**
  * Return mixins for non-positional channels with scales.  (Text doesn't have scale.)
  */
-export function nonPosition(channel: typeof NONSPATIAL_SCALE_CHANNELS[0], model: UnitModel, opt: {defaultValue?: number | string | boolean, vgChannel?: string, defaultRef?: VgValueRef} = {}): VgEncodeEntry {
+export function nonPosition(channel: typeof NONPOSITION_SCALE_CHANNELS[0], model: UnitModel, opt: {defaultValue?: number | string | boolean, vgChannel?: string, defaultRef?: VgValueRef} = {}): VgEncodeEntry {
   // TODO: refactor how we refer to scale as discussed in https://github.com/vega/vega-lite/pull/1613
 
   const {defaultValue, vgChannel} = opt;

--- a/src/compile/resolve.ts
+++ b/src/compile/resolve.ts
@@ -1,4 +1,4 @@
-import {ScaleChannel, SPATIAL_SCALE_CHANNELS} from '../channel';
+import {POSITION_SCALE_CHANNELS, ScaleChannel} from '../channel';
 import * as log from '../log';
 import {Resolve, ResolveMode} from '../resolve';
 import {contains} from '../util';
@@ -8,7 +8,7 @@ export function defaultScaleResolve(channel: ScaleChannel, model: Model): Resolv
   if (isLayerModel(model) || isFacetModel(model)) {
     return 'shared';
   } else if (isConcatModel(model) || isRepeatModel(model)) {
-    return contains(SPATIAL_SCALE_CHANNELS, channel) ? 'independent' : 'shared';
+    return contains(POSITION_SCALE_CHANNELS, channel) ? 'independent' : 'shared';
   }
   /* istanbul ignore next: should never reach here. */
   throw new Error('invalid model type for resolve');
@@ -16,7 +16,7 @@ export function defaultScaleResolve(channel: ScaleChannel, model: Model): Resolv
 
 export function parseGuideResolve(resolve: Resolve, channel: ScaleChannel): ResolveMode {
   const channelScaleResolve = resolve.scale[channel];
-  const guide = contains(SPATIAL_SCALE_CHANNELS, channel) ? 'axis' : 'legend';
+  const guide = contains(POSITION_SCALE_CHANNELS, channel) ? 'axis' : 'legend';
 
   if (channelScaleResolve === 'independent') {
     if (resolve[guide][channel] === 'shared') {

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -6,9 +6,9 @@ import {VgEventStream} from '../../vega.schema';
 import {UnitModel} from '../unit';
 import {
   channelSignalName,
+  positionalProjections,
   SelectionCompiler,
   SelectionComponent,
-  spatialProjections,
   STORE,
   TUPLE,
   unitName,
@@ -98,7 +98,7 @@ const interval:SelectionCompiler = {
 
   marks: function(model, selCmpt, marks) {
     const name = selCmpt.name;
-    const {xi, yi} = spatialProjections(selCmpt);
+    const {xi, yi} = positionalProjections(selCmpt);
     const store = `data(${stringValue(selCmpt.name + STORE)})`;
 
     // Do not add a brush if we're binding to scales.

--- a/src/compile/selection/selection.ts
+++ b/src/compile/selection/selection.ts
@@ -332,7 +332,7 @@ export function channelSignalName(selCmpt: SelectionComponent, channel: Channel,
   return varName(selCmpt.name + '_' + (range === 'visual' ? channel : selCmpt.fields[channel]));
 }
 
-export function spatialProjections(selCmpt: SelectionComponent) {
+export function positionalProjections(selCmpt: SelectionComponent) {
   let x:ProjectComponent = null;
   let xi:number = null;
   let y:ProjectComponent = null;

--- a/src/compile/selection/transforms/nearest.ts
+++ b/src/compile/selection/transforms/nearest.ts
@@ -1,5 +1,5 @@
 import * as log from '../../../log';
-import {spatialProjections} from '../selection';
+import {positionalProjections} from '../selection';
 import {TransformCompiler} from './transforms';
 
 const VORONOI = 'voronoi';
@@ -10,7 +10,7 @@ const nearest:TransformCompiler = {
   },
 
   marks: function(model, selCmpt, marks) {
-    const {x, y} = spatialProjections(selCmpt);
+    const {x, y} = positionalProjections(selCmpt);
     const markType = model.mark();
     if (markType === 'line' || markType === 'area') {
       log.warn(log.message.nearestNotSupportForContinuous(markType));

--- a/src/compile/selection/transforms/translate.ts
+++ b/src/compile/selection/transforms/translate.ts
@@ -1,7 +1,7 @@
 import {selector as parseSelector} from 'vega-event-selector';
 import {ScaleChannel, X, Y} from '../../../channel';
 import {BRUSH as INTERVAL_BRUSH} from '../interval';
-import {channelSignalName, SelectionComponent, spatialProjections} from '../selection';
+import {channelSignalName, positionalProjections, SelectionComponent} from '../selection';
 import {UnitModel} from './../../unit';
 import {default as scalesCompiler, domain} from './scales';
 import {TransformCompiler} from './transforms';
@@ -19,7 +19,7 @@ const translate:TransformCompiler = {
     const name = selCmpt.name;
     const hasScales = scalesCompiler.has(selCmpt);
     const anchor = name + ANCHOR;
-    const {x, y} = spatialProjections(selCmpt);
+    const {x, y} = positionalProjections(selCmpt);
     let events = parseSelector(selCmpt.translate, 'scope');
 
     if (!hasScales) {

--- a/src/compile/selection/transforms/zoom.ts
+++ b/src/compile/selection/transforms/zoom.ts
@@ -2,7 +2,7 @@ import {selector as parseSelector} from 'vega-event-selector';
 import {ScaleChannel, X, Y} from '../../../channel';
 import {stringValue} from '../../../util';
 import {BRUSH as INTERVAL_BRUSH} from '../interval';
-import {channelSignalName, SelectionComponent, spatialProjections} from '../selection';
+import {channelSignalName, positionalProjections, SelectionComponent} from '../selection';
 import {UnitModel} from './../../unit';
 import {default as scalesCompiler, domain} from './scales';
 import {TransformCompiler} from './transforms';
@@ -20,7 +20,7 @@ const zoom:TransformCompiler = {
     const name = selCmpt.name;
     const hasScales = scalesCompiler.has(selCmpt);
     const delta = name + DELTA;
-    const {x, y} = spatialProjections(selCmpt);
+    const {x, y} = positionalProjections(selCmpt);
     const sx = stringValue(model.scaleName(X));
     const sy = stringValue(model.scaleName(Y));
     let events = parseSelector(selCmpt.zoom, 'scope');

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -1,5 +1,5 @@
 import {Axis} from '../axis';
-import {Channel, NONSPATIAL_SCALE_CHANNELS, SCALE_CHANNELS, ScaleChannel, SingleDefChannel, X, Y} from '../channel';
+import {Channel, NONPOSITION_SCALE_CHANNELS, SCALE_CHANNELS, ScaleChannel, SingleDefChannel, X, Y} from '../channel';
 import {Config} from '../config';
 import * as vlEncoding from '../encoding';
 import {Encoding, normalizeEncoding} from '../encoding';
@@ -151,7 +151,7 @@ export class UnitModel extends ModelWithField {
   }
 
   private initLegend(encoding: Encoding<string>): LegendIndex {
-    return NONSPATIAL_SCALE_CHANNELS.reduce(function(_legend, channel) {
+    return NONPOSITION_SCALE_CHANNELS.reduce(function(_legend, channel) {
       const channelDef = encoding[channel];
       if (channelDef) {
         const legend = isFieldDef(channelDef) ? channelDef.legend :

--- a/src/compositemark/common.ts
+++ b/src/compositemark/common.ts
@@ -1,7 +1,7 @@
-import {NonSpatialChannel} from '../channel';
+import {NonPositionChannel} from '../channel';
 import {MarkConfig} from '../mark';
 
-export function getMarkSpecificConfigMixins(markSpecificConfig: MarkConfig, channel: NonSpatialChannel) {
+export function getMarkSpecificConfigMixins(markSpecificConfig: MarkConfig, channel: NonPositionChannel) {
   const value = markSpecificConfig[channel];
   return value !== undefined ? {[channel]: {value}} : {};
 }

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -210,8 +210,7 @@ export function forEach(mapping: any,
     return;
   }
 
-  keys(mapping).forEach((c: any) => {
-    const channel: Channel = c;
+  keys(mapping).forEach((channel: Channel) => {
     if (isArray(mapping[channel])) {
       mapping[channel].forEach(function(channelDef: ChannelDef<string>) {
         f.call(thisArg, channelDef, channel);
@@ -229,8 +228,7 @@ export function reduce<T, U>(mapping: U,
     return init;
   }
 
-  return keys(mapping).reduce((r: T, c: any) => {
-    const channel: Channel = c;
+  return keys(mapping).reduce((r: T, channel: Channel) => {
     if (isArray(mapping[channel])) {
       return mapping[channel].reduce(function(r1: T, channelDef: ChannelDef<string>) {
         return f.call(thisArg, r1, channelDef, channel);

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -1,4 +1,4 @@
-import {NonspatialScaleChannel, ScaleChannel, SpatialScaleChannel} from './channel';
+import {NonPositionScaleChannel, PositionScaleChannel, ScaleChannel} from './channel';
 
 
 export type ResolveMode = 'independent' | 'shared';
@@ -16,9 +16,9 @@ export type ScaleResolveMap = {
 };
 
 export type AxisResolveMap = {
-  [C in SpatialScaleChannel]?: ResolveMode
+  [C in PositionScaleChannel]?: ResolveMode
 };
 
 export type LegendResolveMap = {
-  [C in NonspatialScaleChannel]?: ResolveMode
+  [C in NonPositionScaleChannel]?: ResolveMode
 };

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -1,5 +1,5 @@
 import {SUM_OPS} from './aggregate';
-import {NONSPATIAL_CHANNELS, NonSpatialChannel, X, X2, Y, Y2} from './channel';
+import {NONPOSITION_CHANNELS, NonPositionChannel, X, X2, Y, Y2} from './channel';
 import {channelHasField, Encoding, isAggregate} from './encoding';
 import {Field, FieldDef, getFieldDef, isFieldDef, PositionFieldDef} from './fielddef';
 import * as log from './log';
@@ -20,7 +20,7 @@ export interface StackProperties {
   /** Stack-by fields e.g., color, detail */
   stackBy: {
     fieldDef: FieldDef<string>,
-    channel: NonSpatialChannel
+    channel: NonPositionChannel
   }[];
 
   /**
@@ -53,7 +53,7 @@ export function stack(m: Mark | MarkDef, encoding: Encoding<Field>, stackConfig:
   }
 
   // Should have grouping level of detail
-  const stackBy = NONSPATIAL_CHANNELS.reduce((sc, channel) => {
+  const stackBy = NONPOSITION_CHANNELS.reduce((sc, channel) => {
     if (channelHasField(encoding, channel)) {
       const channelDef = encoding[channel];
       (isArray(channelDef) ? channelDef : [channelDef]).forEach((cDef) => {

--- a/test/channel.test.ts
+++ b/test/channel.test.ts
@@ -1,6 +1,6 @@
 import {assert} from 'chai';
 import {Channel, isScaleChannel, rangeType, SINGLE_DEF_CHANNELS} from '../src/channel';
-import {CHANNELS, NONSPATIAL_SCALE_CHANNELS, SCALE_CHANNELS, UNIT_CHANNELS} from '../src/channel';
+import {CHANNELS, NONPOSITION_SCALE_CHANNELS, SCALE_CHANNELS, UNIT_CHANNELS} from '../src/channel';
 import {without} from '../src/util';
 
 describe('channel', () => {
@@ -22,9 +22,9 @@ describe('channel', () => {
     });
   });
 
-  describe('NONSPATIAL_SCALE_CHANNELS', () => {
+  describe('NONPOSITION_SCALE_CHANNELS', () => {
     it('should be SCALE_CHANNELS without x, y, x2, y2', () => {
-      assert.deepEqual(NONSPATIAL_SCALE_CHANNELS, without(SCALE_CHANNELS, ['x', 'y']));
+      assert.deepEqual(NONPOSITION_SCALE_CHANNELS, without(SCALE_CHANNELS, ['x', 'y']));
     });
   });
 

--- a/test/compile/scale/properties.test.ts
+++ b/test/compile/scale/properties.test.ts
@@ -2,7 +2,7 @@
 
 import {assert} from 'chai';
 
-import {Channel, NONSPATIAL_SCALE_CHANNELS} from '../../../src/channel';
+import {Channel, NONPOSITION_SCALE_CHANNELS} from '../../../src/channel';
 import {ScaleType} from '../../../src/scale';
 
 import * as rules from '../../../src/compile/scale/properties';
@@ -43,7 +43,7 @@ describe('compile/scale', () => {
     });
 
     it('should be undefined for non-xy channels.', () => {
-      for (const c of NONSPATIAL_SCALE_CHANNELS) {
+      for (const c of NONPOSITION_SCALE_CHANNELS) {
         assert.equal(rules.paddingInner(undefined, c, {bandPaddingInner: 15}), undefined);
       }
     });
@@ -68,7 +68,7 @@ describe('compile/scale', () => {
     });
 
     it('should be undefined for non-xy channels.', () => {
-      for (const c of NONSPATIAL_SCALE_CHANNELS) {
+      for (const c of NONPOSITION_SCALE_CHANNELS) {
         for (const scaleType of ['point', 'band'] as ScaleType[]) {
           assert.equal(rules.paddingOuter(undefined, c, scaleType, 0, {}), undefined);
         }


### PR DESCRIPTION
(We use position more than spatial so let's use position.)