### PR TITLE
Automatically convert constant value to valueDef  (e.g., `x:5` to `x:…

### DIFF
--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -1,5 +1,6 @@
 // utility for a field definition object
 
+import {isNumber} from 'vega-util';
 import {AggregateOp, isAggregateOp, isCountingAggregateOp} from './aggregate';
 import {Axis} from './axis';
 import {autoMaxBins, BinParams, binToString} from './bin';
@@ -374,6 +375,13 @@ export function getFieldDef<F>(channelDef: ChannelDef<F>): FieldDef<F> {
  * Convert type to full, lowercase type, or augment the fieldDef with a default type if missing.
  */
 export function normalize(channelDef: ChannelDef<string>, channel: Channel): ChannelDef<any> {
+  if (isString(channelDef) || isNumber(channelDef) || isBoolean(channelDef)) {
+    const primitiveType = isString(channelDef) ? 'string' :
+      isNumber(channelDef) ? 'number' : 'boolean';
+    log.warn(log.message.primitiveChannelDef(channel, primitiveType, channelDef));
+    return {value: channelDef};
+  }
+
   // If a fieldDef contains a field, we need type.
   if (isFieldDef(channelDef)) {
     return normalizeFieldDef(channelDef, channel);

--- a/src/log.ts
+++ b/src/log.ts
@@ -145,6 +145,11 @@ export namespace message {
   export const NO_FIELDS_NEEDS_AS = 'If "from.fields" is not specified, "as" has to be a string that specifies the key to be used for the the data from the secondary source.';
 
   // ENCODING & FACET
+
+  export function primitiveChannelDef(channel: Channel, type: 'string' | 'number' | 'boolean', value: string | number | boolean) {
+    return `Channel ${channel} is a ${type}. Converted to {value: ${value}}.`;
+  }
+
   export function invalidFieldType(type: Type) {
     return `Invalid field type "${type}"`;
   }

--- a/test/fielddef.test.ts
+++ b/test/fielddef.test.ts
@@ -31,6 +31,11 @@ describe('fieldDef', () => {
   });
 
   describe('normalize()', () => {
+    it('should convert primitive type to value def', log.wrap((localLogger) => {
+      assert.deepEqual<ChannelDef<string>>(normalize(5 as any, 'x'), {value: 5});
+      assert.equal(localLogger.warns.length, 1);
+    }));
+
     it('should return fieldDef with full type name.', () => {
       const fieldDef: FieldDef<string> = {field: 'a', type: 'q' as any};
       assert.deepEqual<ChannelDef<string>>(normalize(fieldDef, 'x'), {field: 'a', type: 'quantitative'});


### PR DESCRIPTION
… {value: 5}`)

I think I mistakenly forgot to wrap constant with `{value: ...}` a few times already.  This would be helpful to users to inform them about the right syntax. 

We may revise if we wanna include this in the schema in the future, but I'm not sure if we should do that yet, but I'm pretty sure that having some warning & conversion is helpful. 