### PR TITLE
Better wording for logger docs. We throw errors.

### DIFF
--- a/site/usage/compile.md
+++ b/site/usage/compile.md
@@ -20,7 +20,7 @@ If you want access to the compiled Vega spec from a Javascript program, you can 
 var vgSpec = vl.compile(vlSpec).spec;
 ```
 
-By default, warnings and other messages are printed to the JavaScript console. To customize how information is logged, you can pass a customize logger to the compile function.
+By default, warnings and other messages are printed to the JavaScript console (via `console.log/warn` methods). To redirect the log messages, you can pass a customize logger to the compile function to listen to all logging events.
 
 ```js
 var vgSpec = vl.compile(vlSpec, logger).spec;

--- a/site/usage/compile.md
+++ b/site/usage/compile.md
@@ -20,7 +20,7 @@ If you want access to the compiled Vega spec from a Javascript program, you can 
 var vgSpec = vl.compile(vlSpec).spec;
 ```
 
-By default, warnings and other messages are printed to the JavaScript console (via `console.log/warn` methods). To redirect the log messages, you can pass a customize logger to the compile function to listen to all logging events.
+By default, warnings and other messages are printed to the JavaScript console (via `console.log/warn` methods). To redirect the log messages, you can pass a customize logger to the compile function.
 
 ```js
 var vgSpec = vl.compile(vlSpec, logger).spec;

--- a/site/usage/compile.md
+++ b/site/usage/compile.md
@@ -20,7 +20,7 @@ If you want access to the compiled Vega spec from a Javascript program, you can 
 var vgSpec = vl.compile(vlSpec).spec;
 ```
 
-By default, warnings and other messages are printed to the JavaScript console. To customize how infromation is logged, you can pass a customize logger to the compile function.
+By default, warnings and other messages are printed to the JavaScript console. To customize how information is logged, you can pass a customize logger to the compile function.
 
 ```js
 var vgSpec = vl.compile(vlSpec, logger).spec;

--- a/site/usage/compile.md
+++ b/site/usage/compile.md
@@ -20,7 +20,7 @@ If you want access to the compiled Vega spec from a Javascript program, you can 
 var vgSpec = vl.compile(vlSpec).spec;
 ```
 
-By default, warnings and errors are printed to the JavaScript console. To customize how errors and warnings are handled, you can pass a customize logger to the compile function. 
+By default, warnings and other messages are printed to the JavaScript console. To customize how infromation is logged, you can pass a customize logger to the compile function.
 
 ```js
 var vgSpec = vl.compile(vlSpec, logger).spec;


### PR DESCRIPTION
cc @nyurik 