### PR TITLE
Make axis.labelOverlap used if specified

### DIFF
--- a/src/compile/axis/properties.ts
+++ b/src/compile/axis/properties.ts
@@ -42,6 +42,10 @@ export function gridScale(model: UnitModel, channel: PositionScaleChannel, isGri
 
 
 export function labelOverlap(fieldDef: FieldDef<string>, specifiedAxis: Axis, channel: PositionScaleChannel, scaleType: ScaleType) {
+  if (specifiedAxis.labelOverlap !== undefined) {
+    return specifiedAxis.labelOverlap;
+  }
+
   // do not prevent overlap for nominal data because there is no way to infer what the missing labels are
   if (fieldDef.type !== 'nominal') {
     if (scaleType === 'log') {


### PR DESCRIPTION
Fix #3045

