### PR TITLE
Added marked-vega

### DIFF
--- a/site/usage/applications.md
+++ b/site/usage/applications.md
@@ -29,6 +29,7 @@ This is an incomplete list of integrations, applications, and extensions of the 
 * [vega-desktop](https://github.com/kristw/vega-desktop), a desktop app that let you open `.vg.json` and `.vl.json` to see visualizations just like you open image files with an image viewer. Can also be used for [creating visualizations with Vega/Vega-Lite locally](https://medium.com/@kristw/create-visualizations-with-vega-on-your-machine-using-your-preferred-editor-529e1be875c0).
 * [Visdown](http://visdown.com), a web app to create Vega-Lite visualizations in Markdown. Specs are written in [YAML](http://www.yaml.org/) (not JSON) within `code` blocks.
 * [vega-element](https://www.webcomponents.org/element/PolymerVis/vega-element) is a Polymer web component to embed Vega or Vega-Lite visualization using custom HTML tags.
+* [marked-vega](https://www.webcomponents.org/element/PolymerVis/marked-vega) is a Polymer web component to parse image/code markdowns into Vega and Vega-Lite charts.
 
 ## Libraries
 


### PR DESCRIPTION
Added `marked-vega` to list of application for Vega-Lite.

`marked-vega` is a Polymer webcomponent to parse image/code markdowns into Vega or Vega-Lite charts.

