### PR TITLE
We don’t use vega extend.

### DIFF
--- a/typings/vega-util.d.ts
+++ b/typings/vega-util.d.ts
@@ -14,11 +14,6 @@ declare module 'vega-util' {
   export function log(...args: any[]): void;
   export function logger(_: number): LoggerInterface;
 
-  export function extend<T, U, V, W>(a: T, b: U, c: V, d: W): T & U & V & W;
-  export function extend<T, U, V>(a: T, b: U, c: V): T & U & V;
-  export function extend<T, U>(a: T, b: U): T & U;
-  export function extend(...all: any[]): any;
-
   export function truncate(a: string, length: number): string;
 
   export function isArray<T>(a: any | T[]): a is T[];


### PR DESCRIPTION
Removing this prevents us from accidentally using it. 