### PR TITLE
Use Vega datasets from npm so it can be cached.

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "typescript": "^2.5.3",
     "uglify-js": "^3.1.5",
     "vega": "^3.0.7",
-    "vega-datasets": "vega/vega-datasets#gh-pages",
+    "vega-datasets": "^1.10.0",
     "vega-embed": "^3.0.0-rc6",
     "vega-tooltip": "^0.4.4",
     "watchify": "^3.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5561,7 +5561,7 @@ vega-dataflow@3:
     vega-loader "2"
     vega-util "1"
 
-"vega-datasets@github:vega/vega-datasets#gh-pages", vega-datasets@vega/vega-datasets#gh-pages:
+vega-datasets@^1.10.0, vega-datasets@vega/vega-datasets#gh-pages:
   version "1.10.0"
   resolved "https://codeload.github.com/vega/vega-datasets/tar.gz/7080ba8297825d27495bdfb8386d10cff83cbacf"
 


### PR DESCRIPTION
See https://github.com/jupyterlab/jupyter-renderers/pull/15#issuecomment-340522499