### PR TITLE
Added gulp-marked-vega

### DIFF
--- a/site/usage/applications.md
+++ b/site/usage/applications.md
@@ -38,3 +38,4 @@ This is an incomplete list of integrations, applications, and extensions of the 
 * [Tooltips for Vega and Vega-Lite](https://github.com/vega/vega-lite-tooltip)
 * [vega-element](https://www.webcomponents.org/element/PolymerVis/vega-element) is a Polymer web component to embed Vega or Vega-Lite visualization using custom HTML tags.
 * [marked-vega](https://www.webcomponents.org/element/PolymerVis/marked-vega) is a Polymer web component to parse image/code markdowns into Vega and Vega-Lite charts.
+* [gulp-marked-vega](https://github.com/e2fyi/gulp-marked-vega) is a gulp plugin (comes with a cli tool also) to replace [marked-vega](https://www.webcomponents.org/element/PolymerVis/marked-vega) markdown syntax with base64 embedded image tags, so that any standard markdown parser can render the Vega and Vega-Lite charts without modifying their render rules.


### PR DESCRIPTION
Added `gulp-marked-vega` to libraries available for Vega and Vega-Lite markdowns. 

`gulp-marked-vega` is a gulp plugin and a cli tool to replace `marked-vega` markdown syntax with base64 embedded image tags so that standard markdown parser can render the charts without any additional plugins or modification to the rendering rules. 
