### PR TITLE
Remove an error thrown for condition-only def

### DIFF
--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -133,7 +133,7 @@ export function midPoint(channel: Channel, channelDef: ChannelDef<string>, scale
     } else if (isValueDef(channelDef)) {
       return {value: channelDef.value};
     } else {
-      throw new Error('A channel definition has neither field nor value.'); // FIXME add this to log.message
+      return undefined;
     }
   }
 

--- a/test/compile/mark/point.test.ts
+++ b/test/compile/mark/point.test.ts
@@ -159,6 +159,24 @@ describe('Mark: Point', function() {
     });
   });
 
+  describe('with x, y, and condition-only color', function () {
+    const model = parseUnitModelWithScaleAndLayoutSize({
+      ...pointXY({
+      "color": {"condition": {"selection": "test", "field": "yield", "type": "quantitative"}}
+      }),
+      selection: {test: {type: 'single'}}
+    });
+    model.parseSelection();
+    const props = point.encodeEntry(model);
+
+    it('should have one condition for color with scale for "yield"', function () {
+      assert.isArray(props.stroke);
+      assert.equal(props.stroke['length'], 1);
+      assert.equal(props.stroke[0].scale, COLOR);
+      assert.equal(props.stroke[0].field, 'yield');
+    });
+  });
+
   describe('with x, y, shape', function () {
     const model = parseUnitModelWithScaleAndLayoutSize(pointXY({
       "shape": {"field": "site", "type": "nominal"}


### PR DESCRIPTION
  For example, this spec should not get error:

```
{
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "description": "Select multiple points with the shift key.",
  "data": {"url": "data/cars.json"},
  "selection": {
    "paintbrush": {
      "type": "multi", "on": "mouseover",
      "nearest": true
    }
  },
  "mark": "point",
  "encoding": {
    "x": {"field": "Horsepower", "type": "quantitative"},
    "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
    "size": {
      "condition": {"selection": "paintbrush", "value": 300}
    }
  }
}
```