### PR TITLE
Default Boxplot to Tukey boxplot

### DIFF
--- a/examples/compiled/box-plot_minmax_1D_horizontal.vg.json
+++ b/examples/compiled/box-plot_minmax_1D_horizontal.vg.json
@@ -35,9 +35,24 @@
                         "lower_box_people",
                         "upper_box_people",
                         "mid_box_people",
-                        "lower_whisker_people",
-                        "upper_whisker_people"
+                        "min_people",
+                        "max_people"
                     ]
+                },
+                {
+                    "type": "formula",
+                    "expr": "datum.upper_box_people - datum.lower_box_people",
+                    "as": "iqr_people"
+                },
+                {
+                    "type": "formula",
+                    "expr": "min(datum.upper_box_people + datum.iqr_people * 1.5, datum.max_people)",
+                    "as": "upper_whisker_people"
+                },
+                {
+                    "type": "formula",
+                    "expr": "max(datum.lower_box_people - datum.iqr_people * 1.5, datum.min_people)",
+                    "as": "lower_whisker_people"
                 }
             ]
         },

--- a/examples/compiled/box-plot_minmax_1D_vertical.vg.json
+++ b/examples/compiled/box-plot_minmax_1D_vertical.vg.json
@@ -35,9 +35,24 @@
                         "lower_box_people",
                         "upper_box_people",
                         "mid_box_people",
-                        "lower_whisker_people",
-                        "upper_whisker_people"
+                        "min_people",
+                        "max_people"
                     ]
+                },
+                {
+                    "type": "formula",
+                    "expr": "datum.upper_box_people - datum.lower_box_people",
+                    "as": "iqr_people"
+                },
+                {
+                    "type": "formula",
+                    "expr": "min(datum.upper_box_people + datum.iqr_people * 1.5, datum.max_people)",
+                    "as": "upper_whisker_people"
+                },
+                {
+                    "type": "formula",
+                    "expr": "max(datum.lower_box_people - datum.iqr_people * 1.5, datum.min_people)",
+                    "as": "lower_whisker_people"
                 }
             ]
         },

--- a/examples/compiled/box-plot_minmax_2D_horizontal_explicit_aggregate.vg.json
+++ b/examples/compiled/box-plot_minmax_2D_horizontal_explicit_aggregate.vg.json
@@ -36,9 +36,24 @@
                         "lower_box_people",
                         "upper_box_people",
                         "mid_box_people",
-                        "lower_whisker_people",
-                        "upper_whisker_people"
+                        "min_people",
+                        "max_people"
                     ]
+                },
+                {
+                    "type": "formula",
+                    "expr": "datum.upper_box_people - datum.lower_box_people",
+                    "as": "iqr_people"
+                },
+                {
+                    "type": "formula",
+                    "expr": "min(datum.upper_box_people + datum.iqr_people * 1.5, datum.max_people)",
+                    "as": "upper_whisker_people"
+                },
+                {
+                    "type": "formula",
+                    "expr": "max(datum.lower_box_people - datum.iqr_people * 1.5, datum.min_people)",
+                    "as": "lower_whisker_people"
                 }
             ]
         },

--- a/examples/compiled/box-plot_minmax_2D_vertical.vg.json
+++ b/examples/compiled/box-plot_minmax_2D_vertical.vg.json
@@ -36,9 +36,24 @@
                         "lower_box_people",
                         "upper_box_people",
                         "mid_box_people",
-                        "lower_whisker_people",
-                        "upper_whisker_people"
+                        "min_people",
+                        "max_people"
                     ]
+                },
+                {
+                    "type": "formula",
+                    "expr": "datum.upper_box_people - datum.lower_box_people",
+                    "as": "iqr_people"
+                },
+                {
+                    "type": "formula",
+                    "expr": "min(datum.upper_box_people + datum.iqr_people * 1.5, datum.max_people)",
+                    "as": "upper_whisker_people"
+                },
+                {
+                    "type": "formula",
+                    "expr": "max(datum.lower_box_people - datum.iqr_people * 1.5, datum.min_people)",
+                    "as": "lower_whisker_people"
                 }
             ]
         },

--- a/examples/compiled/layer_box-plot_circle.vg.json
+++ b/examples/compiled/layer_box-plot_circle.vg.json
@@ -40,9 +40,24 @@
                         "lower_box_people",
                         "upper_box_people",
                         "mid_box_people",
-                        "lower_whisker_people",
-                        "upper_whisker_people"
+                        "min_people",
+                        "max_people"
                     ]
+                },
+                {
+                    "type": "formula",
+                    "expr": "datum.upper_box_people - datum.lower_box_people",
+                    "as": "iqr_people"
+                },
+                {
+                    "type": "formula",
+                    "expr": "min(datum.upper_box_people + datum.iqr_people * 1.5, datum.max_people)",
+                    "as": "upper_whisker_people"
+                },
+                {
+                    "type": "formula",
+                    "expr": "max(datum.lower_box_people - datum.iqr_people * 1.5, datum.min_people)",
+                    "as": "lower_whisker_people"
                 }
             ]
         },

--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -47,7 +47,10 @@ export const BOXPLOT_STYLES: BoxPlotStyle[] = ['boxWhisker', 'box', 'boxMid'];
 export interface BoxPlotConfig extends MarkConfig {
   /** Size of the box and mid tick of a box plot */
   size?: number;
-  /** Same as BoxPlotDef extent property */
+  /** The default extent, which is used to determine where the whiskers extend to. The options are
+   * - `"min-max": min and max are the lower and upper whiskers respectively.
+   * - `"number": A scalar (integer or floating point number) that will be multiplied by the IQR and the product will be added to the third quartile to get the upper whisker and subtracted from the first quartile to get the lower whisker.
+   */
   extent?: 'min-max' | number;
 }
 

--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -1,4 +1,4 @@
-import {isNumber} from 'vega-util';
+import {isNumber} from 'util';
 import {Channel} from '../channel';
 import {Config} from '../config';
 import {reduce} from '../encoding';
@@ -32,8 +32,8 @@ export interface BoxPlotDef {
   /**
    * Extent is used to determine where the whiskers extend to. The options are
    * - `"min-max": min and max are the lower and upper whiskers respectively.
-   * - `"number": A scalar (integer or floating point number) that will be multiplied by the IQR and the product will be added to the third quartile to get the upper whisker and subtracted from the first quartile to get the lower whisker.
-   * __Default value:__ `"min-max"`.
+   * -  A scalar (integer or floating point number) that will be multiplied by the IQR and the product will be added to the third quartile to get the upper whisker and subtracted from the first quartile to get the lower whisker.
+   * __Default value:__ `"1.5"`.
    */
   extent?: 'min-max' | number;
 }
@@ -47,6 +47,8 @@ export const BOXPLOT_STYLES: BoxPlotStyle[] = ['boxWhisker', 'box', 'boxMid'];
 export interface BoxPlotConfig extends MarkConfig {
   /** Size of the box and mid tick of a box plot */
   size?: number;
+  /** Same as BoxPlotDef extent property */
+  extent?: 'min-max' | number;
 }
 
 export interface BoxPlotConfigMixins {
@@ -70,7 +72,7 @@ export interface BoxPlotConfigMixins {
 export const VL_ONLY_BOXPLOT_CONFIG_PROPERTY_INDEX: {
   [k in keyof BoxPlotConfigMixins]?: (keyof BoxPlotConfigMixins[k])[]
 } = {
-  box: ['size', 'color'],
+  box: ['size', 'color', 'extent'],
   boxWhisker: ['color'],
   boxMid: ['color']
 };
@@ -96,10 +98,14 @@ export function normalizeBoxPlot(spec: GenericUnitSpec<Encoding<string>, BOXPLOT
   const {mark, encoding, selection, projection: _p, ...outerSpec} = spec;
 
   let kIQRScalar: number = undefined;
+  if (isNumber(config.box.extent)) {
+    kIQRScalar = config.box.extent;
+  }
+
   if (isBoxPlotDef(mark)) {
     if (mark.extent) {
-      if(isNumber(mark.extent)) {
-        kIQRScalar = mark.extent;
+      if(mark.extent === 'min-max') {
+        kIQRScalar = undefined;
       }
     }
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -262,7 +262,7 @@ export const defaultConfig: Config = {
   text: {color: 'black'}, // Need this to override default color in mark config
   tick: mark.defaultTickConfig,
 
-  box: {size: 14},
+  box: {size: 14, extent: 1.5},
   boxWhisker: {},
   boxMid: {color: 'white'},
 

--- a/test/compositemark/boxplot.test.ts
+++ b/test/compositemark/boxplot.test.ts
@@ -14,7 +14,10 @@ describe("normalizeBoxMinMax", () => {
       normalize({
         "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
         "data": {"url": "data/population.json"},
-        mark: "box-plot",
+        mark: {
+          type: "box-plot",
+          extent: "min-max"
+        },
         encoding: {
           "x": {"aggregate": "box-plot", "field": "people","type": "quantitative"},
           "y": {
@@ -34,7 +37,10 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
      assert.deepEqual<GenericSpec<GenericUnitSpec<Encoding<Field>, string | MarkDef>>>(normalize({
         "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
         "data": {"url": "data/population.json"},
-        mark: "box-plot",
+        mark: {
+          type: "box-plot",
+          extent: "min-max"
+        },
         encoding: {
           "x": {"field": "age","type": "quantitative"},
           "y": {
@@ -159,7 +165,10 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
       normalize({
         "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
         "data": {"url": "data/population.json"},
-        mark: "box-plot",
+        mark: {
+          type: "box-plot",
+          extent: "min-max"
+        },
         encoding: {
           "size": {"value": 5},
           "color": {"value" : "skyblue"}
@@ -172,7 +181,10 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
     normalize({
         "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
         "data": {"url": "data/population.json"},
-        mark: "box-plot",
+        mark: {
+          type: "box-plot",
+          extent: "min-max"
+        },
         encoding: {
           "x": {"field": "age","type": "ordinal"},
           "y": {
@@ -207,7 +219,10 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
       normalize({
         "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
         "data": {"url": "data/population.json"},
-        mark: "box-plot",
+        mark: {
+          type: "box-plot",
+          extent: "min-max"
+        },
         encoding: {
           "x": {"field": "age","type": "ordinal"},
           "y": {
@@ -227,7 +242,10 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
       normalize({
         "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
         "data": {"url": "data/population.json"},
-        mark: "box-plot",
+        mark: {
+          type: "box-plot",
+          extent: "min-max"
+        },
         encoding: {
           "x": {"field": "age","type": "ordinal"},
           "y": {
@@ -390,7 +408,8 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
         "data": {"url": "data/population.json"},
         mark: {
           type: "box-plot",
-          orient: "horizontal"
+          orient: "horizontal",
+          extent: "min-max"
         },
         encoding: {
           "y": {"field": "age","type": "quantitative"},
@@ -515,7 +534,10 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
      assert.deepEqual<GenericSpec<GenericUnitSpec<Encoding<Field>, string | MarkDef>>>(normalize({
         "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
         "data": {"url": "data/population.json"},
-        mark: "box-plot",
+        mark: {
+          type: "box-plot",
+          extent: "min-max"
+        },
         encoding: {
           "x": {"field": "age","type": "quantitative"},
           "y": {
@@ -640,7 +662,10 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
      assert.deepEqual<GenericSpec<GenericUnitSpec<Encoding<Field>, string | MarkDef>>>(normalize({
         "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
         "data": {"url": "data/population.json"},
-        mark: "box-plot",
+        mark: {
+          type: "box-plot",
+          extent: "min-max"
+        },
         encoding: {
           "y": {"field": "age","type": "quantitative"},
           "x": {
@@ -765,7 +790,10 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
      assert.deepEqual<GenericSpec<GenericUnitSpec<Encoding<Field>, string | MarkDef>>>(normalize({
         "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
         "data": {"url": "data/population.json"},
-        mark: "box-plot",
+        mark: {
+          type: "box-plot",
+          extent: "min-max"
+        },
         encoding: {
           "x": {"field": "age","type": "ordinal"},
           "y": {
@@ -889,7 +917,10 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
      assert.deepEqual<GenericSpec<GenericUnitSpec<Encoding<Field>, string | MarkDef>>>(normalize({
         "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
         "data": {"url": "data/population.json"},
-        mark: "box-plot",
+        mark: {
+          type: "box-plot",
+          extent: "min-max"
+        },
         encoding: {
           "y": {"field": "age","type": "ordinal"},
           "x": {
@@ -1013,7 +1044,10 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
      assert.deepEqual<GenericSpec<GenericUnitSpec<Encoding<Field>, string | MarkDef>>>(normalize({
         "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
         "data": {"url": "data/population.json"},
-        mark: "box-plot",
+        mark: {
+          type: "box-plot",
+          extent: "min-max"
+        },
         encoding: {
           "y": {"field": "age","type": "ordinal"},
           "x": {
@@ -1134,7 +1168,10 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
      assert.deepEqual<GenericSpec<GenericUnitSpec<Encoding<Field>, string | MarkDef>>>(normalize({
         "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
         "data": {"url": "data/population.json"},
-        mark: "box-plot",
+        mark: {
+          type: "box-plot",
+          extent: "min-max"
+        },
         encoding: {
           "x": {
             "field": "people",
@@ -1250,7 +1287,10 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
      assert.deepEqual<GenericSpec<GenericUnitSpec<Encoding<Field>, string | MarkDef>>>(normalize({
         "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
         "data": {"url": "data/population.json"},
-        mark: "box-plot",
+        mark: {
+          type: "box-plot",
+          extent: "min-max"
+        },
         encoding: {
           "y": {
             "field": "people",
@@ -1365,6 +1405,142 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
 
 
 describe("normalizeBoxIQR", () => {
+
+  it("should produce correct layered specs for vertical boxplot with two quantitative axes and use default orientation for a 1.5 * IQR whiskers with boxplot mark type", () => {
+    assert.deepEqual<GenericSpec<GenericUnitSpec<Encoding<Field>, string | MarkDef>>>(normalize({
+       "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
+       "data": {"url": "data/population.json"},
+       mark: "box-plot",
+       encoding: {
+         "x": {"field": "age","type": "quantitative"},
+         "y": {
+           "field": "people",
+           "type": "quantitative",
+           "axis": {"title": "population"}
+         },
+         "size": {"value": 5},
+         "color": {"value" : "skyblue"}
+       }
+     }, defaultConfig), {
+       "description": "A box plot showing median, min, and max in the US population distribution of age groups in 2000.",
+       "data": {"url": "data/population.json"},
+       "transform": [
+         {
+           "aggregate": [
+             {
+               "op": "q1",
+               "field": "people",
+               "as": "lower_box_people"
+             },
+             {
+               "op": "q3",
+               "field": "people",
+               "as": "upper_box_people"
+             },
+             {
+               "op": "median",
+               "field": "people",
+               "as": "mid_box_people"
+             },
+             {
+               "op": "min",
+               "field": "people",
+               "as": "min_people"
+             },
+             {
+               "op": "max",
+               "field": "people",
+               "as": "max_people"
+             }
+           ],
+           "groupby": ["age"]
+         },
+         {
+           calculate: 'datum.upper_box_people - datum.lower_box_people',
+           as: 'iqr_people'
+         },
+         {
+           "calculate": `min(datum.upper_box_people + datum.iqr_people * ${defaultConfig.box.extent}, datum.max_people)`,
+           "as": "upper_whisker_people"
+         },
+         {
+           "calculate": `max(datum.lower_box_people - datum.iqr_people * ${defaultConfig.box.extent}, datum.min_people)`,
+           "as": "lower_whisker_people"
+         }
+       ],
+       "layer": [
+         {
+           mark: {
+             type: 'rule',
+             style: 'boxWhisker'
+           },
+           "encoding": {
+             "x": {"field": "age","type": "quantitative"},
+             "y": {
+               "field": "lower_whisker_people",
+               "type": "quantitative",
+               "axis": {"title": "population"}
+             },
+             "y2": {
+               "field": "lower_box_people",
+               "type": "quantitative"
+             }
+           }
+         },
+         {
+           mark: {
+             type: 'rule',
+             style: 'boxWhisker'
+           },
+           "encoding": {
+             "x": {"field": "age","type": "quantitative"},
+             "y": {
+               "field": "upper_box_people",
+               "type": "quantitative"
+             },
+             "y2": {
+               "field": "upper_whisker_people",
+               "type": "quantitative"
+             }
+           }
+         },
+         {
+           mark: {
+             type: 'bar',
+             style: 'box'
+           },
+           "encoding": {
+             "x": {"field": "age","type": "quantitative"},
+             "y": {
+               "field": "lower_box_people",
+               "type": "quantitative"
+             },
+             "y2": {
+               "field": "upper_box_people",
+               "type": "quantitative"
+             },
+             "size": {"value": 5},
+             "color": {"value" : "skyblue"}
+           }
+         },
+         {
+           mark: {
+             type: 'tick',
+             style: 'boxMid'
+           },
+           "encoding": {
+             "x": {"field": "age","type": "quantitative"},
+             "y": {
+               "field": "mid_box_people",
+               "type": "quantitative"
+             },
+             "color": {"value": "white"},
+             "size": {"value": 5}
+           }
+         }
+       ]
+     });
+  });
 
   it("should produce correct layered specs for vertical boxplot with two quantitative axes and use default orientation for a 1.5 * IQR whiskers", () => {
      assert.deepEqual<GenericSpec<GenericUnitSpec<Encoding<Field>, string | MarkDef>>>(normalize({


### PR DESCRIPTION
Refers to #3242.

Changes:
- Added to config property box a property called extent to make the default extent value to be 1.5
- Added test for boxplot mark type for tukey box plot