### PR TITLE
Fix type of RangeConfig for strict null checks

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -102,7 +102,7 @@ export const defaultViewConfig: ViewConfig = {
 
 export type RangeConfigValue = (number|string)[] | VgScheme | {step: number};
 
-export interface RangeConfig {
+export interface RangeConfig extends Partial<Record<string, RangeConfigValue>> {
   /**
    * Default range for _nominal_ (categorical) fields.
    */
@@ -132,8 +132,6 @@ export interface RangeConfig {
    * Default range palette for the `shape` channel.
    */
   symbol?: string[];
-
-  [name: string]: RangeConfigValue | undefined;
 }
 
 export interface VLOnlyConfig {

--- a/src/config.ts
+++ b/src/config.ts
@@ -133,7 +133,7 @@ export interface RangeConfig {
    */
   symbol?: string[];
 
-  [name: string]: RangeConfigValue;
+  [name: string]: RangeConfigValue | undefined;
 }
 
 export interface VLOnlyConfig {


### PR DESCRIPTION
With `strictNullChecks` enabled in TS 2.6, this definition wasn't type checking; each other field under `RangeConfig` was being flagged with a variant of this error:

```
Property 'category' of type 'VgScheme | string[] | undefined' is not assignable to string index type 'RangeConfigValue'.
```
