### PR TITLE
Clarify top-level vs view-level in transform.md

### DIFF
--- a/site/docs/transform/transform.md
+++ b/site/docs/transform/transform.md
@@ -5,11 +5,11 @@ title: Transformation
 permalink: /docs/transform.html
 ---
 
-Data transformations in Vega-Lite are described via either top-level transforms (the `transform` property) or [field transforms inside `encoding`](encoding.html#field-transform) (`aggregate`, `bin`, `timeUnit`, and `sort`).
+Data transformations in Vega-Lite are described via either [view-level](spec.html#common) transforms (the `transform` property) or [field transforms inside `encoding`](encoding.html#field-transform) (`aggregate`, `bin`, `timeUnit`, and `sort`).
 
-When both types of transforms are specified, the top-level `transform`s are executed first based on the order in the array. Then the inline transforms are executed in this order: `bin`, `timeUnit`, `aggregate`, and `sort`.
+When both types of transforms are specified, the view-level `transform`s are executed first based on the order in the array. Then the inline transforms are executed in this order: `bin`, `timeUnit`, `aggregate`, and `sort`.
 
-## Top-level Transform Property
+## View-level Transform Property
 
 {: .suppress-error}
 ```json
@@ -24,7 +24,7 @@ When both types of transforms are specified, the top-level `transform`s are exec
 }
 ```
 
-The top-level `transform` object is an array of objects describing transformations. The transformations are executed in the order in which they are specified in the array.
+The View-level `transform` object is an array of objects describing transformations. The transformations are executed in the order in which they are specified in the array.
 Vega-Lite's `transform` supports the following types of transformations:
 
 - [Aggregate](aggregate.html#transform)


### PR DESCRIPTION
The View spec.mp differentiates between "Common Properties of Specifications" and "Top-Level Specifications".
The documentation for transform.md was updated to follow this differentiation.