### PR TITLE
use vega-util's error instead of util.error

### DIFF
--- a/src/compile/projection/assemble.ts
+++ b/src/compile/projection/assemble.ts
@@ -1,4 +1,4 @@
-import {error} from 'util';
+import {error} from 'vega-util';
 import {contains} from '../../util';
 import {isVgSignalRef, VgProjection, VgSignalRef} from '../../vega.schema';
 import {isConcatModel, isLayerModel, isRepeatModel, Model} from '../model';


### PR DESCRIPTION
[`util.error` is the deprecated predecessor to `console.error`](https://nodejs.org/api/util.html#util_util_error_strings).

As suggested in this PR, this uses `vega-util`'s error, which _will_ throw rather than erroring in the console.

Can this also get backported to the 1.x line?