### PR TITLE
switch from node's util to vega-util for isString

### DIFF
--- a/src/toplevelprops.ts
+++ b/src/toplevelprops.ts
@@ -1,4 +1,5 @@
-import {isString} from 'util';
+import {isString} from 'vega-util';
+
 import * as log from './log';
 
 /**


### PR DESCRIPTION
`util.isString` [is deprecated](https://nodejs.org/api/util.html#util_util_isstring_object) and `vega-util` provides `isString` as well.

I'd like to get rid of all usage of node's `util` in this project (also see #3394), to make it simpler to work with webpack and conflicting definitions of browser side `util` versions. Unfun story at the moment.

I'd also love to see this change as part of the 1.x line.