### PR TITLE
Top level datastore

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1326,6 +1326,10 @@
           "description": "Default axis and legend title for count fields.\n\n__Default value:__ `'Number of Records'`.",
           "type": "string"
         },
+        "datasets": {
+          "$ref": "#/definitions/Dict<InlineDataset>",
+          "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
+        },
         "fieldTitle": {
           "description": "Defines how Vega-Lite generates title for fields.  There are three possible styles:\n- `\"verbal\"` (Default) - displays function in a verbal style (e.g., \"Sum of field\", \"Year-month of date\", \"field (binned)\").\n- `\"function\"` - displays function using parentheses and capitalized texts (e.g., \"SUM(field)\", \"YEARMONTH(date)\", \"BIN(field)\").\n- `\"plain\"` - displays only the field name without functions (e.g., \"field\", \"date\", \"field\").",
           "enum": [
@@ -1564,6 +1568,12 @@
       "maximum": 7,
       "minimum": 1,
       "type": "number"
+    },
+    "Dict<InlineDataset>": {
+      "additionalProperties": {
+        "$ref": "#/definitions/InlineDataset"
+      },
+      "type": "object"
     },
     "Encoding": {
       "additionalProperties": false,
@@ -2837,38 +2847,7 @@
           "description": "An object that specifies the format for parsing the data values."
         },
         "values": {
-          "anyOf": [
-            {
-              "items": {
-                "type": "number"
-              },
-              "type": "array"
-            },
-            {
-              "items": {
-                "type": "string"
-              },
-              "type": "array"
-            },
-            {
-              "items": {
-                "type": "boolean"
-              },
-              "type": "array"
-            },
-            {
-              "items": {
-                "type": "object"
-              },
-              "type": "array"
-            },
-            {
-              "type": "string"
-            },
-            {
-              "type": "object"
-            }
-          ],
+          "$ref": "#/definitions/InlineDataset",
           "description": "The full data set, included inline. This can be an array of objects or primitive values or a string.\nArrays of primitive values are ingested as objects with a `data` property. Strings are parsed according to the specified format type."
         }
       },
@@ -2876,6 +2855,40 @@
         "values"
       ],
       "type": "object"
+    },
+    "InlineDataset": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "items": {
+            "type": "boolean"
+          },
+          "type": "array"
+        },
+        {
+          "items": {
+            "type": "object"
+          },
+          "type": "array"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "type": "object"
+        }
+      ]
     },
     "Interpolate": {
       "enum": [
@@ -5747,6 +5760,10 @@
           "$ref": "#/definitions/Data",
           "description": "An object describing the data source"
         },
+        "datasets": {
+          "$ref": "#/definitions/Dict<InlineDataset>",
+          "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
+        },
         "description": {
           "description": "Description of this mark for commenting purpose.",
           "type": "string"
@@ -5841,6 +5858,10 @@
           "$ref": "#/definitions/Data",
           "description": "An object describing the data source"
         },
+        "datasets": {
+          "$ref": "#/definitions/Dict<InlineDataset>",
+          "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
+        },
         "description": {
           "description": "Description of this mark for commenting purpose.",
           "type": "string"
@@ -5928,6 +5949,10 @@
           "$ref": "#/definitions/Data",
           "description": "An object describing the data source"
         },
+        "datasets": {
+          "$ref": "#/definitions/Dict<InlineDataset>",
+          "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
+        },
         "description": {
           "description": "Description of this mark for commenting purpose.",
           "type": "string"
@@ -6005,6 +6030,10 @@
         "data": {
           "$ref": "#/definitions/Data",
           "description": "An object describing the data source"
+        },
+        "datasets": {
+          "$ref": "#/definitions/Dict<InlineDataset>",
+          "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
         },
         "description": {
           "description": "Description of this mark for commenting purpose.",
@@ -6099,6 +6128,10 @@
           "$ref": "#/definitions/Data",
           "description": "An object describing the data source"
         },
+        "datasets": {
+          "$ref": "#/definitions/Dict<InlineDataset>",
+          "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
+        },
         "description": {
           "description": "Description of this mark for commenting purpose.",
           "type": "string"
@@ -6177,6 +6210,10 @@
         "data": {
           "$ref": "#/definitions/Data",
           "description": "An object describing the data source"
+        },
+        "datasets": {
+          "$ref": "#/definitions/Dict<InlineDataset>",
+          "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
         },
         "description": {
           "description": "Description of this mark for commenting purpose.",

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1327,7 +1327,7 @@
           "type": "string"
         },
         "datasets": {
-          "$ref": "#/definitions/Dict<InlineDataset>",
+          "$ref": "#/definitions/Datasets",
           "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
         },
         "fieldTitle": {
@@ -1490,6 +1490,9 @@
           "$ref": "#/definitions/TopoDataFormat"
         }
       ]
+    },
+    "Datasets": {
+      "$ref": "#/definitions/Dict<InlineDataset>"
     },
     "DateTime": {
       "additionalProperties": false,
@@ -5761,7 +5764,7 @@
           "description": "An object describing the data source"
         },
         "datasets": {
-          "$ref": "#/definitions/Dict<InlineDataset>",
+          "$ref": "#/definitions/Datasets",
           "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
         },
         "description": {
@@ -5859,7 +5862,7 @@
           "description": "An object describing the data source"
         },
         "datasets": {
-          "$ref": "#/definitions/Dict<InlineDataset>",
+          "$ref": "#/definitions/Datasets",
           "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
         },
         "description": {
@@ -5950,7 +5953,7 @@
           "description": "An object describing the data source"
         },
         "datasets": {
-          "$ref": "#/definitions/Dict<InlineDataset>",
+          "$ref": "#/definitions/Datasets",
           "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
         },
         "description": {
@@ -6032,7 +6035,7 @@
           "description": "An object describing the data source"
         },
         "datasets": {
-          "$ref": "#/definitions/Dict<InlineDataset>",
+          "$ref": "#/definitions/Datasets",
           "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
         },
         "description": {
@@ -6129,7 +6132,7 @@
           "description": "An object describing the data source"
         },
         "datasets": {
-          "$ref": "#/definitions/Dict<InlineDataset>",
+          "$ref": "#/definitions/Datasets",
           "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
         },
         "description": {
@@ -6212,7 +6215,7 @@
           "description": "An object describing the data source"
         },
         "datasets": {
-          "$ref": "#/definitions/Dict<InlineDataset>",
+          "$ref": "#/definitions/Datasets",
           "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
         },
         "description": {

--- a/site/docs/data.md
+++ b/site/docs/data.md
@@ -7,7 +7,7 @@ permalink: /docs/data.html
 
 Akin to [Vega](https://www.github.com/vega/vega)'s [data model](https://vega.github.io/vega/docs/data/), the basic data model used by Vega-Lite is *tabular* data, similar to a spreadsheet or a database table. Individual data sets are assumed to contain a collection of records, which may contain any number of named data fields.
 
-Vega-Lite's `data` property describes the visualization's data source as part of the specification, which can be either [inline data](#inline) (`values`) or [a URL from which to load the data](#url) (`url`).  Alternatively, we can create an empty, [named data source](#named) (`name`), which can be [bound at runtime](https://vega.github.io/vega/docs/api/view/#data).
+Vega-Lite's `data` property describes the visualization's data source as part of the specification, which can be either [inline data](#inline) (`values`) or [a URL from which to load the data](#url) (`url`).  Alternatively, we can create an empty, [named data source](#named) (`name`), which can be [bound at runtime](https://vega.github.io/vega/docs/api/view/#data) or populated from top-level [datasets](#datasets).
 
 ## Documentation Overview
 {:.no_toc}
@@ -96,3 +96,18 @@ Load a tab-separated values (TSV) file. This format type does not support any ad
 Load a JavaScript Object Notation (JSON) file using the TopoJSON format. The input file must contain valid TopoJSON data. The TopoJSON input is then converted into a GeoJSON format. There are two mutually exclusive properties that can be used to specify the conversion process:
 
 {% include table.html props="feature,mesh" source="TopoDataFormat" %}
+
+## Datasets
+
+Vega-Lite supports a top-level `datasets` property. This can be useful when the same data should be inlined in different places in the spec. Instead of setting values inline, specify datasets at the top level and then refer to the [named](#named) datasource in the rest of the spec. `datasets` is a mapping from name to an [inline](#inline) dataset.
+
+{: .suppress-error}
+```json
+```
+    "datasets": {
+      "somedata": [1,2,3]
+    },
+    "data": {
+      "name": "somedata"
+    }
+```

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -124,8 +124,10 @@ function assembleTopLevelModel(model: Model, topLevelProperties: TopLevelPropert
   const data = [].concat(
     model.assembleSelectionData([]),
     // only assemble data in the root
-    assembleRootData(model.component.data)
+    assembleRootData(model.component.data, topLevelProperties.datasets || {})
   );
+
+  delete topLevelProperties.datasets;
 
   const projections = model.assembleProjections();
   const title = model.assembleTitle();

--- a/src/compile/data/assemble.ts
+++ b/src/compile/data/assemble.ts
@@ -1,5 +1,5 @@
-import {isUrlData} from '../../data';
-import {vals} from '../../util';
+import {InlineDataset, isUrlData} from '../../data';
+import {Dict, vals} from '../../util';
 import {VgData} from '../../vega.schema';
 import {DataComponent} from './';
 import {AggregateNode} from './aggregate';
@@ -198,7 +198,7 @@ export function assembleFacetData(root: FacetNode): VgData[] {
  * @param  data array
  * @return modified data array
  */
-export function assembleRootData(dataComponent: DataComponent): VgData[] {
+export function assembleRootData(dataComponent: DataComponent, datasets: Dict<InlineDataset>): VgData[] {
   const roots: SourceNode[] = vals(dataComponent.sources);
   const data: VgData[] = [];
 
@@ -235,6 +235,13 @@ export function assembleRootData(dataComponent: DataComponent): VgData[] {
       if (t.type === 'lookup') {
         t.from = dataComponent.outputNodes[t.from].getSource();
       }
+    }
+  }
+
+  // inline values for datasets that are in the datastore
+  for (const d of data) {
+    if (d.name in datasets) {
+      d.values = datasets[d.name];
     }
   }
 

--- a/src/data.ts
+++ b/src/data.ts
@@ -68,6 +68,8 @@ export type DataFormatType = 'json' | 'csv' | 'tsv' | 'topojson';
 
 export type Data = UrlData | InlineData | NamedData;
 
+export type InlineDataset = number[] | string[] | boolean[] | object[] | string | object;
+
 export interface UrlData {
   /**
    * An object that specifies the format for parsing the data file.
@@ -90,7 +92,7 @@ export interface InlineData {
    * The full data set, included inline. This can be an array of objects or primitive values or a string.
    * Arrays of primitive values are ingested as objects with a `data` property. Strings are parsed according to the specified format type.
    */
-  values: number[] | string[] | boolean[] | object[] | string | object;
+  values: InlineDataset;
 }
 
 export interface NamedData {

--- a/src/toplevelprops.ts
+++ b/src/toplevelprops.ts
@@ -9,6 +9,8 @@ import {Dict} from './util';
  */
 export type Padding = number | {top?: number, bottom?: number, left?: number, right?: number};
 
+export type Datasets = Dict<InlineDataset>;
+
 export interface TopLevelProperties {
   /**
    * CSS color property to use as the background of visualization.
@@ -38,7 +40,7 @@ export interface TopLevelProperties {
    * A global data store for named datasets. This is a mapping from names to inline datasets.
    * This can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property.
    */
-  datasets?: Dict<InlineDataset>;
+  datasets?: Datasets;
 }
 
 export type AutosizeType = 'pad' | 'fit' | 'none';

--- a/src/toplevelprops.ts
+++ b/src/toplevelprops.ts
@@ -1,6 +1,8 @@
 import {isString} from 'vega-util';
 
+import {InlineDataset} from './data';
 import * as log from './log';
+import {Dict} from './util';
 
 /**
  * @minimum 0
@@ -31,6 +33,12 @@ export interface TopLevelProperties {
    * __Default value__: `pad`
    */
   autosize?: AutosizeType | AutoSizeParams;
+
+  /**
+   * A global data store for named datasets. This is a mapping from names to inline datasets.
+   * This can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property.
+   */
+  datasets?: Dict<InlineDataset>;
 }
 
 export type AutosizeType = 'pad' | 'fit' | 'none';
@@ -80,7 +88,7 @@ export function normalizeAutoSize(topLevelAutosize: AutosizeType | AutoSizeParam
 }
 
 const TOP_LEVEL_PROPERTIES: (keyof TopLevelProperties)[] = [
-  'background', 'padding'
+  'background', 'padding', 'datasets'
   // We do not include "autosize" here as it is supported by only unit and layer specs and thus need to be normalized
 ];
 

--- a/test/compile/data/assemble.test.ts
+++ b/test/compile/data/assemble.test.ts
@@ -66,5 +66,27 @@ describe('compile/data/assemble', () => {
         }]}
       ]);
     });
+
+    it('should assemble named datasets with datastore', () => {
+      const src = new SourceNode({name: 'foo'});
+      const outputNodeRefCounts = {};
+      const main = new OutputNode('mainOut', 'main', outputNodeRefCounts);
+      main.parent = src;
+
+      const data = assembleRootData({
+        sources: {named: src},
+        outputNodes: {out: main},
+        outputNodeRefCounts,
+        ancestorParse: {},
+        isFaceted: false
+      }, {
+        foo: [1,2,3]
+      });
+
+      assert.deepEqual<VgData[]>(data, [{
+        name: 'foo',
+        values: [1,2,3]
+      }]);
+    });
   });
 });

--- a/test/compile/data/assemble.test.ts
+++ b/test/compile/data/assemble.test.ts
@@ -23,7 +23,7 @@ describe('compile/data/assemble', () => {
         outputNodeRefCounts,
         ancestorParse: {},
         isFaceted: false
-      });
+      }, {});
 
       assert.equal(data.length, 1);
       assert.equal(data[0].name, "foo");
@@ -48,7 +48,7 @@ describe('compile/data/assemble', () => {
         outputNodeRefCounts,
         ancestorParse: {},
         isFaceted: false
-      });
+      }, {});
 
       assert.deepEqual<VgData[]>(data, [{
         name: 'source_0',

--- a/test/compile/selection/identifier.test.ts
+++ b/test/compile/selection/identifier.test.ts
@@ -22,7 +22,7 @@ function getVgData(selection: any, x?: any, y?: any, mark?: Mark, enc?: any, tra
   });
   model.parse();
   optimizeDataflow(model.component.data);
-  return assembleRootData(model.component.data);
+  return assembleRootData(model.component.data, {});
 }
 
 describe('Identifier transform', function() {

--- a/test/compile/selection/timeunit.test.ts
+++ b/test/compile/selection/timeunit.test.ts
@@ -11,7 +11,7 @@ import {parseModel, parseUnitModel} from '../../util';
 
 function getData(model: Model) {
   optimizeDataflow(model.component.data);
-  return assembleRootData(model.component.data);
+  return assembleRootData(model.component.data, {});
 }
 
 function getModel(unit2: UnitSpec) {


### PR DESCRIPTION
Fixes #3268

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
  "description": "A simple bar chart with embedded data.",
  "data": {
    "name": "my_data"
  },
  "mark": "bar",
  "encoding": {
    "x": {"field": "a", "type": "ordinal"},
    "y": {"field": "b", "type": "quantitative"}
  },
  "datasets": {
    "my_data":  [
      {"a": "A","b": 28}, {"a": "B","b": 55}, {"a": "C","b": 43},
      {"a": "D","b": 91}, {"a": "E","b": 81}, {"a": "F","b": 53},
      {"a": "G","b": 19}, {"a": "H","b": 87}, {"a": "I","b": 52}
    ]
  }
}
```

I am pretty sure that we only need to replace datasets at the top level and not inside facets. Named datasets will always be at the top level. 

cc @ellisonbg