### PR TITLE
Docs Improvement: Made unordered lists consistent

### DIFF
--- a/site/docs/composition/composition.md
+++ b/site/docs/composition/composition.md
@@ -14,7 +14,7 @@ Vega-Lite's compiler infers how input data should be reused across constituent v
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 ## Faceting

--- a/site/docs/composition/concat.md
+++ b/site/docs/composition/concat.md
@@ -12,7 +12,7 @@ If you concatenate similar views where the only difference is the field that is 
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 ## Horizontal Concatenation

--- a/site/docs/composition/facet.md
+++ b/site/docs/composition/facet.md
@@ -16,7 +16,7 @@ Second, as a shortcut you can use the [`column` or `row` encoding channels](#fac
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 ## Facet Operator

--- a/site/docs/composition/repeat.md
+++ b/site/docs/composition/repeat.md
@@ -10,7 +10,7 @@ The `repeat` operator is part of Vega-Lite's [view composition](composition.html
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 ## Repeat Operator

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -29,7 +29,7 @@ Vega-Lite's `config` object lists configuration properties of a visualization fo
 
 The rest of this page outlines different types of config properties:
 
-* TOC
+- TOC
 {:toc}
 
 {:#top-level-config}

--- a/site/docs/data.md
+++ b/site/docs/data.md
@@ -12,7 +12,7 @@ Vega-Lite's `data` property describes the visualization's data source as part of
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 ## Types of Data Sources

--- a/site/docs/encoding/axis.md
+++ b/site/docs/encoding/axis.md
@@ -16,7 +16,7 @@ Besides `axis` property of a field definition, the configuration object ([`confi
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 

--- a/site/docs/encoding/legend.md
+++ b/site/docs/encoding/legend.md
@@ -12,7 +12,7 @@ User can set the `legend` property of a [mark property channel's field definitio
 
 Besides `legend` property of a field definition, the configuration object ([`config`](config.html)) also provides [legend config](#config) (`config: {legend: {...}}`) for setting default legend properties for all legends.
 
-* TOC
+- TOC
 {:toc}
 
 ## Legend Types

--- a/site/docs/encoding/scale.md
+++ b/site/docs/encoding/scale.md
@@ -42,7 +42,7 @@ For more information about guides that visualize the scales, please see the [axe
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 {:#type}

--- a/site/docs/encoding/stack.md
+++ b/site/docs/encoding/stack.md
@@ -30,7 +30,7 @@ determines type of stacking offset if the field should be stacked.
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 

--- a/site/docs/mark/area.md
+++ b/site/docs/mark/area.md
@@ -21,7 +21,7 @@ permalink: /docs/area.html
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 

--- a/site/docs/mark/bar.md
+++ b/site/docs/mark/bar.md
@@ -21,7 +21,7 @@ Bar marks are useful in many visualizations, including bar charts, [stacked bar 
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 

--- a/site/docs/mark/line.md
+++ b/site/docs/mark/line.md
@@ -20,7 +20,7 @@ The `line` mark represents the data points stored in a field with a line connect
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 

--- a/site/docs/mark/mark.md
+++ b/site/docs/mark/mark.md
@@ -43,7 +43,7 @@ For example, a bar chart has `mark` as a simple string `"bar"`.
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 ## Mark Definition Object

--- a/site/docs/mark/point.md
+++ b/site/docs/mark/point.md
@@ -20,7 +20,7 @@ permalink: /docs/point.html
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 ## Dot Plot

--- a/site/docs/mark/rect.md
+++ b/site/docs/mark/rect.md
@@ -21,7 +21,7 @@ The `rect` mark represents an arbitrary rectangle.
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 ### Heatmap

--- a/site/docs/mark/rule.md
+++ b/site/docs/mark/rule.md
@@ -21,7 +21,7 @@ The `rule` mark represents each data point as a line segment. It can be used in 
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 ## Width/Height-Spanning Rules

--- a/site/docs/mark/text.md
+++ b/site/docs/mark/text.md
@@ -22,7 +22,7 @@ permalink: /docs/text.html
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 ## Text Table Heatmap

--- a/site/docs/mark/tick.md
+++ b/site/docs/mark/tick.md
@@ -22,7 +22,7 @@ The `tick` mark represents each data point as a short line. This is a useful mar
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 

--- a/site/docs/selection/bind.md
+++ b/site/docs/selection/bind.md
@@ -7,8 +7,8 @@ permalink: /docs/bind.html
 
 Using the `bind` property, selections can be bound in two ways:
 
-  * Single selections can be bound to [input elements](#input-element-binding) also known as dynamic query widgets.
-  * Interval selections can be bound to their own [view's scales](#scale-binding) to enable panning &amp; zooming.
+  - Single selections can be bound to [input elements](#input-element-binding) also known as dynamic query widgets.
+  - Interval selections can be bound to their own [view's scales](#scale-binding) to enable panning &amp; zooming.
 
 ## Input Element Binding
 

--- a/site/docs/selection/nearest.md
+++ b/site/docs/selection/nearest.md
@@ -19,4 +19,4 @@ The `nearest` transform also respects any [position encoding projections](projec
 
 ## Current Limitations
 
-* The `nearest` transform is not supported for continuous mark types (i.e., `line` and `area`). For these mark types, consider layering a discrete mark type (e.g., `point`) with a 0-value `opacity` as in the last example above.
+- The `nearest` transform is not supported for continuous mark types (i.e., `line` and `area`). For these mark types, consider layering a discrete mark type (e.g., `point`) with a 0-value `opacity` as in the last example above.

--- a/site/docs/selection/project.md
+++ b/site/docs/selection/project.md
@@ -7,8 +7,8 @@ permalink: /docs/project.html
 
 A [selection's type](selection.html#selection-types) determines which data values fall within it by default:
 
-  * For `single` and `multi` selections, only values that have been directly interacted with (i.e., those that have been clicked on) are considered to be "selected."
-  * For `interval` selections, values that fall within _both_ the horizontal (`x`) and vertical (`y`) extents are considered to be "selected."
+  - For `single` and `multi` selections, only values that have been directly interacted with (i.e., those that have been clicked on) are considered to be "selected."
+  - For `interval` selections, values that fall within _both_ the horizontal (`x`) and vertical (`y`) extents are considered to be "selected."
 
 These default inclusion criteria can be modified with the **project** selection transformation, which offers the following two properties:
 
@@ -26,9 +26,9 @@ With interval selections, the project transformation can be used to restrict the
 
 ## Current Limitations
 
-* Selections projected over aggregated `fields`/`encodings` can only be used within the same view they are defined in.
-* Interval selections can only be projected using `encodings`.
-* Interval selections projected over binned or `timeUnit` fields remain continuous selections. Thus, if the visual encoding discretizes them, conditional encodings will no longer work. Instead, use a layered view as shown in the example below. The bar mark discretizes the binned `Acceleration` field. As a result, to highlight selected bars, we use a second layered view rather than a conditional color encoding within the same view.
+- Selections projected over aggregated `fields`/`encodings` can only be used within the same view they are defined in.
+- Interval selections can only be projected using `encodings`.
+- Interval selections projected over binned or `timeUnit` fields remain continuous selections. Thus, if the visual encoding discretizes them, conditional encodings will no longer work. Instead, use a layered view as shown in the example below. The bar mark discretizes the binned `Acceleration` field. As a result, to highlight selected bars, we use a second layered view rather than a conditional color encoding within the same view.
 
 <div class="vl-example" data-name="selection_project_binned_interval"></div>
 

--- a/site/docs/selection/selection.md
+++ b/site/docs/selection/selection.md
@@ -23,7 +23,7 @@ Selections are the basic building block in Vega-Lite's _grammar of interaction._
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 {:#type}
@@ -71,19 +71,19 @@ _Note:_ the two intervals do not have any effect on the visualization yet (we'll
 
 Vega-Lite provides a number of selection _transformations_ to further customize the behaviour of a selection. These include:
 
-* For `single` selections:
-  * [`bind`](bind.html) to input elements (also known as dynamic query widgets).
-  * [`nearest`](nearest.html) to accelerate selecting values.
-  * project over [`fields`](project.html) or [`encodings`](project.html) to change the inclusion criteria (or data query).
-* For `multi` selections:
-  * [`toggle`](toggle.html) to insert or remove data values based on their membership within the selection.
-  * [`nearest`](nearest.html) to accelerate selecting values.
-  * project over [`fields`](project.html) or [`encodings`](project.html) to change the inclusion criteria (or data query).
-* For `interval` selections:
-  * [`bind`](bind.html) to scale functions to enable panning &amp; zooming.
-  * project over [`fields`](project.html) or [`encodings`](project.html) to change the inclusion criteria (or data query).
-  * [`translate`](translate.html) to move the selection back-and-forth.
-  * [`zoom`](zoom.html) to resize the selection.
+- For `single` selections:
+  - [`bind`](bind.html) to input elements (also known as dynamic query widgets).
+  - [`nearest`](nearest.html) to accelerate selecting values.
+  - project over [`fields`](project.html) or [`encodings`](project.html) to change the inclusion criteria (or data query).
+- For `multi` selections:
+  - [`toggle`](toggle.html) to insert or remove data values based on their membership within the selection.
+  - [`nearest`](nearest.html) to accelerate selecting values.
+  - project over [`fields`](project.html) or [`encodings`](project.html) to change the inclusion criteria (or data query).
+- For `interval` selections:
+  - [`bind`](bind.html) to scale functions to enable panning &amp; zooming.
+  - project over [`fields`](project.html) or [`encodings`](project.html) to change the inclusion criteria (or data query).
+  - [`translate`](translate.html) to move the selection back-and-forth.
+  - [`zoom`](zoom.html) to resize the selection.
 
 ## Using Selections
 
@@ -128,8 +128,8 @@ However, setting the scale domains (rather than filtering data out) yields super
 
 If the selection is [projected](project.html) over _multiple_ fields or encodings, one must be given as part of the scale domain definition. Vega-Lite automatically infers this property if the selection is only projected over a single field or encoding. Thus, with the above example, the scale domain can be specified more explicitly as:
 
-  * `"scale": {"domain": {"selection": "brush", "encoding": "x"}}` or
-  * `"scale": {"domain": {"selection": "brush", "field": "date"}}`
+  - `"scale": {"domain": {"selection": "brush", "encoding": "x"}}` or
+  - `"scale": {"domain": {"selection": "brush", "field": "date"}}`
 
 _Note:_ For a selection to manipulate the scales of its own view, use the [bind](bind.html#scale-binding) operator instead.
 
@@ -147,8 +147,8 @@ For example, we had previously seen how we could setup two interval selections f
 
 With these operators, selections can be combined in arbitrary ways:
 
-  * `"selection": {"not": {"and": ["alex", "morgan"]}}`
-  * `"selection": {"or": ["alex", {"not": "morgan"}]}`
+  - `"selection": {"not": {"and": ["alex", "morgan"]}}`
+  - `"selection": {"or": ["alex", {"not": "morgan"}]}`
 
 When using selections with filter operators, logical composition can be used to mix selections with other filter operators. For example, as shown below, the `Displacement x Acceleration` scatterplot now visualizes points that lie within the brushed region **and** have a `Weight_in_lbs > 3000`.
 
@@ -163,11 +163,11 @@ When a selection is defined within a data-driven view (i.e., a view that is part
 
 The aptly named `resolve` property addresses this ambiguity, and can be set to one of the following values (click to apply it to the SPLOM example, and drag out an interval in different cells):
 
-  * <a href="javascript:changeSpec('selection_resolution', 'selection_resolution_global')">`global`</a> (**default**) -- only one brush exists for the entire SPLOM. When the user begins to drag, any previous brushes are cleared, and a new one is constructed.
+  - <a href="javascript:changeSpec('selection_resolution', 'selection_resolution_global')">`global`</a> (**default**) -- only one brush exists for the entire SPLOM. When the user begins to drag, any previous brushes are cleared, and a new one is constructed.
 
-  * <a href="javascript:changeSpec('selection_resolution', 'selection_resolution_union')">`union`</a> -- each cell contains its own brush, and points are highlighted if they lie within _any_ of these individual brushes.
+  - <a href="javascript:changeSpec('selection_resolution', 'selection_resolution_union')">`union`</a> -- each cell contains its own brush, and points are highlighted if they lie within _any_ of these individual brushes.
 
-  * <a href="javascript:changeSpec('selection_resolution', 'selection_resolution_intersect')">`intersect`</a> -- each cell contains its own brush, and points are highlighted only if they fall within _all_ of these individual brushes.
+  - <a href="javascript:changeSpec('selection_resolution', 'selection_resolution_intersect')">`intersect`</a> -- each cell contains its own brush, and points are highlighted only if they fall within _all_ of these individual brushes.
 
 <div id="selection_resolution" class="vl-example" data-name="selection_resolution_global"></div>
 

--- a/site/docs/selection/toggle.md
+++ b/site/docs/selection/toggle.md
@@ -9,8 +9,8 @@ The `toggle` selection transformation inserts or removes data values from a mult
 
 It can take one of the following values:
 
-  * `false` -- disables toggling behaviour; as the user interacts, data values are only inserted into the multi selection and never removed.
-  * A [Vega expression](https://vega.github.io/vega/docs/expressions/) which is re-evaluated as the user interacts. If the expression evaluates to `true`, the data value is toggled into or out of the multi selection. If the expression evaluates to `false`, the multi selection is first clear, and the data value is then inserted.
+  - `false` -- disables toggling behaviour; as the user interacts, data values are only inserted into the multi selection and never removed.
+  - A [Vega expression](https://vega.github.io/vega/docs/expressions/) which is re-evaluated as the user interacts. If the expression evaluates to `true`, the data value is toggled into or out of the multi selection. If the expression evaluates to `false`, the multi selection is first clear, and the data value is then inserted.
 
 Vega-Lite automatically adds a toggle transformation to all multi selections by default, with the following definition: `"toggle": "event.shiftKey"`. As a result, data values are toggled when the user interacts with the shift-key pressed.
 

--- a/site/docs/selection/translate.md
+++ b/site/docs/selection/translate.md
@@ -7,8 +7,8 @@ permalink: /docs/translate.html
 
 The `translate` selection transformation allows a user to interactively move an interval selection back-and-forth. It can take one of the following values:
 
-  * `false` -- disables the ability to pan an interval selection.
-  * A [Vega event stream definition](https://vega.github.io/vega/docs/event-streams/) to indicate which events should trigger panning of the interval selection. The event stream must be structured to include a [start and end event](https://vega.github.io/vega/docs/event-streams/#between-filters) to represent continuous panning interactions. Discrete panning (e.g., pressing the left/right arrow keys) will be supported in future versions.
+  - `false` -- disables the ability to pan an interval selection.
+  - A [Vega event stream definition](https://vega.github.io/vega/docs/event-streams/) to indicate which events should trigger panning of the interval selection. The event stream must be structured to include a [start and end event](https://vega.github.io/vega/docs/event-streams/#between-filters) to represent continuous panning interactions. Discrete panning (e.g., pressing the left/right arrow keys) will be supported in future versions.
 
 Vega-Lite automatically adds a translate transform to all interval selections by default, with the following definition: `"translate": "[mousedown, window:mouseup] > window:mousemove!"`. As a result, once users drag out an interval selection, they can click and drag within it to reposition it.
 

--- a/site/docs/selection/zoom.md
+++ b/site/docs/selection/zoom.md
@@ -7,8 +7,8 @@ permalink: /docs/zoom.html
 
 The `zoom` selection transformation allows a user to interactively resize an interval selection. It can take one of the following values:
 
-  * `false` -- disables the ability to zoom an interval selection.
-  * A [Vega event stream definition](https://vega.github.io/vega/docs/event-streams/) to indicate which events should trigger panning of the interval selection. Currently, only `wheel` event types are supported, but custom event streams can still be used to specify filters, debouncing, and throttling. Future versions will expand the set of events that can trigger this transformation.
+  - `false` -- disables the ability to zoom an interval selection.
+  - A [Vega event stream definition](https://vega.github.io/vega/docs/event-streams/) to indicate which events should trigger panning of the interval selection. Currently, only `wheel` event types are supported, but custom event streams can still be used to specify filters, debouncing, and throttling. Future versions will expand the set of events that can trigger this transformation.
 
 Vega-Lite automatically adds a zoom transform to all interval selections by default, with the following definition: `"zoom": "wheel!"`. As a result, once users drag out an interval selection, they can click and drag within it to reposition it.
 

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -13,7 +13,7 @@ These operators include [`layer`](layer.html), [`facet`](facet.html), [`concat`]
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 

--- a/site/docs/tooltip.md
+++ b/site/docs/tooltip.md
@@ -10,7 +10,7 @@ Tooltip can provide details of a particular data point on demand. There are two 
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 ## Using Tooltip channel

--- a/site/docs/transform/aggregate.md
+++ b/site/docs/transform/aggregate.md
@@ -9,7 +9,7 @@ To aggregate data in Vega-Lite, users can either use use an `aggregate` property
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 

--- a/site/docs/transform/bin.md
+++ b/site/docs/transform/bin.md
@@ -11,7 +11,7 @@ There are two ways to define binning in Vega-Lite: [the `bin` property in encodi
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 

--- a/site/docs/transform/timeunit.md
+++ b/site/docs/transform/timeunit.md
@@ -23,7 +23,7 @@ By default, all time units represent date time using local time.  To use UTC tim
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 

--- a/site/docs/view/size.md
+++ b/site/docs/view/size.md
@@ -11,7 +11,7 @@ This page describe how to adjust width and height of visualizations in Vega-lite
 ## Documentation Overview
 {:.no_toc}
 
-* TOC
+- TOC
 {:toc}
 
 ## Width and Height of Single and Layered Plots
@@ -72,8 +72,8 @@ The total size of a Vega-Lite visualization may be determined by multiple factor
 
 In order to `fit` a chart into specified dimensions, it has to satisfy two requirements:
 
-* The view must be either a [single](spec.html#single) view or a [layered](layer.html) view. Fit does not work with other kinds of composed views (`facet`/`hconcat`/`vconcat`/`repeat`).
-* The width and height of the chart cannot depend on an explicitly specified `rangeStep` of a discrete scale. Any specified `rangeStep` will be ignored.
+- The view must be either a [single](spec.html#single) view or a [layered](layer.html) view. Fit does not work with other kinds of composed views (`facet`/`hconcat`/`vconcat`/`repeat`).
+- The width and height of the chart cannot depend on an explicitly specified `rangeStep` of a discrete scale. Any specified `rangeStep` will be ignored.
 
 #### Example
 

--- a/site/index.md
+++ b/site/index.md
@@ -76,10 +76,10 @@ Read our [introduction article to Vega-Lite v2 on Medium](https://medium.com/@uw
 
 ## Additional Links
 
-* Award winning [research paper](http://idl.cs.washington.edu/papers/vega-lite) and [video of our OpenVis Conf talk](https://www.youtube.com/watch?v=9uaHRWj04D4) on the design of Vega-Lite
-* [JSON schema](http://json-schema.org/) specification for [Vega-Lite](https://github.com/vega/schema) ([latest](https://vega.github.io/schema/vega-lite/v2.json))
-* Ask questions about Vega-Lite in the [Vega Discussion Group / Mailing List](https://groups.google.com/forum/?fromgroups#!forum/vega-js)
-* Fork our [Vega-Lite Block](https://bl.ocks.org/domoritz/455e1c7872c4b38a58b90df0c3d7b1b9), or [Observable Notebook](https://beta.observablehq.com/@domoritz/vega-lite-demo).
+- Award winning [research paper](http://idl.cs.washington.edu/papers/vega-lite) and [video of our OpenVis Conf talk](https://www.youtube.com/watch?v=9uaHRWj04D4) on the design of Vega-Lite
+- [JSON schema](http://json-schema.org/) specification for [Vega-Lite](https://github.com/vega/schema) ([latest](https://vega.github.io/schema/vega-lite/v2.json))
+- Ask questions about Vega-Lite in the [Vega Discussion Group / Mailing List](https://groups.google.com/forum/?fromgroups#!forum/vega-js)
+- Fork our [Vega-Lite Block](https://bl.ocks.org/domoritz/455e1c7872c4b38a58b90df0c3d7b1b9), or [Observable Notebook](https://beta.observablehq.com/@domoritz/vega-lite-demo).
 
 
 ## Team

--- a/site/tutorials/getting_started.md
+++ b/site/tutorials/getting_started.md
@@ -11,7 +11,7 @@ We suggest that you follow along the tutorial by building a visualization in the
 
 ## Tutorial Overview
 
-* TOC
+- TOC
 {:toc}
 
 ## The Data
@@ -203,8 +203,8 @@ If viewed in a browser, this page displays our bar chart like on our [demo page]
 
 Now you can create a website that embeds a Vega-Lite specification. If you want to learn more about Vega-Lite, please feel free to:
 
-* Read the [next tutorial]({{site.baseurl}}/tutorials/explore.html).
-* See the [examples gallery]({{site.baseurl}}/examples/).
-* Build your own visualizations in the [online editor](https://vega.github.io/editor/#/custom/vega-lite).
-* Browse through the [documentation]({{site.baseurl}}/docs/).
-* See the [list of applications](https://vega.github.io/vega-lite/applications.html) that you can use Vega-Lite with.
+- Read the [next tutorial]({{site.baseurl}}/tutorials/explore.html).
+- See the [examples gallery]({{site.baseurl}}/examples/).
+- Build your own visualizations in the [online editor](https://vega.github.io/editor/#/custom/vega-lite).
+- Browse through the [documentation]({{site.baseurl}}/docs/).
+- See the [list of applications](https://vega.github.io/vega-lite/applications.html) that you can use Vega-Lite with.

--- a/site/usage/compile.md
+++ b/site/usage/compile.md
@@ -22,9 +22,9 @@ var vgSpec = vl.compile(vlSpec, options).spec;
 
 If provided, the `options` argument should be an object with one or more of the following properties:
 
-* [`config`](#config) sets a default config
-* [`logger`](#logging) sets a logger
-* ['fieldTitle`](#field-title) sets a field title formatter
+- [`config`](#config) sets a default config
+- [`logger`](#logging) sets a logger
+- ['fieldTitle`](#field-title) sets a field title formatter
 
 {:#config}
 ### Customized Configuration


### PR DESCRIPTION
**Docs Improvement: Made unordered lists consistent**

- All `*` are replaced with `-` in markdown files (unordered lists).

Solves #3256.