### PR TITLE
Fix Boxplot usage of deprecated isNumber

### DIFF
--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -1,4 +1,4 @@
-import {isNumber} from 'util';
+import {isNumber} from 'vega-util';
 import {Channel} from '../channel';
 import {Config} from '../config';
 import {reduce} from '../encoding';


### PR DESCRIPTION
Use `isNumber` from `vega-util` instead of util`.

Fixes #3445
