### PR TITLE
Typos/Misspells Fixes

### DIFF
--- a/site/docs/encoding.md
+++ b/site/docs/encoding.md
@@ -211,7 +211,7 @@ In addition to the constant `value`, [value definitions](#value-def) of `text` a
 {:#href}
 ## Hyperlink Channel
 
-By setting the `href` channel, a mark becomes a hyperlink. The specified URL is loaded upon a muse click. The [`cursor` mark property](mark.html#hyperlink) can be set to `pointer` to serve as affordance for hyperlinks.
+By setting the `href` channel, a mark becomes a hyperlink. The specified URL is loaded upon a mouse click. The [`cursor` mark property](mark.html#hyperlink) can be set to `pointer` to serve as affordance for hyperlinks.
 
 {% include table.html props="href" source="Encoding" %}
 

--- a/src/compile/projection/parse.ts
+++ b/src/compile/projection/parse.ts
@@ -16,7 +16,7 @@ export function parseProjection(model: Model) {
     model.component.projection = parseUnitProjection(model);
   } else {
     // because parse happens from leaves up (unit specs before layer spec),
-    // we can be sure that the above if statement has already occured
+    // we can be sure that the above if statement has already occurred
     // and therefore we have access to child.component.projection
     // for each of model's children
     model.component.projection = parseNonUnitProjections(model);

--- a/src/compile/selection/multi.ts
+++ b/src/compile/selection/multi.ts
@@ -26,7 +26,7 @@ const multi:SelectionCompiler = {
     }).join(', ');
 
     // Only add a discrete selection to the store if a datum is present _and_
-    // the interaction isn't occuring on a group mark. This guards against
+    // the interaction isn't occurring on a group mark. This guards against
     // polluting interactive state with invalid values in faceted displays
     // as the group marks are also data-driven. We force the update to account
     // for constant null states but varying toggles (e.g., shift-click in

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -141,7 +141,7 @@ export class UnitModel extends ModelWithField {
 
         const axisSpec = isFieldDef(channelDef) ? channelDef.axis : null;
 
-        // We no longer support false in the schema, but we keep false here for backward compatability.
+        // We no longer support false in the schema, but we keep false here for backward compatibility.
         if (axisSpec !== null && axisSpec !== false) {
           _axis[channel] = {
             ...axisSpec

--- a/test/compile/mark/rect.test.ts
+++ b/test/compile/mark/rect.test.ts
@@ -122,7 +122,7 @@ describe('Mark: Rect', function() {
     });
     const props = rect.encodeEntry(model);
 
-    it('should draw rectange with x, x2, y, y2', function() {
+    it('should draw rectangle with x, x2, y, y2', function() {
       assert.deepEqual(props.x, {scale: 'x', field: 'min_Acceleration'});
       assert.deepEqual(props.x2, {scale: 'x', field: 'max_Acceleration'});
       assert.deepEqual(props.y, {scale: 'y', field: 'min_Horsepower'});


### PR DESCRIPTION
**Typos/Misspells Fixes**

- This PR fixes few typos/misspells which are found using [misspell](https://github.com/client9/misspell).