### PR TITLE
Rename  Boxplot's `mid` to `median`

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -785,6 +785,9 @@
         "box": {
           "$ref": "#/definitions/MarkConfig"
         },
+        "center": {
+          "$ref": "#/definitions/MarkConfig"
+        },
         "extent": {
           "anyOf": [
             {
@@ -799,11 +802,8 @@
           ],
           "description": "The extent of the whiskers. Available options include:\n- `\"min-max\": min and max are the lower and upper whiskers respectively.\n- `\"number\": multiples of the interquartile range (Q3-Q1) A number that will be multiplied by the IQR and the product will be added to the third quartile to get the upper whisker and subtracted from the first quartile to get the lower whisker.\n\n__Default value:__ `\"1.5\"`."
         },
-        "mid": {
-          "$ref": "#/definitions/MarkConfig"
-        },
         "size": {
-          "description": "Size of the box and mid tick of a box plot ",
+          "description": "Size of the box and center tick of a box plot ",
           "type": "number"
         },
         "whisker": {
@@ -818,6 +818,9 @@
         "box": {
           "$ref": "#/definitions/MarkConfig"
         },
+        "center": {
+          "$ref": "#/definitions/MarkConfig"
+        },
         "extent": {
           "anyOf": [
             {
@@ -832,15 +835,12 @@
           ],
           "description": "The extent of the whiskers. Available options include:\n- `\"min-max\": min and max are the lower and upper whiskers respectively.\n- `\"number\": multiples of the interquartile range (Q3-Q1) A number that will be multiplied by the IQR and the product will be added to the third quartile to get the upper whisker and subtracted from the first quartile to get the lower whisker.\n\n__Default value:__ `\"1.5\"`."
         },
-        "mid": {
-          "$ref": "#/definitions/MarkConfig"
-        },
         "orient": {
           "$ref": "#/definitions/Orient",
           "description": "Orientation of the box plot.  This is normally automatically determined, but can be specified when the orientation is ambiguous and cannot be automatically determined."
         },
         "size": {
-          "description": "Size of the box and mid tick of a box plot ",
+          "description": "Size of the box and center tick of a box plot ",
           "type": "number"
         },
         "type": {

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -785,9 +785,6 @@
         "box": {
           "$ref": "#/definitions/MarkConfig"
         },
-        "center": {
-          "$ref": "#/definitions/MarkConfig"
-        },
         "extent": {
           "anyOf": [
             {
@@ -802,8 +799,11 @@
           ],
           "description": "The extent of the whiskers. Available options include:\n- `\"min-max\": min and max are the lower and upper whiskers respectively.\n- `\"number\": multiples of the interquartile range (Q3-Q1) A number that will be multiplied by the IQR and the product will be added to the third quartile to get the upper whisker and subtracted from the first quartile to get the lower whisker.\n\n__Default value:__ `\"1.5\"`."
         },
+        "median": {
+          "$ref": "#/definitions/MarkConfig"
+        },
         "size": {
-          "description": "Size of the box and center tick of a box plot ",
+          "description": "Size of the box and median tick of a box plot ",
           "type": "number"
         },
         "whisker": {
@@ -818,9 +818,6 @@
         "box": {
           "$ref": "#/definitions/MarkConfig"
         },
-        "center": {
-          "$ref": "#/definitions/MarkConfig"
-        },
         "extent": {
           "anyOf": [
             {
@@ -835,12 +832,15 @@
           ],
           "description": "The extent of the whiskers. Available options include:\n- `\"min-max\": min and max are the lower and upper whiskers respectively.\n- `\"number\": multiples of the interquartile range (Q3-Q1) A number that will be multiplied by the IQR and the product will be added to the third quartile to get the upper whisker and subtracted from the first quartile to get the lower whisker.\n\n__Default value:__ `\"1.5\"`."
         },
+        "median": {
+          "$ref": "#/definitions/MarkConfig"
+        },
         "orient": {
           "$ref": "#/definitions/Orient",
           "description": "Orientation of the box plot.  This is normally automatically determined, but can be specified when the orientation is ambiguous and cannot be automatically determined."
         },
         "size": {
-          "description": "Size of the box and center tick of a box plot ",
+          "description": "Size of the box and median tick of a box plot ",
           "type": "number"
         },
         "type": {

--- a/examples/compiled/boxplot_minmax_1D_horizontal.vg.json
+++ b/examples/compiled/boxplot_minmax_1D_horizontal.vg.json
@@ -231,7 +231,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-mid"
+                "boxplot-center"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_minmax_1D_horizontal.vg.json
+++ b/examples/compiled/boxplot_minmax_1D_horizontal.vg.json
@@ -231,7 +231,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-center"
+                "boxplot-median"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_minmax_1D_vertical.vg.json
+++ b/examples/compiled/boxplot_minmax_1D_vertical.vg.json
@@ -231,7 +231,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-mid"
+                "boxplot-center"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_minmax_1D_vertical.vg.json
+++ b/examples/compiled/boxplot_minmax_1D_vertical.vg.json
@@ -231,7 +231,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-center"
+                "boxplot-median"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_minmax_2D_horizontal.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_horizontal.vg.json
@@ -230,7 +230,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-mid"
+                "boxplot-center"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_minmax_2D_horizontal.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_horizontal.vg.json
@@ -230,7 +230,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-center"
+                "boxplot-median"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_minmax_2D_horizontal_IQR.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_horizontal_IQR.vg.json
@@ -245,7 +245,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-center"
+                "boxplot-median"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_minmax_2D_horizontal_IQR.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_horizontal_IQR.vg.json
@@ -245,7 +245,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-mid"
+                "boxplot-center"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_minmax_2D_horizontal_color_size.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_horizontal_color_size.vg.json
@@ -230,7 +230,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-mid"
+                "boxplot-center"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_minmax_2D_horizontal_color_size.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_horizontal_color_size.vg.json
@@ -230,7 +230,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-center"
+                "boxplot-median"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_minmax_2D_horizontal_custom_midtick_color.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_horizontal_custom_midtick_color.vg.json
@@ -230,7 +230,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-mid"
+                "boxplot-center"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_minmax_2D_horizontal_custom_midtick_color.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_horizontal_custom_midtick_color.vg.json
@@ -230,7 +230,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-center"
+                "boxplot-median"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_minmax_2D_horizontal_explicit_aggregate.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_horizontal_explicit_aggregate.vg.json
@@ -245,7 +245,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-center"
+                "boxplot-median"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_minmax_2D_horizontal_explicit_aggregate.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_horizontal_explicit_aggregate.vg.json
@@ -245,7 +245,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-mid"
+                "boxplot-center"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_minmax_2D_vertical.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_vertical.vg.json
@@ -245,7 +245,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-center"
+                "boxplot-median"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_minmax_2D_vertical.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_vertical.vg.json
@@ -245,7 +245,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-mid"
+                "boxplot-center"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_tukey_2D_vertical.vg.json
+++ b/examples/compiled/boxplot_tukey_2D_vertical.vg.json
@@ -245,7 +245,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-center"
+                "boxplot-median"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/boxplot_tukey_2D_vertical.vg.json
+++ b/examples/compiled/boxplot_tukey_2D_vertical.vg.json
@@ -245,7 +245,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-mid"
+                "boxplot-center"
             ],
             "from": {
                 "data": "data_3"

--- a/examples/compiled/layer_boxplot_circle.vg.json
+++ b/examples/compiled/layer_boxplot_circle.vg.json
@@ -264,7 +264,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-mid"
+                "boxplot-center"
             ],
             "from": {
                 "data": "data_4"

--- a/examples/compiled/layer_boxplot_circle.vg.json
+++ b/examples/compiled/layer_boxplot_circle.vg.json
@@ -264,7 +264,7 @@
             "type": "rect",
             "style": [
                 "tick",
-                "boxplot-center"
+                "boxplot-median"
             ],
             "from": {
                 "data": "data_4"

--- a/examples/specs/boxplot_minmax_2D_horizontal_custom_midtick_color.vl.json
+++ b/examples/specs/boxplot_minmax_2D_horizontal_custom_midtick_color.vl.json
@@ -15,7 +15,7 @@
     }
   },
   "config": {
-    "boxplot": {"center": {"color": "orange"}}
+    "boxplot": {"median": {"color": "orange"}}
   }
 }
 

--- a/examples/specs/boxplot_minmax_2D_horizontal_custom_midtick_color.vl.json
+++ b/examples/specs/boxplot_minmax_2D_horizontal_custom_midtick_color.vl.json
@@ -15,7 +15,7 @@
     }
   },
   "config": {
-    "boxplot": {"mid": {"color": "orange"}}
+    "boxplot": {"center": {"color": "orange"}}
   }
 }
 

--- a/examples/specs/normalized/boxplot_minmax_1D_horizontal_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_1D_horizontal_normalized.vl.json
@@ -105,7 +105,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-mid",
+        "style": "boxplot-center",
         "color": "white"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_1D_horizontal_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_1D_horizontal_normalized.vl.json
@@ -105,7 +105,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-center",
+        "style": "boxplot-median",
         "color": "white"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_1D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_1D_vertical_normalized.vl.json
@@ -105,7 +105,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-mid",
+        "style": "boxplot-center",
         "color": "white"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_1D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_1D_vertical_normalized.vl.json
@@ -105,7 +105,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-center",
+        "style": "boxplot-median",
         "color": "white"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_2D_horizontal_IQR_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_horizontal_IQR_normalized.vl.json
@@ -119,7 +119,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-mid",
+        "style": "boxplot-center",
         "color": "white"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_2D_horizontal_IQR_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_horizontal_IQR_normalized.vl.json
@@ -119,7 +119,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-center",
+        "style": "boxplot-median",
         "color": "white"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_2D_horizontal_color_size_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_horizontal_color_size_normalized.vl.json
@@ -113,7 +113,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-center",
+        "style": "boxplot-median",
         "color": "white"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_2D_horizontal_color_size_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_horizontal_color_size_normalized.vl.json
@@ -113,7 +113,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-mid",
+        "style": "boxplot-center",
         "color": "white"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_2D_horizontal_custom_midtick_color_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_horizontal_custom_midtick_color_normalized.vl.json
@@ -6,7 +6,7 @@
   },
   "config": {
     "boxplot": {
-      "center": {
+      "median": {
         "color": "orange"
       }
     }
@@ -114,7 +114,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-center",
+        "style": "boxplot-median",
         "color": "orange"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_2D_horizontal_custom_midtick_color_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_horizontal_custom_midtick_color_normalized.vl.json
@@ -6,7 +6,7 @@
   },
   "config": {
     "boxplot": {
-      "mid": {
+      "center": {
         "color": "orange"
       }
     }
@@ -114,7 +114,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-mid",
+        "style": "boxplot-center",
         "color": "orange"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_2D_horizontal_explicit_aggregate_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_horizontal_explicit_aggregate_normalized.vl.json
@@ -119,7 +119,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-mid",
+        "style": "boxplot-center",
         "color": "white"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_2D_horizontal_explicit_aggregate_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_horizontal_explicit_aggregate_normalized.vl.json
@@ -119,7 +119,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-center",
+        "style": "boxplot-median",
         "color": "white"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_2D_horizontal_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_horizontal_normalized.vl.json
@@ -107,7 +107,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-center",
+        "style": "boxplot-median",
         "color": "white"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_2D_horizontal_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_horizontal_normalized.vl.json
@@ -107,7 +107,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-mid",
+        "style": "boxplot-center",
         "color": "white"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_2D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_vertical_normalized.vl.json
@@ -119,7 +119,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-mid",
+        "style": "boxplot-center",
         "color": "white"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_2D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_vertical_normalized.vl.json
@@ -119,7 +119,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-center",
+        "style": "boxplot-median",
         "color": "white"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_tukey_2D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_tukey_2D_vertical_normalized.vl.json
@@ -122,7 +122,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-mid",
+        "style": "boxplot-center",
         "color": "white"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_tukey_2D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_tukey_2D_vertical_normalized.vl.json
@@ -122,7 +122,7 @@
       "mark": {
         "type": "tick",
         "size": 14,
-        "style": "boxplot-center",
+        "style": "boxplot-median",
         "color": "white"
       },
       "encoding": {

--- a/examples/specs/normalized/layer_boxplot_circle_normalized.vl.json
+++ b/examples/specs/normalized/layer_boxplot_circle_normalized.vl.json
@@ -122,7 +122,7 @@
           "mark": {
             "type": "tick",
             "size": 14,
-            "style": "boxplot-mid",
+            "style": "boxplot-center",
             "color": "white"
           },
           "encoding": {

--- a/examples/specs/normalized/layer_boxplot_circle_normalized.vl.json
+++ b/examples/specs/normalized/layer_boxplot_circle_normalized.vl.json
@@ -122,7 +122,7 @@
           "mark": {
             "type": "tick",
             "size": 14,
-            "style": "boxplot-center",
+            "style": "boxplot-median",
             "color": "white"
           },
           "encoding": {

--- a/site/docs/compositemark.md
+++ b/site/docs/compositemark.md
@@ -10,9 +10,9 @@ Composite marks are "macros" for more complex layered graphics with multiple pri
 {:#boxplot}
 ## Box Plot
 
-`boxplot` composite mark represents a [box plot](https://en.wikipedia.org/wiki/Box_plot). The middle tick in the box represents the median. The lower and upper part of the box represents the first and third quartile respectively. The ends of the whiskers can represent several possible alternative values, depending on the [`extent`](#boxplot-types) property.
+`boxplot` composite mark represents a [box plot](https://en.wikipedia.org/wiki/Box_plot). The median tick in the box represents the median. The lower and upper part of the box represents the first and third quartile respectively. The ends of the whiskers can represent several possible alternative values, depending on the [`extent`](#boxplot-types) property.
 
-`boxplot` is important because it effectively and quickly shows a summary of data with a five-number summary (lower and upper parts of the box, center tick in the box, and the lower and upper whiskers). It is a great visualization choice to indicate whether the distribution is skewed.
+`boxplot` is important because it effectively and quickly shows a summary of data with a five-number summary (lower and upper parts of the box, median tick in the box, and the lower and upper whiskers). It is a great visualization choice to indicate whether the distribution is skewed.
 <!-- TODO: Ideally we should have an annotated figure for this, but let's not do it for now-->
 
 To create a box plot, you can set `mark` to `"boxplot"`:
@@ -30,7 +30,7 @@ Alternatively, you can use box plot's mark definition object, which supports the
 
 {% include table.html props="type,extent,orient,size" source="BoxPlotDef" %}
 
-Besides the properties listed above, `box`, `center`, `whisker` can be used to specifying the underlying mark properties for different parts of the box plots as well.
+Besides the properties listed above, `box`, `median`, `whisker` can be used to specifying the underlying mark properties for different parts of the box plots as well.
 
 ### Basic Usage
 {:#boxplot-types}

--- a/site/docs/compositemark.md
+++ b/site/docs/compositemark.md
@@ -12,7 +12,7 @@ Composite marks are "macros" for more complex layered graphics with multiple pri
 
 `boxplot` composite mark represents a [box plot](https://en.wikipedia.org/wiki/Box_plot). The middle tick in the box represents the median. The lower and upper part of the box represents the first and third quartile respectively. The ends of the whiskers can represent several possible alternative values, depending on the [`extent`](#boxplot-types) property.
 
-`boxplot` is important because it effectively and quickly shows a summary of data with a five-number summary (lower and upper parts of the box, mid tick in the box, and the lower and upper whiskers). It is a great visualization choice to indicate whether the distribution is skewed.
+`boxplot` is important because it effectively and quickly shows a summary of data with a five-number summary (lower and upper parts of the box, center tick in the box, and the lower and upper whiskers). It is a great visualization choice to indicate whether the distribution is skewed.
 <!-- TODO: Ideally we should have an annotated figure for this, but let's not do it for now-->
 
 To create a box plot, you can set `mark` to `"boxplot"`:
@@ -28,7 +28,9 @@ To create a box plot, you can set `mark` to `"boxplot"`:
 
 Alternatively, you can use box plot's mark definition object, which supports the following properties:
 
-{% include table.html props="type,extent,orient" source="BoxPlotDef" %}
+{% include table.html props="type,extent,orient,size" source="BoxPlotDef" %}
+
+Besides the properties listed above, `box`, `center`, `whisker` can be used to specifying the underlying mark properties for different parts of the box plots as well.
 
 ### Basic Usage
 {:#boxplot-types}

--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -16,11 +16,11 @@ import {getMarkDefMixins} from './common';
 export const BOXPLOT: 'boxplot' = 'boxplot';
 export type BoxPlot = typeof BOXPLOT;
 
-export type BoxPlotPart = 'box' | 'center' | 'whisker';
+export type BoxPlotPart = 'box' | 'median' | 'whisker';
 
 const BOXPLOT_PART_INDEX: Flag<BoxPlotPart> = {
   box: 1,
-  center: 1,
+  median: 1,
   whisker: 1
 };
 
@@ -33,7 +33,7 @@ export type BoxPlotPartsMixins = {
 };
 
 export interface BoxPlotConfig extends BoxPlotPartsMixins {
-  /** Size of the box and center tick of a box plot */
+  /** Size of the box and median tick of a box plot */
   size?: number;
 
   /**
@@ -153,11 +153,11 @@ export function normalizeBoxPlot(spec: GenericUnitSpec<Encoding<string>, BoxPlot
           ...encodingWithoutContinuousAxis,
           ...(size ? {size} : {})
         }
-      }, { // center tick
+      }, { // median tick
         mark: {
           type: 'tick',
           ...(sizeValue ? {size: sizeValue} : {}),
-          ...getMarkDefMixins<BoxPlotPartsMixins>(markDef, 'center', config.boxplot)
+          ...getMarkDefMixins<BoxPlotPartsMixins>(markDef, 'median', config.boxplot)
         },
         encoding: {
           [continuousAxis]: {

--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -16,11 +16,11 @@ import {getMarkDefMixins} from './common';
 export const BOXPLOT: 'boxplot' = 'boxplot';
 export type BoxPlot = typeof BOXPLOT;
 
-export type BoxPlotPart = 'box' | 'mid' | 'whisker';
+export type BoxPlotPart = 'box' | 'center' | 'whisker';
 
 const BOXPLOT_PART_INDEX: Flag<BoxPlotPart> = {
   box: 1,
-  mid: 1,
+  center: 1,
   whisker: 1
 };
 
@@ -33,7 +33,7 @@ export type BoxPlotPartsMixins = {
 };
 
 export interface BoxPlotConfig extends BoxPlotPartsMixins {
-  /** Size of the box and mid tick of a box plot */
+  /** Size of the box and center tick of a box plot */
   size?: number;
 
   /**
@@ -153,11 +153,11 @@ export function normalizeBoxPlot(spec: GenericUnitSpec<Encoding<string>, BoxPlot
           ...encodingWithoutContinuousAxis,
           ...(size ? {size} : {})
         }
-      }, { // mid tick
+      }, { // center tick
         mark: {
           type: 'tick',
           ...(sizeValue ? {size: sizeValue} : {}),
-          ...getMarkDefMixins<BoxPlotPartsMixins>(markDef, 'mid', config.boxplot)
+          ...getMarkDefMixins<BoxPlotPartsMixins>(markDef, 'center', config.boxplot)
         },
         encoding: {
           [continuousAxis]: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -266,7 +266,7 @@ export const defaultConfig: Config = {
     size: 14,
     extent: 1.5,
     box: {},
-    center: {color: 'white'},
+    median: {color: 'white'},
     whisker: {}
   },
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -266,7 +266,7 @@ export const defaultConfig: Config = {
     size: 14,
     extent: 1.5,
     box: {},
-    mid: {color: 'white'},
+    center: {color: 'white'},
     whisker: {}
   },
 

--- a/test/compositemark/boxplot.test.ts
+++ b/test/compositemark/boxplot.test.ts
@@ -143,7 +143,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-mid',
+              style: 'boxplot-center',
               color: 'white',
               size: 5
             },
@@ -380,7 +380,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-mid',
+              style: 'boxplot-center',
               size: 14,
               color: 'white'
             },
@@ -507,7 +507,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-mid',
+              style: 'boxplot-center',
               color: 'white',
               size: 14
             },
@@ -634,7 +634,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-mid',
+              style: 'boxplot-center',
               color: 'white',
               size: 14
             },
@@ -761,7 +761,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-mid',
+              style: 'boxplot-center',
               color: 'white',
               size: 14
             },
@@ -887,7 +887,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-mid',
+              style: 'boxplot-center',
               color: 'white',
               size: 14
             },
@@ -1013,7 +1013,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-mid',
+              style: 'boxplot-center',
               color: 'white',
               size: 14
             },
@@ -1137,7 +1137,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-mid',
+              style: 'boxplot-center',
               color: 'white',
               size: 14
             },
@@ -1257,7 +1257,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-mid',
+              style: 'boxplot-center',
               color: 'white',
               size: 14
             },
@@ -1376,7 +1376,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-mid',
+              style: 'boxplot-center',
               color: 'white',
               size: 14
             },
@@ -1514,7 +1514,7 @@ describe("normalizeBoxIQR", () => {
          {
            mark: {
              type: 'tick',
-             style: 'boxplot-mid',
+             style: 'boxplot-center',
              color: 'white',
              size: 14
            },
@@ -1652,7 +1652,7 @@ describe("normalizeBoxIQR", () => {
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-mid',
+              style: 'boxplot-center',
               color: 'white',
               size: 14
             },
@@ -1802,7 +1802,7 @@ describe("normalizeBoxIQR", () => {
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-mid',
+              style: 'boxplot-center',
               color: 'white',
               size: 14
             },

--- a/test/compositemark/boxplot.test.ts
+++ b/test/compositemark/boxplot.test.ts
@@ -143,7 +143,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-center',
+              style: 'boxplot-median',
               color: 'white',
               size: 5
             },
@@ -380,7 +380,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-center',
+              style: 'boxplot-median',
               size: 14,
               color: 'white'
             },
@@ -507,7 +507,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-center',
+              style: 'boxplot-median',
               color: 'white',
               size: 14
             },
@@ -634,7 +634,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-center',
+              style: 'boxplot-median',
               color: 'white',
               size: 14
             },
@@ -761,7 +761,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-center',
+              style: 'boxplot-median',
               color: 'white',
               size: 14
             },
@@ -887,7 +887,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-center',
+              style: 'boxplot-median',
               color: 'white',
               size: 14
             },
@@ -1013,7 +1013,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-center',
+              style: 'boxplot-median',
               color: 'white',
               size: 14
             },
@@ -1137,7 +1137,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-center',
+              style: 'boxplot-median',
               color: 'white',
               size: 14
             },
@@ -1257,7 +1257,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-center',
+              style: 'boxplot-median',
               color: 'white',
               size: 14
             },
@@ -1376,7 +1376,7 @@ it("should produce correct layered specs for vertical boxplot with two quantitat
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-center',
+              style: 'boxplot-median',
               color: 'white',
               size: 14
             },
@@ -1514,7 +1514,7 @@ describe("normalizeBoxIQR", () => {
          {
            mark: {
              type: 'tick',
-             style: 'boxplot-center',
+             style: 'boxplot-median',
              color: 'white',
              size: 14
            },
@@ -1652,7 +1652,7 @@ describe("normalizeBoxIQR", () => {
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-center',
+              style: 'boxplot-median',
               color: 'white',
               size: 14
             },
@@ -1802,7 +1802,7 @@ describe("normalizeBoxIQR", () => {
           {
             mark: {
               type: 'tick',
-              style: 'boxplot-center',
+              style: 'boxplot-median',
               color: 'white',
               size: 14
             },

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -27,7 +27,7 @@ describe('config', () => {
         whisker: {
           fill: 'red'
         },
-        center: {
+        median: {
           color: 'white'
         }
       }
@@ -60,7 +60,7 @@ describe('config', () => {
       assert.deepEqual(output.style['boxplot-whisker'], {fill: 'red'}, `config.boxplot.whisker should be redirect to config.style['boxplot-whisker]`);
 
       assert.isUndefined(output.boxplot, `Boxplot config should be redirected`);
-      assert.isUndefined(output.style['boxplot-center'], `Boxplot center's color config should be stripped`);
+      assert.isUndefined(output.style['boxplot-median'], `Boxplot median tick's color config should be stripped`);
     });
 
     it('should redirect config.title to config.style.group-title and rename color to fill', () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -27,7 +27,7 @@ describe('config', () => {
         whisker: {
           fill: 'red'
         },
-        mid: {
+        center: {
           color: 'white'
         }
       }
@@ -60,7 +60,7 @@ describe('config', () => {
       assert.deepEqual(output.style['boxplot-whisker'], {fill: 'red'}, `config.boxplot.whisker should be redirect to config.style['boxplot-whisker]`);
 
       assert.isUndefined(output.boxplot, `Boxplot config should be redirected`);
-      assert.isUndefined(output.style['boxplot-mid'], `Boxplot mid's color config should be stripped`);
+      assert.isUndefined(output.style['boxplot-center'], `Boxplot center's color config should be stripped`);
     });
 
     it('should redirect config.title to config.style.group-title and rename color to fill', () => {


### PR DESCRIPTION
"Mid" can't be a noun but "center" can so I like center better.  

~~We should merge https://github.com/vega/vega-lite/pull/3454 first.~~  