### PR TITLE
Rename `Spec` => `NormalizedSpec`, `TopLevelExtendedSpec` => `TopLevelSpec`

### DIFF
--- a/examples/examples.test.ts
+++ b/examples/examples.test.ts
@@ -2,7 +2,7 @@ import * as Ajv from 'ajv';
 import {assert} from 'chai';
 
 import {compile} from '../src/compile/compile';
-import {TopLevelExtendedSpec} from '../src/spec';
+import {TopLevelSpec} from '../src/spec';
 
 const inspect = require('util').inspect;
 const fs = require('fs');
@@ -24,7 +24,7 @@ ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-04.json'));  // for Ve
 const validateVl = ajv.compile(vlSchema);
 const validateVg = ajv.compile(vgSchema);
 
-function validateVL(spec: TopLevelExtendedSpec) {
+function validateVL(spec: TopLevelSpec) {
   const valid = validateVl(spec);
   const errors = validateVl.errors;
   if (!valid) {
@@ -35,7 +35,7 @@ function validateVL(spec: TopLevelExtendedSpec) {
   assert.equal(spec.$schema.substr(0, 42), 'https://vega.github.io/schema/vega-lite/v2');
 }
 
-function validateVega(spec: TopLevelExtendedSpec) {
+function validateVega(spec: TopLevelSpec) {
   const vegaSpec = compile(spec).spec;
 
   const valid = validateVg(vegaSpec);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vega-lite",
   "author": "Jeffrey Heer, Dominik Moritz, Kanit \"Ham\" Wongsuphasawat",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "collaborators": [
     "Kanit Wongsuphasawat <kanitw@gmail.com> (http://kanitw.yellowpigz.com)",
     "Dominik Moritz <domoritz@cs.washington.edu> (https://www.domoritz.de)",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "poststart": "rm examples/all-examples.json",
 
     "preschema": "npm run prebuild",
-    "schema": "ts-json-schema-generator --path tsconfig.json --type TopLevelExtendedSpec > build/vega-lite-schema.json && npm run renameschema && cp build/vega-lite-schema.json _data/",
+    "schema": "ts-json-schema-generator --path tsconfig.json --type TopLevelSpec > build/vega-lite-schema.json && npm run renameschema && cp build/vega-lite-schema.json _data/",
     "renameschema": "scripts/rename-schema.sh",
     "presite": "npm run prebuild && npm run data && npm run build:site && npm run build:toc && npm run build:versions && scripts/create-example-pages",
     "site": "bundle exec jekyll serve --incremental",

--- a/src/compile/buildmodel.ts
+++ b/src/compile/buildmodel.ts
@@ -1,6 +1,6 @@
 import {Config} from '../config';
 import * as log from '../log';
-import {isConcatSpec, isFacetSpec, isLayerSpec, isRepeatSpec, isUnitSpec, LayoutSizeMixins, Spec} from '../spec';
+import {isConcatSpec, isFacetSpec, isLayerSpec, isRepeatSpec, isUnitSpec, LayoutSizeMixins, NormalizedSpec} from '../spec';
 import {ConcatModel} from './concat';
 import {FacetModel} from './facet';
 import {LayerModel} from './layer';
@@ -9,7 +9,7 @@ import {RepeatModel} from './repeat';
 import {RepeaterValue} from './repeater';
 import {UnitModel} from './unit';
 
-export function buildModel(spec: Spec, parent: Model, parentGivenName: string,
+export function buildModel(spec: NormalizedSpec, parent: Model, parentGivenName: string,
   unitSize: LayoutSizeMixins, repeater: RepeaterValue, config: Config, fit: boolean): Model {
   if (isFacetSpec(spec)) {
     return new FacetModel(spec, parent, parentGivenName, repeater, config);

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -1,7 +1,7 @@
 import {Config, initConfig, stripAndRedirectConfig} from '../config';
 import * as vlFieldDef from '../fielddef';
 import * as log from '../log';
-import {isLayerSpec, isUnitSpec, LayoutSizeMixins, normalize, TopLevel, TopLevelExtendedSpec} from '../spec';
+import {isLayerSpec, isUnitSpec, LayoutSizeMixins, normalize, TopLevel, TopLevelSpec} from '../spec';
 import {AutoSizeParams, extractTopLevelProperties, normalizeAutoSize, TopLevelProperties} from '../toplevelprops';
 import {keys, mergeDeep} from '../util';
 import {buildModel} from './buildmodel';
@@ -43,7 +43,7 @@ export interface CompileOptions {
  *     v
  * Vega spec
  */
-export function compile(inputSpec: TopLevelExtendedSpec, opt: CompileOptions = {}) {
+export function compile(inputSpec: TopLevelSpec, opt: CompileOptions = {}) {
   // 0. Augment opt with default opts
   if (opt.logger) {
     // set the singleton logger to the provided logger

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -209,9 +209,9 @@ export type ConcatSpec = GenericVConcatSpec<UnitSpec> | GenericHConcatSpec<UnitS
 
 export type GenericSpec<U extends GenericUnitSpec<any, any>> = U | GenericLayerSpec<U> | GenericFacetSpec<U> | GenericRepeatSpec<U> | GenericVConcatSpec<U> | GenericHConcatSpec<U>;
 
-export type Spec = GenericSpec<UnitSpec>;
+export type NormalizedSpec = GenericSpec<UnitSpec>;
 
-export type TopLevelExtendedSpec = TopLevel<FacetedCompositeUnitSpec> | TopLevel<GenericLayerSpec<CompositeUnitSpec>> | TopLevel<GenericFacetSpec<CompositeUnitSpec>> | TopLevel<GenericRepeatSpec<CompositeUnitSpec>> | TopLevel<GenericVConcatSpec<CompositeUnitSpec>> | TopLevel<GenericHConcatSpec<CompositeUnitSpec>>;
+export type TopLevelSpec = TopLevel<FacetedCompositeUnitSpec> | TopLevel<GenericLayerSpec<CompositeUnitSpec>> | TopLevel<GenericFacetSpec<CompositeUnitSpec>> | TopLevel<GenericRepeatSpec<CompositeUnitSpec>> | TopLevel<GenericVConcatSpec<CompositeUnitSpec>> | TopLevel<GenericHConcatSpec<CompositeUnitSpec>>;
 
 /* Custom type guards */
 
@@ -248,7 +248,7 @@ export function isHConcatSpec(spec: BaseSpec): spec is GenericHConcatSpec<Generi
  * Decompose extended unit specs into composition of pure unit specs.
  */
 // TODO: consider moving this to another file.  Maybe vl.spec.normalize or vl.normalize
-export function normalize(spec: TopLevelExtendedSpec, config: Config): Spec {
+export function normalize(spec: TopLevelSpec, config: Config): NormalizedSpec {
   if (isFacetSpec(spec)) {
     return normalizeFacet(spec, config);
   }

--- a/test-runtime/util.ts
+++ b/test-runtime/util.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs';
 import {sync as mkdirp} from 'mkdirp';
 import {stringValue} from 'vega-util';
 import {SelectionResolution, SelectionType} from '../src/selection';
-import {LayerSpec, TopLevelExtendedSpec, UnitSpec} from '../src/spec';
+import {LayerSpec, TopLevelSpec, UnitSpec} from '../src/spec';
 
 export const generate = process.env.VL_GENERATE_TESTS;
 export const output = 'test-runtime/resources';
@@ -100,7 +100,7 @@ function base(iter: number, sel: any, opts: any = {}): UnitSpec | LayerSpec {
   };
 }
 
-export function spec(compose: ComposeType, iter: number, sel: any, opts: any = {}): TopLevelExtendedSpec {
+export function spec(compose: ComposeType, iter: number, sel: any, opts: any = {}): TopLevelSpec {
   const {data, ...specification} = base(iter, sel, opts);
   const resolve = opts.resolve;
   switch (compose) {
@@ -146,7 +146,7 @@ export function pt(key: string, idx: number, parent?: string) {
 }
 
 export function embedFn(browser: WebdriverIO.Client<void>) {
-  return function(specification: TopLevelExtendedSpec) {
+  return function(specification: TopLevelSpec) {
     browser.execute((_) => window['embed'](_), specification);
   };
 }

--- a/test/spec.test.ts
+++ b/test/spec.test.ts
@@ -4,7 +4,7 @@ import {assert} from 'chai';
 import {Encoding} from '../src/encoding';
 import {Field, FieldDef} from '../src/fielddef';
 import {MarkDef} from '../src/mark';
-import {fieldDefs, GenericSpec, GenericUnitSpec, normalize, Spec, TopLevelExtendedSpec} from '../src/spec';
+import {fieldDefs, GenericSpec, GenericUnitSpec, normalize, NormalizedSpec, TopLevel, TopLevelSpec} from '../src/spec';
 import {defaultConfig, initConfig} from './../src/config';
 
 // describe('isStacked()') -- tested as part of stackOffset in stack.test.ts
@@ -303,7 +303,7 @@ describe('normalize()', function () {
 
   describe('normalizeOverlay', () => {
     it('correctly normalizes line with overlayed point.', () => {
-      const spec: TopLevelExtendedSpec = {
+      const spec: TopLevelSpec = {
         "data": {"url": "data/stocks.csv", "format": {"type": "csv"}},
         "mark": "line",
         "encoding": {
@@ -313,7 +313,7 @@ describe('normalize()', function () {
         "config": {"overlay": {"line": true}}
       };
       const normalizedSpec = normalize(spec, spec.config);
-      assert.deepEqual<TopLevelExtendedSpec>(normalizedSpec, {
+      assert.deepEqual<TopLevel<NormalizedSpec>>(normalizedSpec, {
         "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
         "layer": [
           {
@@ -336,7 +336,7 @@ describe('normalize()', function () {
     });
 
     it('correctly normalizes faceted line plots with overlayed point.', () => {
-      const spec: TopLevelExtendedSpec = {
+      const spec: TopLevelSpec = {
         "data": {"url": "data/stocks.csv", "format": {"type": "csv"}},
         "mark": "line",
         "encoding": {
@@ -347,7 +347,7 @@ describe('normalize()', function () {
         "config": {"overlay": {"line": true}}
       };
       const normalizedSpec = normalize(spec, spec.config);
-      assert.deepEqual<TopLevelExtendedSpec>(normalizedSpec, {
+      assert.deepEqual<TopLevel<NormalizedSpec>>(normalizedSpec, {
         "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
         "facet": {
           "row": {"field": "symbol", "type": "nominal"},
@@ -375,7 +375,7 @@ describe('normalize()', function () {
     });
 
     it('correctly normalizes area with overlay line and point', () => {
-      const spec: TopLevelExtendedSpec = {
+      const spec: TopLevelSpec = {
         "data": {"url": "data/stocks.csv", "format": {"type": "csv"}},
         "mark": "area",
         "encoding": {
@@ -385,7 +385,7 @@ describe('normalize()', function () {
         "config": {"overlay": {"area": 'linepoint'}}
       };
       const normalizedSpec = normalize(spec, spec.config);
-      assert.deepEqual<TopLevelExtendedSpec>(normalizedSpec, {
+      assert.deepEqual<TopLevel<NormalizedSpec>>(normalizedSpec, {
         "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
         "layer": [
           {
@@ -415,7 +415,7 @@ describe('normalize()', function () {
     });
 
     it('correctly normalizes area with overlay line', () => {
-      const spec: TopLevelExtendedSpec = {
+      const spec: TopLevelSpec = {
         "data": {"url": "data/stocks.csv", "format": {"type": "csv"}},
         "mark": "area",
         "encoding": {
@@ -425,7 +425,7 @@ describe('normalize()', function () {
         "config": {"overlay": {"area": 'line'}}
       };
       const normalizedSpec = normalize(spec, spec.config);
-      assert.deepEqual<TopLevelExtendedSpec>(normalizedSpec, {
+      assert.deepEqual<TopLevel<NormalizedSpec>>(normalizedSpec, {
         "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
         "layer": [
           {
@@ -448,7 +448,7 @@ describe('normalize()', function () {
     });
 
     it('correctly normalizes stacked area with overlay line', () => {
-      const spec: TopLevelExtendedSpec = {
+      const spec: TopLevelSpec = {
         "data": {"url": "data/stocks.csv", "format": {"type": "csv"}},
         "mark": "area",
         "encoding": {
@@ -459,7 +459,7 @@ describe('normalize()', function () {
         "config": {"overlay": {"area": 'line'}}
       };
       const normalizedSpec = normalize(spec, spec.config);
-      assert.deepEqual<TopLevelExtendedSpec>(normalizedSpec, {
+      assert.deepEqual<TopLevel<NormalizedSpec>>(normalizedSpec, {
         "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
         "layer": [
           {
@@ -484,7 +484,7 @@ describe('normalize()', function () {
     });
 
     it('correctly normalizes streamgraph with overlay line', () => {
-      const spec: TopLevelExtendedSpec = {
+      const spec: TopLevelSpec = {
         "data": {"url": "data/stocks.csv", "format": {"type": "csv"}},
         "mark": "area",
         "encoding": {
@@ -495,7 +495,7 @@ describe('normalize()', function () {
         "config": {"overlay": {"area": 'line'}}
       };
       const normalizedSpec = normalize(spec, spec.config);
-      assert.deepEqual<TopLevelExtendedSpec>(normalizedSpec, {
+      assert.deepEqual<TopLevel<NormalizedSpec>>(normalizedSpec, {
         "data": {"url": "data/stocks.csv","format": {"type": "csv"}},
         "layer": [
           {
@@ -523,7 +523,7 @@ describe('normalize()', function () {
 
 describe('normalizeRangedUnitSpec', () => {
   it('should convert y2 -> y if there is no y in the encoding', function() {
-    const spec: Spec = {
+    const spec: NormalizedSpec = {
       "data": {"url": "data/population.json"},
       "mark": "rule",
       "encoding": {
@@ -533,7 +533,7 @@ describe('normalizeRangedUnitSpec', () => {
       }
     };
 
-    assert.deepEqual<Spec>(normalize(spec, defaultConfig), {
+    assert.deepEqual<NormalizedSpec>(normalize(spec, defaultConfig), {
       "data": {"url": "data/population.json"},
       "mark": "rule",
       "encoding": {
@@ -545,7 +545,7 @@ describe('normalizeRangedUnitSpec', () => {
   });
 
   it('should do nothing if there is no missing x or y', function() {
-    const spec: TopLevelExtendedSpec = {
+    const spec: TopLevelSpec = {
       "data": {"url": "data/population.json"},
       "mark": "rule",
       "encoding": {
@@ -555,11 +555,11 @@ describe('normalizeRangedUnitSpec', () => {
       }
     };
 
-    assert.deepEqual<TopLevelExtendedSpec>(normalize(spec, defaultConfig), spec);
+    assert.deepEqual<TopLevelSpec>(normalize(spec, defaultConfig), spec);
   });
 
   it('should convert x2 -> x if there is no x in the encoding', function() {
-    const spec: Spec = {
+    const spec: NormalizedSpec = {
       "data": {"url": "data/population.json"},
       "mark": "rule",
       "encoding": {
@@ -569,7 +569,7 @@ describe('normalizeRangedUnitSpec', () => {
       }
     };
 
-    assert.deepEqual<Spec>(normalize(spec, defaultConfig), {
+    assert.deepEqual<NormalizedSpec>(normalize(spec, defaultConfig), {
       "data": {"url": "data/population.json"},
       "mark": "rule",
       "encoding": {

--- a/test/util.ts
+++ b/test/util.ts
@@ -13,20 +13,20 @@ import {
   normalize,
   RepeatSpec,
   TopLevel,
-  TopLevelExtendedSpec,
+  TopLevelSpec,
   UnitSpec,
 } from '../src/spec';
 import {isLayerSpec, isUnitSpec} from '../src/spec';
 import {normalizeAutoSize} from '../src/toplevelprops';
 
-export function parseModel(inputSpec: TopLevelExtendedSpec): Model {
+export function parseModel(inputSpec: TopLevelSpec): Model {
   const config = initConfig(inputSpec.config);
   const spec = normalize(inputSpec, config);
   const autosize = normalizeAutoSize(inputSpec.autosize, config.autosize, isLayerSpec(spec) || isUnitSpec(spec));
   return buildModel(spec, null, '', undefined, undefined, config, autosize.type === 'fit');
 }
 
-export function parseModelWithScale(inputSpec: TopLevelExtendedSpec): Model {
+export function parseModelWithScale(inputSpec: TopLevelSpec): Model {
   const model = parseModel(inputSpec);
   model.parseScale();
   return model;


### PR DESCRIPTION
cc: @jakevdp  

The name `TopLevelExtendedSpec` is a bit too much, so we're simplifying it. 