### PR TITLE
Support `sort` for non-path marks + consolidate redundant code

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1641,7 +1641,7 @@
               "type": "array"
             }
           ],
-          "description": "Stack order for stacked marks or order of data points in line marks for connected scatter plots.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
+          "description": "Order of the marks.\n- For stacked marks, this `order` channel encodes stack order.\n- For line marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/layer_connected_scatterplot.html).\n- Otherwise, this `order` channel encodes layer order of the marks.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
         },
         "shape": {
           "anyOf": [
@@ -1800,7 +1800,7 @@
               "type": "array"
             }
           ],
-          "description": "Stack order for stacked marks or order of data points in line marks for connected scatter plots.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
+          "description": "Order of the marks.\n- For stacked marks, this `order` channel encodes stack order.\n- For line marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/layer_connected_scatterplot.html).\n- Otherwise, this `order` channel encodes layer order of the marks.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
         },
         "row": {
           "$ref": "#/definitions/FacetFieldDef",

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -38,36 +38,19 @@ export function parseMarkGroup(model: UnitModel): any[] {
   if (contains([LINE, AREA], model.mark())) {
     return parsePathMark(model);
   } else {
-    return parseNonPathMark(model);
+    return getMarkGroups(model);
   }
 }
 
 const FACETED_PATH_PREFIX = 'faceted_path_';
 
 function parsePathMark(model: UnitModel) {
-  const mark = model.mark();
   const details = pathGroupingFields(model.encoding);
 
-  const postEncodingTransform = markCompiler[mark].postEncodingTransform ? markCompiler[mark].postEncodingTransform(model) : null;
-
-  const clip = model.markDef.clip !== undefined ? !!model.markDef.clip : scaleClip(model);
-  const style = getStyles(model.markDef);
-  const sort = getPathSort(model);
-
-  const pathMarks: any = [
-    {
-      name: model.getName('marks'),
-      type: markCompiler[mark].vgMark,
-      ...(clip ? {clip: true} : {}),
-      ...(style? {style} : {}),
-      ...(sort? {sort} : {}),
-      // If has subfacet for line/area group, need to use faceted data from below.
-      // FIXME: support sorting path order (in connected scatterplot)
-      from: {data: (details.length > 0 ? FACETED_PATH_PREFIX : '') + model.requestDataName(MAIN)},
-      encode: {update: markCompiler[mark].encodeEntry(model)},
-      ...postEncodingTransform ? {transform: postEncodingTransform} : {}
-    }
-  ];
+  const pathMarks = getMarkGroups(model, {
+    // If has subfacet for line/area group, need to use faceted data from below.
+    fromPrefix: (details.length > 0 ? FACETED_PATH_PREFIX : '')
+  });
 
   if (details.length > 0) { // have level of details - need to facet line into subgroups
     // TODO: for non-stacked plot, map order to zindex. (Maybe rename order for layer to zindex?)
@@ -95,11 +78,11 @@ function parsePathMark(model: UnitModel) {
   }
 }
 
-export function getPathSort(model: UnitModel) {
-  if (model.mark() === 'line' && model.channelHasField('order')) {
-    // For only line, sort by the order field if it is specified.
+export function getSort(model: UnitModel) {
+  if (model.channelHasField('order') && !model.stack) {
+    // Sort by the order field if it is specified and the field is not stacked. (For stacked field, order specify stack order.)
     return sortParams(model.encoding.order, {expr: 'datum'});
-  } else {
+  } else if (contains(['line', 'area'], model.mark())) {
     // For both line and area, we sort values based on dimension by default
     const dimensionChannel: 'x' | 'y' = model.markDef.orient === 'horizontal' ? 'y' : 'x';
     const s = model.sort(dimensionChannel);
@@ -123,31 +106,35 @@ export function getPathSort(model: UnitModel) {
       } :
       undefined;
   }
+  return undefined;
 }
 
-function parseNonPathMark(model: UnitModel) {
+function getMarkGroups(model: UnitModel, opt: {
+  fromPrefix: string
+} = {fromPrefix: ''}) {
   const mark = model.mark();
 
   const style = getStyles(model.markDef);
   const clip = model.markDef.clip !== undefined ? !!model.markDef.clip : scaleClip(model);
+  const sort = getSort(model);
 
   const postEncodingTransform = markCompiler[mark].postEncodingTransform ? markCompiler[mark].postEncodingTransform(model) : null;
 
-  const marks: any[] = []; // TODO: vgMarks
-
-  // TODO: for non-stacked plot, map order to zindex. (Maybe rename order for layer to zindex?)
-
-  marks.push({
+  return [{
     name: model.getName('marks'),
     type: markCompiler[mark].vgMark,
     ...(clip ? {clip: true} : {}),
-    ...(style? {style} : {}),
-    from: {data: model.requestDataName(MAIN)},
-    encode: {update: markCompiler[mark].encodeEntry(model)},
-    ...(postEncodingTransform ? {transform: postEncodingTransform} : {})
-  });
+    ...(style ? {style} : {}),
+    ...(sort ? {sort} : {}),
+    from: {data: opt.fromPrefix + model.requestDataName(MAIN)},
+    encode: {
+      update: markCompiler[mark].encodeEntry(model)
+    },
+    ...(postEncodingTransform ? {
+      transform: postEncodingTransform
+    } : {})
+  }];
 
-  return marks;
 }
 
 /**

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -107,7 +107,10 @@ export interface Encoding<F> {
   href?: FieldDefWithCondition<FieldDef<F>> | ValueDefWithCondition<FieldDef<F>>;
 
   /**
-   * Stack order for stacked marks or order of data points in line marks for connected scatter plots.
+   * Order of the marks.
+   * - For stacked marks, this `order` channel encodes stack order.
+   * - For line marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/layer_connected_scatterplot.html).
+   * - Otherwise, this `order` channel encodes layer order of the marks.
    *
    * __Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping.
    */

--- a/test/compile/mark/mark.test.ts
+++ b/test/compile/mark/mark.test.ts
@@ -2,7 +2,7 @@
 
 import {assert} from 'chai';
 import {COLOR, DETAIL, OPACITY, SIZE, UNIT_CHANNELS} from '../../../src/channel';
-import {getPathSort, parseMarkGroup, pathGroupingFields} from '../../../src/compile/mark/mark';
+import {getSort, parseMarkGroup, pathGroupingFields} from '../../../src/compile/mark/mark';
 import {UnitModel} from '../../../src/compile/unit';
 import {GEOSHAPE} from '../../../src/mark';
 import {parseFacetModel, parseUnitModel, parseUnitModelWithScale, parseUnitModelWithScaleAndLayoutSize} from '../../util';
@@ -209,9 +209,9 @@ describe('Mark', function() {
     });
   });
 
-  describe('getPathSort', () => {
+  describe('getSort', () => {
     describe('compileUnit', function() {
-      it('should order by order field for line with order (connected scatterplot)', function () {
+      it('should order by order field', function () {
         const model = parseUnitModel({
           "data": {"url": "data/driving.json"},
           "mark": "line",
@@ -221,7 +221,7 @@ describe('Mark', function() {
             "order": {"field": "year","type": "temporal"}
           }
         });
-        assert.deepEqual(getPathSort(model), {
+        assert.deepEqual(getSort(model), {
           field: ['datum[\"year\"]'],
           order: ['ascending']
         });
@@ -247,7 +247,7 @@ describe('Mark', function() {
             }
           }
         });
-        assert.deepEqual(getPathSort(model), {
+        assert.deepEqual(getSort(model), {
           field: 'datum[\"bin_maxbins_10_IMDB_Rating\"]',
           order: 'descending'
         });
@@ -268,7 +268,7 @@ describe('Mark', function() {
             }
           }
         });
-        assert.deepEqual(getPathSort(model), undefined);
+        assert.deepEqual(getSort(model), undefined);
       });
     });
   });


### PR DESCRIPTION
Fix #3495

