### PR TITLE
Add fill & stroke channels

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1610,7 +1610,7 @@
               "$ref": "#/definitions/MarkPropValueDefWithCondition"
             }
           ],
-          "description": "Color of the marks – either fill or stroke color based on mark type.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](config.html#mark)'s `color` property.\n\n_Note:_ See the scale documentation for more information about customizing [color scheme](scale.html#scheme)."
+          "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.\n2) See the scale documentation for more information about customizing [color scheme](scale.html#scheme)."
         },
         "detail": {
           "anyOf": [
@@ -1625,6 +1625,17 @@
             }
           ],
           "description": "Additional levels of detail for grouping data in aggregate views and\nin line and area marks without mapping data to a specific visual channel."
+        },
+        "fill": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MarkPropFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/MarkPropValueDefWithCondition"
+            }
+          ],
+          "description": "Fill color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](config.html#mark)'s `color` property.\n\n_Note:_ The `fill` channel has higher precedence than `color` and will override color value."
         },
         "href": {
           "anyOf": [
@@ -1687,6 +1698,17 @@
             }
           ],
           "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is currently unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`."
+        },
+        "stroke": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MarkPropFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/MarkPropValueDefWithCondition"
+            }
+          ],
+          "description": "Stroke color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](config.html#mark)'s `color` property.\n\n_Note:_ The `stroke` channel has higher precedence than `color` and will override color value."
         },
         "text": {
           "anyOf": [
@@ -1769,7 +1791,7 @@
               "$ref": "#/definitions/MarkPropValueDefWithCondition"
             }
           ],
-          "description": "Color of the marks – either fill or stroke color based on mark type.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](config.html#mark)'s `color` property.\n\n_Note:_ See the scale documentation for more information about customizing [color scheme](scale.html#scheme)."
+          "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.\n2) See the scale documentation for more information about customizing [color scheme](scale.html#scheme)."
         },
         "column": {
           "$ref": "#/definitions/FacetFieldDef",
@@ -1788,6 +1810,17 @@
             }
           ],
           "description": "Additional levels of detail for grouping data in aggregate views and\nin line and area marks without mapping data to a specific visual channel."
+        },
+        "fill": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MarkPropFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/MarkPropValueDefWithCondition"
+            }
+          ],
+          "description": "Fill color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](config.html#mark)'s `color` property.\n\n_Note:_ The `fill` channel has higher precedence than `color` and will override color value."
         },
         "href": {
           "anyOf": [
@@ -1854,6 +1887,17 @@
             }
           ],
           "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is currently unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`."
+        },
+        "stroke": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MarkPropFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/MarkPropValueDefWithCondition"
+            }
+          ],
+          "description": "Stroke color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](config.html#mark)'s `color` property.\n\n_Note:_ The `stroke` channel has higher precedence than `color` and will override color value."
         },
         "text": {
           "anyOf": [
@@ -3353,6 +3397,9 @@
         "color": {
           "$ref": "#/definitions/ResolveMode"
         },
+        "fill": {
+          "$ref": "#/definitions/ResolveMode"
+        },
         "opacity": {
           "$ref": "#/definitions/ResolveMode"
         },
@@ -3360,6 +3407,9 @@
           "$ref": "#/definitions/ResolveMode"
         },
         "size": {
+          "$ref": "#/definitions/ResolveMode"
+        },
+        "stroke": {
           "$ref": "#/definitions/ResolveMode"
         }
       },
@@ -4958,6 +5008,9 @@
         "color": {
           "$ref": "#/definitions/ResolveMode"
         },
+        "fill": {
+          "$ref": "#/definitions/ResolveMode"
+        },
         "opacity": {
           "$ref": "#/definitions/ResolveMode"
         },
@@ -4965,6 +5018,9 @@
           "$ref": "#/definitions/ResolveMode"
         },
         "size": {
+          "$ref": "#/definitions/ResolveMode"
+        },
+        "stroke": {
           "$ref": "#/definitions/ResolveMode"
         },
         "x": {
@@ -5111,9 +5167,11 @@
         "y2",
         "row",
         "column",
+        "color",
+        "fill",
+        "stroke",
         "size",
         "shape",
-        "color",
         "opacity",
         "text",
         "tooltip",

--- a/examples/compiled/circle_natural_disasters.vg.json
+++ b/examples/compiled/circle_natural_disasters.vg.json
@@ -105,6 +105,16 @@
             "padding": 0.5
         },
         {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Entity",
+                "sort": true
+            },
+            "range": "category"
+        },
+        {
             "name": "size",
             "type": "linear",
             "domain": {
@@ -117,16 +127,6 @@
             ],
             "nice": false,
             "zero": true
-        },
-        {
-            "name": "color",
-            "type": "ordinal",
-            "domain": {
-                "data": "source_0",
-                "field": "Entity",
-                "sort": true
-            },
-            "range": "category"
         }
     ],
     "axes": [

--- a/examples/compiled/errorbar_aggregate.vg.json
+++ b/examples/compiled/errorbar_aggregate.vg.json
@@ -243,11 +243,11 @@
             },
             "encode": {
                 "update": {
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/errorbar_horizontal_aggregate.vg.json
+++ b/examples/compiled/errorbar_horizontal_aggregate.vg.json
@@ -243,11 +243,11 @@
             },
             "encode": {
                 "update": {
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/facet_column_facet_column_point_future.vg.json
+++ b/examples/compiled/facet_column_facet_column_point_future.vg.json
@@ -305,11 +305,11 @@
                                     "opacity": {
                                         "value": 0.7
                                     },
-                                    "stroke": {
-                                        "value": "#4c78a8"
-                                    },
                                     "fill": {
                                         "value": "transparent"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
                                     },
                                     "x": {
                                         "scale": "x",

--- a/examples/compiled/facet_column_facet_row_point_future.vg.json
+++ b/examples/compiled/facet_column_facet_row_point_future.vg.json
@@ -297,11 +297,11 @@
                                     "opacity": {
                                         "value": 0.7
                                     },
-                                    "stroke": {
-                                        "value": "#4c78a8"
-                                    },
                                     "fill": {
                                         "value": "transparent"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
                                     },
                                     "x": {
                                         "scale": "x",

--- a/examples/compiled/facet_independent_scale_layer.vg.json
+++ b/examples/compiled/facet_independent_scale_layer.vg.json
@@ -357,12 +357,12 @@
                     },
                     "encode": {
                         "update": {
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "gender"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_x",

--- a/examples/compiled/facet_row_facet_row_point_future.vg.json
+++ b/examples/compiled/facet_row_facet_row_point_future.vg.json
@@ -273,11 +273,11 @@
                                     "opacity": {
                                         "value": 0.7
                                     },
-                                    "stroke": {
-                                        "value": "#4c78a8"
-                                    },
                                     "fill": {
                                         "value": "transparent"
+                                    },
+                                    "stroke": {
+                                        "value": "#4c78a8"
                                     },
                                     "x": {
                                         "scale": "x",

--- a/examples/compiled/geo_layer_line_london.vg.json
+++ b/examples/compiled/geo_layer_line_london.vg.json
@@ -147,12 +147,12 @@
                     "strokeWidth": {
                         "value": 2
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": {
                         "scale": "color",
                         "field": "id"
-                    },
-                    "fill": {
-                        "value": "transparent"
                     }
                 }
             },

--- a/examples/compiled/hconcat_weather.vg.json
+++ b/examples/compiled/hconcat_weather.vg.json
@@ -281,11 +281,11 @@
                     },
                     "encode": {
                         "update": {
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
                             "fill": {
                                 "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
                             },
                             "x": {
                                 "signal": "(scale(\"concat_1_x\", datum[\"bin_maxbins_10_temp_min\"]) + scale(\"concat_1_x\", datum[\"bin_maxbins_10_temp_min_end\"]))/2"

--- a/examples/compiled/interactive_brush.vg.json
+++ b/examples/compiled/interactive_brush.vg.json
@@ -347,6 +347,9 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": [
                         {
                             "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
@@ -357,9 +360,6 @@
                             "value": "grey"
                         }
                     ],
-                    "fill": {
-                        "value": "transparent"
-                    },
                     "x": {
                         "scale": "x",
                         "field": "Horsepower"

--- a/examples/compiled/interactive_concat_layer.vg.json
+++ b/examples/compiled/interactive_concat_layer.vg.json
@@ -291,11 +291,11 @@
                     },
                     "encode": {
                         "update": {
-                            "stroke": {
-                                "value": "#666"
-                            },
                             "fill": {
                                 "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "#666"
                             },
                             "x": {
                                 "signal": "(scale(\"concat_0_x\", datum[\"bin_maxbins_10_IMDB_Rating\"]) + scale(\"concat_0_x\", datum[\"bin_maxbins_10_IMDB_Rating_end\"]))/2"

--- a/examples/compiled/interactive_dashboard_europe_pop.vg.json
+++ b/examples/compiled/interactive_dashboard_europe_pop.vg.json
@@ -1489,6 +1489,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (!(vlInterval(\"brush_store\", datum)))",
@@ -1498,9 +1501,6 @@
                                     "value": "goldenrod"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "concat_2_x",
                                 "field": "Population_ages_65_and_above_of_total"

--- a/examples/compiled/interactive_multi_line_tooltip.vg.json
+++ b/examples/compiled/interactive_multi_line_tooltip.vg.json
@@ -223,12 +223,12 @@
                             "value": 0
                         }
                     ],
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": {
                         "scale": "color",
                         "field": "symbol"
-                    },
-                    "fill": {
-                        "value": "transparent"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/interactive_paintbrush.vg.json
+++ b/examples/compiled/interactive_paintbrush.vg.json
@@ -101,11 +101,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/interactive_paintbrush_interval.vg.json
+++ b/examples/compiled/interactive_paintbrush_interval.vg.json
@@ -347,11 +347,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/interactive_paintbrush_simple_all.vg.json
+++ b/examples/compiled/interactive_paintbrush_simple_all.vg.json
@@ -100,11 +100,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/interactive_paintbrush_simple_none.vg.json
+++ b/examples/compiled/interactive_paintbrush_simple_none.vg.json
@@ -100,11 +100,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/interactive_panzoom_splom.vg.json
+++ b/examples/compiled/interactive_panzoom_splom.vg.json
@@ -380,12 +380,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_Horsepower_Miles_per_Gallon_x",
@@ -620,12 +620,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_Horsepower_Acceleration_x",
@@ -839,12 +839,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_Horsepower_Horsepower_x",
@@ -1079,12 +1079,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_Acceleration_Miles_per_Gallon_x",
@@ -1298,12 +1298,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_Acceleration_Acceleration_x",
@@ -1538,12 +1538,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_Acceleration_Horsepower_x",
@@ -1757,12 +1757,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",
@@ -1997,12 +1997,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Acceleration_x",
@@ -2237,12 +2237,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Horsepower_x",

--- a/examples/compiled/interactive_panzoom_vconcat_shared.vg.json
+++ b/examples/compiled/interactive_panzoom_vconcat_shared.vg.json
@@ -259,11 +259,11 @@
                             "opacity": {
                                 "value": 0.7
                             },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
                             "fill": {
                                 "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
                             },
                             "x": {
                                 "scale": "concat_0_x",
@@ -361,11 +361,11 @@
                             "opacity": {
                                 "value": 0.7
                             },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
                             "fill": {
                                 "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
                             },
                             "x": {
                                 "scale": "concat_1_x",

--- a/examples/compiled/interactive_splom.vg.json
+++ b/examples/compiled/interactive_splom.vg.json
@@ -679,6 +679,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -689,9 +692,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Horsepower_Miles_per_Gallon_x",
                                 "field": "Miles_per_Gallon"
@@ -1250,6 +1250,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -1260,9 +1263,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Horsepower_Acceleration_x",
                                 "field": "Acceleration"
@@ -1731,6 +1731,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -1741,9 +1744,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Horsepower_Horsepower_x",
                                 "field": "Horsepower"
@@ -2304,6 +2304,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -2314,9 +2317,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Acceleration_Miles_per_Gallon_x",
                                 "field": "Miles_per_Gallon"
@@ -2785,6 +2785,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -2795,9 +2798,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Acceleration_Acceleration_x",
                                 "field": "Acceleration"
@@ -3358,6 +3358,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -3368,9 +3371,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Acceleration_Horsepower_x",
                                 "field": "Horsepower"
@@ -3839,6 +3839,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -3849,9 +3852,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",
                                 "field": "Miles_per_Gallon"
@@ -4412,6 +4412,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -4422,9 +4425,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Acceleration_x",
                                 "field": "Acceleration"
@@ -4983,6 +4983,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -4993,9 +4996,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Horsepower_x",
                                 "field": "Horsepower"

--- a/examples/compiled/interactive_stocks_nearest_index.vg.json
+++ b/examples/compiled/interactive_stocks_nearest_index.vg.json
@@ -212,12 +212,12 @@
                     "opacity": {
                         "value": 0
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": {
                         "scale": "color",
                         "field": "symbol"
-                    },
-                    "fill": {
-                        "value": "transparent"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/layer_falkensee.vg.json
+++ b/examples/compiled/layer_falkensee.vg.json
@@ -351,11 +351,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#333"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#333"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/layer_global_mean_dev.vg.json
+++ b/examples/compiled/layer_global_mean_dev.vg.json
@@ -117,11 +117,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/layer_rect_extent.vg.json
+++ b/examples/compiled/layer_rect_extent.vg.json
@@ -125,11 +125,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_1d.vg.json
+++ b/examples/compiled/point_1d.vg.json
@@ -38,11 +38,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_1d_array.vg.json
+++ b/examples/compiled/point_1d_array.vg.json
@@ -72,11 +72,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_2d.vg.json
+++ b/examples/compiled/point_2d.vg.json
@@ -40,11 +40,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_2d_aggregate.vg.json
+++ b/examples/compiled/point_2d_aggregate.vg.json
@@ -95,11 +95,11 @@
             },
             "encode": {
                 "update": {
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_2d_array.vg.json
+++ b/examples/compiled/point_2d_array.vg.json
@@ -87,11 +87,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_2d_array_named.vg.json
+++ b/examples/compiled/point_2d_array_named.vg.json
@@ -87,11 +87,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "plotname_x",

--- a/examples/compiled/point_aggregate_detail.vg.json
+++ b/examples/compiled/point_aggregate_detail.vg.json
@@ -51,11 +51,11 @@
             },
             "encode": {
                 "update": {
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_binned_color.vg.json
+++ b/examples/compiled/point_binned_color.vg.json
@@ -59,12 +59,12 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": {
                         "scale": "color",
                         "field": "bin_maxbins_6_Acceleration"
-                    },
-                    "fill": {
-                        "value": "transparent"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_binned_opacity.vg.json
+++ b/examples/compiled/point_binned_opacity.vg.json
@@ -60,11 +60,11 @@
                         "scale": "opacity",
                         "field": "bin_maxbins_6_Acceleration"
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_binned_size.vg.json
+++ b/examples/compiled/point_binned_size.vg.json
@@ -59,11 +59,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_bubble.vg.json
+++ b/examples/compiled/point_bubble.vg.json
@@ -41,11 +41,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_color.vg.json
+++ b/examples/compiled/point_color.vg.json
@@ -39,12 +39,12 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": {
                         "scale": "color",
                         "field": "Origin"
-                    },
-                    "fill": {
-                        "value": "transparent"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_color_custom.vg.json
+++ b/examples/compiled/point_color_custom.vg.json
@@ -39,12 +39,12 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": {
                         "scale": "color",
                         "field": "Origin"
-                    },
-                    "fill": {
-                        "value": "transparent"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_color_ordinal.vg.json
+++ b/examples/compiled/point_color_ordinal.vg.json
@@ -39,12 +39,12 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": {
                         "scale": "color",
                         "field": "Cylinders"
-                    },
-                    "fill": {
-                        "value": "transparent"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_color_quantitative.vg.json
+++ b/examples/compiled/point_color_quantitative.vg.json
@@ -40,12 +40,12 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": {
                         "scale": "color",
                         "field": "Displacement"
-                    },
-                    "fill": {
-                        "value": "transparent"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_color_shape_constant.vg.json
+++ b/examples/compiled/point_color_shape_constant.vg.json
@@ -39,11 +39,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#ff9900"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#ff9900"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_color_with_shape.vg.json
+++ b/examples/compiled/point_color_with_shape.vg.json
@@ -40,12 +40,12 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": {
                         "scale": "color",
                         "field": "Origin"
-                    },
-                    "fill": {
-                        "value": "transparent"
                     },
                     "x": {
                         "scale": "x",
@@ -97,16 +97,6 @@
             "zero": true
         },
         {
-            "name": "shape",
-            "type": "ordinal",
-            "domain": {
-                "data": "source_0",
-                "field": "Origin",
-                "sort": true
-            },
-            "range": "symbol"
-        },
-        {
             "name": "color",
             "type": "ordinal",
             "domain": {
@@ -115,6 +105,16 @@
                 "sort": true
             },
             "range": "category"
+        },
+        {
+            "name": "shape",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": "symbol"
         }
     ],
     "axes": [

--- a/examples/compiled/point_colorramp_size.vg.json
+++ b/examples/compiled/point_colorramp_size.vg.json
@@ -40,12 +40,12 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": {
                         "scale": "color",
                         "field": "Miles_per_Gallon"
-                    },
-                    "fill": {
-                        "value": "transparent"
                     },
                     "x": {
                         "scale": "x",
@@ -97,6 +97,17 @@
             "zero": true
         },
         {
+            "name": "color",
+            "type": "sequential",
+            "domain": {
+                "data": "source_0",
+                "field": "Miles_per_Gallon"
+            },
+            "range": "ramp",
+            "nice": false,
+            "zero": false
+        },
+        {
             "name": "size",
             "type": "linear",
             "domain": {
@@ -109,17 +120,6 @@
             ],
             "nice": false,
             "zero": true
-        },
-        {
-            "name": "color",
-            "type": "sequential",
-            "domain": {
-                "data": "source_0",
-                "field": "Miles_per_Gallon"
-            },
-            "range": "ramp",
-            "nice": false,
-            "zero": false
         }
     ],
     "axes": [

--- a/examples/compiled/point_diverging_color.vg.json
+++ b/examples/compiled/point_diverging_color.vg.json
@@ -41,12 +41,12 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": {
                         "scale": "color",
                         "field": "Weight_in_lbs"
-                    },
-                    "fill": {
-                        "value": "transparent"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_dot_timeunit_color.vg.json
+++ b/examples/compiled/point_dot_timeunit_color.vg.json
@@ -56,12 +56,12 @@
             },
             "encode": {
                 "update": {
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": {
                         "scale": "color",
                         "field": "yearmonth_date"
-                    },
-                    "fill": {
-                        "value": "transparent"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_invalid_color.vg.json
+++ b/examples/compiled/point_invalid_color.vg.json
@@ -33,6 +33,9 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": [
                         {
                             "test": "datum.IMDB_Rating === null || datum.Rotten_Tomatoes_Rating === null",
@@ -42,9 +45,6 @@
                             "value": "#4c78a8"
                         }
                     ],
-                    "fill": {
-                        "value": "transparent"
-                    },
                     "x": {
                         "scale": "x",
                         "field": "IMDB_Rating"

--- a/examples/compiled/point_log.vg.json
+++ b/examples/compiled/point_log.vg.json
@@ -79,11 +79,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_no_axis_domain_grid.vg.json
+++ b/examples/compiled/point_no_axis_domain_grid.vg.json
@@ -40,11 +40,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_ordinal_color.vg.json
+++ b/examples/compiled/point_ordinal_color.vg.json
@@ -77,12 +77,12 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": {
                         "scale": "color",
                         "field": "a"
-                    },
-                    "fill": {
-                        "value": "transparent"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/point_overlap.vg.json
+++ b/examples/compiled/point_overlap.vg.json
@@ -63,11 +63,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "signal": "width",

--- a/examples/compiled/point_shape_custom.vg.json
+++ b/examples/compiled/point_shape_custom.vg.json
@@ -41,12 +41,12 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": {
                         "scale": "color",
                         "field": "Cylinders"
-                    },
-                    "fill": {
-                        "value": "transparent"
                     },
                     "x": {
                         "scale": "x",
@@ -101,6 +101,16 @@
             "zero": true
         },
         {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Cylinders",
+                "sort": true
+            },
+            "range": "category"
+        },
+        {
             "name": "size",
             "type": "linear",
             "domain": {
@@ -113,16 +123,6 @@
             ],
             "nice": false,
             "zero": true
-        },
-        {
-            "name": "color",
-            "type": "ordinal",
-            "domain": {
-                "data": "source_0",
-                "field": "Cylinders",
-                "sort": true
-            },
-            "range": "category"
         }
     ],
     "axes": [

--- a/examples/compiled/point_tooltip.vg.json
+++ b/examples/compiled/point_tooltip.vg.json
@@ -40,11 +40,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "tooltip": {
                         "signal": "''+datum[\"Origin\"]"

--- a/examples/compiled/repeat_independent_colors.vg.json
+++ b/examples/compiled/repeat_independent_colors.vg.json
@@ -93,12 +93,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "child_Origin_color",
                                 "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_Origin_x",
@@ -210,12 +210,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "child_Cylinders_color",
                                 "field": "Cylinders"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_Cylinders_x",

--- a/examples/compiled/repeat_splom_cars.vg.json
+++ b/examples/compiled/repeat_splom_cars.vg.json
@@ -128,12 +128,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_Displacement_Horsepower_x",
@@ -230,12 +230,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_Displacement_Miles_per_Gallon_x",
@@ -332,12 +332,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Horsepower_x",
@@ -434,12 +434,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "Origin"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",

--- a/examples/compiled/repeat_splom_iris.vg.json
+++ b/examples/compiled/repeat_splom_iris.vg.json
@@ -353,12 +353,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_petalWidth_sepalLength_x",
@@ -455,12 +455,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_petalWidth_sepalWidth_x",
@@ -557,12 +557,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_petalWidth_petalLength_x",
@@ -659,12 +659,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_petalWidth_petalWidth_x",
@@ -761,12 +761,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_petalLength_sepalLength_x",
@@ -863,12 +863,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_petalLength_sepalWidth_x",
@@ -965,12 +965,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_petalLength_petalLength_x",
@@ -1067,12 +1067,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_petalLength_petalWidth_x",
@@ -1169,12 +1169,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_sepalWidth_sepalLength_x",
@@ -1271,12 +1271,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_sepalWidth_sepalWidth_x",
@@ -1373,12 +1373,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_sepalWidth_petalLength_x",
@@ -1475,12 +1475,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_sepalWidth_petalWidth_x",
@@ -1577,12 +1577,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_sepalLength_sepalLength_x",
@@ -1679,12 +1679,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_sepalLength_sepalWidth_x",
@@ -1781,12 +1781,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_sepalLength_petalLength_x",
@@ -1883,12 +1883,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "species"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "child_sepalLength_petalWidth_x",

--- a/examples/compiled/selection_bind_origin.vg.json
+++ b/examples/compiled/selection_bind_origin.vg.json
@@ -96,6 +96,9 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": [
                         {
                             "test": "!(length(data(\"org_store\"))) || (vlSingle(\"org_store\", datum))",
@@ -106,9 +109,6 @@
                             "value": "grey"
                         }
                     ],
-                    "fill": {
-                        "value": "transparent"
-                    },
                     "x": {
                         "scale": "x",
                         "field": "Horsepower"

--- a/examples/compiled/selection_brush_timeunit.vg.json
+++ b/examples/compiled/selection_brush_timeunit.vg.json
@@ -378,6 +378,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
@@ -387,9 +390,6 @@
                                     "value": "steelblue"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "concat_0_x",
                                 "field": "seconds_date"
@@ -549,11 +549,11 @@
                             "opacity": {
                                 "value": 0.7
                             },
-                            "stroke": {
-                                "value": "goldenrod"
-                            },
                             "fill": {
                                 "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "goldenrod"
                             },
                             "x": {
                                 "scale": "concat_1_x",

--- a/examples/compiled/selection_concat.vg.json
+++ b/examples/compiled/selection_concat.vg.json
@@ -418,11 +418,11 @@
                             "opacity": {
                                 "value": 0.7
                             },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
                             "fill": {
                                 "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
                             },
                             "x": {
                                 "scale": "concat_0_x",
@@ -710,6 +710,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
@@ -719,9 +722,6 @@
                                     "value": "red"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "concat_1_x",
                                 "field": "Displacement"

--- a/examples/compiled/selection_filter.vg.json
+++ b/examples/compiled/selection_filter.vg.json
@@ -413,11 +413,11 @@
                             "opacity": {
                                 "value": 0.7
                             },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
                             "fill": {
                                 "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
                             },
                             "x": {
                                 "scale": "concat_0_x",
@@ -567,11 +567,11 @@
                             "opacity": {
                                 "value": 0.7
                             },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
                             "fill": {
                                 "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
                             },
                             "x": {
                                 "scale": "concat_1_x",

--- a/examples/compiled/selection_filter_composition.vg.json
+++ b/examples/compiled/selection_filter_composition.vg.json
@@ -413,11 +413,11 @@
                             "opacity": {
                                 "value": 0.7
                             },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
                             "fill": {
                                 "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
                             },
                             "x": {
                                 "scale": "concat_0_x",
@@ -567,11 +567,11 @@
                             "opacity": {
                                 "value": 0.7
                             },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
                             "fill": {
                                 "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
                             },
                             "x": {
                                 "scale": "concat_1_x",

--- a/examples/compiled/selection_multi_condition.vg.json
+++ b/examples/compiled/selection_multi_condition.vg.json
@@ -396,6 +396,9 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": [
                         {
                             "test": "!(length(data(\"hoverbrush_store\"))) || (vlMulti(\"hoverbrush_store\", datum))",
@@ -409,9 +412,6 @@
                             "value": "grey"
                         }
                     ],
-                    "fill": {
-                        "value": "transparent"
-                    },
                     "x": {
                         "scale": "x",
                         "field": "Horsepower"

--- a/examples/compiled/selection_project_multi.vg.json
+++ b/examples/compiled/selection_project_multi.vg.json
@@ -100,6 +100,9 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": [
                         {
                             "test": "!(length(data(\"pts_store\"))) || (vlMulti(\"pts_store\", datum))",
@@ -110,9 +113,6 @@
                             "value": "grey"
                         }
                     ],
-                    "fill": {
-                        "value": "transparent"
-                    },
                     "x": {
                         "scale": "x",
                         "field": "Horsepower"

--- a/examples/compiled/selection_project_multi_cylinders.vg.json
+++ b/examples/compiled/selection_project_multi_cylinders.vg.json
@@ -96,6 +96,9 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": [
                         {
                             "test": "!(length(data(\"pts_store\"))) || (vlMulti(\"pts_store\", datum))",
@@ -106,9 +109,6 @@
                             "value": "grey"
                         }
                     ],
-                    "fill": {
-                        "value": "transparent"
-                    },
                     "x": {
                         "scale": "x",
                         "field": "Horsepower"

--- a/examples/compiled/selection_project_multi_cylinders_origin.vg.json
+++ b/examples/compiled/selection_project_multi_cylinders_origin.vg.json
@@ -96,6 +96,9 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": [
                         {
                             "test": "!(length(data(\"pts_store\"))) || (vlMulti(\"pts_store\", datum))",
@@ -106,9 +109,6 @@
                             "value": "grey"
                         }
                     ],
-                    "fill": {
-                        "value": "transparent"
-                    },
                     "x": {
                         "scale": "x",
                         "field": "Horsepower"
@@ -174,6 +174,18 @@
             "zero": true
         },
         {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Cylinders",
+                "sort": true
+            },
+            "range": {
+                "scheme": "yelloworangebrown"
+            }
+        },
+        {
             "name": "shape",
             "type": "ordinal",
             "domain": {
@@ -186,18 +198,6 @@
                 "triangle-right",
                 "triangle-up"
             ]
-        },
-        {
-            "name": "color",
-            "type": "ordinal",
-            "domain": {
-                "data": "source_0",
-                "field": "Cylinders",
-                "sort": true
-            },
-            "range": {
-                "scheme": "yelloworangebrown"
-            }
         }
     ],
     "axes": [

--- a/examples/compiled/selection_project_multi_origin.vg.json
+++ b/examples/compiled/selection_project_multi_origin.vg.json
@@ -96,6 +96,9 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": [
                         {
                             "test": "!(length(data(\"pts_store\"))) || (vlMulti(\"pts_store\", datum))",
@@ -106,9 +109,6 @@
                             "value": "grey"
                         }
                     ],
-                    "fill": {
-                        "value": "transparent"
-                    },
                     "x": {
                         "scale": "x",
                         "field": "Horsepower"
@@ -174,6 +174,18 @@
             "zero": true
         },
         {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Cylinders",
+                "sort": true
+            },
+            "range": {
+                "scheme": "yelloworangebrown"
+            }
+        },
+        {
             "name": "shape",
             "type": "ordinal",
             "domain": {
@@ -186,18 +198,6 @@
                 "triangle-right",
                 "triangle-up"
             ]
-        },
-        {
-            "name": "color",
-            "type": "ordinal",
-            "domain": {
-                "data": "source_0",
-                "field": "Cylinders",
-                "sort": true
-            },
-            "range": {
-                "scheme": "yelloworangebrown"
-            }
         }
     ],
     "axes": [

--- a/examples/compiled/selection_project_single.vg.json
+++ b/examples/compiled/selection_project_single.vg.json
@@ -89,6 +89,9 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": [
                         {
                             "test": "!(length(data(\"pts_store\"))) || (vlSingle(\"pts_store\", datum))",
@@ -99,9 +102,6 @@
                             "value": "grey"
                         }
                     ],
-                    "fill": {
-                        "value": "transparent"
-                    },
                     "x": {
                         "scale": "x",
                         "field": "Horsepower"

--- a/examples/compiled/selection_project_single_cylinders.vg.json
+++ b/examples/compiled/selection_project_single_cylinders.vg.json
@@ -85,6 +85,9 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": [
                         {
                             "test": "!(length(data(\"pts_store\"))) || (vlSingle(\"pts_store\", datum))",
@@ -95,9 +98,6 @@
                             "value": "grey"
                         }
                     ],
-                    "fill": {
-                        "value": "transparent"
-                    },
                     "x": {
                         "scale": "x",
                         "field": "Horsepower"

--- a/examples/compiled/selection_project_single_cylinders_origin.vg.json
+++ b/examples/compiled/selection_project_single_cylinders_origin.vg.json
@@ -85,6 +85,9 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": [
                         {
                             "test": "!(length(data(\"pts_store\"))) || (vlSingle(\"pts_store\", datum))",
@@ -95,9 +98,6 @@
                             "value": "grey"
                         }
                     ],
-                    "fill": {
-                        "value": "transparent"
-                    },
                     "x": {
                         "scale": "x",
                         "field": "Horsepower"
@@ -163,6 +163,18 @@
             "zero": true
         },
         {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Cylinders",
+                "sort": true
+            },
+            "range": {
+                "scheme": "yelloworangebrown"
+            }
+        },
+        {
             "name": "shape",
             "type": "ordinal",
             "domain": {
@@ -175,18 +187,6 @@
                 "triangle-right",
                 "triangle-up"
             ]
-        },
-        {
-            "name": "color",
-            "type": "ordinal",
-            "domain": {
-                "data": "source_0",
-                "field": "Cylinders",
-                "sort": true
-            },
-            "range": {
-                "scheme": "yelloworangebrown"
-            }
         }
     ],
     "axes": [

--- a/examples/compiled/selection_project_single_origin.vg.json
+++ b/examples/compiled/selection_project_single_origin.vg.json
@@ -85,6 +85,9 @@
                     "opacity": {
                         "value": 0.7
                     },
+                    "fill": {
+                        "value": "transparent"
+                    },
                     "stroke": [
                         {
                             "test": "!(length(data(\"pts_store\"))) || (vlSingle(\"pts_store\", datum))",
@@ -95,9 +98,6 @@
                             "value": "grey"
                         }
                     ],
-                    "fill": {
-                        "value": "transparent"
-                    },
                     "x": {
                         "scale": "x",
                         "field": "Horsepower"
@@ -163,6 +163,18 @@
             "zero": true
         },
         {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Cylinders",
+                "sort": true
+            },
+            "range": {
+                "scheme": "yelloworangebrown"
+            }
+        },
+        {
             "name": "shape",
             "type": "ordinal",
             "domain": {
@@ -175,18 +187,6 @@
                 "triangle-right",
                 "triangle-up"
             ]
-        },
-        {
-            "name": "color",
-            "type": "ordinal",
-            "domain": {
-                "data": "source_0",
-                "field": "Cylinders",
-                "sort": true
-            },
-            "range": {
-                "scheme": "yelloworangebrown"
-            }
         }
     ],
     "axes": [

--- a/examples/compiled/selection_resolution_global.vg.json
+++ b/examples/compiled/selection_resolution_global.vg.json
@@ -527,6 +527,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
@@ -537,9 +540,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Horsepower_Miles_per_Gallon_x",
                                 "field": "Miles_per_Gallon"
@@ -982,6 +982,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
@@ -992,9 +995,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Horsepower_Acceleration_x",
                                 "field": "Acceleration"
@@ -1370,6 +1370,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
@@ -1380,9 +1383,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Horsepower_Horsepower_x",
                                 "field": "Horsepower"
@@ -1827,6 +1827,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
@@ -1837,9 +1840,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Acceleration_Miles_per_Gallon_x",
                                 "field": "Miles_per_Gallon"
@@ -2215,6 +2215,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
@@ -2225,9 +2228,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Acceleration_Acceleration_x",
                                 "field": "Acceleration"
@@ -2672,6 +2672,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
@@ -2682,9 +2685,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Acceleration_Horsepower_x",
                                 "field": "Horsepower"
@@ -3060,6 +3060,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
@@ -3070,9 +3073,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",
                                 "field": "Miles_per_Gallon"
@@ -3517,6 +3517,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
@@ -3527,9 +3530,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Acceleration_x",
                                 "field": "Acceleration"
@@ -3972,6 +3972,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum))",
@@ -3982,9 +3985,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Horsepower_x",
                                 "field": "Horsepower"

--- a/examples/compiled/selection_resolution_intersect.vg.json
+++ b/examples/compiled/selection_resolution_intersect.vg.json
@@ -503,6 +503,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
@@ -513,9 +516,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Horsepower_Miles_per_Gallon_x",
                                 "field": "Miles_per_Gallon"
@@ -910,6 +910,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
@@ -920,9 +923,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Horsepower_Acceleration_x",
                                 "field": "Acceleration"
@@ -1250,6 +1250,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
@@ -1260,9 +1263,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Horsepower_Horsepower_x",
                                 "field": "Horsepower"
@@ -1659,6 +1659,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
@@ -1669,9 +1672,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Acceleration_Miles_per_Gallon_x",
                                 "field": "Miles_per_Gallon"
@@ -1999,6 +1999,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
@@ -2009,9 +2012,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Acceleration_Acceleration_x",
                                 "field": "Acceleration"
@@ -2408,6 +2408,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
@@ -2418,9 +2421,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Acceleration_Horsepower_x",
                                 "field": "Horsepower"
@@ -2748,6 +2748,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
@@ -2758,9 +2761,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",
                                 "field": "Miles_per_Gallon"
@@ -3157,6 +3157,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
@@ -3167,9 +3170,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Acceleration_x",
                                 "field": "Acceleration"
@@ -3564,6 +3564,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"intersect\"))",
@@ -3574,9 +3577,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Horsepower_x",
                                 "field": "Horsepower"

--- a/examples/compiled/selection_resolution_union.vg.json
+++ b/examples/compiled/selection_resolution_union.vg.json
@@ -503,6 +503,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -513,9 +516,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Horsepower_Miles_per_Gallon_x",
                                 "field": "Miles_per_Gallon"
@@ -910,6 +910,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -920,9 +923,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Horsepower_Acceleration_x",
                                 "field": "Acceleration"
@@ -1250,6 +1250,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -1260,9 +1263,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Horsepower_Horsepower_x",
                                 "field": "Horsepower"
@@ -1659,6 +1659,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -1669,9 +1672,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Acceleration_Miles_per_Gallon_x",
                                 "field": "Miles_per_Gallon"
@@ -1999,6 +1999,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -2009,9 +2012,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Acceleration_Acceleration_x",
                                 "field": "Acceleration"
@@ -2408,6 +2408,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -2418,9 +2421,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Acceleration_Horsepower_x",
                                 "field": "Horsepower"
@@ -2748,6 +2748,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -2758,9 +2761,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Miles_per_Gallon_x",
                                 "field": "Miles_per_Gallon"
@@ -3157,6 +3157,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -3167,9 +3170,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Acceleration_x",
                                 "field": "Acceleration"
@@ -3564,6 +3564,9 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": [
                                 {
                                     "test": "!(length(data(\"brush_store\"))) || (vlInterval(\"brush_store\", datum, \"union\"))",
@@ -3574,9 +3577,6 @@
                                     "value": "grey"
                                 }
                             ],
-                            "fill": {
-                                "value": "transparent"
-                            },
                             "x": {
                                 "scale": "child_Miles_per_Gallon_Horsepower_x",
                                 "field": "Horsepower"

--- a/examples/compiled/selection_translate_brush_drag.vg.json
+++ b/examples/compiled/selection_translate_brush_drag.vg.json
@@ -464,6 +464,16 @@
             "zero": false
         },
         {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": "category"
+        },
+        {
             "name": "size",
             "type": "linear",
             "domain": {
@@ -476,16 +486,6 @@
             ],
             "nice": false,
             "zero": true
-        },
-        {
-            "name": "color",
-            "type": "ordinal",
-            "domain": {
-                "data": "source_0",
-                "field": "Origin",
-                "sort": true
-            },
-            "range": "category"
         }
     ],
     "axes": [

--- a/examples/compiled/selection_translate_brush_shift-drag.vg.json
+++ b/examples/compiled/selection_translate_brush_shift-drag.vg.json
@@ -470,6 +470,16 @@
             "zero": false
         },
         {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": "category"
+        },
+        {
             "name": "size",
             "type": "linear",
             "domain": {
@@ -482,16 +492,6 @@
             ],
             "nice": false,
             "zero": true
-        },
-        {
-            "name": "color",
-            "type": "ordinal",
-            "domain": {
-                "data": "source_0",
-                "field": "Origin",
-                "sort": true
-            },
-            "range": "category"
         }
     ],
     "axes": [

--- a/examples/compiled/selection_zoom_brush_shift-wheel.vg.json
+++ b/examples/compiled/selection_zoom_brush_shift-wheel.vg.json
@@ -470,6 +470,16 @@
             "zero": false
         },
         {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": "category"
+        },
+        {
             "name": "size",
             "type": "linear",
             "domain": {
@@ -482,16 +492,6 @@
             ],
             "nice": false,
             "zero": true
-        },
-        {
-            "name": "color",
-            "type": "ordinal",
-            "domain": {
-                "data": "source_0",
-                "field": "Origin",
-                "sort": true
-            },
-            "range": "category"
         }
     ],
     "axes": [

--- a/examples/compiled/selection_zoom_brush_wheel.vg.json
+++ b/examples/compiled/selection_zoom_brush_wheel.vg.json
@@ -464,6 +464,16 @@
             "zero": false
         },
         {
+            "name": "color",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": "category"
+        },
+        {
             "name": "size",
             "type": "linear",
             "domain": {
@@ -476,16 +486,6 @@
             ],
             "nice": false,
             "zero": true
-        },
-        {
-            "name": "color",
-            "type": "ordinal",
-            "domain": {
-                "data": "source_0",
-                "field": "Origin",
-                "sort": true
-            },
-            "range": "category"
         }
     ],
     "axes": [

--- a/examples/compiled/test_embedded_csv.vg.json
+++ b/examples/compiled/test_embedded_csv.vg.json
@@ -44,11 +44,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "signal": "width",

--- a/examples/compiled/test_field_with_spaces.vg.json
+++ b/examples/compiled/test_field_with_spaces.vg.json
@@ -87,11 +87,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/test_single_point_color.vg.json
+++ b/examples/compiled/test_single_point_color.vg.json
@@ -30,11 +30,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "purple"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "purple"
                     },
                     "x": {
                         "signal": "width",

--- a/examples/compiled/test_subobject.vg.json
+++ b/examples/compiled/test_subobject.vg.json
@@ -94,11 +94,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/test_subobject_nested.vg.json
+++ b/examples/compiled/test_subobject_nested.vg.json
@@ -114,11 +114,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "scale": "x",

--- a/examples/compiled/time_parse_local.vg.json
+++ b/examples/compiled/time_parse_local.vg.json
@@ -59,11 +59,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "signal": "width",

--- a/examples/compiled/time_parse_utc_format.vg.json
+++ b/examples/compiled/time_parse_utc_format.vg.json
@@ -60,11 +60,11 @@
                     "opacity": {
                         "value": 0.7
                     },
-                    "stroke": {
-                        "value": "#4c78a8"
-                    },
                     "fill": {
                         "value": "transparent"
+                    },
+                    "stroke": {
+                        "value": "#4c78a8"
                     },
                     "x": {
                         "signal": "width",

--- a/examples/compiled/trellis_barley.vg.json
+++ b/examples/compiled/trellis_barley.vg.json
@@ -228,12 +228,12 @@
                     },
                     "encode": {
                         "update": {
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "trellis_barley_color",
                                 "field": "year"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "trellis_barley_x",

--- a/examples/compiled/trellis_line_quarter.vg.json
+++ b/examples/compiled/trellis_line_quarter.vg.json
@@ -246,12 +246,12 @@
                     },
                     "encode": {
                         "update": {
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "symbol"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "x",

--- a/examples/compiled/trellis_row_column.vg.json
+++ b/examples/compiled/trellis_row_column.vg.json
@@ -265,12 +265,12 @@
                             "opacity": {
                                 "value": 0.7
                             },
+                            "fill": {
+                                "value": "transparent"
+                            },
                             "stroke": {
                                 "scale": "color",
                                 "field": "Cylinders"
-                            },
-                            "fill": {
-                                "value": "transparent"
                             },
                             "x": {
                                 "scale": "x",
@@ -356,16 +356,6 @@
             "zero": true
         },
         {
-            "name": "shape",
-            "type": "ordinal",
-            "domain": {
-                "data": "source_0",
-                "field": "Origin",
-                "sort": true
-            },
-            "range": "symbol"
-        },
-        {
             "name": "color",
             "type": "ordinal",
             "domain": {
@@ -374,6 +364,16 @@
                 "sort": true
             },
             "range": "category"
+        },
+        {
+            "name": "shape",
+            "type": "ordinal",
+            "domain": {
+                "data": "source_0",
+                "field": "Origin",
+                "sort": true
+            },
+            "range": "symbol"
         }
     ],
     "legends": [

--- a/examples/compiled/trellis_scatter.vg.json
+++ b/examples/compiled/trellis_scatter.vg.json
@@ -207,11 +207,11 @@
                             "opacity": {
                                 "value": 0.7
                             },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
                             "fill": {
                                 "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
                             },
                             "x": {
                                 "scale": "x",

--- a/examples/compiled/trellis_scatter_binned_row.vg.json
+++ b/examples/compiled/trellis_scatter_binned_row.vg.json
@@ -210,11 +210,11 @@
                             "opacity": {
                                 "value": 0.7
                             },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
                             "fill": {
                                 "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
                             },
                             "x": {
                                 "scale": "x",

--- a/examples/compiled/trellis_scatter_small.vg.json
+++ b/examples/compiled/trellis_scatter_small.vg.json
@@ -207,11 +207,11 @@
                             "opacity": {
                                 "value": 0.7
                             },
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
                             "fill": {
                                 "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
                             },
                             "x": {
                                 "scale": "x",

--- a/examples/compiled/vconcat_weather.vg.json
+++ b/examples/compiled/vconcat_weather.vg.json
@@ -289,11 +289,11 @@
                     },
                     "encode": {
                         "update": {
-                            "stroke": {
-                                "value": "#4c78a8"
-                            },
                             "fill": {
                                 "value": "transparent"
+                            },
+                            "stroke": {
+                                "value": "#4c78a8"
                             },
                             "x": {
                                 "signal": "(scale(\"concat_1_x\", datum[\"bin_maxbins_10_temp_min\"]) + scale(\"concat_1_x\", datum[\"bin_maxbins_10_temp_min_end\"]))/2"

--- a/site/docs/encoding.md
+++ b/site/docs/encoding.md
@@ -163,7 +163,7 @@ In addition, definitions of mark property channels can include the `condition` p
 
 Here are the list of mark property channels:
 
-{% include table.html props="color,opacity,shape,size" source="Encoding" %}
+{% include table.html props="color,fill,stroke,opacity,shape,size" source="Encoding" %}
 
 {:#mark-prop-field-def}
 ### Mark Property Field Definition

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,5 +1,5 @@
 import {isBoolean} from 'vega-util';
-import {Channel, COLOR, COLUMN, OPACITY, ROW, SHAPE, SIZE} from './channel';
+import {Channel, COLOR, COLUMN, FILL, OPACITY, ROW, SHAPE, SIZE, STROKE} from './channel';
 import {keys, varName} from './util';
 
 
@@ -74,6 +74,8 @@ export function autoMaxBins(channel: Channel): number {
     case COLUMN:
     case SIZE:
     case COLOR:
+    case FILL:
+    case STROKE:
     case OPACITY:
       // Facets and Size shouldn't have too many bins
       // We choose 6 like shape to simplify the rule

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -22,6 +22,11 @@ export namespace Channel {
 
   // Mark property with scale
   export const COLOR: 'color' = 'color';
+
+  export const FILL: 'fill' = 'fill';
+
+  export const STROKE: 'stroke' = 'stroke';
+
   export const SHAPE: 'shape' = 'shape';
   export const SIZE: 'size' = 'size';
   export const OPACITY: 'opacity' = 'opacity';
@@ -47,6 +52,9 @@ export const COLUMN = Channel.COLUMN;
 export const SHAPE = Channel.SHAPE;
 export const SIZE = Channel.SIZE;
 export const COLOR = Channel.COLOR;
+
+export const FILL = Channel.FILL;
+export const STROKE = Channel.STROKE;
 export const TEXT = Channel.TEXT;
 export const DETAIL = Channel.DETAIL;
 export const KEY = Channel.KEY;
@@ -56,21 +64,36 @@ export const TOOLTIP = Channel.TOOLTIP;
 export const HREF = Channel.HREF;
 
 const UNIT_CHANNEL_INDEX: Flag<keyof Encoding<any>> = {
+  // position
   x: 1,
   y: 1,
   x2: 1,
   y2: 1,
+
+  // color
+  color: 1,
+  fill: 1,
+  stroke: 1,
+
+  // other non-position with scale
+  opacity: 1,
   size: 1,
   shape: 1,
-  color: 1,
+
+  // channels without scales
   order: 1,
-  opacity: 1,
   text: 1,
   detail: 1,
   key: 1,
   tooltip: 1,
   href: 1,
 };
+
+export type ColorChannel = 'color' | 'fill' | 'stroke';
+
+export function isColorChannel(channel: Channel): channel is ColorChannel {
+  return channel === 'color' || channel === 'fill' || channel === 'stroke';
+}
 
 const FACET_CHANNEL_INDEX: Flag<keyof FacetMapping<any>> = {
   row: 1,
@@ -99,9 +122,11 @@ export const SINGLE_DEF_CHANNELS: SingleDefChannel[] = flagKeys(SINGLE_DEF_CHANN
 // Using the following line leads to TypeError: Cannot read property 'elementTypes' of undefined
 // when running the schema generator
 // export type SingleDefChannel = typeof SINGLE_DEF_CHANNELS[0];
-export type SingleDefChannel = 'x' | 'y' | 'x2' | 'y2' | 'row' | 'column' | 'size' | 'shape' | 'color' | 'opacity' | 'text' | 'tooltip' | 'href' | 'key';
-
-
+export type SingleDefChannel = 'x' | 'y' | 'x2' | 'y2' |
+  'row' | 'column' |
+  'color' | 'fill' | 'stroke' |
+  'size' | 'shape' | 'opacity' |
+  'text' | 'tooltip' | 'href' | 'key';
 
 export function isChannel(str: string): str is Channel {
   return !!CHANNEL_INDEX[str];
@@ -187,6 +212,9 @@ export function supportMark(channel: Channel, mark: Mark) {
 export function getSupportedMark(channel: Channel): SupportedMark {
   switch (channel) {
     case COLOR:
+    case FILL:
+    case STROKE:
+
     case DETAIL:
     case KEY:
     case TOOLTIP:
@@ -244,6 +272,8 @@ export function rangeType(channel: Channel): RangeType {
 
     // Color can be either continuous or discrete, depending on scale type.
     case COLOR:
+    case FILL:
+    case STROKE:
       return 'flexible';
 
     // No scale, no range type.
@@ -253,5 +283,5 @@ export function rangeType(channel: Channel): RangeType {
       return undefined;
   }
   /* istanbul ignore next: should never reach here. */
-  throw new Error('getSupportedRole not implemented for ' + channel);
+  throw new Error('rangeType not implemented for ' + channel);
 }

--- a/src/compile/legend/parse.ts
+++ b/src/compile/legend/parse.ts
@@ -1,4 +1,4 @@
-import {Channel, COLOR, NonPositionScaleChannel, OPACITY, SHAPE, SIZE} from '../../channel';
+import {COLOR, FILL, NonPositionScaleChannel, OPACITY, SHAPE, SIZE, STROKE} from '../../channel';
 import {isFieldDef, title as fieldDefTitle} from '../../fielddef';
 import {Legend, LEGEND_PROPERTIES, VG_LEGEND_PROPERTIES} from '../../legend';
 import {GEOJSON} from '../../type';
@@ -25,7 +25,7 @@ export function parseLegend(model: Model) {
 
 function parseUnitLegend(model: UnitModel): LegendComponentIndex {
   const {encoding} = model;
-  return [COLOR, SIZE, SHAPE, OPACITY].reduce(function (legendComponent, channel) {
+  return [COLOR, FILL, STROKE, SIZE, SHAPE, OPACITY].reduce(function (legendComponent, channel) {
     const def = encoding[channel];
     if (model.legend(channel) && model.getScaleComponent(channel) && !(isFieldDef(def) && (channel === SHAPE && def.type === GEOJSON))) {
       legendComponent[channel] = parseLegendForChannel(model, channel);
@@ -34,20 +34,19 @@ function parseUnitLegend(model: UnitModel): LegendComponentIndex {
   }, {});
 }
 
-function getLegendDefWithScale(model: UnitModel, channel: Channel): VgLegend {
+function getLegendDefWithScale(model: UnitModel, channel: NonPositionScaleChannel): VgLegend {
   // For binned field with continuous scale, use a special scale so we can overrride the mark props and labels
   switch (channel) {
     case COLOR:
       const scale = model.scaleName(COLOR);
       return model.markDef.filled ? {fill: scale} : {stroke: scale};
+    case FILL:
+    case STROKE:
     case SIZE:
-      return {size: model.scaleName(SIZE)};
     case SHAPE:
-      return {shape: model.scaleName(SHAPE)};
     case OPACITY:
-      return {opacity: model.scaleName(OPACITY)};
+      return {[channel]: model.scaleName(channel)};
   }
-  return null;
 }
 
 export function parseLegendForChannel(model: UnitModel, channel: NonPositionScaleChannel): LegendComponent {

--- a/src/compile/legend/properties.ts
+++ b/src/compile/legend/properties.ts
@@ -1,4 +1,4 @@
-import {Channel, COLOR} from '../../channel';
+import {Channel, isColorChannel} from '../../channel';
 import {DateTime, dateTimeExpr, isDateTime} from '../../datetime';
 import {Legend} from '../../legend';
 import {isBinScale, ScaleType} from '../../scale';
@@ -18,7 +18,7 @@ export function values(legend: Legend) {
 
 export function type(t: Type, channel: Channel, scaleType: ScaleType): 'gradient' {
   if (
-      channel === COLOR && (
+      isColorChannel(channel) && (
         (t === 'quantitative' && !isBinScale(scaleType)) ||
         (t === 'temporal' && contains<ScaleType>(['time', 'utc'], scaleType))
       )

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -174,6 +174,8 @@ export function pathGroupingFields(encoding: Encoding<string>): string[] {
         }
         return details;
       case 'color':
+      case 'fill':
+      case 'stroke':
       case 'size':
       case 'opacity':
       // TODO strokeDashOffset:

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -1,6 +1,6 @@
 import {isNumber} from 'vega-util';
 
-import {Channel, COLOR, OPACITY, SCALE_CHANNELS, ScaleChannel, SHAPE, SIZE, X, Y} from '../../channel';
+import {Channel, COLOR, FILL, OPACITY, SCALE_CHANNELS, ScaleChannel, SHAPE, SIZE, STROKE, X, Y} from '../../channel';
 import {Config} from '../../config';
 import * as log from '../../log';
 import {Mark} from '../../mark';
@@ -197,6 +197,8 @@ export function defaultRange(
     case SHAPE:
       return 'symbol';
     case COLOR:
+    case FILL:
+    case STROKE:
       if (scaleType === 'ordinal') {
         // Only nominal data uses ordinal scale by default
         return type === 'nominal' ? 'category' : 'ordinal';

--- a/src/compile/scale/type.ts
+++ b/src/compile/scale/type.ts
@@ -1,4 +1,4 @@
-import {Channel, isScaleChannel, rangeType} from '../../channel';
+import {Channel, isColorChannel, isScaleChannel, rangeType} from '../../channel';
 import {FieldDef} from '../../fielddef';
 import * as log from '../../log';
 import {Mark} from '../../mark';
@@ -56,7 +56,7 @@ function defaultType(
   switch (fieldDef.type) {
     case 'nominal':
     case 'ordinal':
-      if (channel === 'color' || rangeType(channel) === 'discrete') {
+      if (isColorChannel(channel)|| rangeType(channel) === 'discrete') {
         if (channel === 'shape' && fieldDef.type === 'ordinal') {
           log.warn(log.message.discreteChannelCannotEncode(channel, 'ordinal'));
         }
@@ -77,7 +77,7 @@ function defaultType(
       return 'point';
 
     case 'temporal':
-      if (channel === 'color') {
+      if (isColorChannel(channel)) {
         return 'sequential';
       } else if (rangeType(channel) === 'discrete') {
         log.warn(log.message.discreteChannelCannotEncode(channel, 'temporal'));
@@ -87,7 +87,7 @@ function defaultType(
       return 'time';
 
     case 'quantitative':
-      if (channel === 'color') {
+      if (isColorChannel(channel)) {
         if (fieldDef.bin) {
           return 'bin-ordinal';
         }

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -49,15 +49,35 @@ export interface Encoding<F> {
   y2?: FieldDef<F> | ValueDef;
 
   /**
-   * Color of the marks – either fill or stroke color based on mark type.
+   * Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.
    * By default, `color` represents fill color for `"area"`, `"bar"`, `"tick"`,
    * `"text"`, `"circle"`, and `"square"` / stroke color for `"line"` and `"point"`.
    *
    * __Default value:__ If undefined, the default color depends on [mark config](config.html#mark)'s `color` property.
    *
-   * _Note:_ See the scale documentation for more information about customizing [color scheme](scale.html#scheme).
+   * _Note:_
+   * 1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.
+   * 2) See the scale documentation for more information about customizing [color scheme](scale.html#scheme).
    */
   color?: FieldDefWithCondition<MarkPropFieldDef<F>> | ValueDefWithCondition<MarkPropFieldDef<F>>;
+
+  /**
+   * Fill color of the marks.
+   * __Default value:__ If undefined, the default color depends on [mark config](config.html#mark)'s `color` property.
+   *
+   * _Note:_ The `fill` channel has higher precedence than `color` and will override color value.
+   */
+  fill?: FieldDefWithCondition<MarkPropFieldDef<F>> | ValueDefWithCondition<MarkPropFieldDef<F>>;
+
+
+  /**
+   * Stroke color of the marks.
+   * __Default value:__ If undefined, the default color depends on [mark config](config.html#mark)'s `color` property.
+   *
+   * _Note:_ The `stroke` channel has higher precedence than `color` and will override color value.
+   */
+  stroke?: FieldDefWithCondition<MarkPropFieldDef<F>> | ValueDefWithCondition<MarkPropFieldDef<F>>;
+
 
   /**
    * Opacity of the marks – either can be a value or a range.

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -546,6 +546,8 @@ export function channelCompatibility(fieldDef: FieldDef<Field>, channel: Channel
     case 'x':
     case 'y':
     case 'color':
+    case 'fill':
+    case 'stroke':
     case 'text':
     case 'detail':
     case 'key':

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -1,5 +1,5 @@
 import {toSet} from 'vega-util';
-import {Channel} from './channel';
+import {Channel, isColorChannel} from './channel';
 import {DateTime} from './datetime';
 import * as log from './log';
 import {contains, Flag, flagKeys, keys} from './util';
@@ -636,7 +636,7 @@ export function channelScalePropertyIncompatability(channel: Channel, propName: 
   switch (propName) {
     case 'interpolate':
     case 'scheme':
-      if (channel !== 'color') {
+      if (!isColorChannel(channel)) {
         return log.message.cannotUseScalePropertyWithNonColor(channel);
       }
       return undefined;
@@ -669,8 +669,12 @@ export function channelSupportScaleType(channel: Channel, scaleType: ScaleType):
       // Although it generally doesn't make sense to use band with size and opacity,
       // it can also work since we use band: 0.5 to get midpoint.
       return isContinuousToContinuous(scaleType) || contains(['band', 'point'], scaleType);
+
     case Channel.COLOR:
+    case Channel.FILL:
+    case Channel.STROKE:
       return scaleType !== 'band';    // band does not make sense with color
+
     case Channel.SHAPE:
       return scaleType === 'ordinal'; // shape = lookup only
   }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -29,15 +29,15 @@ export interface SupportedChannelMap {
  * Supported Encoding Channel for each mark type
  */
 export const DEFAULT_SUPPORTED_CHANNEL_TYPE: SupportedChannelMap = {
-  bar:      toSet(['row', 'column', 'x', 'y', 'size', 'color', 'detail']),
-  line:     toSet(['row', 'column', 'x', 'y', 'color', 'detail']),                    // TODO: add size when Vega supports
-  area:     toSet(['row', 'column', 'x', 'y', 'color', 'detail']),
-  tick:     toSet(['row', 'column', 'x', 'y', 'color', 'detail']),
-  circle:   toSet(['row', 'column', 'x', 'y', 'color', 'size', 'detail']),
-  square:   toSet(['row', 'column', 'x', 'y', 'color', 'size', 'detail']),
-  point:    toSet(['row', 'column', 'x', 'y', 'color', 'size', 'detail', 'shape']),
-  geoshape: toSet(['row', 'column', 'color', 'detail', 'shape']),
-  text:     toSet(['row', 'column', 'size', 'color', 'text'])                         // TODO(#724) revise
+  bar:      toSet(['row', 'column', 'x', 'y', 'size', 'color', 'fill', 'stroke', 'detail']),
+  line:     toSet(['row', 'column', 'x', 'y', 'color', 'fill', 'stroke', 'color', 'detail']),                    // TODO: add size when Vega supports
+  area: toSet(['row', 'column', 'x', 'y', 'color', 'fill', 'stroke', 'detail']),
+  tick: toSet(['row', 'column', 'x', 'y', 'color', 'fill', 'stroke', 'detail']),
+  circle: toSet(['row', 'column', 'x', 'y', 'color', 'fill', 'stroke', 'size', 'detail']),
+  square: toSet(['row', 'column', 'x', 'y', 'color', 'fill', 'stroke', 'size', 'detail']),
+  point: toSet(['row', 'column', 'x', 'y', 'color', 'fill', 'stroke', 'size', 'detail', 'shape']),
+  geoshape: toSet(['row', 'column', 'color', 'fill', 'stroke', 'detail', 'shape']),
+  text: toSet(['row', 'column', 'size', 'color', 'fill', 'stroke', 'text'])                         // TODO(#724) revise
 };
 
 // TODO: consider if we should add validate method and


### PR DESCRIPTION
Part of #1855 

Note that if you specify fill/stroke, the default stroke/fill for mark isn't automatically removed.
I think this is a less confusing rule as adding fill/stroke encoding will only cause one change to the visualization.

That said, an alternative rule is to ignore mark.color, config.mark.color when fill/stroke channels are specified.  But it's also unclear what to do then users specify color channel with fill/stroke channel.  The current approach I take is simply including everything (defaults + specified encodings), and make fill/stroke have higher precedence.
