### PR TITLE
Restructure mark documentation

### DIFF
--- a/site/docs/mark/area.md
+++ b/site/docs/mark/area.md
@@ -25,38 +25,62 @@ permalink: /docs/area.html
 {:toc}
 
 
-## Area Chart
+{:#properties}
+## Area Mark Properties
+
+
+{: .suppress-error}
+```json
+// Single View Specification
+{
+  ...
+  "mark": {
+    "type": "area",
+    ...
+  },
+  "encoding": ... ,
+  ...
+}
+```
+
+An area mark definition can contain any [standard mark properties](mark.html#mark-def) and the following special properties:
+
+{% include table.html props="orient,interpolate,tension" source="MarkDef" %}
+
+
+## Examples
+
+### Area Chart
 
 Using `area` mark with one temporal or ordinal field (typically on `x`) and one quantitative field (typically on `y`) produces an area chart. For example, the following area chart shows a number of unemployment people in the US over time.
 
 <span class="vl-example" data-name="area"></span>
 
-## Stacked Area Chart
+### Stacked Area Chart
 
 Adding a color field to area chart creates stacked area chart by default. For example, here we split the area chart by industry.
 
 <span class="vl-example" data-name="stacked_area"></span>
 
-## Normalized Stacked Area Chart
+### Normalized Stacked Area Chart
 
 You can also create a normalized stacked area chart by setting `"stack"` to `"normalize"` in the encoding channel. Here we can easily see the percentage of unemployment across industries.
 
 <span class="vl-example" data-name="stacked_area_normalize"></span>
 
-## Streamgraph
+### Streamgraph
 
 We can also shift the stacked area chart's baseline to center and produces a [streamgraph](http://www.leebyron.com/else/streamgraph/) by setting `"stack"` to `"center"` in the encoding channel.
 
 <span class="vl-example" data-name="stacked_area_stream"></span>
 
 {:#ranged}
-## Ranged Area
+### Ranged Area
 
 Specifying `x2` or `y2` for the quantitative axis of area marks produce ranged areas.
 For example, we can use ranged area with the `ci0` and `ci0` [aggregation operators](aggregate.html#ops) to highlight 95% confidence interval of a line chart that shows mean values over time.
 
 <span class="vl-example" data-name="layer_area_ci"></span>
-
 
 {:#config}
 ## Area Config
@@ -75,4 +99,4 @@ For example, we can use ranged area with the `ci0` and `ci0` [aggregation operat
 
 The `area` property of the top-level [`config`](config.html) object sets the default properties for all area marks.  If [mark property encoding channels](encoding.html#mark-prop) are specified for marks, these config values will be overridden.
 
-For the list of all supported properties, please see the [mark config documentation](mark.html#config).
+The area config can contain any [area mark properties](#properties) (except `type`, `style`, `clip`, and `orient`).

--- a/site/docs/mark/bar.md
+++ b/site/docs/mark/bar.md
@@ -25,14 +25,38 @@ Bar marks are useful in many visualizations, including bar charts, [stacked bar 
 {:toc}
 
 
-## Single Bar Chart
+{:#properties}
+## Bar Mark Properties
+
+{: .suppress-error}
+```json
+// Single View Specification
+{
+  ...
+  "mark": {
+    "type": "bar",
+    ...
+  },
+  "encoding": ... ,
+  ...
+}
+```
+
+A bar mark definition can contain any [standard mark properties](mark.html#mark-def) and the following special properties:
+
+{% include table.html props="orient" source="MarkDef" %}
+
+
+## Examples
+
+### Single Bar Chart
 
 Mapping a quantitative field to either `x` or `y` of the `bar` mark produces a single bar chart.
 
 <span class="vl-example" data-name="bar_1d"></span>
 
 
-## Bar Chart
+### Bar Chart
 
 If we map a different discrete field to the `y` channel, we can produce a horizontal bar chart. Specifying `scale.rangeStep` of the discrete field will adjust the [band and point scale's range step](scale.html#band).
 
@@ -47,8 +71,8 @@ If you want to use a discrete scale instead, you can cast the field to have an `
 
 <span class="vl-example" data-name="bar_month"></span>
 
+### Histogram
 
-## Histogram
 If the data is not pre-aggregated (i.e. each record in the data field represents one item),
 mapping a [binned](bin.html) quantitative field to `x` and aggregate `count` to `y` produces a histogram.
 
@@ -57,16 +81,15 @@ mapping a [binned](bin.html) quantitative field to `x` and aggregate `count` to 
 If you prefer to have histogram without gaps between bars, you can set the [`barBinSpacing` mark config](#histogram-spacing) to `0`.
 
 {:#stack}
-## Stacked Bar Chart
+### Stacked Bar Chart
 
 Adding color to the bar chart (by using the `color` attribute) creates a stacked bar chart by default. Here we also customize the color's scale range to make the color a little nicer.
 (See [`stack`](stack.html) for more details about customizing stack.)
 
-
 <span class="vl-example" data-name="stacked_bar_population"></span>
 
 
-## Layered Bar Chart
+### Layered Bar Chart
 
 To disable stacking, you can alternatively set [`stack`](stack.html) to `null`.
 This produces a layered bar chart.
@@ -75,7 +98,7 @@ To make it clear that bars are layered, we can make marks semi-transparent by se
 <span class="vl-example" data-name="bar_layered_transparent"></span>
 
 
-## Normalized Stacked Bar Chart
+### Normalized Stacked Bar Chart
 
 <!-- TODO: better explain this -->
 You can also create a normalized stacked bar chart by setting [`stack`](stack.html) to `"normalize"`. Here we can easily see the percentage of male and female population at different ages.
@@ -83,15 +106,16 @@ You can also create a normalized stacked bar chart by setting [`stack`](stack.ht
 <span class="vl-example" data-name="stacked_bar_normalize"></span>
 
 
-## Grouped Bar Chart
+### Grouped Bar Chart
 
 <!-- TODO: better explain this -->
 [Faceting](facet.html) a bar chart produces a grouped bar chart.
 
 <span class="vl-example" data-name="bar_grouped"></span>
 
+
 {:#ranged}
-## Ranged Bars
+### Ranged Bars
 
 Specifying `x2` or `y2` for the quantitative axis of bar marks creates ranged bars.
 For example, we can use ranged bars to create a gantt chart.

--- a/site/docs/mark/circle.md
+++ b/site/docs/mark/circle.md
@@ -18,12 +18,35 @@ permalink: /docs/circle.html
 
 `circle` mark is similar to [`point`](point.html) mark, except that (1) the `shape` value is always set to `circle` (2) they are filled by default.
 
-## Scatterplot with Circle
+{:#properties}
+## Circle Mark Properties
+
+{: .suppress-error}
+```json
+// Single View Specification
+{
+  ...
+  "mark": {
+    "type": "circle",
+    ...
+  },
+  "encoding": ... ,
+  ...
+}
+```
+
+A circle mark definition can contain any [standard mark properties](mark.html#mark-def) and the following special properties:
+
+{% include table.html props="size" source="MarkDef" %}
+
+
+## Examples
+
+### Scatterplot with Circle
 
 Here is an example scatter plot with `circle` marks:
 
 <span class="vl-example" data-name="circle"></span>
-
 
 {:#config}
 ## Circle Config
@@ -42,4 +65,4 @@ Here is an example scatter plot with `circle` marks:
 
 The `circle` property of the top-level [`config`](config.html) object sets the default properties for all circle marks.  If [mark property encoding channels](encoding.html#mark-prop) are specified for marks, these config values will be overridden.
 
-For the list of all supported properties, please see the [mark config documentation](mark.html#config).
+The circle config can contain any [circle mark properties](#properties) (except `type`, `style`, and `clip`).

--- a/site/docs/mark/line.md
+++ b/site/docs/mark/line.md
@@ -25,8 +25,31 @@ __Note:__ For line segments that connect (x,y) positions to (x2,y2) positions, p
 - TOC
 {:toc}
 
+{:#properties}
+## Line Mark Properties
 
-## Line Chart
+{: .suppress-error}
+```json
+// Single View Specification
+{
+  ...
+  "mark": {
+    "type": "line",
+    ...
+  },
+  "encoding": ... ,
+  ...
+}
+```
+
+An line mark definition can contain any [standard mark properties](mark.html#mark-def) and the following line interpolation properties:
+
+{% include table.html props="orient,interpolate,tension" source="MarkDef" %}
+
+
+## Examples
+
+### Line Chart
 
 Using `line` with one temporal or ordinal field (typically on `x`) and another quantitative field (typically on `y`) produces a simple line chart with a single line.
 
@@ -34,14 +57,14 @@ Using `line` with one temporal or ordinal field (typically on `x`) and another q
 
 We can add create multiple lines by grouping along different attributes, such as `color` or `detail`.
 
-### Multi-series Colored Line Chart
+#### Multi-series Colored Line Chart
 
 Adding a field to a [mark property channel](encoding.html#mark-prop) such as `color` groups data points into different series, producing a multi-series colored line chart.
 
 <span class="vl-example" data-name="line_color"></span>
 
 {:#line-detail}
-## Multi-series Line Chart with the Detail Channel
+### Multi-series Line Chart with the Detail Channel
 
 To group lines by a field without mapping the field to any visual properties, we can map the field to the [`detail`](encoding.html#detail) channel to create a multi-series line chart with the same color.
 
@@ -52,7 +75,7 @@ The same method can be used to group lines for a ranged dot plot.
 <span class="vl-example" data-name="layer_ranged_dot"></span>
 
 {:#connected-scatter-plot}
-## Connected Scatter Plot (Line Chart with Custom Path)
+### Connected Scatter Plot (Line Chart with Custom Path)
 
 As shown in previous example, the line's path (order of points in the line) is determined by data values on the temporal/ordinal field by default. However, a field can be mapped to the [`order`](encoding.html#order) channel for determining a custom path.
 
@@ -60,7 +83,7 @@ For example, to show a pattern of data change over time between gasoline price a
 
 <span class="vl-example" data-name="layer_connected_scatterplot"></span>
 
-## Line interpolation
+### Line interpolation
 
 The `interpolate` property of a [mark definition](mark.html#mark-def) can be used to change line interpolation method.  For example, we can set `interpolate` to `"monotone"`.
 
@@ -72,11 +95,12 @@ We can also set `interpolate` to `"step-after"` to create a step-chart.
 
 For the list of all supported `interpolate` properties, please see the [mark definition](mark.html#mark-def) documentation.
 
-## Geo Line
+### Geo Line
 
 By mapping geographic coordinate data to `longitude` and `latitude` channels of a corresponding [projection](projection.html), we can draw lines through geographic points.
 
 <span class="vl-example" data-name="geo_line"></span>
+
 
 {:#config}
 ## Line Config
@@ -96,4 +120,4 @@ By mapping geographic coordinate data to `longitude` and `latitude` channels of 
 
 The `line` property of the top-level [`config`](config.html) object sets the default properties for all line marks.  If [mark property encoding channels](encoding.html#mark-prop) are specified for marks, these config values will be overridden.
 
-For the list of all supported properties, please see the [mark config documentation](mark.html#config).
+The line config can contain any [line mark properties](#properties) (except `type`, `style`, and `clip`).

--- a/site/docs/mark/mark.md
+++ b/site/docs/mark/mark.md
@@ -63,32 +63,31 @@ For example, a bar chart has `mark` as a simple string `"bar"`.
 }
 ```
 
-A mark definition object can contains the following properties and [all properties of the mark config](#config):
-
-{% include table.html props="type,style,clip" source="MarkDef" %}
+To customize properties of a mark, users can set `mark` to be a mark definition object instead of a string describing mark type. The rest of this section lists all standard mark properties.  In addition, some marks may be special mark properties (listed in their documentation page).
 
 Note: If [mark property encoding channels](encoding.html#mark-prop) are specified, these mark properties will be overridden.
 
-### Example: Filled Points
 
-By default, `point` marks have filled borders and are transparent inside. Setting `filled` to `true` creates filled points instead.
+### General Mark Properties
 
-<span class="vl-example" data-name="point_filled"></span>
+{% include table.html props="type,style,clip" source="MarkDef" %}
 
-### Example: Interpolate with `monotone`
+{:#color}
+### Color Properties
 
-<span class="vl-example" data-name="line_monotone"></span>
+{% include table.html props="filled,color,fill,stroke,opacity,fillOpacity,strokeOpacity" source="MarkDef" %}
 
-### Example: Interpolate with `line-step` (Step-Chart)
+{:#stroke}
+### Stroke Style Properties
 
-<span class="vl-example" data-name="line_step"></span>
+{% include table.html props="strokeWidth,strokeDash,strokeDashOffset" source="MarkDef" %}
 
-### Example: Offsetting Labels
+{:#hyperlink}
+### Hyperlink Properties
 
-You can use [`text`](text.html) marks as labels and set its offset (`dx` or `dy`), `align`, and `baseline` properties of the mark definition.
+Marks can act as hyperlinks when the `href` property or [channel](encoding.html#href) is defined. A `cursor` property can also be provided to serve as affordance for the links.
 
-<span class="vl-example" data-name="layer_bar_labels"></span>
-
+{% include table.html props="href,cursor" source="MarkDef" %}
 
 {:#config}
 ## Mark Config
@@ -117,54 +116,9 @@ You can use [`text`](text.html) marks as labels and set its offset (`dx` or `dy`
 
 The `mark` property of the [`config`](config.html) object sets the default properties for all marks. In addition, the `config` object also provides mark-specific config using its mark type as the property name (e.g., `config.area`) for defining default properties for each mark.
 
+The global mark config (`config.mark`) supports all standard mark properties (except `type`, `style`, `clip`, and `orient`).  For mark-specific config, please see the documentation for each mark type.
+
 Note: If [mark properties in mark definition](#mark-def) or [mark property encoding channels](encoding.html#mark-prop) are specified, these config values will be overridden.
-
-The rest of this section describe groups of properties supported by the `mark` config and all mark-specific configs.  Besides the properties listed below, [`"bar"`](bar.html#config), [`"text"`](text.html#config), and [`"tick"`](tick.html#config) marks contain additional mark-specific config properties:
-
-### Color
-
-{% include table.html props="filled,color,fill,stroke" source="MarkConfig" %}
-
-### Opacity
-
-{% include table.html props="opacity,fillOpacity,strokeOpacity" source="MarkConfig" %}
-
-### Stroke Style
-
-{% include table.html props="strokeWidth,strokeDash,strokeDashOffset" source="MarkConfig" %}
-
-{:#hyperlink}
-### Hyperlink Properties
-
-Marks can act as hyperlinks when the `href` property or [channel](encoding.html#href) is defined. A `cursor` property can also be provided to serve as affordance for the links.
-
-{% include table.html props="href,cursor" source="MarkConfig" %}
-
-<!-- one example for custom fill/stroke -->
-
-{:#interpolate}
-### Interpolation (for Line and Area Marks)
-
-{% include table.html props="interpolate,tension" source="MarkConfig" %}
-
-{:#orient}
-### Orientation (for Bar, Tick, Line, and Area Marks)
-
-{% include table.html props="orient" source="MarkConfig" %}
-
-### Shape Config (for Point)
-
-{% include table.html props="shape" source="MarkConfig" %}
-
-
-### Point Size Config (for Point, Circle, and Square Marks)
-
-{% include table.html props="size" source="MarkConfig" %}
-
-
-### Text Config (for Text Marks)
-
-{% include table.html props="angle,align,baseline,dx,dy,font,fontSize,fontStyle,fontWeight,radius,text,theta" source="MarkConfig" %}
 
 
 {:#style-config}

--- a/site/docs/mark/point.md
+++ b/site/docs/mark/point.md
@@ -23,13 +23,38 @@ permalink: /docs/point.html
 - TOC
 {:toc}
 
-## Dot Plot
+{:#properties}
+## Point Mark Properties
+
+
+{: .suppress-error}
+```json
+// Single View Specification
+{
+  ...
+  "mark": {
+    "type": "point",
+    ...
+  },
+  "encoding": ... ,
+  ...
+}
+```
+
+A point mark definition can contain any [standard mark properties](mark.html#mark-def) and the following special properties:
+
+{% include table.html props="shape,size" source="MarkDef" %}
+
+
+## Examples
+
+### Dot Plot
 
 Mapping a field to either only `x` or only `y` of `point` marks creates a **dot plot**.
 
 <span class="vl-example" data-name="point_1d"></span>
 
-## Scatter Plot
+### Scatter Plot
 
 Mapping fields to both the `x` and `y` channels creates a scatter plot.
 
@@ -40,7 +65,7 @@ By default, `point` marks only have borders and are transparent inside.  You can
 
 <span class="vl-example" data-name="point_filled"></span>
 
-## Bubble Plot
+### Bubble Plot
 
 By mapping a third field to the `size` channel in the [scatter plot](#scatter), we can create a bubble plot instead.
 
@@ -48,18 +73,19 @@ By mapping a third field to the `size` channel in the [scatter plot](#scatter), 
 
 {:#color}
 
-## Scatter Plot with Color and/or Shape
+### Scatter Plot with Color and/or Shape
 
 Fields can also be encoded in the [scatter plot](#scatter) using the `color` or `shape` channels.
 For example, this specification encodes the field `Origin` with both `color` and `shape`.
 
 <span class="vl-example" data-name="point_color_with_shape"></span>
 
-## Geo Point
+### Geo Point
 
 By mapping geographic coordinate data to `longitude` and `latitude` channels of a corresponding [projection](projection.html), we can visualize geographic points. The example below shows major airports in the US.
 
 <span class="vl-example" data-name="geo_point"></span>
+
 
 {:#config}
 ## Point Config
@@ -79,4 +105,5 @@ By mapping geographic coordinate data to `longitude` and `latitude` channels of 
 
 The `point` property of the top-level [`config`](config.html) object sets the default properties for all point marks.  If [mark property encoding channels](encoding.html#mark-prop) are specified for marks, these config values will be overridden.
 
-For the list of all supported properties, please see the [mark config documentation](mark.html#config).
+The point config can contain any [point mark properties](#properties) (except `type`, `style`, and `clip`).
+

--- a/site/docs/mark/rect.md
+++ b/site/docs/mark/rect.md
@@ -23,6 +23,27 @@ The `rect` mark represents an arbitrary rectangle.
 
 - TOC
 {:toc}
+{:#properties}
+## Rect Mark Properties
+
+
+{: .suppress-error}
+```json
+// Single View Specification
+{
+  ...
+  "mark": {
+    "type": "rect",
+    ...
+  },
+  "encoding": ... ,
+  ...
+}
+```
+
+A rect mark definition can contain any [standard mark properties](mark.html#mark-def).
+
+## Examples
 
 ### Heatmap
 
@@ -61,4 +82,4 @@ We can also use `rect` to show a band covering one standard deviation over and b
 
 The `rect` property of the top-level [`config`](config.html) object sets the default properties for all rect marks.  If [mark property encoding channels](encoding.html#mark-prop) are specified for marks, these config values will be overridden.
 
-For the list of all supported properties, please see the [mark config documentation](mark.html#config).
+The rect config can contain any [rect mark properties](#properties) (except `type`, `style`, and `clip`).

--- a/site/docs/mark/rule.md
+++ b/site/docs/mark/rule.md
@@ -24,7 +24,29 @@ The `rule` mark represents each data point as a line segment. It can be used in 
 - TOC
 {:toc}
 
-## Width/Height-Spanning Rules
+{:#properties}
+## Rule Mark Properties
+
+
+{: .suppress-error}
+```json
+// Single View Specification
+{
+  ...
+  "mark": {
+    "type": "rule",
+    ...
+  },
+  "encoding": ... ,
+  ...
+}
+```
+
+A rule mark definition can contain any [standard mark properties](mark.html#mark-def).
+
+## Examples
+
+### Width/Height-Spanning Rules
 
 If the `rule` mark only has `y` encoding, the output view produces horizontal rules that  spans the complete width.  Similarly, if the `rule` mark only has `x` encoding, the output view produces vertical rules that spans the height.
 
@@ -41,7 +63,7 @@ We can also use a rule mark to show global mean value over a histogram.
 <span class="vl-example" data-name="layer_histogram_global_mean"></span>
 
 {:#ranged}
-## Ranged Rules
+### Ranged Rules
 
 To control the spans of horizontal/vertical rules, `x` and `x2`/`y` and `y2` channels can be specified.
 
@@ -75,4 +97,4 @@ Alternatively, we can create error bars showing one standard deviation (`stdev`)
 
 The `rule` property of the top-level [`config`](config.html) object sets the default properties for all rule marks.  If [mark property encoding channels](encoding.html#mark-prop) are specified for marks, these config values will be overridden.
 
-For the list of all supported properties, please see the [mark config documentation](mark.html#config).
+The rule config can contain any [rule mark properties](#properties) (except `type`, `style`, and `clip`).

--- a/site/docs/mark/square.md
+++ b/site/docs/mark/square.md
@@ -18,11 +18,21 @@ permalink: /docs/square.html
 
 `square` marks is similar to [`point`](point.html) mark, except that (1) the `shape` value is always set to `square` (2) they are filled by default.
 
-## Scatterplot with Square
+
+{:#properties}
+## Square Mark Properties
+
+A square mark definition can contain any [standard mark properties](mark.html#mark-def) and the following special properties:
+
+{% include table.html props="size" source="MarkConfig" %}
+
+
+## Example: Scatterplot with Square
 
 Here are an example scatter plot with `square` marks:
 
 <span class="vl-example" data-name="square"></span>
+
 
 
 {:#config}
@@ -43,4 +53,4 @@ Here are an example scatter plot with `square` marks:
 
 The `square` property of the top-level [`config`](config.html) object sets the default properties for all square marks.  If [mark property encoding channels](encoding.html#mark-prop) are specified for marks, these config values will be overridden.
 
-For the list of all supported properties, please see the [mark config documentation](mark.html#config).
+The square config can contain any [point mark properties](#properties) (except `type`, `style`, and `clip`).

--- a/site/docs/mark/text.md
+++ b/site/docs/mark/text.md
@@ -25,25 +25,49 @@ permalink: /docs/text.html
 - TOC
 {:toc}
 
-## Text Table Heatmap
+{:#properties}
+## Text Mark Properties
+
+{: .suppress-error}
+```json
+// Single View Specification
+{
+  ...
+  "mark": {
+    "type": "text",
+    ...
+  },
+  "encoding": ... ,
+  ...
+}
+```
+
+
+A text mark definition can contain any [standard mark properties](mark.html#mark-def) and the following special properties:
+
+{% include table.html props="angle,align,baseline,dx,dy,font,fontSize,fontStyle,fontWeight,radius,text,theta" source="MarkDef" %}
+
+## Examples
+
+### Text Table Heatmap
 
 <span class="vl-example" data-name="layer_text_heatmap"></span>
 
 
-## Labels
+### Labels
 
 You can also use `text` marks as labels for other marks and set offset (`dx` or `dy`), `align`, and `baseline` properties of the mark definition.
 
 <span class="vl-example" data-name="layer_bar_labels"></span>
 
-## Scatterplot with Text
+### Scatterplot with Text
 
 Mapping a field to `text` channel of text mark sets the mark's text value. For example, we can make a colored scatterplot with text marks showing the initial character of its origin, instead of [`point`](point.html#color) marks.
 
 <span class="vl-example" data-name="text_scatterplot_colored"></span>
 
 
-## Geo Text
+### Geo Text
 
 By mapping geographic coordinate data to `longitude` and `latitude` channels of a corresponding [projection](projection.html), we can show text at accurate locations. The example below shows the name of every US state capital at the location of the capital.
 
@@ -67,6 +91,6 @@ By mapping geographic coordinate data to `longitude` and `latitude` channels of 
 
 The `text` property of the top-level [`config`](config.html) object sets the default properties for all text marks.  If [mark property encoding channels](encoding.html#mark-prop) are specified for marks, these config values will be overridden.
 
-Besides standard [mark config properties](mark.html#config), text config can contain `shortTimeLabels`.
+Besides standard [mark properties](mark.html#config) and [special properties for text marks](#properties), text config can contain the following additional properties:
 
 {% include table.html props="shortTimeLabels" source="TextConfig" %}

--- a/site/docs/mark/tick.md
+++ b/site/docs/mark/tick.md
@@ -26,13 +26,22 @@ The `tick` mark represents each data point as a short line. This is a useful mar
 {:toc}
 
 
-## Dot Plot
+{:#properties}
+## Tick Mark Properties
+
+A tick mark definition can contain any [standard mark properties](mark.html#mark-def) and the following special properties:
+
+{% include table.html props="orient" source="MarkConfig" %}
+
+## Examples
+
+### Dot Plot
 
 For example, the following dot plot uses tick marks to show the distribution of each car's Horsepower.
 
 <span class="vl-example" data-name="tick_dot"></span>
 
-## Strip Plot
+### Strip Plot
 
 <!-- TODO: better explain this -->
 The following strip-plot use `tick` mark to represent its data.


### PR DESCRIPTION
- List all mark-specific properties (and config) in their corresponding pages.

Fix #3487

