### PR TITLE
DOC: Change default nominal scheme reference

### DIFF
--- a/site/docs/encoding/scale.md
+++ b/site/docs/encoding/scale.md
@@ -124,7 +124,7 @@ Color schemes provide a set of named color palettes as a scale range for the `co
 
 By default, Vega-Lite assigns different [default color schemes](#range-config) based on the types of the encoded fields:
 
--  _Nominal_ fields use the `"categorical"` [pre-defined named range](#range-config) (the `"category20"` scheme by default).
+-  _Nominal_ fields use the `"categorical"` [pre-defined named range](#range-config) (the `"tableau10"` scheme by default).
 
 <div class="vl-example" data-name="point_color"></div>
 

--- a/site/docs/encoding/scale.md
+++ b/site/docs/encoding/scale.md
@@ -124,15 +124,15 @@ Color schemes provide a set of named color palettes as a scale range for the `co
 
 By default, Vega-Lite assigns different [default color schemes](#range-config) based on the types of the encoded fields:
 
--  _Nominal_ fields use the `"categorical"` [pre-defined named range](#range-config) (the `"tableau10"` scheme by default).
+-  _Nominal_ fields use the `"categorical"` [pre-defined named range](#range-config) (the [`"tableau10"`](https://vega.github.io/vega/docs/schemes/#tableau10) scheme by default).
 
 <div class="vl-example" data-name="point_color"></div>
 
-- _Ordinal_ fields use the `"ordinal"` [pre-defined named color range](#range-config) (the `"blues"` color scheme by default).
+- _Ordinal_ fields use the `"ordinal"` [pre-defined named color range](#range-config) (the [`"blues"`](https://vega.github.io/vega/docs/schemes/#blues) color scheme by default).
 
 <div class="vl-example" data-name="point_color_ordinal"></div>
 
-- _Quantitative_ and _temporal_ fields use the [pre-defined named color range](#range-config) `"heatmap"` (the `"viridis"` scheme by default) for rect marks and `"ramp"` (the `"blues"` scheme by default) for other marks.
+- _Quantitative_ and _temporal_ fields use the [pre-defined named color range](#range-config) `"heatmap"` (the [`"viridis"`](https://vega.github.io/vega/docs/schemes/#viridis) scheme by default) for rect marks and `"ramp"` (the [`"blues"`](https://vega.github.io/vega/docs/schemes/#blues) scheme by default) for other marks.
 
 <div class="vl-example" data-name="rect_heatmap"></div>
 


### PR DESCRIPTION
I believe that there is a typo in the documentation.

Based on the defaults listed in the [vega-parser](https://github.com/vega/vega-parser/blob/master/src/config.js#L188) it looks like categorical scales use the `tableau10 ` color scheme by default. 

```
    // defaults for scale ranges
    range: {
      category: {
        scheme: 'tableau10'
      },
```