### PR TITLE
Fix Window Examples for Mean and Mean by Year

### DIFF
--- a/examples/compiled/window_mean_difference.vg.json
+++ b/examples/compiled/window_mean_difference.vg.json
@@ -13,6 +13,10 @@
             },
             "transform": [
                 {
+                    "type": "filter",
+                    "expr": "datum.IMDB_Rating != null"
+                },
+                {
                     "type": "window",
                     "params": [
                         null

--- a/examples/compiled/window_mean_difference_by_year.vg.json
+++ b/examples/compiled/window_mean_difference_by_year.vg.json
@@ -17,6 +17,10 @@
             },
             "transform": [
                 {
+                    "type": "filter",
+                    "expr": "datum.IMDB_Rating != null"
+                },
+                {
                     "type": "formula",
                     "as": "year",
                     "expr": "datetime(year(datum[\"Release_Date\"]), 0, 1, 0, 0, 0, 0)"

--- a/examples/specs/window_mean_difference.vl.json
+++ b/examples/specs/window_mean_difference.vl.json
@@ -2,6 +2,7 @@
   "$schema": "https://vega.github.io/schema/vega-lite/v2.json",
   "data": {"url": "data/movies.json"},
   "transform": [
+    {"filter": "datum.IMDB_Rating != null"},
     {
       "window": [{
         "op": "mean",

--- a/examples/specs/window_mean_difference_by_year.vl.json
+++ b/examples/specs/window_mean_difference_by_year.vl.json
@@ -8,6 +8,7 @@
     }
   },
   "transform": [
+      {"filter": "datum.IMDB_Rating != null"},
       {"timeUnit": "year", "field": "Release_Date", "as": "year"},
       {
         "window": [{


### PR DESCRIPTION
Updated to filter null in the examples `window_mean_difference` and  `window_mean_difference_by_year`