### PR TITLE
Add Enigma Public Tutorial to Examples

### DIFF
--- a/site/examples/index.md
+++ b/site/examples/index.md
@@ -39,3 +39,4 @@ Here we list great examples of Vega-Lite visualizations that were created by the
 * [Bicycle Count Time-series with Dynamic Scale](https://bl.ocks.org/jakevdp/b511d09ed4e2797234bd6236d7b428f7) by @jakevdp
 * [Vega-Lite downloads](https://bl.ocks.org/domoritz/81008b55ae2e2649eb42f600440f87d2) by @domoritz
 * [Interactive Exploration of Seattle Weather](https://bl.ocks.org/jakevdp/5d1915d808d3d91ce86f0bc3ca066d48) by @jakevdp
+* [Bar, Small Multiple, Heatmap, Gantt Charts: Exploring NYC Event Permits](https://medium.com/enigma-engineering/exploring-new-york-city-event-permits-with-vega-lite-f83178ff9a8d) by [@hydrosquall](https://twitter.com/hydrosquall)


### PR DESCRIPTION
* Add "community examples" link to my ObservableHQ [Tutorial](https://medium.com/enigma-engineering/exploring-new-york-city-event-permits-with-vega-lite-f83178ff9a8d) on using Enigma Public's API with Vega-Lite

