### PR TITLE
Improve deleteNestedProperty from O(n^2) to O(n+1) -- fix issue #2957

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -269,17 +269,14 @@ export type Omit<T, K extends keyof T> = {[P in Diff<keyof T, K>]: T[P]};
  * Delete nested property of an object, and delete the ancestors of the property if they become empty.
  */
 export function deleteNestedProperty(obj: any, orderedProps: string[]) {
-  let isEmpty = true;
-  while (orderedProps.length > 0 && isEmpty) {
-    let o = obj;
-    for (let i=0; i < orderedProps.length-1; i++) {
-      o = o[orderedProps[i]];
-    }
-    delete o[orderedProps.pop()];
-    if (keys(o).length !== 0) {
-      isEmpty = false;
-    }
+  if (orderedProps.length === 0) {
+    return true;
   }
+  const prop = orderedProps.shift();
+  if (deleteNestedProperty(obj[prop], orderedProps)) {
+    delete obj[prop];
+  }
+  return Object.keys(obj).length === 0;
 }
 
 export function titlecase(s: string) {

--- a/test/util.test.ts
+++ b/test/util.test.ts
@@ -1,5 +1,5 @@
 import {assert} from 'chai';
-import {hash, stringify, varName} from '../src/util';
+import {deleteNestedProperty, hash, stringify, varName} from '../src/util';
 
 describe('util', () => {
   describe('varName', () => {
@@ -46,5 +46,49 @@ describe('util', () => {
     it('hashes objects', () => {
       assert.equal(hash({foo: 42}), '{"foo":42}');
     });
+  });
+  describe('deleteNestedProperty', () => {
+      it('removes a property from an object', () => {
+        const originalObject = {
+          property1: {property1: 'value1'},
+          property2: {property5: 'value2'},
+          property3: {property6: 'value3', property7: 'value4'}
+        };
+        const newObject = {
+          property2: {property5: 'value2'},
+          property3: {property6: 'value3', property7: 'value4'}
+        };
+        deleteNestedProperty(originalObject, ['property1']);
+        assert.equal(stringify(originalObject), stringify(newObject));
+      });
+
+      it('removes nested properties', () => {
+        const originalObject = {
+          property1: {property4: 'value1'},
+          property2: {property5: 'value2'},
+          property3: {property6: 'value3', property7: 'value4'}
+        };
+        const newObject = {
+          property2: {property5: 'value2'},
+          property3: {property6: 'value3', property7: 'value4'}
+        };
+        deleteNestedProperty(originalObject, ['property1', 'property4']);
+        assert.equal(stringify(originalObject), stringify(newObject));
+      });
+
+      it('stops when it does not empty the last element', () => {
+        const originalObject = {
+          property1: {property4: 'value1'},
+          property2: {property5: 'value2'},
+          property3: {property6: 'value3', property7: 'value4'}
+        };
+        const newObject = {
+          property1: {property4: 'value1'},
+          property2: {property5: 'value2'},
+          property3: {property6: 'value3'}
+        };
+        deleteNestedProperty(originalObject, ['property3', 'property7']);
+        assert.equal(stringify(originalObject), stringify(newObject));
+      });
   });
 });


### PR DESCRIPTION
The method deleteNestedProperty is used when merging legends. This method has been changed to reduce the number of times it iterated through the objects in order to remove nested elements.  Recursion is now used.  Unit tests were added before the code was changed in order to ensure the new code was equivalent.

-------------------------------------------------------------


Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are multiple relevant issues that would not make sense in isolation. For the latter case, please make atomic commits so we can easily review each issue.
  - Please add new commit(s) when addressing comments, so we can see easily the new changeset (instead of the whole changeset).  
- [x] Provide a test case & update the documentation under `site/docs/`
- [x] Make lint and test pass. (Run `yarn lint` and `yarn test`.  If your change affects Vega outputs of some examples, run `yarn build:example EXAMPLE_NAME` to re-compile a specific example or `yarn build:examples` to re-compile all examples.)
- [x] Rebase onto the latest `master` branch.
- [x] Provide a concise title that we can copy to our release note.
  - Use imperative mood and present tense.
  - Mention relevant issues. (e.g., `#1`)
- [x] Make a pass over the whole changeset as if you're a reviewer yourself. This will help us focus on catching issues that you might not notice yourself. (If you're still working on your PR, you can add "[WIP]" prefix to the PR's title. When the PR is ready, you can then remove "[WIP]" and add a comment to notify us.) 

Pro-Tip: https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice pull request.

