### PR TITLE
Make Travis fails if normalized example is outdated

### DIFF
--- a/scripts/check-examples.sh
+++ b/scripts/check-examples.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Check only Vega file for now as Travis is having problem when generating SVG
-if ! git diff --word-diff=color --exit-code HEAD -- ./examples/compiled/*.vg.json
+if ! git diff --word-diff=color --exit-code HEAD -- ./examples/compiled/*.vg.json ./examples/specs/normalized/*.vl.json
 then
   echo "Output examples vega specs are outdated."
   exit 1


### PR DESCRIPTION
Fix https://github.com/vega/vega-lite/issues/2574


