### PR TITLE
For mark overlays, do not apply selection to the augmented layers yet.

### DIFF
--- a/src/spec.ts
+++ b/src/spec.ts
@@ -560,6 +560,7 @@ function normalizePathOverlay(spec: NormalizedUnitSpec, config: Config = {}): No
   }
 
   const layer: NormalizedUnitSpec[] = [{
+    ...(selection ? {selection} : {}),
     // Do not include point / line overlay in the normalize spec
     mark: dropLineAndPoint({
       ...markDef,
@@ -595,7 +596,6 @@ function normalizePathOverlay(spec: NormalizedUnitSpec, config: Config = {}): No
         type: 'line',
         ...lineOverlay
       },
-      ...(selection ? {selection} : {}),
       encoding: overlayEncoding
     });
   }
@@ -608,7 +608,6 @@ function normalizePathOverlay(spec: NormalizedUnitSpec, config: Config = {}): No
         filled: true,
         ...pointOverlay
       },
-      ...(selection ? {selection} : {}),
       encoding: overlayEncoding
     });
   }


### PR DESCRIPTION
(We will properly do that later in https://github.com/vega/vega-lite/issues/3702)


