### PR TITLE
Add Index for supported Scale Types given encoding channels

### DIFF
--- a/src/compile/scale/type.ts
+++ b/src/compile/scale/type.ts
@@ -2,7 +2,7 @@ import {Channel, isColorChannel, isScaleChannel, rangeType} from '../../channel'
 import {FieldDef} from '../../fielddef';
 import * as log from '../../log';
 import {Mark} from '../../mark';
-import {channelSupportScaleType, fieldDefMatchScaleType, ScaleConfig, ScaleType} from '../../scale';
+import {channelSupportScaleType, ScaleConfig, ScaleType, scaleTypeSupportDataType} from '../../scale';
 import * as util from '../../util';
 
 export type RangeType = 'continuous' | 'discrete' | 'flexible' | undefined;
@@ -31,7 +31,7 @@ export function scaleType(
     }
 
     // Check if explicitly specified scale type is supported by the data type
-    if (!fieldDefMatchScaleType(specifiedType, fieldDef.type, fieldDef.bin)) {
+    if (!scaleTypeSupportDataType(specifiedType, fieldDef.type, fieldDef.bin)) {
       log.warn(log.message.scaleTypeNotWorkWithFieldDef(specifiedType, defaultScaleType));
       return defaultScaleType;
     }

--- a/src/compile/scale/type.ts
+++ b/src/compile/scale/type.ts
@@ -2,12 +2,8 @@ import {Channel, isColorChannel, isScaleChannel, rangeType} from '../../channel'
 import {FieldDef} from '../../fielddef';
 import * as log from '../../log';
 import {Mark} from '../../mark';
-import {channelSupportScaleType, ScaleConfig, ScaleType} from '../../scale';
-import {hasDiscreteDomain} from '../../scale';
-import {Type} from '../../type';
+import {channelSupportScaleType, fieldDefMatchScaleType, ScaleConfig, ScaleType} from '../../scale';
 import * as util from '../../util';
-import {contains} from '../../util';
-
 
 export type RangeType = 'continuous' | 'discrete' | 'flexible' | undefined;
 
@@ -35,7 +31,7 @@ export function scaleType(
     }
 
     // Check if explicitly specified scale type is supported by the data type
-    if (!fieldDefMatchScaleType(specifiedType, fieldDef)) {
+    if (!fieldDefMatchScaleType(specifiedType, fieldDef.type, fieldDef.bin)) {
       log.warn(log.message.scaleTypeNotWorkWithFieldDef(specifiedType, defaultScaleType));
       return defaultScaleType;
     }
@@ -115,20 +111,4 @@ function defaultType(
 
   /* istanbul ignore next: should never reach this */
   throw new Error(log.message.invalidFieldType(fieldDef.type));
-}
-
-export function fieldDefMatchScaleType(specifiedType: ScaleType, fieldDef: FieldDef<string>):boolean {
-  const type: Type = fieldDef.type;
-  if (contains([Type.ORDINAL, Type.NOMINAL], type)) {
-    return specifiedType === undefined || hasDiscreteDomain(specifiedType);
-  } else if (type === Type.TEMPORAL) {
-    return contains([ScaleType.TIME, ScaleType.UTC, ScaleType.SEQUENTIAL, undefined], specifiedType);
-  } else if (type === Type.QUANTITATIVE) {
-    if (fieldDef.bin) {
-      return contains([ScaleType.BIN_LINEAR, ScaleType.BIN_ORDINAL, ScaleType.LINEAR], specifiedType);
-    }
-    return contains([ScaleType.LOG, ScaleType.POW, ScaleType.SQRT, ScaleType.QUANTILE, ScaleType.QUANTIZE, ScaleType.LINEAR, ScaleType.SEQUENTIAL, undefined], specifiedType);
-  }
-
-  return true;
 }

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -1,7 +1,9 @@
 import {toSet} from 'vega-util';
-import {Channel, isColorChannel} from './channel';
+import {BinParams} from './bin';
+import {Channel, CHANNELS, isColorChannel} from './channel';
 import {DateTime} from './datetime';
 import * as log from './log';
+import {Type, TYPE_INDEX} from './type';
 import {contains, Flag, flagKeys, keys} from './util';
 import {ScaleInterpolate, ScaleInterpolateParams} from './vega.schema';
 
@@ -587,6 +589,8 @@ const {type, domain, range, rangeStep, scheme, ...NON_TYPE_DOMAIN_RANGE_VEGA_SCA
 
 export const NON_TYPE_DOMAIN_RANGE_VEGA_SCALE_PROPERTIES = flagKeys(NON_TYPE_DOMAIN_RANGE_VEGA_SCALE_PROPERTY_INDEX);
 
+export const SCALE_TYPE_INDEX = generateScaleTypeIndex();
+
 export function scaleTypeSupportProperty(scaleType: ScaleType, propName: keyof Scale) {
   switch (propName) {
     case 'type':
@@ -660,6 +664,21 @@ export function channelScalePropertyIncompatability(channel: Channel, propName: 
   throw new Error(`Invalid scale property "${propName}".`);
 }
 
+export function fieldDefMatchScaleType(specifiedType: ScaleType, fieldDefType: Type, bin?: boolean|BinParams):boolean {
+  if (contains([Type.ORDINAL, Type.NOMINAL], fieldDefType)) {
+    return specifiedType === undefined || hasDiscreteDomain(specifiedType);
+  } else if (fieldDefType === Type.TEMPORAL) {
+    return contains([ScaleType.TIME, ScaleType.UTC, ScaleType.SEQUENTIAL, undefined], specifiedType);
+  } else if (fieldDefType === Type.QUANTITATIVE) {
+    if (bin) {
+      return contains([ScaleType.BIN_LINEAR, ScaleType.BIN_ORDINAL, ScaleType.LINEAR], specifiedType);
+    }
+    return contains([ScaleType.LOG, ScaleType.POW, ScaleType.SQRT, ScaleType.QUANTILE, ScaleType.QUANTIZE, ScaleType.LINEAR, ScaleType.SEQUENTIAL, undefined], specifiedType);
+  }
+
+  return true;
+}
+
 export function channelSupportScaleType(channel: Channel, scaleType: ScaleType): boolean {
   switch (channel) {
     case Channel.X:
@@ -680,4 +699,44 @@ export function channelSupportScaleType(channel: Channel, scaleType: ScaleType):
   }
   /* istanbul ignore next: it should never reach here */
   return false;
+}
+
+export function getSupportedScaleType(channel: Channel, fieldDefType: Type, bin?: boolean) {
+  return SCALE_TYPE_INDEX[generateScaleTypeIndexKey(channel, fieldDefType, bin)];
+}
+
+export interface ScaleTypeIndex {
+  [channel: string]: ScaleType[];
+}
+
+// generates ScaleTypeIndex where keys are encoding channels and values are list of valid ScaleTypes
+export function generateScaleTypeIndex() {
+  const index: ScaleTypeIndex = {};
+  for (const channel of CHANNELS) {
+    for (const fieldDefType of keys(TYPE_INDEX)) {
+      for (const scaleType of SCALE_TYPES) {
+        const key = generateScaleTypeIndexKey(channel, fieldDefType);
+        if (channelSupportScaleType(channel, scaleType) && fieldDefMatchScaleType(scaleType, fieldDefType)) {
+          index[key] ? index[key].push(scaleType) : index[key] = [scaleType];
+        }
+      }
+    }
+  }
+
+  // add quantitative binned keys to index
+  for (const channel of CHANNELS) {
+    for (const scaleType of SCALE_TYPES) {
+      const key = generateScaleTypeIndexKey(channel, Type.QUANTITATIVE, true);
+      if (channelSupportScaleType(channel, scaleType) && fieldDefMatchScaleType(scaleType, Type.QUANTITATIVE, true)) {
+        index[key] ? index[key].push(scaleType) : index[key] = [scaleType];
+      }
+    }
+  }
+
+  return index;
+}
+
+export function generateScaleTypeIndexKey(channel: Channel, fieldDefType: Type, bin?: boolean) {
+  const key = channel + '_' + fieldDefType;
+  return bin !== undefined ? key + '_bin' : key;
 }

--- a/src/type.ts
+++ b/src/type.ts
@@ -17,7 +17,7 @@ export type GeoType = typeof Type.LATITUDE | typeof Type.LONGITUDE | typeof Type
 
 export type Type = BasicType | GeoType;
 
-const TYPE_INDEX: Flag<Type> = {
+export const TYPE_INDEX: Flag<Type> = {
   quantitative: 1,
   ordinal: 1,
   temporal: 1,

--- a/test/scale.test.ts
+++ b/test/scale.test.ts
@@ -1,7 +1,14 @@
 import {assert} from 'chai';
-import {SCALE_CHANNELS, ScaleChannel} from '../src/channel';
+import {Channel, SCALE_CHANNELS, ScaleChannel} from '../src/channel';
 import * as scale from '../src/scale';
-import {channelSupportScaleType, CONTINUOUS_TO_CONTINUOUS_SCALES, SCALE_TYPES, ScaleType} from '../src/scale';
+import {
+  channelSupportScaleType,
+  CONTINUOUS_TO_CONTINUOUS_SCALES,
+  generateScaleTypeIndexKey, SCALE_TYPE_INDEX,
+  SCALE_TYPES,
+  ScaleType
+} from '../src/scale';
+import {Type} from '../src/type';
 import {some, without} from '../src/util';
 
 describe('scale', () => {
@@ -62,6 +69,7 @@ describe('scale', () => {
       }
     });
 
+
     it('x, y, size, opacity should support all continuous scale type as well as band and point', () => {
       // x,y should use either band or point for ordinal input
       const scaleTypes = [...CONTINUOUS_TO_CONTINUOUS_SCALES, ScaleType.BAND, ScaleType.POINT];
@@ -73,6 +81,72 @@ describe('scale', () => {
           assert(channelSupportScaleType(channel, scaleType), `Error: ${channel}, ${scaleType}`);
         }
       }
+    });
+  });
+
+  describe('generateScaleTypeIndexKey', () => {
+    it('key for quantitative channel with quantitative type should generate correct index key', () => {
+      const key = generateScaleTypeIndexKey(Channel.X, Type.QUANTITATIVE);
+      assert.equal(key, 'x_quantitative');
+    });
+
+    it('key for quantitative channel with binned quantitative type should generate correct index key that includes bin', () => {
+      const key = generateScaleTypeIndexKey(Channel.X, Type.QUANTITATIVE, true);
+      assert.equal(key, 'x_quantitative_bin');
+    });
+  });
+
+  describe('generateScaleTypeIndex', () => {
+    it('SCALE_TYPE_INDEX should return correct scale types for quantitative positional channels', () => {
+      const type = Type.QUANTITATIVE;
+      const positionalScaleTypes = [ScaleType.LINEAR, ScaleType.LOG, ScaleType.POW, ScaleType.SQRT];
+
+      // x channel
+      let key = generateScaleTypeIndexKey(Channel.X, type);
+      let scaleTypes = SCALE_TYPE_INDEX[key];
+      assert.deepEqual(positionalScaleTypes, scaleTypes);
+
+      // y channel
+      key = generateScaleTypeIndexKey(Channel.Y, Type.QUANTITATIVE);
+      scaleTypes = SCALE_TYPE_INDEX[key];
+      assert.deepEqual(scaleTypes, positionalScaleTypes);
+    });
+
+    it('SCALE_TYPE_INDEX should return correct scale types for quantitative positional channels with bin', () => {
+      const type = Type.QUANTITATIVE;
+      const positionalScaleTypesBinned = [ScaleType.LINEAR, ScaleType.BIN_LINEAR];
+
+      // x channel
+      let key = generateScaleTypeIndexKey(Channel.X, type, true);
+      let scaleTypes = SCALE_TYPE_INDEX[key];
+      assert.deepEqual(scaleTypes, positionalScaleTypesBinned);
+
+      // y channel
+      key = generateScaleTypeIndexKey(Channel.Y, type, true);
+      scaleTypes = SCALE_TYPE_INDEX[key];
+      assert.deepEqual(scaleTypes, positionalScaleTypesBinned);
+    });
+
+    it('SCALE_TYPE_INDEX should return correct scale types for nominal positional channels', () => {
+      const type = Type.NOMINAL;
+      const nominalPositionalScaleTypes = [ScaleType.POINT, ScaleType.BAND];
+
+      let key = generateScaleTypeIndexKey(Channel.X, type);
+      let scaleTypes = SCALE_TYPE_INDEX[key];
+      assert.deepEqual(scaleTypes, nominalPositionalScaleTypes);
+
+      key = generateScaleTypeIndexKey(Channel.Y, type);
+      scaleTypes = SCALE_TYPE_INDEX[key];
+      assert.deepEqual(scaleTypes, nominalPositionalScaleTypes);
+    });
+
+    it('SCALE_TYPE_INDEX should return correct scale types for temporal positional channels', () => {
+      const type = Type.TEMPORAL;
+      const temporalPositionalScaleTypes = [ScaleType.TIME, ScaleType.UTC];
+
+      const key = generateScaleTypeIndexKey(Channel.X, type);
+      const scaleTypes = SCALE_TYPE_INDEX[key];
+      assert.deepEqual(scaleTypes, temporalPositionalScaleTypes);
     });
   });
 });

--- a/test/scale.test.ts
+++ b/test/scale.test.ts
@@ -83,8 +83,8 @@ describe('scale', () => {
     });
   });
 
-  describe('generateScaleTypeIndex', () => {
-    it('SCALE_TYPE_INDEX should return correct scale types for quantitative positional channels', () => {
+  describe('getSupportedScaleType', () => {
+    it('should return correct scale types for quantitative positional channels', () => {
       const type = Type.QUANTITATIVE;
       const positionalScaleTypes = [ScaleType.LINEAR, ScaleType.LOG, ScaleType.POW, ScaleType.SQRT];
 
@@ -97,7 +97,7 @@ describe('scale', () => {
       assert.deepEqual(scaleTypes, positionalScaleTypes);
     });
 
-    it('SCALE_TYPE_INDEX should return correct scale types for quantitative positional channels with bin', () => {
+    it('should return correct scale types for quantitative positional channels with bin', () => {
       const type = Type.QUANTITATIVE;
       const positionalScaleTypesBinned = [ScaleType.LINEAR, ScaleType.BIN_LINEAR];
 
@@ -110,7 +110,7 @@ describe('scale', () => {
       assert.deepEqual(scaleTypes, positionalScaleTypesBinned);
     });
 
-    it('SCALE_TYPE_INDEX should return correct scale types for nominal positional channels', () => {
+    it('should return correct scale types for nominal positional channels', () => {
       const type = Type.NOMINAL;
       const nominalPositionalScaleTypes = [ScaleType.POINT, ScaleType.BAND];
 
@@ -121,7 +121,7 @@ describe('scale', () => {
       assert.deepEqual(scaleTypes, nominalPositionalScaleTypes);
     });
 
-    it('SCALE_TYPE_INDEX should return correct scale types for temporal positional channels', () => {
+    it('should return correct scale types for temporal positional channels', () => {
       const type = Type.TEMPORAL;
       const temporalPositionalScaleTypes = [ScaleType.TIME, ScaleType.UTC];
 

--- a/test/scale.test.ts
+++ b/test/scale.test.ts
@@ -3,8 +3,7 @@ import {Channel, SCALE_CHANNELS, ScaleChannel} from '../src/channel';
 import * as scale from '../src/scale';
 import {
   channelSupportScaleType,
-  CONTINUOUS_TO_CONTINUOUS_SCALES,
-  generateScaleTypeIndexKey, SCALE_TYPE_INDEX,
+  CONTINUOUS_TO_CONTINUOUS_SCALES, getSupportedScaleType,
   SCALE_TYPES,
   ScaleType
 } from '../src/scale';
@@ -84,31 +83,17 @@ describe('scale', () => {
     });
   });
 
-  describe('generateScaleTypeIndexKey', () => {
-    it('key for quantitative channel with quantitative type should generate correct index key', () => {
-      const key = generateScaleTypeIndexKey(Channel.X, Type.QUANTITATIVE);
-      assert.equal(key, 'x_quantitative');
-    });
-
-    it('key for quantitative channel with binned quantitative type should generate correct index key that includes bin', () => {
-      const key = generateScaleTypeIndexKey(Channel.X, Type.QUANTITATIVE, true);
-      assert.equal(key, 'x_quantitative_bin');
-    });
-  });
-
   describe('generateScaleTypeIndex', () => {
     it('SCALE_TYPE_INDEX should return correct scale types for quantitative positional channels', () => {
       const type = Type.QUANTITATIVE;
       const positionalScaleTypes = [ScaleType.LINEAR, ScaleType.LOG, ScaleType.POW, ScaleType.SQRT];
 
       // x channel
-      let key = generateScaleTypeIndexKey(Channel.X, type);
-      let scaleTypes = SCALE_TYPE_INDEX[key];
+      let scaleTypes = getSupportedScaleType(Channel.X, type);
       assert.deepEqual(positionalScaleTypes, scaleTypes);
 
       // y channel
-      key = generateScaleTypeIndexKey(Channel.Y, Type.QUANTITATIVE);
-      scaleTypes = SCALE_TYPE_INDEX[key];
+      scaleTypes = getSupportedScaleType(Channel.Y, Type.QUANTITATIVE);
       assert.deepEqual(scaleTypes, positionalScaleTypes);
     });
 
@@ -117,13 +102,11 @@ describe('scale', () => {
       const positionalScaleTypesBinned = [ScaleType.LINEAR, ScaleType.BIN_LINEAR];
 
       // x channel
-      let key = generateScaleTypeIndexKey(Channel.X, type, true);
-      let scaleTypes = SCALE_TYPE_INDEX[key];
+      let scaleTypes = getSupportedScaleType(Channel.X, type, true);
       assert.deepEqual(scaleTypes, positionalScaleTypesBinned);
 
       // y channel
-      key = generateScaleTypeIndexKey(Channel.Y, type, true);
-      scaleTypes = SCALE_TYPE_INDEX[key];
+      scaleTypes = getSupportedScaleType(Channel.Y, type, true);
       assert.deepEqual(scaleTypes, positionalScaleTypesBinned);
     });
 
@@ -131,12 +114,10 @@ describe('scale', () => {
       const type = Type.NOMINAL;
       const nominalPositionalScaleTypes = [ScaleType.POINT, ScaleType.BAND];
 
-      let key = generateScaleTypeIndexKey(Channel.X, type);
-      let scaleTypes = SCALE_TYPE_INDEX[key];
+      let scaleTypes = getSupportedScaleType(Channel.X, type);
       assert.deepEqual(scaleTypes, nominalPositionalScaleTypes);
 
-      key = generateScaleTypeIndexKey(Channel.Y, type);
-      scaleTypes = SCALE_TYPE_INDEX[key];
+      scaleTypes = getSupportedScaleType(Channel.Y, type);
       assert.deepEqual(scaleTypes, nominalPositionalScaleTypes);
     });
 
@@ -144,8 +125,10 @@ describe('scale', () => {
       const type = Type.TEMPORAL;
       const temporalPositionalScaleTypes = [ScaleType.TIME, ScaleType.UTC];
 
-      const key = generateScaleTypeIndexKey(Channel.X, type);
-      const scaleTypes = SCALE_TYPE_INDEX[key];
+      let scaleTypes = getSupportedScaleType(Channel.X, type);
+      assert.deepEqual(scaleTypes, temporalPositionalScaleTypes);
+
+      scaleTypes = getSupportedScaleType(Channel.Y, type);
       assert.deepEqual(scaleTypes, temporalPositionalScaleTypes);
     });
   });


### PR DESCRIPTION
Fix #3725 

Expose method `getSupportedScaleType` that returns the valid scaleTypes given an encoding channel, FieldDef type, and optional bin parameter. Function calls generated index for pre-computed valid scale types.