### PR TITLE
Rename `SortField` => `EncodingSortField`, `WindowSortField` => `SortField`

### DIFF
--- a/_data/link.yml
+++ b/_data/link.yml
@@ -62,7 +62,7 @@ Day:
 # Transform - Window
 WindowFieldDef:
   link: window.html#field-def
-WindowSortField:
+SortField:
   link: window.html#sort-field-def
 WindowOnlyOp:
   link: window.html#ops
@@ -183,7 +183,7 @@ Scale:
   link: scale.html
 SortOrder:
   name: String
-SortField:
+EncodingSortField:
   link: "sort.html#sort-field"
 StackOffset:
   name: String

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1211,7 +1211,7 @@
               "$ref": "#/definitions/SortOrder"
             },
             {
-              "$ref": "#/definitions/SortField"
+              "$ref": "#/definitions/EncodingSortField"
             },
             {
               "type": "null"
@@ -1445,7 +1445,7 @@
               "$ref": "#/definitions/SortOrder"
             },
             {
-              "$ref": "#/definitions/SortField"
+              "$ref": "#/definitions/EncodingSortField"
             },
             {
               "type": "null"
@@ -2129,6 +2129,35 @@
       },
       "type": "object"
     },
+    "EncodingSortField": {
+      "additionalProperties": false,
+      "description": "A sort definition for sorting a discrete scale in an encoding field definition.",
+      "properties": {
+        "field": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/RepeatRef"
+            }
+          ],
+          "description": "The data [field](field.html) to sort by.\n\n__Default value:__ If unspecified, defaults to the field specified in the outer data reference."
+        },
+        "op": {
+          "$ref": "#/definitions/AggregateOp",
+          "description": "An [aggregate operation](aggregate.html#ops) to perform on the field prior to sorting (e.g., `\"count\"`, `\"mean\"` and `\"median\"`).\nThis property is required in cases where the sort field and the data reference field do not match.\nThe input data objects will be aggregated, grouped by the encoded data field.\n\nFor a full list of operations, please see the documentation for [aggregate](aggregate.html#ops)."
+        },
+        "order": {
+          "$ref": "#/definitions/SortOrder",
+          "description": "The sort order. One of `\"ascending\"` (default), `\"descending\"`, or `null` (no not sort)."
+        }
+      },
+      "required": [
+        "op"
+      ],
+      "type": "object"
+    },
     "EncodingWithFacet": {
       "additionalProperties": false,
       "properties": {
@@ -2683,7 +2712,7 @@
               "$ref": "#/definitions/SortOrder"
             },
             {
-              "$ref": "#/definitions/SortField"
+              "$ref": "#/definitions/EncodingSortField"
             },
             {
               "type": "null"
@@ -5064,7 +5093,7 @@
               "$ref": "#/definitions/SortOrder"
             },
             {
-              "$ref": "#/definitions/SortField"
+              "$ref": "#/definitions/EncodingSortField"
             },
             {
               "type": "null"
@@ -6077,29 +6106,19 @@
     },
     "SortField": {
       "additionalProperties": false,
+      "description": "A sort definition for transform",
       "properties": {
         "field": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/RepeatRef"
-            }
-          ],
-          "description": "The data [field](field.html) to sort by.\n\n__Default value:__ If unspecified, defaults to the field specified in the outer data reference."
-        },
-        "op": {
-          "$ref": "#/definitions/AggregateOp",
-          "description": "An [aggregate operation](aggregate.html#ops) to perform on the field prior to sorting (e.g., `\"count\"`, `\"mean\"` and `\"median\"`).\nThis property is required in cases where the sort field and the data reference field do not match.\nThe input data objects will be aggregated, grouped by the encoded data field.\n\nFor a full list of operations, please see the documentation for [aggregate](aggregate.html#ops)."
+          "description": "The name of the field to sort.",
+          "type": "string"
         },
         "order": {
-          "$ref": "#/definitions/SortOrder",
-          "description": "The sort order. One of `\"ascending\"` (default), `\"descending\"`, or `null` (no not sort)."
+          "$ref": "#/definitions/VgComparatorOrder",
+          "description": "Whether to sort the field in ascending or descending order."
         }
       },
       "required": [
-        "op"
+        "field"
       ],
       "type": "object"
     },
@@ -8166,24 +8185,6 @@
       ],
       "type": "string"
     },
-    "WindowSortField": {
-      "additionalProperties": false,
-      "description": "A compartor for fields within the window transform",
-      "properties": {
-        "field": {
-          "description": "The name of the field to sort.",
-          "type": "string"
-        },
-        "order": {
-          "$ref": "#/definitions/VgComparatorOrder",
-          "description": "Whether to sort the field in ascending or descending order."
-        }
-      },
-      "required": [
-        "field"
-      ],
-      "type": "object"
-    },
     "WindowTransform": {
       "additionalProperties": false,
       "properties": {
@@ -8209,9 +8210,9 @@
           "type": "boolean"
         },
         "sort": {
-          "description": "A comparator definition for sorting data objects within a window. If two data objects are considered equal by the comparator, they are considered “peer” values of equal rank. If sort is not specified, the order is undefined: data objects are processed in the order they are observed and none are considered peers (the ignorePeers parameter is ignored and treated as if set to `true`).",
+          "description": "A sort field definition for sorting data objects within a window. If two data objects are considered equal by the comparator, they are considered “peer” values of equal rank. If sort is not specified, the order is undefined: data objects are processed in the order they are observed and none are considered peers (the ignorePeers parameter is ignored and treated as if set to `true`).",
           "items": {
-            "$ref": "#/definitions/WindowSortField"
+            "$ref": "#/definitions/SortField"
           },
           "type": "array"
         },

--- a/site/docs/encoding/sort.md
+++ b/site/docs/encoding/sort.md
@@ -49,9 +49,9 @@ If the channel has a discrete scale (`band`, `point` or `ordinal`), the field's 
 
 {:#sort-field}
 
-2) Sorting by aggregated value of another "sort" field. In this case, `sort` is a __sort field definition object__, which has the following properties:
+2) Sorting by aggregated value of another "sort" field. In this case, `sort` is an __encoding sort field definition__, which has the following properties:
 
-{% include table.html props="field,op,order" source="SortField" %}
+{% include table.html props="field,op,order" source="EncodingSortField" %}
 
 3) Unsorted – `null` – The field is not sorted. This is equivalent to specifying `sort: false` in [Vega's scales](https://vega.github.io/vega/docs/scales/#sort).
 
@@ -65,7 +65,7 @@ In the case that sort array contains every field value, the sort order will foll
 
 <div class="vl-example" data-name="bar_custom_sort_full"></div>
 
-If some values are ignored, the sort order will precede by the specified values in the array while unspecified values will follow their original order.  For example, this plots orders `B`, `A` and `C` first, followed by `Z`, `Y`, `X`. 
+If some values are ignored, the sort order will precede by the specified values in the array while unspecified values will follow their original order.  For example, this plots orders `B`, `A` and `C` first, followed by `Z`, `Y`, `X`.
 
 <div class="vl-example" data-name="bar_custom_sort_partial"></div>
 

--- a/site/docs/transform/window.md
+++ b/site/docs/transform/window.md
@@ -56,9 +56,9 @@ The window transform performs calculations over sorted groups of data objects. T
 
 {:#sort-field-def}
 
-### Window Sort Field Definition
+### Sort Field Definition
 
-{% include table.html props="field,order" source="WindowSortField" %}
+{% include table.html props="field,order" source="SortField" %}
 
 {:#ops}
 

--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -7,7 +7,7 @@ import {DateTime, dateTimeExpr, isDateTime} from '../../datetime';
 import {FieldDef, ScaleFieldDef} from '../../fielddef';
 import * as log from '../../log';
 import {Domain, hasDiscreteDomain, isBinScale, isSelectionDomain, ScaleConfig, ScaleType} from '../../scale';
-import {isSortArray, isSortField, SortField} from '../../sort';
+import {EncodingSortField, isSortArray, isSortField} from '../../sort';
 import {hash} from '../../util';
 import * as util from '../../util';
 import {isDataRefUnionedDomain, isFieldRefUnionDomain} from '../../vega.schema';
@@ -269,7 +269,7 @@ function parseSingleChannelDomain(scaleType: ScaleType, domain: Domain, model: U
 }
 
 
-export function domainSort(model: UnitModel, channel: ScaleChannel, scaleType: ScaleType): true | SortField<string> {
+export function domainSort(model: UnitModel, channel: ScaleChannel, scaleType: ScaleType): true | EncodingSortField<string> {
   if (!hasDiscreteDomain(scaleType)) {
     return undefined;
   }

--- a/src/compile/scale/properties.ts
+++ b/src/compile/scale/properties.ts
@@ -4,7 +4,7 @@ import {FieldDef, ScaleFieldDef} from '../../fielddef';
 import * as log from '../../log';
 import {BarConfig, MarkDef} from '../../mark';
 import {channelScalePropertyIncompatability, Domain, hasContinuousDomain, isContinuousToContinuous, NiceTime, Scale, ScaleConfig, ScaleType, scaleTypeSupportProperty} from '../../scale';
-import {SortField, SortOrder} from '../../sort';
+import {EncodingSortField, SortOrder} from '../../sort';
 import {contains, keys} from '../../util';
 import * as util from '../../util';
 import {VgScale} from '../../vega.schema';
@@ -205,7 +205,7 @@ export function paddingOuter(paddingValue: number, channel: Channel, scaleType: 
   return undefined;
 }
 
-export function reverse(scaleType: ScaleType, sort: SortOrder | SortField<string> | string[]) {
+export function reverse(scaleType: ScaleType, sort: SortOrder | EncodingSortField<string> | string[]) {
   if (hasContinuousDomain(scaleType) && sort === 'descending') {
     // For continuous domain scales, Vega does not support domain sort.
     // Thus, we reverse range instead if sort is descending

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -9,7 +9,7 @@ import {isMarkDef, Mark, MarkDef} from '../mark';
 import {Projection} from '../projection';
 import {Domain, Scale} from '../scale';
 import {SelectionDef} from '../selection';
-import {SortField, SortOrder} from '../sort';
+import {EncodingSortField, SortOrder} from '../sort';
 import {LayoutSizeMixins, NormalizedUnitSpec} from '../spec';
 import {stack, StackProperties} from '../stack';
 import {Dict, duplicate} from '../util';

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -14,7 +14,7 @@ import * as log from './log';
 import {LogicalOperand} from './logical';
 import {Predicate} from './predicate';
 import {Scale} from './scale';
-import {SortField, SortOrder} from './sort';
+import {EncodingSortField, SortOrder} from './sort';
 import {StackOffset} from './stack';
 import {getTimeUnitParts, normalizeTimeUnit, TimeUnit} from './timeunit';
 import {getFullName, QUANTITATIVE, Type} from './type';
@@ -190,7 +190,7 @@ export interface ScaleFieldDef<F> extends FieldDef<F> {
    *
    * __Default value:__ `"ascending"`
    */
-  sort?: string[] | SortOrder | SortField<F> | null;
+  sort?: string[] | SortOrder | EncodingSortField<F> | null;
 }
 
 export interface PositionFieldDef<F> extends ScaleFieldDef<F> {

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -6,7 +6,28 @@ import {VgComparatorOrder} from './vega.schema';
 
 export type SortOrder = VgComparatorOrder | null;
 
-export interface SortField<F> {
+
+/**
+ * A sort definition for transform
+ */
+export interface SortField {
+  /**
+   * The name of the field to sort.
+   */
+  field: string;
+
+  /**
+   * Whether to sort the field in ascending or descending order.
+   */
+  order?: VgComparatorOrder;
+}
+
+
+/**
+ * A sort definition for sorting a discrete scale in an encoding field definition.
+ */
+
+export interface EncodingSortField<F> {
   /**
    * The data [field](field.html) to sort by.
    *
@@ -28,10 +49,10 @@ export interface SortField<F> {
   order?: SortOrder;
 }
 
-export function isSortField<F>(sort: string[] | SortOrder | SortField<F>): sort is SortField<F> {
+export function isSortField<F>(sort: string[] | SortOrder | EncodingSortField<F>): sort is EncodingSortField<F> {
   return !!sort && (sort['op'] === 'count' || !!sort['field']) && !!sort['op'];
 }
 
-export function isSortArray<F>(sort: string[] | SortOrder | SortField<F>): sort is string[] {
+export function isSortArray<F>(sort: string[] | SortOrder | EncodingSortField<F>): sort is string[] {
   return !!sort && isArray(sort) && sort.every(s => isString(s));
 }

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -4,8 +4,8 @@ import {BinParams} from './bin';
 import {Data} from './data';
 import {LogicalOperand, normalizeLogicalOperand} from './logical';
 import {normalizePredicate, Predicate} from './predicate';
+import {SortField} from './sort';
 import {TimeUnit} from './timeunit';
-import {VgComparatorOrder} from './vega.schema';
 
 export interface FilterTransform {
   /**
@@ -166,9 +166,9 @@ export interface WindowTransform {
   groupby?: string[];
 
   /**
-   * A comparator definition for sorting data objects within a window. If two data objects are considered equal by the comparator, they are considered “peer” values of equal rank. If sort is not specified, the order is undefined: data objects are processed in the order they are observed and none are considered peers (the ignorePeers parameter is ignored and treated as if set to `true`).
+   * A sort field definition for sorting data objects within a window. If two data objects are considered equal by the comparator, they are considered “peer” values of equal rank. If sort is not specified, the order is undefined: data objects are processed in the order they are observed and none are considered peers (the ignorePeers parameter is ignored and treated as if set to `true`).
    */
-  sort?: WindowSortField[];
+  sort?: SortField[];
 }
 
 export interface LookupData {
@@ -214,20 +214,6 @@ export interface LookupTransform {
 }
 
 
-/**
- * A compartor for fields within the window transform
- */
-export interface WindowSortField {
-  /**
-   * The name of the field to sort.
-   */
-  field: string;
-
-  /**
-   * Whether to sort the field in ascending or descending order.
-   */
-  order?: VgComparatorOrder;
-}
 
 export function isLookup(t: Transform): t is LookupTransform {
   return t['lookup'] !== undefined;

--- a/test/compile/scale/domain.test.ts
+++ b/test/compile/scale/domain.test.ts
@@ -9,7 +9,7 @@ import {MAIN} from '../../../src/data';
 import {PositionFieldDef} from '../../../src/fielddef';
 import * as log from '../../../src/log';
 import {ScaleType} from '../../../src/scale';
-import {SortField} from '../../../src/sort';
+import {EncodingSortField} from '../../../src/sort';
 import {VgDomain, VgSortField} from '../../../src/vega.schema';
 import {parseUnitModel} from '../../util';
 
@@ -324,7 +324,7 @@ describe('compile/scale', () => {
 
         it('should return the correct domain for month O when specify sort',
           function() {
-            const sortDef: SortField<string> = {op: 'mean', field: 'precipitation', order: 'descending'} ;
+            const sortDef: EncodingSortField<string> = {op: 'mean', field: 'precipitation', order: 'descending'} ;
             const model = parseUnitModel({
               mark: "bar",
               encoding: {
@@ -386,7 +386,7 @@ describe('compile/scale', () => {
 
     describe('for nominal', function() {
       it('should return correct domain with the provided sort property', function() {
-        const sortDef: SortField<string> = {op: 'min' as 'min', field:'Acceleration'};
+        const sortDef: EncodingSortField<string> = {op: 'min' as 'min', field:'Acceleration'};
         const model = parseUnitModel({
             mark: "point",
             encoding: {
@@ -401,7 +401,7 @@ describe('compile/scale', () => {
       });
 
       it('should return correct domain with the provided sort property with order property', function() {
-        const sortDef: SortField<string> = {op: 'min', field:'Acceleration', order: "descending"} ;
+        const sortDef: EncodingSortField<string> = {op: 'min', field:'Acceleration', order: "descending"} ;
         const model = parseUnitModel({
             mark: "point",
             encoding: {


### PR DESCRIPTION
Rationale: WindowSortField will be used in Stack too and this is like a more general version of SortField while the encoding one is specific to one place.  

(Note that I opt for this simpler change that we discussed earlier as SortField are used in many places and they are not exactly the same thing anyway.) 

