### PR TITLE
Make boxplot output tick orient consistent with the box plot

### DIFF
--- a/examples/specs/normalized/boxplot_1D_horizontal_custom_mark_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_1D_horizontal_custom_mark_normalized.vl.json
@@ -91,6 +91,7 @@
             "type": "tick",
             "color": "black",
             "opacity": 1,
+            "orient": "vertical",
             "style": "boxplot-ticks"
           },
           "encoding": {
@@ -108,6 +109,7 @@
             "type": "tick",
             "color": "black",
             "opacity": 1,
+            "orient": "vertical",
             "style": "boxplot-ticks"
           },
           "encoding": {
@@ -139,6 +141,7 @@
             "color": "red",
             "type": "tick",
             "size": 14,
+            "orient": "vertical",
             "style": "boxplot-median"
           },
           "encoding": {

--- a/examples/specs/normalized/boxplot_1D_horizontal_explicit_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_1D_horizontal_explicit_normalized.vl.json
@@ -108,6 +108,7 @@
             "color": "white",
             "type": "tick",
             "size": 14,
+            "orient": "vertical",
             "style": "boxplot-median"
           },
           "encoding": {

--- a/examples/specs/normalized/boxplot_1D_horizontal_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_1D_horizontal_normalized.vl.json
@@ -108,6 +108,7 @@
             "color": "white",
             "type": "tick",
             "size": 14,
+            "orient": "vertical",
             "style": "boxplot-median"
           },
           "encoding": {

--- a/examples/specs/normalized/boxplot_1D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_1D_vertical_normalized.vl.json
@@ -108,6 +108,7 @@
             "color": "white",
             "type": "tick",
             "size": 14,
+            "orient": "horizontal",
             "style": "boxplot-median"
           },
           "encoding": {

--- a/examples/specs/normalized/boxplot_2D_horizontal_color_size_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_2D_horizontal_color_size_normalized.vl.json
@@ -128,6 +128,7 @@
             "color": "white",
             "type": "tick",
             "size": 14,
+            "orient": "vertical",
             "style": "boxplot-median"
           },
           "encoding": {

--- a/examples/specs/normalized/boxplot_2D_horizontal_explicit_aggregate_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_2D_horizontal_explicit_aggregate_normalized.vl.json
@@ -122,6 +122,7 @@
             "color": "white",
             "type": "tick",
             "size": 14,
+            "orient": "vertical",
             "style": "boxplot-median"
           },
           "encoding": {

--- a/examples/specs/normalized/boxplot_2D_horizontal_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_2D_horizontal_normalized.vl.json
@@ -122,6 +122,7 @@
             "color": "white",
             "type": "tick",
             "size": 14,
+            "orient": "vertical",
             "style": "boxplot-median"
           },
           "encoding": {

--- a/examples/specs/normalized/boxplot_2D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_2D_vertical_normalized.vl.json
@@ -125,6 +125,7 @@
             "color": "white",
             "type": "tick",
             "size": 14,
+            "orient": "horizontal",
             "style": "boxplot-median"
           },
           "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_2D_horizontal_custom_midtick_color_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_horizontal_custom_midtick_color_normalized.vl.json
@@ -115,6 +115,7 @@
         "color": "orange",
         "type": "tick",
         "size": 14,
+        "orient": "vertical",
         "style": "boxplot-median"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_2D_horizontal_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_horizontal_normalized.vl.json
@@ -108,6 +108,7 @@
         "color": "white",
         "type": "tick",
         "size": 14,
+        "orient": "vertical",
         "style": "boxplot-median"
       },
       "encoding": {

--- a/examples/specs/normalized/boxplot_minmax_2D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_vertical_normalized.vl.json
@@ -108,6 +108,7 @@
         "color": "white",
         "type": "tick",
         "size": 14,
+        "orient": "horizontal",
         "style": "boxplot-median"
       },
       "encoding": {

--- a/examples/specs/normalized/layer_boxplot_circle_normalized.vl.json
+++ b/examples/specs/normalized/layer_boxplot_circle_normalized.vl.json
@@ -123,6 +123,7 @@
             "color": "white",
             "type": "tick",
             "size": 14,
+            "orient": "vertical",
             "style": "boxplot-median"
           },
           "encoding": {

--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -74,7 +74,7 @@ export function normalizeBoxPlot(spec: GenericUnitSpec<Encoding<string>, BoxPlot
   const isMinMax = !isNumber(extent);
 
 
-  const {transform, continuousAxisChannelDef, continuousAxis, groupby, encodingWithoutContinuousAxis} = boxParams(spec, extent);
+  const {transform, continuousAxisChannelDef, continuousAxis, groupby, encodingWithoutContinuousAxis, tickOrient} = boxParams(spec, extent);
 
   const {color, size, ...encodingWithoutSizeColorAndContinuousAxis} = encodingWithoutContinuousAxis;
 
@@ -123,7 +123,7 @@ export function normalizeBoxPlot(spec: GenericUnitSpec<Encoding<string>, BoxPlot
     ...partLayerMixins<BoxPlotPartsMixins>(
       markDef, 'ticks', config.boxplot,
       {
-        mark: {type: 'tick', color: 'black', opacity: 1},
+        mark: {type: 'tick', color: 'black', opacity: 1, orient: tickOrient},
         encoding: {
           [continuousAxis]: {
             field: 'lower_whisker_' + continuousAxisChannelDef.field,
@@ -139,7 +139,7 @@ export function normalizeBoxPlot(spec: GenericUnitSpec<Encoding<string>, BoxPlot
     ...partLayerMixins<BoxPlotPartsMixins>(
       markDef, 'ticks', config.boxplot,
       {
-        mark: {type: 'tick', color: 'black', opacity: 1},
+        mark: {type: 'tick', color: 'black', opacity: 1, orient: tickOrient},
         encoding: {
           [continuousAxis]: {
             field: 'upper_whisker_' + continuousAxisChannelDef.field,
@@ -178,7 +178,8 @@ export function normalizeBoxPlot(spec: GenericUnitSpec<Encoding<string>, BoxPlot
         mark: {
           type: 'tick',
           ...(isObject(config.boxplot.median) && config.boxplot.median.color ? {color: config.boxplot.median.color} : {}),
-          ...(sizeValue ? {size: sizeValue} : {})
+          ...(sizeValue ? {size: sizeValue} : {}),
+          orient: tickOrient
         },
         encoding: {
           [continuousAxis]: {
@@ -301,6 +302,8 @@ function boxParams(spec: GenericUnitSpec<Encoding<string>, BoxPlot | BoxPlotDef>
 
   const {bins, timeUnits, aggregate, groupby, encoding: encodingWithoutContinuousAxis} = extractTransformsFromEncoding(oldEncodingWithoutContinuousAxis);
 
+  const tickOrient: Orient = orient === 'vertical' ? 'horizontal' : 'vertical';
+
   return {
     transform: [
       ...bins,
@@ -314,6 +317,7 @@ function boxParams(spec: GenericUnitSpec<Encoding<string>, BoxPlot | BoxPlotDef>
     groupby,
     continuousAxisChannelDef,
     continuousAxis,
-    encodingWithoutContinuousAxis
+    encodingWithoutContinuousAxis,
+    tickOrient
   };
 }

--- a/test/compositemark/boxplot.test.ts
+++ b/test/compositemark/boxplot.test.ts
@@ -141,6 +141,7 @@ describe("normalizeBoxMinMax", () => {
           {
             mark: {
               type: 'tick',
+              orient: 'horizontal',
               style: 'boxplot-median',
               color: 'white',
               size: 5
@@ -378,6 +379,7 @@ describe("normalizeBoxMinMax", () => {
           {
             mark: {
               type: 'tick',
+              orient: 'horizontal',
               style: 'boxplot-median',
               size: 14,
               color: 'white'
@@ -505,6 +507,7 @@ describe("normalizeBoxMinMax", () => {
           {
             mark: {
               type: 'tick',
+              orient: 'vertical',
               style: 'boxplot-median',
               color: 'white',
               size: 14
@@ -632,6 +635,7 @@ describe("normalizeBoxMinMax", () => {
           {
             mark: {
               type: 'tick',
+              orient: 'horizontal',
               style: 'boxplot-median',
               color: 'white',
               size: 14
@@ -759,6 +763,7 @@ describe("normalizeBoxMinMax", () => {
           {
             mark: {
               type: 'tick',
+              orient: 'vertical',
               style: 'boxplot-median',
               color: 'white',
               size: 14
@@ -885,6 +890,7 @@ describe("normalizeBoxMinMax", () => {
           {
             mark: {
               type: 'tick',
+              orient: 'horizontal',
               style: 'boxplot-median',
               color: 'white',
               size: 14
@@ -1011,6 +1017,7 @@ describe("normalizeBoxMinMax", () => {
           {
             mark: {
               type: 'tick',
+              orient: 'vertical',
               style: 'boxplot-median',
               color: 'white',
               size: 14
@@ -1135,6 +1142,7 @@ describe("normalizeBoxMinMax", () => {
           {
             mark: {
               type: 'tick',
+              orient: 'vertical',
               style: 'boxplot-median',
               color: 'white',
               size: 14
@@ -1255,6 +1263,7 @@ describe("normalizeBoxMinMax", () => {
           {
             mark: {
               type: 'tick',
+              orient: 'vertical',
               style: 'boxplot-median',
               color: 'white',
               size: 14
@@ -1374,6 +1383,7 @@ describe("normalizeBoxMinMax", () => {
           {
             mark: {
               type: 'tick',
+              orient: 'horizontal',
               style: 'boxplot-median',
               color: 'white',
               size: 14
@@ -1514,6 +1524,7 @@ describe("normalizeBoxIQR", () => {
             {
               mark: {
                 type: 'tick',
+                orient: 'horizontal',
                 style: 'boxplot-median',
                 color: 'white',
                 size: 14
@@ -1690,6 +1701,7 @@ describe("normalizeBoxIQR", () => {
               {
                 mark: {
                   type: 'tick',
+                  orient: 'horizontal',
                   style: 'boxplot-median',
                   color: 'white',
                   size: 14
@@ -1878,6 +1890,7 @@ describe("normalizeBoxIQR", () => {
               {
                 mark: {
                   type: 'tick',
+                  orient: 'horizontal',
                   style: 'boxplot-median',
                   color: 'white',
                   size: 14


### PR DESCRIPTION
(so if the dimension is binned, the tick direction is still correct)


