### PR TITLE
Use latest VSCode's organize import on save

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,11 @@
   "tslint.autoFixOnSave": true,
   "tsimporter.filesToExclude": ["build/**"],
   "tsimporter.spaceBetweenBraces": false,
-  "typescriptHero.resolver.insertSpaceBeforeAndAfterImportBraces": false,
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.format.insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false,
+  "[typescript]": {
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": true
+    }
+  }
 }


### PR DESCRIPTION
Caveat: it will introduce braces on save -- l saw that this will be [fixed in the next version of VSCode](https://github.com/Microsoft/vscode/issues/47654)


