### PR TITLE
Drop shape from overlay line output

### DIFF
--- a/examples/specs/normalized/line_shape_overlay_normalized.vl.json
+++ b/examples/specs/normalized/line_shape_overlay_normalized.vl.json
@@ -20,9 +20,6 @@
         "y": {
           "field": "price",
           "type": "quantitative"
-        },
-        "shape": {
-          "value": "square"
         }
       }
     },

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -17,7 +17,7 @@ import {stack} from './stack';
 import {TitleParams} from './title';
 import {TopLevelProperties} from './toplevelprops';
 import {Transform} from './transform';
-import {Dict, duplicate, hash, keys, vals} from './util';
+import {Dict, duplicate, hash, keys, omit, vals} from './util';
 
 
 export type TopLevel<S extends BaseSpec> = S & TopLevelProperties & {
@@ -568,7 +568,8 @@ function normalizePathOverlay(spec: NormalizedUnitSpec, config: Config = {}): No
       // TODO: extract this 0.7 to be shared with default opacity for point/tick/...
       ...(markDef.type === 'area' ? {opacity: 0.7} : {}),
     }),
-    encoding
+    // drop shape from encoding as this might be used to trigger point overlay
+    encoding: omit(encoding, ['shape'])
   }];
 
   // FIXME: disable tooltip for the line layer if tooltip is not group-by field.

--- a/src/util.ts
+++ b/src/util.ts
@@ -29,7 +29,7 @@ export function pick(obj: object, props: string[]) {
  * and inherited enumerable string keyed properties of object that are not omitted.
  */
 export function omit(obj: object, props: string[]) {
-  const copy = duplicate(obj);
+  const copy = {...obj};
   for (const prop of props) {
     delete copy[prop];
   }


### PR DESCRIPTION
Also make omit use shallow duplication.  (It's actually not used elsewhere.)