### PR TITLE
Add missing mark properties

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -124,6 +124,10 @@
           "$ref": "#/definitions/Cursor",
           "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
         },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of ltr (left-to-right, default) or rtl (right-to-left). This property determines on which side is truncated in response to the limit parameter."
+        },
         "dx": {
           "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
           "type": "number"
@@ -131,6 +135,10 @@
         "dy": {
           "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
           "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter (default “…”).",
+          "type": "string"
         },
         "fill": {
           "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)",
@@ -708,6 +716,10 @@
           "$ref": "#/definitions/Cursor",
           "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
         },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of ltr (left-to-right, default) or rtl (right-to-left). This property determines on which side is truncated in response to the limit parameter."
+        },
         "discreteBandSize": {
           "description": "The size of the bars.  If unspecified, the default size is  `bandSize-1`,\nwhich provides 1 pixel offset between bars.",
           "minimum": 0,
@@ -720,6 +732,10 @@
         "dy": {
           "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
           "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter (default “…”).",
+          "type": "string"
         },
         "fill": {
           "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)",
@@ -1882,6 +1898,13 @@
         "$ref": "#/definitions/InlineDataset"
       },
       "type": "object"
+    },
+    "Dir": {
+      "enum": [
+        "ltr",
+        "rtl"
+      ],
+      "type": "string"
     },
     "DsvDataFormat": {
       "additionalProperties": false,
@@ -4069,6 +4092,10 @@
           "$ref": "#/definitions/Cursor",
           "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
         },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of ltr (left-to-right, default) or rtl (right-to-left). This property determines on which side is truncated in response to the limit parameter."
+        },
         "dx": {
           "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
           "type": "number"
@@ -4076,6 +4103,10 @@
         "dy": {
           "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
           "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter (default “…”).",
+          "type": "string"
         },
         "fill": {
           "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)",
@@ -4476,6 +4507,10 @@
           "$ref": "#/definitions/Cursor",
           "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
         },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of ltr (left-to-right, default) or rtl (right-to-left). This property determines on which side is truncated in response to the limit parameter."
+        },
         "dx": {
           "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
           "type": "number"
@@ -4483,6 +4518,10 @@
         "dy": {
           "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
           "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter (default “…”).",
+          "type": "string"
         },
         "fill": {
           "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)",
@@ -4648,6 +4687,10 @@
           "$ref": "#/definitions/Cursor",
           "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
         },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of ltr (left-to-right, default) or rtl (right-to-left). This property determines on which side is truncated in response to the limit parameter."
+        },
         "dx": {
           "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
           "type": "number"
@@ -4655,6 +4698,10 @@
         "dy": {
           "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
           "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter (default “…”).",
+          "type": "string"
         },
         "fill": {
           "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)",
@@ -6308,6 +6355,10 @@
           "$ref": "#/definitions/Cursor",
           "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
         },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of ltr (left-to-right, default) or rtl (right-to-left). This property determines on which side is truncated in response to the limit parameter."
+        },
         "dx": {
           "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
           "type": "number"
@@ -6315,6 +6366,10 @@
         "dy": {
           "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
           "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter (default “…”).",
+          "type": "string"
         },
         "fill": {
           "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)",
@@ -6534,6 +6589,10 @@
           "$ref": "#/definitions/Cursor",
           "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
         },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of ltr (left-to-right, default) or rtl (right-to-left). This property determines on which side is truncated in response to the limit parameter."
+        },
         "dx": {
           "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
           "type": "number"
@@ -6541,6 +6600,10 @@
         "dy": {
           "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
           "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter (default “…”).",
+          "type": "string"
         },
         "fill": {
           "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)",
@@ -7876,6 +7939,10 @@
           "$ref": "#/definitions/Cursor",
           "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
         },
+        "dir": {
+          "$ref": "#/definitions/Dir",
+          "description": "The direction of the text. One of ltr (left-to-right, default) or rtl (right-to-left). This property determines on which side is truncated in response to the limit parameter."
+        },
         "dx": {
           "description": "The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
           "type": "number"
@@ -7883,6 +7950,10 @@
         "dy": {
           "description": "The vertical offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.",
           "type": "number"
+        },
+        "ellipsis": {
+          "description": "The ellipsis string for text truncated in response to the limit parameter (default “…”).",
+          "type": "string"
         },
         "fill": {
           "description": "Default Fill Color.  This has higher precedence than `config.color`\n\n__Default value:__ (None)",
@@ -8176,10 +8247,6 @@
         "clip": {
           "description": "Whether the view should be clipped.",
           "type": "boolean"
-        },
-        "cornerRadius": {
-          "description": "The radius in pixels of rounded rectangle corners (default 0).",
-          "type": "number"
         },
         "fill": {
           "description": "The fill color.\n\n__Default value:__ (none)",

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -116,6 +116,10 @@
           "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
           "type": "string"
         },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners (default 0).",
+          "type": "number"
+        },
         "cursor": {
           "$ref": "#/definitions/Cursor",
           "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
@@ -243,6 +247,14 @@
           "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
           "type": "number"
         },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of miter (default), round or bevel."
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
         "strokeOpacity": {
           "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
           "maximum": 1,
@@ -267,6 +279,9 @@
         "theta": {
           "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
           "type": "number"
+        },
+        "tooltip": {
+          "description": "The tooltip text to show upon mouse hover."
         }
       },
       "type": "object"
@@ -685,6 +700,10 @@
           "minimum": 0,
           "type": "number"
         },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners (default 0).",
+          "type": "number"
+        },
         "cursor": {
           "$ref": "#/definitions/Cursor",
           "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
@@ -789,6 +808,14 @@
           "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
           "type": "number"
         },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of miter (default), round or bevel."
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
         "strokeOpacity": {
           "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
           "maximum": 1,
@@ -813,6 +840,9 @@
         "theta": {
           "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
           "type": "number"
+        },
+        "tooltip": {
+          "description": "The tooltip text to show upon mouse hover."
         }
       },
       "type": "object"
@@ -4031,6 +4061,10 @@
           "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
           "type": "string"
         },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners (default 0).",
+          "type": "number"
+        },
         "cursor": {
           "$ref": "#/definitions/Cursor",
           "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
@@ -4147,6 +4181,14 @@
           "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
           "type": "number"
         },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of miter (default), round or bevel."
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
         "strokeOpacity": {
           "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
           "maximum": 1,
@@ -4171,6 +4213,9 @@
         "theta": {
           "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
           "type": "number"
+        },
+        "tooltip": {
+          "description": "The tooltip text to show upon mouse hover."
         }
       },
       "type": "object"
@@ -4423,6 +4468,10 @@
           "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
           "type": "string"
         },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners (default 0).",
+          "type": "number"
+        },
         "cursor": {
           "$ref": "#/definitions/Cursor",
           "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
@@ -4522,6 +4571,14 @@
           "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
           "type": "number"
         },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of miter (default), round or bevel."
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
         "strokeOpacity": {
           "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
           "maximum": 1,
@@ -4546,6 +4603,9 @@
         "theta": {
           "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
           "type": "number"
+        },
+        "tooltip": {
+          "description": "The tooltip text to show upon mouse hover."
         }
       },
       "type": "object"
@@ -4579,6 +4639,10 @@
         "color": {
           "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
           "type": "string"
+        },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners (default 0).",
+          "type": "number"
         },
         "cursor": {
           "$ref": "#/definitions/Cursor",
@@ -4707,6 +4771,14 @@
           "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
           "type": "number"
         },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of miter (default), round or bevel."
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
         "strokeOpacity": {
           "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
           "maximum": 1,
@@ -4750,6 +4822,9 @@
           "description": "Thickness of the tick mark.\n\n__Default value:__  `1`",
           "minimum": 0,
           "type": "number"
+        },
+        "tooltip": {
+          "description": "The tooltip text to show upon mouse hover."
         },
         "type": {
           "$ref": "#/definitions/Mark",
@@ -6190,6 +6265,14 @@
       ],
       "type": "string"
     },
+    "StrokeJoin": {
+      "enum": [
+        "miter",
+        "round",
+        "bevel"
+      ],
+      "type": "string"
+    },
     "StyleConfigIndex": {
       "additionalProperties": {
         "$ref": "#/definitions/VgMarkConfig"
@@ -6216,6 +6299,10 @@
         "color": {
           "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
           "type": "string"
+        },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners (default 0).",
+          "type": "number"
         },
         "cursor": {
           "$ref": "#/definitions/Cursor",
@@ -6320,6 +6407,14 @@
           "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
           "type": "number"
         },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of miter (default), round or bevel."
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
         "strokeOpacity": {
           "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
           "maximum": 1,
@@ -6344,6 +6439,9 @@
         "theta": {
           "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
           "type": "number"
+        },
+        "tooltip": {
+          "description": "The tooltip text to show upon mouse hover."
         }
       },
       "type": "object"
@@ -6427,6 +6525,10 @@
         "color": {
           "description": "Default color.  Note that `fill` and `stroke` have higher precedence than `color` and will override `color`.\n\n__Default value:__ <span style=\"color: #4682b4;\">&#9632;</span> `\"#4682b4\"`\n\n__Note:__ This property cannot be used in a [style config](https://vega.github.io/vega-lite/docs/mark.html#style-config).",
           "type": "string"
+        },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners (default 0).",
+          "type": "number"
         },
         "cursor": {
           "$ref": "#/definitions/Cursor",
@@ -6527,6 +6629,14 @@
           "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
           "type": "number"
         },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of miter (default), round or bevel."
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
         "strokeOpacity": {
           "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
           "maximum": 1,
@@ -6556,6 +6666,9 @@
           "description": "Thickness of the tick mark.\n\n__Default value:__  `1`",
           "minimum": 0,
           "type": "number"
+        },
+        "tooltip": {
+          "description": "The tooltip text to show upon mouse hover."
         }
       },
       "type": "object"
@@ -7755,6 +7868,10 @@
           "$ref": "#/definitions/VerticalAlign",
           "description": "The vertical alignment of the text. One of `\"top\"`, `\"middle\"`, `\"bottom\"`.\n\n__Default value:__ `\"middle\"`"
         },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners (default 0).",
+          "type": "number"
+        },
         "cursor": {
           "$ref": "#/definitions/Cursor",
           "description": "The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used."
@@ -7850,6 +7967,14 @@
           "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
           "type": "number"
         },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of miter (default), round or bevel."
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
         "strokeOpacity": {
           "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
           "maximum": 1,
@@ -7874,6 +7999,9 @@
         "theta": {
           "description": "Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating \"north\".",
           "type": "number"
+        },
+        "tooltip": {
+          "description": "The tooltip text to show upon mouse hover."
         }
       },
       "type": "object"
@@ -8049,6 +8177,10 @@
           "description": "Whether the view should be clipped.",
           "type": "boolean"
         },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners (default 0).",
+          "type": "number"
+        },
         "fill": {
           "description": "The fill color.\n\n__Default value:__ (none)",
           "type": "string"
@@ -8074,6 +8206,14 @@
         },
         "strokeDashOffset": {
           "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.\n\n__Default value:__ (none)",
+          "type": "number"
+        },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of miter (default), round or bevel.\n\n__Default value:__ 'miter'"
+        },
+        "strokeMiterLimit": {
+          "description": "The stroke line join method. One of miter (default), round or bevel.\n\n__Default value:__ 'miter'",
           "type": "number"
         },
         "strokeOpacity": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,7 @@ import {StackOffset} from './stack';
 import {extractTitleConfig} from './title';
 import {TopLevelProperties} from './toplevelprops';
 import {duplicate, keys, mergeDeep} from './util';
-import {VgMarkConfig, VgScheme, VgTitleConfig} from './vega.schema';
+import {StrokeJoin, VgMarkConfig, VgScheme, VgTitleConfig} from './vega.schema';
 
 
 export interface ViewConfig {
@@ -94,6 +94,27 @@ export interface ViewConfig {
    *
    */
   strokeDashOffset?: number;
+
+  /**
+   * The stroke line join method. One of miter (default), round or bevel.
+   *
+   * __Default value:__ 'miter'
+   *
+   */
+  strokeJoin?: StrokeJoin;
+
+  /**
+   * The stroke line join method. One of miter (default), round or bevel.
+   *
+   * __Default value:__ 'miter'
+   *
+   */
+  strokeMiterLimit?: number;
+
+  /**
+   * The radius in pixels of rounded rectangle corners (default 0).
+   */
+  cornerRadius?: number;
 }
 
 export const defaultViewConfig: ViewConfig = {

--- a/src/config.ts
+++ b/src/config.ts
@@ -110,11 +110,6 @@ export interface ViewConfig {
    *
    */
   strokeMiterLimit?: number;
-
-  /**
-   * The radius in pixels of rounded rectangle corners (default 0).
-   */
-  cornerRadius?: number;
 }
 
 export const defaultViewConfig: ViewConfig = {

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -121,7 +121,7 @@ export function isPrimitiveMark(mark: CompositeMark | CompositeMarkDef | Mark | 
 }
 
 export const STROKE_CONFIG = ['stroke', 'strokeWidth',
-  'strokeDash', 'strokeDashOffset', 'strokeOpacity'];
+  'strokeDash', 'strokeDashOffset', 'strokeOpacity', 'strokeJoin', 'strokeMiterLimit'];
 
 export const FILL_CONFIG = ['fill', 'fillOpacity'];
 

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -267,7 +267,7 @@ export interface VgSignal {
   push?: string;
 }
 
-export type VgEncodeChannel = 'x'|'x2'|'xc'|'width'|'y'|'y2'|'yc'|'height'|'opacity'|'fill'|'fillOpacity'|'stroke'|'strokeWidth'|'strokeCap'|'strokeOpacity'|'strokeDash'|'strokeDashOffset'|'cursor'|'clip'|'size'|'shape'|'path'|'innerRadius'|'outerRadius'|'startAngle'|'endAngle'|'interpolate'|'tension'|'orient'|'url'|'align'|'baseline'|'text'|'dir'|'ellipsis'|'limit'|'dx'|'dy'|'radius'|'theta'|'angle'|'font'|'fontSize'|'fontWeight'|'fontStyle'|'tooltip'|'href'|'cursor'|'defined';
+export type VgEncodeChannel = 'x'|'x2'|'xc'|'width'|'y'|'y2'|'yc'|'height'|'opacity'|'fill'|'fillOpacity'|'stroke'|'strokeWidth'|'strokeCap'|'strokeOpacity'|'strokeDash'|'strokeDashOffset'|'strokeMiterLimit'|'strokeJoin'|'cursor'|'clip'|'size'|'shape'|'path'|'innerRadius'|'outerRadius'|'startAngle'|'endAngle'|'interpolate'|'tension'|'orient'|'url'|'align'|'baseline'|'text'|'dir'|'ellipsis'|'limit'|'dx'|'dy'|'radius'|'theta'|'angle'|'font'|'fontSize'|'fontWeight'|'fontStyle'|'tooltip'|'href'|'cursor'|'defined'|'cornerRadius';
 export type VgEncodeEntry = {
   [k in VgEncodeChannel]?: VgValueRef | (VgValueRef & {test?: string})[];
 };
@@ -972,6 +972,7 @@ export type Cursor = 'auto' | 'default' | 'none' |
   'row-resize' | 'all-scroll' | 'zoom-in' |
   'zoom-out' | 'grab' | 'grabbing';
 export type StrokeCap = 'butt' | 'round' | 'square';
+export type StrokeJoin = 'miter' | 'round' | 'bevel';
 
 export interface VgMarkConfig {
 
@@ -1047,6 +1048,16 @@ export interface VgMarkConfig {
    * The offset (in pixels) into which to begin drawing with the stroke dash array.
    */
   strokeDashOffset?: number;
+
+  /**
+   * The stroke line join method. One of miter (default), round or bevel.
+   */
+  strokeJoin?: StrokeJoin;
+
+  /**
+   * The miter limit at which to bevel a line join.
+   */
+  strokeMiterLimit?: number;
 
   // ---------- Orientation: Bar, Tick, Line, Area ----------
   /**
@@ -1190,6 +1201,16 @@ export interface VgMarkConfig {
    * The mouse cursor used over the mark. Any valid [CSS cursor type](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#Values) can be used.
    */
   cursor?: Cursor;
+
+  /**
+   * The tooltip text to show upon mouse hover.
+   */
+  tooltip?: any;
+
+  /**
+   * The radius in pixels of rounded rectangle corners (default 0).
+   */
+  cornerRadius?: number;
 }
 
 const VG_MARK_CONFIG_INDEX: Flag<keyof VgMarkConfig> = {
@@ -1202,6 +1223,8 @@ const VG_MARK_CONFIG_INDEX: Flag<keyof VgMarkConfig> = {
   strokeOpacity: 1,
   strokeDash: 1,
   strokeDashOffset: 1,
+  strokeJoin: 1,
+  strokeMiterLimit: 1,
   size: 1,
   shape: 1,
   interpolate: 1,
@@ -1222,6 +1245,8 @@ const VG_MARK_CONFIG_INDEX: Flag<keyof VgMarkConfig> = {
   fontStyle: 1,
   cursor: 1,
   href: 1,
+  tooltip: 1,
+  cornerRadius: 1,
   // commented below are vg channel that do not have mark config.
   // 'x'|'x2'|'xc'|'width'|'y'|'y2'|'yc'|'height'
   // clip: 1,

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -973,6 +973,7 @@ export type Cursor = 'auto' | 'default' | 'none' |
   'zoom-out' | 'grab' | 'grabbing';
 export type StrokeCap = 'butt' | 'round' | 'square';
 export type StrokeJoin = 'miter' | 'round' | 'bevel';
+export type Dir = 'ltr' | 'rtl';
 
 export interface VgMarkConfig {
 
@@ -1139,6 +1140,11 @@ export interface VgMarkConfig {
   baseline?: VerticalAlign;
 
   /**
+   * The direction of the text. One of ltr (left-to-right, default) or rtl (right-to-left). This property determines on which side is truncated in response to the limit parameter.
+   */
+  dir?: Dir;
+
+  /**
    * The horizontal offset, in pixels, between the text label and its anchor point. The offset is applied after rotation by the _angle_ property.
    */
   dx?: number;
@@ -1158,6 +1164,11 @@ export interface VgMarkConfig {
    * The maximum length of the text mark in pixels (default 0, indicating no limit). The text value will be automatically truncated if the rendered size exceeds the limit.
    */
   limit?: number;
+
+  /**
+   * The ellipsis string for text truncated in response to the limit parameter (default “…”).
+   */
+  ellipsis?: string;
 
   /**
    * Polar coordinate angle, in radians, of the text label from the origin determined by the `x` and `y` properties. Values for `theta` follow the same convention of `arc` mark `startAngle` and `endAngle` properties: angles are measured in radians, with `0` indicating "north".
@@ -1247,11 +1258,11 @@ const VG_MARK_CONFIG_INDEX: Flag<keyof VgMarkConfig> = {
   href: 1,
   tooltip: 1,
   cornerRadius: 1,
+  dir: 1,
+  ellipsis: 1,
   // commented below are vg channel that do not have mark config.
   // 'x'|'x2'|'xc'|'width'|'y'|'y2'|'yc'|'height'
   // clip: 1,
-  // dir: 1,
-  // ellipsis: 1,
   // endAngle: 1,
   // innerRadius: 1,
   // outerRadius: 1,


### PR DESCRIPTION
Issue #3266:

Questions:
1. Should `strokeJoin` and `strokeMiterLimit` be in the list `STROKE_CONFIG` on line 124 of mark.ts? `strokeDash` and `strokeDashOffset` are there but `strokeCap` is not.
2. I added `cornerRadius` to the view config in `config.ts`, but it looks strange when used because the axes do not curve while the inner rectangle does. Is there a way to fix this?

TODO: Update documentation