### PR TITLE
Use HTML ampersand code in examples.json so that markdown for line ov…

### DIFF
--- a/_data/examples.json
+++ b/_data/examples.json
@@ -117,7 +117,7 @@
         "name": "line_overlay",
         "title": "Line Chart with Overlaying Point Markers",
         "style": "background-size: auto 105%; background-position: center center !important;",
-        "description": "By setting the `point` property of the line mark definition to an object defining a property of the overlaying point marks, we can overlay point markers on top of line. Here we set the point color to `\"red\"` and set the line color to `\"green\"`. \n\n Notes: (1) This is equivalent to adding another layer of point marks. \n (2) While `\"point\"` marks are normally semi-transparent, the overlay point marker has `opacity` = 1 by default."
+        "description": "By setting the `point` property of the line mark definition to an object defining a property of the overlaying point marks, we can overlay point markers on top of line. Here we set the point color to `\"red\"` and set the line color to `\"green\"`. \n\n Notes&#58; (1) This is equivalent to adding another layer of point marks. \n (2) While `\"point\"` marks are normally semi-transparent, the overlay point marker has `opacity` = 1 by default."
       },
       {
         "name": "line_color",


### PR DESCRIPTION
…erlay chart is parsable. Fixes #3906. Updates the description field in `_data/examples.json` for the line_overlay graph by replacing the colon with the appropriate HTML ampersand code for a colon.