### PR TITLE
Fix Impute with Falsy values

### DIFF
--- a/src/compile/data/impute.ts
+++ b/src/compile/data/impute.ts
@@ -55,7 +55,7 @@ export class ImputeNode extends DataFlowNode {
         impute: imputedChannel.field,
         key: keyChannel.field,
         ...(method ? {method}:{}),
-        ...(value ? {value} : {}),
+        ...(value !== undefined ? {value} : {}),
         ...(frame ? {frame} : {}),
         ...(groupbyFields.length ? {groupby: groupbyFields} : {} )
       });

--- a/test/compile/data/impute.test.ts
+++ b/test/compile/data/impute.test.ts
@@ -184,6 +184,30 @@ describe('compile/data/impute', () => {
       }]);
     });
 
+    it('should work for falsy value impute', () => {
+      const model = parseUnitModelWithScale ({
+        mark: "bar",
+        encoding: {
+          x : {aggregate: 'sum', field: 'yield', type: 'quantitative'},
+          y : {field: 'variety', type: 'quantitative', impute: {'value': 0}},
+          'color': {field: 'site', type: 'nominal'}
+        }
+      });
+      const result = ImputeNode.makeFromEncoding(null, model);
+      assert.deepEqual(result.assemble() as any, [{
+        type: 'impute',
+        field: 'variety',
+        key: 'yield',
+        method: 'value',
+        groupby: ['site'],
+        value: null
+      }, {
+        type: 'formula',
+        expr: 'datum.variety === null ? 0 : datum.variety',
+        as: 'variety'
+      }]);
+    });
+
     it('should work for method impute', () => {
       const model = parseUnitModelWithScale ({
         mark: "bar",


### PR DESCRIPTION
Fixes imputing with `value`s that are `falsy` like `0` or `null`