### PR TITLE
Correct doc template for array of mixed type e.g., `(null | number)[]`

### DIFF
--- a/_includes/type.html
+++ b/_includes/type.html
@@ -10,17 +10,17 @@ assign type = src.type %}{%
     if src.items.anyOf %}{%
         assign para = src.items.anyOf %}{%
         include type-anyof.html types=para suffix="[]"%}{%
-    else %}{% include type.html source=src.items %}[]{%
+    else %}{% include type.html source=src.items parentheses=true %}[]{%
     endif %}{%
   elsif type == "object" %}{% comment %}case for type is map{% endcomment %}{%
     include type.html source=src.additionalProperties %}{}
   {%
-  elsif type.first != nil %}{% comment %}case for when type in the schema is an array of multiple types{% endcomment %}{%
+  elsif type.first != nil %}{% comment %}case for when type in the schema is an array of multiple types{% endcomment %}{% if include.parentheses %}({% endif %}{%
     for element in type %}{{
       element | capitalize | strip
      }}{%
       unless forloop.last %} | {% endunless %}{%
-    endfor %}{%
+    endfor %}{% if include.parentheses %}){% endif %}{%
   else %}{%comment%}normal case for single type{%endcomment%}{{
     type | capitalize | strip}}{%
   endif %}


### PR DESCRIPTION
Fix #3569

![image](https://user-images.githubusercontent.com/111269/42659532-63250dd6-85dd-11e8-8e2a-41639bbc446c.png)


