### PR TITLE
Auto generated tool tips now check the format and title fields of a channe's axis and legend when appropriate

### DIFF
--- a/examples/compiled/area.vg.json
+++ b/examples/compiled/area.vg.json
@@ -38,7 +38,7 @@
           "orient": {"value": "vertical"},
           "fill": {"value": "#4c78a8"},
           "tooltip": {
-            "signal": "{\"date (year-month)\": timeFormat(datum[\"yearmonth_date\"], '%b %Y'), \"Sum of count\": format(datum[\"sum_count\"], \"\")}"
+            "signal": "{\"date (year-month)\": timeFormat(datum[\"yearmonth_date\"], '%Y'), \"count\": format(datum[\"sum_count\"], \"\")}"
           },
           "x": {"scale": "x", "field": "yearmonth_date"},
           "y": {"scale": "y", "field": "sum_count"},

--- a/examples/compiled/area_horizon.vg.json
+++ b/examples/compiled/area_horizon.vg.json
@@ -84,7 +84,7 @@
           "fill": {"value": "#4c78a8"},
           "opacity": {"value": 0.3},
           "tooltip": {
-            "signal": "{\"x\": format(datum[\"x\"], \"\"), \"ny\": format(datum[\"ny\"], \"\")}"
+            "signal": "{\"x\": format(datum[\"x\"], \"\"), \"y\": format(datum[\"ny\"], \"\")}"
           },
           "x": {"scale": "x", "field": "x"},
           "y": {"scale": "y", "field": "ny"},

--- a/examples/compiled/bar_1d.vg.json
+++ b/examples/compiled/bar_1d.vg.json
@@ -38,7 +38,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"Sum of people\": format(datum[\"sum_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"sum_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "sum_people"},
           "x2": {"scale": "x", "value": 0},

--- a/examples/compiled/bar_1d_rangestep_config.vg.json
+++ b/examples/compiled/bar_1d_rangestep_config.vg.json
@@ -38,7 +38,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"Sum of people\": format(datum[\"sum_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"sum_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "sum_people"},
           "x2": {"scale": "x", "value": 0},

--- a/examples/compiled/bar_aggregate.vg.json
+++ b/examples/compiled/bar_aggregate.vg.json
@@ -45,7 +45,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"Sum of people\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "sum_people"},
           "x2": {"scale": "x", "value": 0},

--- a/examples/compiled/bar_aggregate_format.vg.json
+++ b/examples/compiled/bar_aggregate_format.vg.json
@@ -45,7 +45,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"Sum of people\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"population\": format(datum[\"sum_people\"], \".2e\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "sum_people"},
           "x2": {"scale": "x", "value": 0},

--- a/examples/compiled/bar_aggregate_size.vg.json
+++ b/examples/compiled/bar_aggregate_size.vg.json
@@ -45,7 +45,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"Sum of people\": format(datum[\"sum_people\"], \"\")}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\")}"
           },
           "xc": {"scale": "x", "field": "age", "band": 0.5},
           "width": {"value": 10},

--- a/examples/compiled/bar_diverging_stack_transform.vg.json
+++ b/examples/compiled/bar_diverging_stack_transform.vg.json
@@ -311,7 +311,7 @@
             {"scale": "color", "field": "type"}
           ],
           "tooltip": {
-            "signal": "{\"nx\": format(datum[\"nx\"], \"\"), \"question\": ''+datum[\"question\"], \"nx2\": format(datum[\"nx2\"], \"\"), \"type\": ''+datum[\"type\"]}"
+            "signal": "{\"Percentage\": format(datum[\"nx\"], \"\"), \"Question\": ''+datum[\"question\"], \"nx2\": format(datum[\"nx2\"], \"\"), \"Response\": ''+datum[\"type\"]}"
           },
           "x": {"scale": "x", "field": "nx"},
           "x2": {"scale": "x", "field": "nx2"},

--- a/examples/compiled/bar_grouped.vg.json
+++ b/examples/compiled/bar_grouped.vg.json
@@ -131,7 +131,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"gender\": ''+datum[\"gender\"], \"Sum of people\": format(datum[\"sum_people\"], \"\")}"
+                "signal": "{\"gender\": ''+datum[\"gender\"], \"population\": format(datum[\"sum_people\"], \"\")}"
               },
               "x": {"scale": "x", "field": "gender"},
               "width": {"scale": "x", "band": true},

--- a/examples/compiled/bar_grouped_horizontal.vg.json
+++ b/examples/compiled/bar_grouped_horizontal.vg.json
@@ -119,7 +119,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"Sum of people\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "x", "field": "sum_people"},
               "x2": {"scale": "x", "value": 0},

--- a/examples/compiled/bar_layered_transparent.vg.json
+++ b/examples/compiled/bar_layered_transparent.vg.json
@@ -51,7 +51,7 @@
           ],
           "opacity": {"value": 0.7},
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"Sum of people\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
           },
           "x": {"scale": "x", "field": "age"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/bar_layered_weather.vg.json
+++ b/examples/compiled/bar_layered_weather.vg.json
@@ -86,7 +86,7 @@
             {"value": "#ccc"}
           ],
           "tooltip": {
-            "signal": "{\"id\": ''+datum[\"id\"], \"record.low\": format(datum[\"record.low\"], \"\"), \"record.high\": format(datum[\"record.high\"], \"\")}"
+            "signal": "{\"Day\": ''+datum[\"id\"], \"Temperature (F)\": format(datum[\"record.low\"], \"\"), \"record.high\": format(datum[\"record.high\"], \"\")}"
           },
           "xc": {"scale": "x", "field": "id", "band": 0.5},
           "width": {"value": 20},
@@ -226,7 +226,7 @@
           "dy": {"value": -105},
           "fill": {"value": "black"},
           "tooltip": {
-            "signal": "{\"id\": ''+datum[\"id\"], \"day\": ''+datum[\"day\"]}"
+            "signal": "{\"Day\": ''+datum[\"id\"], \"day\": ''+datum[\"day\"]}"
           },
           "x": {"scale": "x", "field": "id", "band": 0.5},
           "y": {"signal": "height", "mult": 0.5},

--- a/examples/compiled/bar_scale_quantile.vg.json
+++ b/examples/compiled/bar_scale_quantile.vg.json
@@ -51,7 +51,9 @@
             },
             {"scale": "color", "field": "b"}
           ],
-          "tooltip": {"signal": "{\"b\": ''+datum[\"b\"]}"},
+          "tooltip": {
+            "signal": "{\"b\": ''+datum[\"b\"], \"Quantile\": format(datum[\"b\"], \"\")}"
+          },
           "x": {"signal": "width", "mult": 0.5},
           "y": {"scale": "y", "field": "b"},
           "size": {"scale": "size", "field": "b"},

--- a/examples/compiled/bar_scale_quantize.vg.json
+++ b/examples/compiled/bar_scale_quantize.vg.json
@@ -51,7 +51,9 @@
             },
             {"scale": "color", "field": "b"}
           ],
-          "tooltip": {"signal": "{\"b\": ''+datum[\"b\"]}"},
+          "tooltip": {
+            "signal": "{\"b\": ''+datum[\"b\"], \"Quantize\": format(datum[\"b\"], \"\")}"
+          },
           "x": {"signal": "width", "mult": 0.5},
           "y": {"scale": "y", "field": "b"},
           "size": {"scale": "size", "field": "b"},

--- a/examples/compiled/bar_scale_threshold.vg.json
+++ b/examples/compiled/bar_scale_threshold.vg.json
@@ -51,7 +51,9 @@
             },
             {"scale": "color", "field": "b"}
           ],
-          "tooltip": {"signal": "{\"b\": ''+datum[\"b\"]}"},
+          "tooltip": {
+            "signal": "{\"b\": ''+datum[\"b\"], \"Threshold\": format(datum[\"b\"], \"\")}"
+          },
           "x": {"signal": "width", "mult": 0.5},
           "y": {"scale": "y", "field": "b"},
           "size": {"scale": "size", "field": "b"},

--- a/examples/compiled/bar_yearmonth_custom_format.vg.json
+++ b/examples/compiled/bar_yearmonth_custom_format.vg.json
@@ -43,7 +43,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"date (year-month)\": timeFormat(datum[\"yearmonth_date\"], '%b %Y'), \"Mean of temp\": format(datum[\"mean_temp\"], \"\")}"
+            "signal": "{\"date (year-month)\": timeFormat(datum[\"yearmonth_date\"], '%B of %Y'), \"Mean of temp\": format(datum[\"mean_temp\"], \"\")}"
           },
           "xc": {"scale": "x", "field": "yearmonth_date"},
           "width": {"value": 5},

--- a/examples/compiled/boxplot_1D_horizontal.vg.json
+++ b/examples/compiled/boxplot_1D_horizontal.vg.json
@@ -88,7 +88,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"lower_whisker_people\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_whisker_people"},
           "y": {"signal": "height", "mult": 0.5},
@@ -111,7 +111,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "upper_box_people"},
           "y": {"signal": "height", "mult": 0.5},
@@ -134,7 +134,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_box_people"},
           "x2": {"scale": "x", "field": "upper_box_people"},
@@ -159,7 +159,7 @@
             {"value": "white"}
           ],
           "tooltip": {
-            "signal": "{\"mid_box_people\": format(datum[\"mid_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"mid_box_people\"], \"\")}"
           },
           "xc": {"scale": "x", "field": "mid_box_people"},
           "yc": {"signal": "height", "mult": 0.5},

--- a/examples/compiled/boxplot_1D_horizontal_custom_mark.vg.json
+++ b/examples/compiled/boxplot_1D_horizontal_custom_mark.vg.json
@@ -88,7 +88,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"lower_whisker_people\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_whisker_people"},
           "y": {"signal": "height", "mult": 0.5},
@@ -111,7 +111,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "upper_box_people"},
           "y": {"signal": "height", "mult": 0.5},
@@ -135,7 +135,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"lower_whisker_people\": format(datum[\"lower_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\")}"
           },
           "xc": {"scale": "x", "field": "lower_whisker_people"},
           "yc": {"signal": "height", "mult": 0.5},
@@ -160,7 +160,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_whisker_people\"], \"\")}"
           },
           "xc": {"scale": "x", "field": "upper_whisker_people"},
           "yc": {"signal": "height", "mult": 0.5},
@@ -184,7 +184,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_box_people"},
           "x2": {"scale": "x", "field": "upper_box_people"},
@@ -209,7 +209,7 @@
             {"value": "red"}
           ],
           "tooltip": {
-            "signal": "{\"mid_box_people\": format(datum[\"mid_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"mid_box_people\"], \"\")}"
           },
           "xc": {"scale": "x", "field": "mid_box_people"},
           "yc": {"signal": "height", "mult": 0.5},

--- a/examples/compiled/boxplot_1D_horizontal_explicit.vg.json
+++ b/examples/compiled/boxplot_1D_horizontal_explicit.vg.json
@@ -88,7 +88,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"lower_whisker_people\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_whisker_people"},
           "y": {"signal": "height", "mult": 0.5},
@@ -111,7 +111,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "upper_box_people"},
           "y": {"signal": "height", "mult": 0.5},
@@ -134,7 +134,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_box_people"},
           "x2": {"scale": "x", "field": "upper_box_people"},
@@ -159,7 +159,7 @@
             {"value": "white"}
           ],
           "tooltip": {
-            "signal": "{\"mid_box_people\": format(datum[\"mid_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"mid_box_people\"], \"\")}"
           },
           "xc": {"scale": "x", "field": "mid_box_people"},
           "yc": {"signal": "height", "mult": 0.5},

--- a/examples/compiled/boxplot_1D_vertical.vg.json
+++ b/examples/compiled/boxplot_1D_vertical.vg.json
@@ -88,7 +88,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"lower_whisker_people\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
           },
           "x": {"signal": "width", "mult": 0.5},
           "y": {"scale": "y", "field": "lower_whisker_people"},
@@ -111,7 +111,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
           },
           "x": {"signal": "width", "mult": 0.5},
           "y": {"scale": "y", "field": "upper_box_people"},
@@ -134,7 +134,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
           },
           "xc": {"signal": "width", "mult": 0.5},
           "width": {"value": 14},
@@ -159,7 +159,7 @@
             {"value": "white"}
           ],
           "tooltip": {
-            "signal": "{\"mid_box_people\": format(datum[\"mid_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"mid_box_people\"], \"\")}"
           },
           "xc": {"signal": "width", "mult": 0.5},
           "yc": {"scale": "y", "field": "mid_box_people"},

--- a/examples/compiled/boxplot_2D_horizontal.vg.json
+++ b/examples/compiled/boxplot_2D_horizontal.vg.json
@@ -94,7 +94,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"lower_whisker_people\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_whisker_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -117,7 +117,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "upper_box_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -140,7 +140,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_box_people"},
           "x2": {"scale": "x", "field": "upper_box_people"},
@@ -165,7 +165,7 @@
             {"value": "white"}
           ],
           "tooltip": {
-            "signal": "{\"mid_box_people\": format(datum[\"mid_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"population\": format(datum[\"mid_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "xc": {"scale": "x", "field": "mid_box_people"},
           "yc": {"scale": "y", "field": "age", "band": 0.5},

--- a/examples/compiled/boxplot_2D_horizontal_color_size.vg.json
+++ b/examples/compiled/boxplot_2D_horizontal_color_size.vg.json
@@ -94,7 +94,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"lower_whisker_people\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_whisker_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -117,7 +117,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "upper_box_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -140,7 +140,7 @@
             {"value": "blue"}
           ],
           "tooltip": {
-            "signal": "{\"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_box_people"},
           "x2": {"scale": "x", "field": "upper_box_people"},
@@ -165,7 +165,7 @@
             {"value": "white"}
           ],
           "tooltip": {
-            "signal": "{\"mid_box_people\": format(datum[\"mid_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"population\": format(datum[\"mid_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "xc": {"scale": "x", "field": "mid_box_people"},
           "yc": {"scale": "y", "field": "age", "band": 0.5},

--- a/examples/compiled/boxplot_2D_horizontal_explicit_aggregate.vg.json
+++ b/examples/compiled/boxplot_2D_horizontal_explicit_aggregate.vg.json
@@ -94,7 +94,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"lower_whisker_people\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_whisker_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -117,7 +117,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "upper_box_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -140,7 +140,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_box_people"},
           "x2": {"scale": "x", "field": "upper_box_people"},
@@ -165,7 +165,7 @@
             {"value": "white"}
           ],
           "tooltip": {
-            "signal": "{\"mid_box_people\": format(datum[\"mid_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"population\": format(datum[\"mid_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "xc": {"scale": "x", "field": "mid_box_people"},
           "yc": {"scale": "y", "field": "age", "band": 0.5},

--- a/examples/compiled/boxplot_2D_vertical.vg.json
+++ b/examples/compiled/boxplot_2D_vertical.vg.json
@@ -94,7 +94,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"lower_whisker_people\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "age", "band": 0.5},
           "y": {"scale": "y", "field": "lower_whisker_people"},
@@ -117,7 +117,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "age", "band": 0.5},
           "y": {"scale": "y", "field": "upper_box_people"},
@@ -140,7 +140,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
           },
           "xc": {"scale": "x", "field": "age", "band": 0.5},
           "width": {"value": 5},
@@ -165,7 +165,7 @@
             {"value": "white"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"mid_box_people\": format(datum[\"mid_box_people\"], \"\")}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"mid_box_people\"], \"\")}"
           },
           "xc": {"scale": "x", "field": "age", "band": 0.5},
           "yc": {"scale": "y", "field": "mid_box_people"},

--- a/examples/compiled/boxplot_minmax_2D_horizontal.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_horizontal.vg.json
@@ -50,7 +50,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"lower_whisker_people\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_whisker_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -73,7 +73,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "upper_box_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -96,7 +96,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_box_people"},
           "x2": {"scale": "x", "field": "upper_box_people"},
@@ -121,7 +121,7 @@
             {"value": "white"}
           ],
           "tooltip": {
-            "signal": "{\"mid_box_people\": format(datum[\"mid_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"population\": format(datum[\"mid_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "xc": {"scale": "x", "field": "mid_box_people"},
           "yc": {"scale": "y", "field": "age", "band": 0.5},

--- a/examples/compiled/boxplot_minmax_2D_horizontal_custom_midtick_color.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_horizontal_custom_midtick_color.vg.json
@@ -50,7 +50,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"lower_whisker_people\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_whisker_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -73,7 +73,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "upper_box_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -96,7 +96,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_box_people"},
           "x2": {"scale": "x", "field": "upper_box_people"},
@@ -121,7 +121,7 @@
             {"value": "orange"}
           ],
           "tooltip": {
-            "signal": "{\"mid_box_people\": format(datum[\"mid_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"population\": format(datum[\"mid_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "xc": {"scale": "x", "field": "mid_box_people"},
           "yc": {"scale": "y", "field": "age", "band": 0.5},

--- a/examples/compiled/boxplot_minmax_2D_vertical.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_vertical.vg.json
@@ -50,7 +50,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"lower_whisker_people\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "age", "band": 0.5},
           "y": {"scale": "y", "field": "lower_whisker_people"},
@@ -73,7 +73,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "age", "band": 0.5},
           "y": {"scale": "y", "field": "upper_box_people"},
@@ -96,7 +96,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
           },
           "xc": {"scale": "x", "field": "age", "band": 0.5},
           "width": {"value": 14},
@@ -121,7 +121,7 @@
             {"value": "white"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"mid_box_people\": format(datum[\"mid_box_people\"], \"\")}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"mid_box_people\"], \"\")}"
           },
           "xc": {"scale": "x", "field": "age", "band": 0.5},
           "yc": {"scale": "y", "field": "mid_box_people"},

--- a/examples/compiled/circle_natural_disasters.vg.json
+++ b/examples/compiled/circle_natural_disasters.vg.json
@@ -40,7 +40,7 @@
             {"scale": "color", "field": "Entity"}
           ],
           "tooltip": {
-            "signal": "{\"Year\": ''+datum[\"Year\"], \"Entity\": ''+datum[\"Entity\"], \"Deaths\": format(datum[\"Deaths\"], \"\")}"
+            "signal": "{\"Year\": ''+datum[\"Year\"], \"Entity\": ''+datum[\"Entity\"], \"Annual Global Deaths\": format(datum[\"Deaths\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Year"},
           "y": {"scale": "y", "field": "Entity"},

--- a/examples/compiled/concat_bar_layer_circle.vg.json
+++ b/examples/compiled/concat_bar_layer_circle.vg.json
@@ -199,7 +199,7 @@
               ],
               "opacity": {"value": 0.4},
               "tooltip": {
-                "signal": "{\"IMDB_Rating (binned)\": datum[\"bin_maxbins_10_IMDB_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_IMDB_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_IMDB_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_IMDB_Rating_end\"], \"\"), \"Rotten_Tomatoes_Rating (binned)\": datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_end\"], \"\"), \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+                "signal": "{\"IMDB_Rating (binned)\": datum[\"bin_maxbins_10_IMDB_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_IMDB_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_IMDB_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_IMDB_Rating_end\"], \"\"), \"Rotten_Tomatoes_Rating (binned)\": datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_end\"], \"\"), \"All Movies\": format(datum[\"count_*\"], \"\")}"
               },
               "x": {
                 "signal": "scale(\"concat_0_x\", (datum[\"bin_maxbins_10_IMDB_Rating\"] + datum[\"bin_maxbins_10_IMDB_Rating_end\"]) / 2)"
@@ -227,7 +227,7 @@
                 {"value": "#4c78a8"}
               ],
               "tooltip": {
-                "signal": "{\"IMDB_Rating (binned)\": datum[\"bin_maxbins_10_IMDB_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_IMDB_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_IMDB_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_IMDB_Rating_end\"], \"\"), \"Rotten_Tomatoes_Rating (binned)\": datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_end\"], \"\"), \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+                "signal": "{\"IMDB_Rating (binned)\": datum[\"bin_maxbins_10_IMDB_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_IMDB_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_IMDB_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_IMDB_Rating_end\"], \"\"), \"Rotten_Tomatoes_Rating (binned)\": datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_end\"], \"\"), \"In Selected Category\": format(datum[\"count_*\"], \"\")}"
               },
               "x": {
                 "signal": "scale(\"concat_0_x\", (datum[\"bin_maxbins_10_IMDB_Rating\"] + datum[\"bin_maxbins_10_IMDB_Rating_end\"]) / 2)"

--- a/examples/compiled/concat_bar_scales_discretize.vg.json
+++ b/examples/compiled/concat_bar_scales_discretize.vg.json
@@ -78,7 +78,9 @@
                 },
                 {"scale": "concat_0_color", "field": "b"}
               ],
-              "tooltip": {"signal": "{\"b\": ''+datum[\"b\"]}"},
+              "tooltip": {
+                "signal": "{\"b\": ''+datum[\"b\"], \"Quantize\": format(datum[\"b\"], \"\")}"
+              },
               "x": {"signal": "concat_0_width", "mult": 0.5},
               "y": {"scale": "concat_0_y", "field": "b"},
               "size": {"scale": "concat_0_size", "field": "b"},
@@ -139,7 +141,9 @@
                 },
                 {"scale": "concat_1_color", "field": "b"}
               ],
-              "tooltip": {"signal": "{\"b\": ''+datum[\"b\"]}"},
+              "tooltip": {
+                "signal": "{\"b\": ''+datum[\"b\"], \"Quantile\": format(datum[\"b\"], \"d\")}"
+              },
               "x": {"signal": "concat_1_width", "mult": 0.5},
               "y": {"scale": "concat_1_y", "field": "b"},
               "size": {"scale": "concat_1_size", "field": "b"},
@@ -202,7 +206,9 @@
                 },
                 {"scale": "concat_2_color", "field": "b"}
               ],
-              "tooltip": {"signal": "{\"b\": ''+datum[\"b\"]}"},
+              "tooltip": {
+                "signal": "{\"b\": ''+datum[\"b\"], \"Threshold\": format(datum[\"b\"], \"\")}"
+              },
               "x": {"signal": "concat_2_width", "mult": 0.5},
               "y": {"scale": "concat_2_y", "field": "b"},
               "size": {"scale": "concat_2_size", "field": "b"},

--- a/examples/compiled/concat_population_pyramid.vg.json
+++ b/examples/compiled/concat_population_pyramid.vg.json
@@ -121,7 +121,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"Sum of people\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "concat_0_x", "field": "sum_people_end"},
               "x2": {"scale": "concat_0_x", "field": "sum_people_start"},
@@ -213,7 +213,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"Sum of people\": format(datum[\"sum_people\"], \"\"), \"null\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"null\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "concat_2_x", "field": "sum_people_end"},
               "x2": {"scale": "concat_2_x", "field": "sum_people_start"},

--- a/examples/compiled/errorbar_aggregate.vg.json
+++ b/examples/compiled/errorbar_aggregate.vg.json
@@ -95,7 +95,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"Min of people\": format(datum[\"min_people\"], \"\"), \"Max of people\": format(datum[\"max_people\"], \"\")}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"min_people\"], \"\"), \"Max of people\": format(datum[\"max_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "age", "band": 0.5},
           "y": {"scale": "y", "field": "min_people"},
@@ -118,7 +118,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"Min of people\": format(datum[\"min_people\"], \"\")}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"min_people\"], \"\")}"
           },
           "xc": {"scale": "x", "field": "age", "band": 0.5},
           "yc": {"scale": "y", "field": "min_people"},
@@ -142,7 +142,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"Max of people\": format(datum[\"max_people\"], \"\")}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"max_people\"], \"\")}"
           },
           "xc": {"scale": "x", "field": "age", "band": 0.5},
           "yc": {"scale": "y", "field": "max_people"},
@@ -173,7 +173,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"Mean of people\": format(datum[\"mean_people\"], \"\")}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"mean_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "age", "band": 0.5},
           "y": {"scale": "y", "field": "mean_people"},

--- a/examples/compiled/errorbar_horizontal_aggregate.vg.json
+++ b/examples/compiled/errorbar_horizontal_aggregate.vg.json
@@ -95,7 +95,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"Min of people\": format(datum[\"min_people\"], \"\"), \"age\": ''+datum[\"age\"], \"Max of people\": format(datum[\"max_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"min_people\"], \"\"), \"age\": ''+datum[\"age\"], \"Max of people\": format(datum[\"max_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "min_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -118,7 +118,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"Min of people\": format(datum[\"min_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"population\": format(datum[\"min_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "xc": {"scale": "x", "field": "min_people"},
           "yc": {"scale": "y", "field": "age", "band": 0.5},
@@ -142,7 +142,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"Max of people\": format(datum[\"max_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"population\": format(datum[\"max_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "xc": {"scale": "x", "field": "max_people"},
           "yc": {"scale": "y", "field": "age", "band": 0.5},
@@ -173,7 +173,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"Mean of people\": format(datum[\"mean_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"population\": format(datum[\"mean_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "mean_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},

--- a/examples/compiled/facet_custom.vg.json
+++ b/examples/compiled/facet_custom.vg.json
@@ -148,7 +148,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"age\": ''+datum[\"age\"], \"Sum of people\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "x", "field": "age"},
               "width": {"scale": "x", "band": true},

--- a/examples/compiled/facet_custom_header.vg.json
+++ b/examples/compiled/facet_custom_header.vg.json
@@ -148,7 +148,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"age\": ''+datum[\"age\"], \"Sum of people\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "x", "field": "age"},
               "width": {"scale": "x", "band": true},

--- a/examples/compiled/facet_independent_scale.vg.json
+++ b/examples/compiled/facet_independent_scale.vg.json
@@ -142,7 +142,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"age\": ''+datum[\"age\"], \"Sum of people\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "child_x", "field": "age"},
               "width": {"scale": "child_x", "band": true},

--- a/examples/compiled/facet_independent_scale_layer_broken.vg.json
+++ b/examples/compiled/facet_independent_scale_layer_broken.vg.json
@@ -215,7 +215,7 @@
                 "update": {
                   "stroke": {"scale": "color", "field": "gender"},
                   "tooltip": {
-                    "signal": "{\"age\": ''+datum[\"age\"], \"Sum of people\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+                    "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
                   },
                   "x": {"scale": "child_x", "field": "age"},
                   "y": {"scale": "y", "field": "sum_people"},
@@ -249,7 +249,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"age\": ''+datum[\"age\"], \"Sum of people\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "child_x", "field": "age"},
               "y": {"scale": "y", "field": "sum_people"}

--- a/examples/compiled/interactive_concat_layer.vg.json
+++ b/examples/compiled/interactive_concat_layer.vg.json
@@ -198,7 +198,7 @@
                 {"scale": "color", "field": "count_*"}
               ],
               "tooltip": {
-                "signal": "{\"IMDB_Rating (binned)\": datum[\"bin_maxbins_10_IMDB_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_IMDB_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_IMDB_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_IMDB_Rating_end\"], \"\"), \"Rotten_Tomatoes_Rating (binned)\": datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_end\"], \"\"), \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+                "signal": "{\"IMDB_Rating (binned)\": datum[\"bin_maxbins_10_IMDB_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_IMDB_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_IMDB_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_IMDB_Rating_end\"], \"\"), \"Rotten_Tomatoes_Rating (binned)\": datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_end\"], \"\"), \"All Movies\": format(datum[\"count_*\"], \"\")}"
               },
               "x2": {
                 "scale": "concat_0_x",
@@ -241,7 +241,7 @@
                 {"value": "#666"}
               ],
               "tooltip": {
-                "signal": "{\"IMDB_Rating (binned)\": datum[\"bin_maxbins_10_IMDB_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_IMDB_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_IMDB_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_IMDB_Rating_end\"], \"\"), \"Rotten_Tomatoes_Rating (binned)\": datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_end\"], \"\"), \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+                "signal": "{\"IMDB_Rating (binned)\": datum[\"bin_maxbins_10_IMDB_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_IMDB_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_IMDB_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_IMDB_Rating_end\"], \"\"), \"Rotten_Tomatoes_Rating (binned)\": datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_end\"], \"\"), \"In Selected Category\": format(datum[\"count_*\"], \"\")}"
               },
               "x": {
                 "signal": "scale(\"concat_0_x\", (datum[\"bin_maxbins_10_IMDB_Rating\"] + datum[\"bin_maxbins_10_IMDB_Rating_end\"]) / 2)"

--- a/examples/compiled/interactive_overview_detail.vg.json
+++ b/examples/compiled/interactive_overview_detail.vg.json
@@ -326,7 +326,7 @@
               "orient": {"value": "vertical"},
               "fill": {"value": "#4c78a8"},
               "tooltip": {
-                "signal": "{\"date\": timeFormat(datum[\"date\"], ''), \"price\": format(datum[\"price\"], \"\")}"
+                "signal": "{\"date\": timeFormat(datum[\"date\"], '%Y'), \"price\": format(datum[\"price\"], \"\")}"
               },
               "x": {"scale": "concat_1_x", "field": "date"},
               "y": {"scale": "concat_1_y", "field": "price"},

--- a/examples/compiled/interactive_seattle_weather.vg.json
+++ b/examples/compiled/interactive_seattle_weather.vg.json
@@ -315,7 +315,7 @@
                 {"value": "lightgray"}
               ],
               "tooltip": {
-                "signal": "{\"date (month-date)\": timeFormat(datum[\"monthdate_date\"], '%b %d'), \"temp_max\": format(datum[\"temp_max\"], \"\"), \"weather\": ''+datum[\"weather\"], \"precipitation\": format(datum[\"precipitation\"], \"\")}"
+                "signal": "{\"Date\": timeFormat(datum[\"monthdate_date\"], '%b'), \"Maximum Daily Temperature (C)\": format(datum[\"temp_max\"], \"\"), \"weather\": ''+datum[\"weather\"], \"precipitation\": format(datum[\"precipitation\"], \"\")}"
               },
               "x": {"scale": "concat_0_x", "field": "monthdate_date"},
               "y": {"scale": "concat_0_y", "field": "temp_max"},

--- a/examples/compiled/layer_bar_annotations.vg.json
+++ b/examples/compiled/layer_bar_annotations.vg.json
@@ -154,7 +154,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"ThresholdValue\": format(datum[\"ThresholdValue\"], \"\"), \"Threshold\": ''+datum[\"Threshold\"]}"
+            "signal": "{\"PM2.5 Value\": format(datum[\"ThresholdValue\"], \"\"), \"Threshold\": ''+datum[\"Threshold\"]}"
           },
           "x": {"field": {"group": "width"}},
           "y": {"scale": "y", "field": "ThresholdValue"},

--- a/examples/compiled/layer_bar_dual_axis_minmax.vg.json
+++ b/examples/compiled/layer_bar_dual_axis_minmax.vg.json
@@ -97,7 +97,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"Mean of precipitation\": format(datum[\"mean_precipitation\"], \"\")}"
+            "signal": "{\"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"Mean Precipitation\": format(datum[\"mean_precipitation\"], \"\")}"
           },
           "x": {"scale": "x", "field": "month_date"},
           "width": {"scale": "x", "band": true},
@@ -116,7 +116,7 @@
         "update": {
           "stroke": {"value": "firebrick"},
           "tooltip": {
-            "signal": "{\"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"Max of temp_max\": format(datum[\"max_temp_max\"], \"\")}"
+            "signal": "{\"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"Temperature (min and max)\": format(datum[\"max_temp_max\"], \"\")}"
           },
           "x": {"scale": "x", "field": "month_date", "band": 0.5},
           "y": {"scale": "layer_1_y", "field": "max_temp_max"},

--- a/examples/compiled/layer_boxplot_circle.vg.json
+++ b/examples/compiled/layer_boxplot_circle.vg.json
@@ -80,7 +80,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"lower_whisker_people\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_whisker_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -103,7 +103,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "upper_box_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -126,7 +126,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "lower_box_people"},
           "x2": {"scale": "x", "field": "upper_box_people"},
@@ -151,7 +151,7 @@
             {"value": "white"}
           ],
           "tooltip": {
-            "signal": "{\"mid_box_people\": format(datum[\"mid_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"population\": format(datum[\"mid_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "xc": {"scale": "x", "field": "mid_box_people"},
           "yc": {"scale": "y", "field": "age", "band": 0.5},
@@ -176,7 +176,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"people\": format(datum[\"people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"population\": format(datum[\"people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},

--- a/examples/compiled/layer_circle_independent_color.vg.json
+++ b/examples/compiled/layer_circle_independent_color.vg.json
@@ -127,7 +127,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"Acceleration (binned)\": datum[\"bin_maxbins_10_Acceleration\"] === null || isNaN(datum[\"bin_maxbins_10_Acceleration\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Acceleration\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Acceleration_end\"], \"\"), \"Horsepower (binned)\": datum[\"bin_maxbins_10_Horsepower\"] === null || isNaN(datum[\"bin_maxbins_10_Horsepower\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Horsepower\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Horsepower_end\"], \"\"), \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+            "signal": "{\"Acceleration (binned)\": datum[\"bin_maxbins_10_Acceleration\"] === null || isNaN(datum[\"bin_maxbins_10_Acceleration\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Acceleration\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Acceleration_end\"], \"\"), \"Horsepower (binned)\": datum[\"bin_maxbins_10_Horsepower\"] === null || isNaN(datum[\"bin_maxbins_10_Horsepower\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Horsepower\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Horsepower_end\"], \"\"), \"All Cars\": format(datum[\"count_*\"], \"\")}"
           },
           "x": {
             "signal": "scale(\"x\", (datum[\"bin_maxbins_10_Acceleration\"] + datum[\"bin_maxbins_10_Acceleration_end\"]) / 2)"
@@ -155,7 +155,7 @@
             {"value": "firebrick"}
           ],
           "tooltip": {
-            "signal": "{\"Acceleration (binned)\": datum[\"bin_maxbins_10_Acceleration\"] === null || isNaN(datum[\"bin_maxbins_10_Acceleration\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Acceleration\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Acceleration_end\"], \"\"), \"Horsepower (binned)\": datum[\"bin_maxbins_10_Horsepower\"] === null || isNaN(datum[\"bin_maxbins_10_Horsepower\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Horsepower\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Horsepower_end\"], \"\"), \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+            "signal": "{\"Acceleration (binned)\": datum[\"bin_maxbins_10_Acceleration\"] === null || isNaN(datum[\"bin_maxbins_10_Acceleration\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Acceleration\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Acceleration_end\"], \"\"), \"Horsepower (binned)\": datum[\"bin_maxbins_10_Horsepower\"] === null || isNaN(datum[\"bin_maxbins_10_Horsepower\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Horsepower\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Horsepower_end\"], \"\"), \"Cars from Japan\": format(datum[\"count_*\"], \"\")}"
           },
           "x": {
             "signal": "scale(\"x\", (datum[\"bin_maxbins_10_Acceleration\"] + datum[\"bin_maxbins_10_Acceleration_end\"]) / 2)"

--- a/examples/compiled/layer_line_co2_concentration.vg.json
+++ b/examples/compiled/layer_line_co2_concentration.vg.json
@@ -78,7 +78,7 @@
             "update": {
               "stroke": {"scale": "color", "field": "decade"},
               "tooltip": {
-                "signal": "{\"scaled_date\": format(datum[\"scaled_date\"], \"\"), \"CO2 concentration in ppm\": format(datum[\"CO2\"], \"\"), \"decade\": ''+datum[\"decade\"]}"
+                "signal": "{\"Year into Decade\": format(datum[\"scaled_date\"], \"\"), \"CO2 concentration in ppm\": format(datum[\"CO2\"], \"\"), \"decade\": ''+datum[\"decade\"]}"
               },
               "x": {"scale": "x", "field": "scaled_date"},
               "y": {"scale": "y", "field": "CO2"},
@@ -106,7 +106,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"scaled_date\": format(datum[\"scaled_date\"], \"\"), \"CO2 concentration in ppm\": format(datum[\"CO2\"], \"\"), \"year\": ''+datum[\"year\"]}"
+            "signal": "{\"Year into Decade\": format(datum[\"scaled_date\"], \"\"), \"CO2 concentration in ppm\": format(datum[\"CO2\"], \"\"), \"year\": ''+datum[\"year\"]}"
           },
           "x": {"scale": "x", "field": "scaled_date"},
           "y": {"scale": "y", "field": "CO2"},
@@ -130,7 +130,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"scaled_date\": format(datum[\"scaled_date\"], \"\"), \"CO2 concentration in ppm\": format(datum[\"CO2\"], \"\"), \"year\": ''+datum[\"year\"]}"
+            "signal": "{\"Year into Decade\": format(datum[\"scaled_date\"], \"\"), \"CO2 concentration in ppm\": format(datum[\"CO2\"], \"\"), \"year\": ''+datum[\"year\"]}"
           },
           "x": {"scale": "x", "field": "scaled_date"},
           "y": {"scale": "y", "field": "CO2"},

--- a/examples/compiled/layer_ranged_dot.vg.json
+++ b/examples/compiled/layer_ranged_dot.vg.json
@@ -65,7 +65,7 @@
             "update": {
               "stroke": {"value": "#db646f"},
               "tooltip": {
-                "signal": "{\"life_expect\": format(datum[\"life_expect\"], \"\"), \"country\": ''+datum[\"country\"]}"
+                "signal": "{\"Life Expectancy (years)\": format(datum[\"life_expect\"], \"\"), \"Country\": ''+datum[\"country\"], \"country\": ''+datum[\"country\"]}"
               },
               "x": {"scale": "x", "field": "life_expect"},
               "y": {"scale": "y", "field": "country"},
@@ -93,7 +93,7 @@
             {"scale": "color", "field": "year"}
           ],
           "tooltip": {
-            "signal": "{\"life_expect\": format(datum[\"life_expect\"], \"\"), \"country\": ''+datum[\"country\"], \"year\": ''+datum[\"year\"]}"
+            "signal": "{\"Life Expectancy (years)\": format(datum[\"life_expect\"], \"\"), \"Country\": ''+datum[\"country\"], \"Year\": ''+datum[\"year\"]}"
           },
           "x": {"scale": "x", "field": "life_expect"},
           "y": {"scale": "y", "field": "country"},

--- a/examples/compiled/layer_rect_extent.vg.json
+++ b/examples/compiled/layer_rect_extent.vg.json
@@ -79,7 +79,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"Horsepower\": format(datum[\"Horsepower\"], \"\"), \"Miles_per_Gallon\": format(datum[\"Miles_per_Gallon\"], \"\")}"
+            "signal": "{\"Horsepower\": format(datum[\"Horsepower\"], \"\"), \"Miles per Gallon\": format(datum[\"Miles_per_Gallon\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Horsepower"},
           "y": {"scale": "y", "field": "Miles_per_Gallon"}

--- a/examples/compiled/line.vg.json
+++ b/examples/compiled/line.vg.json
@@ -25,7 +25,7 @@
         "update": {
           "stroke": {"value": "#4c78a8"},
           "tooltip": {
-            "signal": "{\"date\": timeFormat(datum[\"date\"], ''), \"price\": format(datum[\"price\"], \"\")}"
+            "signal": "{\"date\": timeFormat(datum[\"date\"], '%Y'), \"price\": format(datum[\"price\"], \"\")}"
           },
           "x": {"scale": "x", "field": "date"},
           "y": {"scale": "y", "field": "price"},

--- a/examples/compiled/line_color.vg.json
+++ b/examples/compiled/line_color.vg.json
@@ -41,7 +41,7 @@
             "update": {
               "stroke": {"scale": "color", "field": "symbol"},
               "tooltip": {
-                "signal": "{\"date\": timeFormat(datum[\"date\"], ''), \"price\": format(datum[\"price\"], \"\"), \"symbol\": ''+datum[\"symbol\"]}"
+                "signal": "{\"date\": timeFormat(datum[\"date\"], '%Y'), \"price\": format(datum[\"price\"], \"\"), \"symbol\": ''+datum[\"symbol\"]}"
               },
               "x": {"scale": "x", "field": "date"},
               "y": {"scale": "y", "field": "price"},

--- a/examples/compiled/line_detail.vg.json
+++ b/examples/compiled/line_detail.vg.json
@@ -41,7 +41,7 @@
             "update": {
               "stroke": {"value": "#4c78a8"},
               "tooltip": {
-                "signal": "{\"date\": timeFormat(datum[\"date\"], ''), \"price\": format(datum[\"price\"], \"\"), \"symbol\": ''+datum[\"symbol\"]}"
+                "signal": "{\"date\": timeFormat(datum[\"date\"], '%Y'), \"price\": format(datum[\"price\"], \"\"), \"symbol\": ''+datum[\"symbol\"]}"
               },
               "x": {"scale": "x", "field": "date"},
               "y": {"scale": "y", "field": "price"},

--- a/examples/compiled/line_timeunit_transform.vg.json
+++ b/examples/compiled/line_timeunit_transform.vg.json
@@ -38,7 +38,7 @@
         "update": {
           "stroke": {"value": "#4c78a8"},
           "tooltip": {
-            "signal": "{\"month\": timeFormat(datum[\"month\"], ''), \"Max of temp_max\": format(datum[\"max_temp_max\"], \"\")}"
+            "signal": "{\"month\": timeFormat(datum[\"month\"], '%b'), \"Max of temp_max\": format(datum[\"max_temp_max\"], \"\")}"
           },
           "x": {"scale": "x", "field": "month"},
           "y": {"scale": "y", "field": "max_temp_max"},

--- a/examples/compiled/rect_heatmap_weather.vg.json
+++ b/examples/compiled/rect_heatmap_weather.vg.json
@@ -58,7 +58,7 @@
             {"scale": "color", "field": "max_temp"}
           ],
           "tooltip": {
-            "signal": "{\"Day\": timeFormat(datum[\"date_date\"], '%d'), \"Month\": timeFormat(datum[\"month_date\"], '%b'), \"Max of temp\": format(datum[\"max_temp\"], \"\")}"
+            "signal": "{\"Day\": timeFormat(datum[\"date_date\"], '%e'), \"Month\": timeFormat(datum[\"month_date\"], '%b'), \"Max of temp\": format(datum[\"max_temp\"], \"\")}"
           },
           "x": {"scale": "x", "field": "date_date"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/rect_lasagna_future.vg.json
+++ b/examples/compiled/rect_lasagna_future.vg.json
@@ -43,7 +43,7 @@
             {"scale": "color", "field": "sum_price"}
           ],
           "tooltip": {
-            "signal": "{\"Time\": timeFormat(datum[\"yearmonthdate_date\"], '%b %d, %Y'), \"\": ''+datum[\"symbol\"], \"Price\": format(datum[\"sum_price\"], \"\")}"
+            "signal": "{\"Time\": timeFormat(datum[\"yearmonthdate_date\"], '%Y'), \"\": ''+datum[\"symbol\"], \"Price\": format(datum[\"sum_price\"], \"\")}"
           },
           "x": {"scale": "x", "field": "yearmonthdate_date"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/rect_mosaic_labelled.vg.json
+++ b/examples/compiled/rect_mosaic_labelled.vg.json
@@ -184,7 +184,7 @@
                 {"value": "black"}
               ],
               "tooltip": {
-                "signal": "{\"xc\": format(datum[\"xc\"], \"\"), \"yc\": format(datum[\"yc\"], \"\"), \"Cylinders\": ''+datum[\"Cylinders\"]}"
+                "signal": "{\"xc\": format(datum[\"xc\"], \"\"), \"Cylinders\": format(datum[\"yc\"], \"\")}"
               },
               "x": {"scale": "x", "field": "xc"},
               "y": {"scale": "concat_1_y", "field": "yc"},

--- a/examples/compiled/rect_mosaic_labelled_with_offset.vg.json
+++ b/examples/compiled/rect_mosaic_labelled_with_offset.vg.json
@@ -218,7 +218,7 @@
                 {"value": "black"}
               ],
               "tooltip": {
-                "signal": "{\"xc\": format(datum[\"xc\"], \"\"), \"yc\": format(datum[\"yc\"], \"\"), \"Cylinders\": ''+datum[\"Cylinders\"]}"
+                "signal": "{\"xc\": format(datum[\"xc\"], \"\"), \"Cylinders\": format(datum[\"yc\"], \"\")}"
               },
               "x": {"scale": "x", "field": "xc"},
               "y": {"scale": "concat_1_y", "field": "yc"},

--- a/examples/compiled/stacked_area.vg.json
+++ b/examples/compiled/stacked_area.vg.json
@@ -72,7 +72,7 @@
               "orient": {"value": "vertical"},
               "fill": {"scale": "color", "field": "series"},
               "tooltip": {
-                "signal": "{\"date (year-month)\": timeFormat(datum[\"yearmonth_date\"], '%b %Y'), \"Sum of count\": format(datum[\"sum_count\"], \"\"), \"series\": ''+datum[\"series\"]}"
+                "signal": "{\"date (year-month)\": timeFormat(datum[\"yearmonth_date\"], '%Y'), \"Sum of count\": format(datum[\"sum_count\"], \"\"), \"series\": ''+datum[\"series\"]}"
               },
               "x": {"scale": "x", "field": "yearmonth_date"},
               "y": {"scale": "y", "field": "sum_count_end"},

--- a/examples/compiled/stacked_area_normalize.vg.json
+++ b/examples/compiled/stacked_area_normalize.vg.json
@@ -71,7 +71,7 @@
               "orient": {"value": "vertical"},
               "fill": {"scale": "color", "field": "series"},
               "tooltip": {
-                "signal": "{\"date (year-month)\": timeFormat(datum[\"yearmonth_date\"], '%b %Y'), \"Sum of count\": format(datum[\"sum_count\"], \"\"), \"series\": ''+datum[\"series\"]}"
+                "signal": "{\"date (year-month)\": timeFormat(datum[\"yearmonth_date\"], '%Y'), \"Sum of count\": format(datum[\"sum_count\"], \"\"), \"series\": ''+datum[\"series\"]}"
               },
               "x": {"scale": "x", "field": "yearmonth_date"},
               "y": {"scale": "y", "field": "sum_count_end"},

--- a/examples/compiled/stacked_area_stream.vg.json
+++ b/examples/compiled/stacked_area_stream.vg.json
@@ -71,7 +71,7 @@
               "orient": {"value": "vertical"},
               "fill": {"scale": "color", "field": "series"},
               "tooltip": {
-                "signal": "{\"date (year-month)\": timeFormat(datum[\"yearmonth_date\"], '%b %Y'), \"Sum of count\": format(datum[\"sum_count\"], \"\"), \"series\": ''+datum[\"series\"]}"
+                "signal": "{\"date (year-month)\": timeFormat(datum[\"yearmonth_date\"], '%Y'), \"Sum of count\": format(datum[\"sum_count\"], \"\"), \"series\": ''+datum[\"series\"]}"
               },
               "x": {"scale": "x", "field": "yearmonth_date"},
               "y": {"scale": "y", "field": "sum_count_end"},

--- a/examples/compiled/stacked_bar_normalize.vg.json
+++ b/examples/compiled/stacked_bar_normalize.vg.json
@@ -57,7 +57,7 @@
             {"scale": "color", "field": "gender"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"Sum of people\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
           },
           "x": {"scale": "x", "field": "age"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/stacked_bar_population.vg.json
+++ b/examples/compiled/stacked_bar_population.vg.json
@@ -58,7 +58,7 @@
             {"scale": "color", "field": "gender"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"Sum of people\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
           },
           "x": {"scale": "x", "field": "age"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/stacked_bar_population_transform.vg.json
+++ b/examples/compiled/stacked_bar_population_transform.vg.json
@@ -51,7 +51,7 @@
             {"scale": "color", "field": "gender"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"v1\": format(datum[\"v1\"], \"\"), \"v2\": format(datum[\"v2\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"v1\"], \"\"), \"v2\": format(datum[\"v2\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
           },
           "x": {"scale": "x", "field": "age"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/stacked_bar_sum_opacity.vg.json
+++ b/examples/compiled/stacked_bar_sum_opacity.vg.json
@@ -59,7 +59,7 @@
           ],
           "opacity": {"scale": "opacity", "field": "people"},
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"Sum of people\": format(datum[\"sum_people\"], \"\"), \"people\": format(datum[\"people\"], \"\")}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"people\": format(datum[\"people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "age"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/stacked_bar_weather.vg.json
+++ b/examples/compiled/stacked_bar_weather.vg.json
@@ -56,7 +56,7 @@
             {"scale": "color", "field": "weather"}
           ],
           "tooltip": {
-            "signal": "{\"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"Number of Records\": format(datum[\"count_*\"], \"\"), \"weather\": ''+datum[\"weather\"]}"
+            "signal": "{\"Month of the year\": timeFormat(datum[\"month_date\"], '%b'), \"Number of Records\": format(datum[\"count_*\"], \"\"), \"Weather type\": ''+datum[\"weather\"]}"
           },
           "x": {"scale": "x", "field": "month_date"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/time_parse_local.vg.json
+++ b/examples/compiled/time_parse_local.vg.json
@@ -45,7 +45,7 @@
           "fill": {"value": "transparent"},
           "stroke": {"value": "#4c78a8"},
           "tooltip": {
-            "signal": "{\"date (hours)\": timeFormat(datum[\"hours_date\"], '%H')}"
+            "signal": "{\"time\": timeFormat(datum[\"hours_date\"], '%H')}"
           },
           "x": {"signal": "width", "mult": 0.5},
           "y": {"scale": "y", "field": "hours_date"}

--- a/examples/compiled/time_parse_utc_format.vg.json
+++ b/examples/compiled/time_parse_utc_format.vg.json
@@ -50,7 +50,7 @@
           "fill": {"value": "transparent"},
           "stroke": {"value": "#4c78a8"},
           "tooltip": {
-            "signal": "{\"date (hours)\": timeFormat(datum[\"hours_date\"], '%H')}"
+            "signal": "{\"time\": timeFormat(datum[\"hours_date\"], '%H')}"
           },
           "x": {"signal": "width", "mult": 0.5},
           "y": {"scale": "y", "field": "hours_date"}

--- a/examples/compiled/trail_color.vg.json
+++ b/examples/compiled/trail_color.vg.json
@@ -41,7 +41,7 @@
             "update": {
               "fill": {"scale": "color", "field": "symbol"},
               "tooltip": {
-                "signal": "{\"date\": timeFormat(datum[\"date\"], ''), \"price\": format(datum[\"price\"], \"\"), \"symbol\": ''+datum[\"symbol\"]}"
+                "signal": "{\"date\": timeFormat(datum[\"date\"], '%Y'), \"price\": format(datum[\"price\"], \"\"), \"symbol\": ''+datum[\"symbol\"]}"
               },
               "x": {"scale": "x", "field": "date"},
               "y": {"scale": "y", "field": "price"},

--- a/examples/compiled/trellis_area.vg.json
+++ b/examples/compiled/trellis_area.vg.json
@@ -149,7 +149,7 @@
                   "orient": {"value": "vertical"},
                   "fill": {"scale": "color", "field": "symbol"},
                   "tooltip": {
-                    "signal": "{\"date\": timeFormat(datum[\"date\"], ''), \"price\": format(datum[\"price\"], \"\"), \"symbol\": ''+datum[\"symbol\"]}"
+                    "signal": "{\"Time\": timeFormat(datum[\"date\"], '%Y'), \"Price\": format(datum[\"price\"], \"\"), \"symbol\": ''+datum[\"symbol\"]}"
                   },
                   "x": {"scale": "x", "field": "date"},
                   "y": {"scale": "y", "field": "price_end"},

--- a/examples/compiled/trellis_area_sort_array.vg.json
+++ b/examples/compiled/trellis_area_sort_array.vg.json
@@ -182,7 +182,7 @@
                   "orient": {"value": "vertical"},
                   "fill": {"scale": "color", "field": "symbol"},
                   "tooltip": {
-                    "signal": "{\"date\": timeFormat(datum[\"date\"], ''), \"price\": format(datum[\"price\"], \"\"), \"symbol\": ''+datum[\"symbol\"]}"
+                    "signal": "{\"Time\": timeFormat(datum[\"date\"], '%Y'), \"Price\": format(datum[\"price\"], \"\"), \"symbol\": ''+datum[\"symbol\"]}"
                   },
                   "x": {"scale": "x", "field": "date"},
                   "y": {"scale": "y", "field": "price_end"},

--- a/examples/compiled/trellis_bar.vg.json
+++ b/examples/compiled/trellis_bar.vg.json
@@ -140,7 +140,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"age\": ''+datum[\"age\"], \"Sum of people\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "x", "field": "age"},
               "width": {"scale": "x", "band": true},

--- a/examples/compiled/window_cumulative_running_average.vg.json
+++ b/examples/compiled/window_cumulative_running_average.vg.json
@@ -94,7 +94,7 @@
         "update": {
           "stroke": {"value": "red"},
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Average_MPG\": format(datum[\"Average_MPG\"], \"\")}"
+            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Miles Per Gallon\": format(datum[\"Average_MPG\"], \"\")}"
           },
           "x": {"scale": "x", "field": "year_Year"},
           "y": {"scale": "y", "field": "Average_MPG"},

--- a/examples/compiled/window_mean_difference.vg.json
+++ b/examples/compiled/window_mean_difference.vg.json
@@ -74,7 +74,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"IMDB_Rating\": format(datum[\"IMDB_Rating\"], \"\"), \"Title\": ''+datum[\"Title\"]}"
+            "signal": "{\"IMDB Rating\": format(datum[\"IMDB_Rating\"], \"\"), \"Title\": ''+datum[\"Title\"]}"
           },
           "x": {"scale": "x", "field": "IMDB_Rating"},
           "x2": {"scale": "x", "value": 0},

--- a/examples/compiled/window_mean_difference_by_year.vg.json
+++ b/examples/compiled/window_mean_difference_by_year.vg.json
@@ -69,7 +69,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"IMDB_Rating\": format(datum[\"IMDB_Rating\"], \"\"), \"Title\": ''+datum[\"Title\"]}"
+            "signal": "{\"IMDB Rating\": format(datum[\"IMDB_Rating\"], \"\"), \"Title\": ''+datum[\"Title\"]}"
           },
           "x": {"scale": "x", "field": "IMDB_Rating"},
           "x2": {"scale": "x", "value": 0},

--- a/examples/compiled/window_percent_of_total.vg.json
+++ b/examples/compiled/window_percent_of_total.vg.json
@@ -60,7 +60,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"PercentOfTotal\": format(datum[\"PercentOfTotal\"], \"\"), \"Activity\": ''+datum[\"Activity\"]}"
+            "signal": "{\"% of total Time\": format(datum[\"PercentOfTotal\"], \"\"), \"Activity\": ''+datum[\"Activity\"]}"
           },
           "x": {"scale": "x", "field": "PercentOfTotal"},
           "x2": {"scale": "x", "value": 0},

--- a/examples/compiled/window_residual_graph.vg.json
+++ b/examples/compiled/window_residual_graph.vg.json
@@ -58,7 +58,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"Release_Date\": timeFormat(datum[\"Release_Date\"], ''), \"RatingDelta\": format(datum[\"RatingDelta\"], \"\")}"
+            "signal": "{\"Release_Date\": timeFormat(datum[\"Release_Date\"], ''), \"Rating Delta\": format(datum[\"RatingDelta\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Release_Date"},
           "y": {"scale": "y", "field": "RatingDelta"}

--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -338,6 +338,14 @@ export function isScaleFieldDef<F>(channelDef: ChannelDef<F>): channelDef is Sca
   return !!channelDef && (!!channelDef['scale'] || !!channelDef['sort']);
 }
 
+export function isPositionFieldDef<F>(channelDef: ChannelDef<F>): channelDef is PositionFieldDef<F> {
+  return !!channelDef && (!!channelDef['axis'] || !!channelDef['stack'] || !!channelDef['impute']);
+}
+
+export function isMarkPropFieldDef<F>(channelDef: ChannelDef<F>): channelDef is MarkPropFieldDef<F> {
+  return !!channelDef && !!channelDef['legend'];
+}
+
 export interface FieldRefOption {
   /** Exclude bin, aggregate, timeUnit */
   nofn?: boolean;

--- a/test/compile/mark/mixins.test.ts
+++ b/test/compile/mark/mixins.test.ts
@@ -292,6 +292,33 @@ describe('compile/mark/mixins', () => {
       const props = tooltip(model);
       assert.deepEqual(props.tooltip, {value: 'haha'});
     });
+
+    it('generates correct keys and values for channels with axis', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        mark: {type: 'point'},
+        encoding: {
+          x: {field: 'Date', type: 'quantitative', axis: {title: 'foo', format: '%y'}},
+          y: {field: 'Displacement', type: 'quantitative', axis: {title: 'bar'}}
+        }
+      });
+      const props = tooltip(model);
+      expect(props.tooltip).toEqual({
+        signal: '{"foo": format(datum["Date"], "%y"), "bar": format(datum["Displacement"], "")}'
+      });
+    });
+
+    it('generates correct keys and values for channels with legends', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        mark: {type: 'point'},
+        encoding: {
+          color: {field: 'Foobar', type: 'nominal', legend: {title: 'baz', format: 's'}}
+        }
+      });
+      const props = tooltip(model);
+      expect(props.tooltip).toEqual({
+        signal: '{"baz": \'\'+datum["Foobar"]}'
+      });
+    });
   });
 
   describe('midPoint()', () => {

--- a/test/compile/mark/text.test.ts
+++ b/test/compile/mark/text.test.ts
@@ -58,7 +58,7 @@ describe('Mark: Text', () => {
     const props = text.encodeEntry(model);
 
     it('should use number template', () => {
-      assert.deepEqual(props.text, {signal: `format(datum["foo"], "d")`});
+      expect(props.text).toEqual({signal: `format(datum["foo"], "d")`});
     });
   });
 
@@ -73,7 +73,7 @@ describe('Mark: Text', () => {
     const props = text.encodeEntry(model);
 
     it('should output correct bin range', () => {
-      assert.deepEqual(props.text, {
+      expect(props.text).toEqual({
         signal: `datum["bin_maxbins_10_foo"] === null || isNaN(datum["bin_maxbins_10_foo"]) ? "null" : format(datum["bin_maxbins_10_foo"], "d") + " - " + format(datum["bin_maxbins_10_foo_end"], "d")`
       });
     });


### PR DESCRIPTION
We used to not check the axis or legend for a specified title or format when generating the key value pairs used in tooltips. This PR adds checks to see if these fields are defined, if so, it'll use them to populate the tooltip keys and values.