### PR TITLE
Remove the note for argmin/max issue in CO2 example

### DIFF
--- a/_data/examples.json
+++ b/_data/examples.json
@@ -165,7 +165,8 @@
       },
       {
         "name": "layer_line_co2_concentration",
-        "title": "Carbon Dioxide in the Atmosphere"
+        "title": "Carbon Dioxide in the Atmosphere",
+        "description": "This example was inspired by [Gregor Aisch](https://github.com/gka)'s [Carbon Dioxide Concentration By Decade](https://www.datawrapper.de/_/OHgEm/)"
       },
       {
         "name": "window_rank",
@@ -320,7 +321,8 @@
       },
       {
         "name": "layer_line_co2_concentration",
-        "title": "Carbon Dioxide in the Atmosphere"
+        "title": "Carbon Dioxide in the Atmosphere",
+        "description": "This example was inspired by [Gregor Aisch](https://github.com/gka)'s [Carbon Dioxide Concentration By Decade](https://www.datawrapper.de/_/OHgEm/)"
       },
       {
         "name": "layer_bar_annotations",

--- a/_data/examples.json
+++ b/_data/examples.json
@@ -165,8 +165,7 @@
       },
       {
         "name": "layer_line_co2_concentration",
-        "title": "Carbon Dioxide in the Atmosphere",
-        "description": "Note&#58; When accessing aggregated argmax or argmin fields, the aggregated fields must be flattened using calculate (see https://github.com/vega/vega-lite/issues/3361)"
+        "title": "Carbon Dioxide in the Atmosphere"
       },
       {
         "name": "window_rank",
@@ -321,8 +320,7 @@
       },
       {
         "name": "layer_line_co2_concentration",
-        "title": "Carbon Dioxide in the Atmosphere",
-        "description": "Note&#58; When accessing aggregated argmax or argmin fields, the aggregated fields must be flattened using calculate (see https://github.com/vega/vega-lite/issues/3361)"
+        "title": "Carbon Dioxide in the Atmosphere"
       },
       {
         "name": "layer_bar_annotations",


### PR DESCRIPTION
Now, we are using `window` instead of `aggregate`; this example does not show a solution to the `argmin/max` issue.