### PR TITLE
Use vega-util, not util, for isArray

### DIFF
--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -1,5 +1,4 @@
-import {isArray} from 'util';
-import {isNumber} from 'vega-util';
+import {isArray, isNumber} from 'vega-util';
 import {Channel, COLOR, FILL, OPACITY, SCALE_CHANNELS, ScaleChannel, SHAPE, SIZE, STROKE, X, Y} from '../../channel';
 import {Config, isVgScheme} from '../../config';
 import * as log from '../../log';


### PR DESCRIPTION
Tiny fix for a tiny (but very impactful) typo. This import from `util` instead of `vega-util` means that vega is able to pass tests in Node, but the UMD builds for the upcoming 3.x series are broken, because they declare a dependency on `util` for the `isArray` function.

I'm pretty close to certain that the fix is to import from vega-util, which also provides isArray, instead of util. That's what this PR does.

---

Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are multiple relevant issues that would not make sense in isolation. For the latter case, please make atomic commits so we can easily review each issue.
  - Please add new commit(s) when addressing comments, so we can see easily the new changeset (instead of the whole changeset).
- [x] Provide a test case & update the documentation under `site/docs/`
- [x] Make lint and test pass. (Run `yarn test`.  If your change affects Vega outputs of some examples, re-run `yarn build` and run `yarn build:example EXAMPLE_NAME` to re-compile a specific example or `yarn build:examples` to re-compile all examples.)
- [x] Rebase onto the latest `master` branch.
- [x] Provide a concise title that we can copy to our release note.
  - Use imperative mood and present tense.
  - Mention relevant issues. (e.g., `#1`)
- [x] Look at the whole changeset as if you're a reviewer yourself. This will help us focus on catching issues that you might not notice yourself. (For a work-in-progress PR, you can add "[WIP]" prefix to the PR's title. When the PR is ready, you can then remove "[WIP]" and add a comment to notify us.)

Pro-Tip: https://medium.com/@greenberg/writing-pull-requests-your-coworkers-might-enjoy-reading-9d0307e93da3 is a nice article about writing a nice pull request.

