### PR TITLE
Add tests for optimizeDataFlow

### DIFF
--- a/test/compile/data/optimize.test.ts
+++ b/test/compile/data/optimize.test.ts
@@ -67,7 +67,7 @@ describe('compile/data/optimize', () => {
     });
     it('should push parse up from lowest level first to avoid conflicting common parse', () => {
       const source = new SourceNode(null);
-      const parseOne = new ParseNode(source, {a: 'time'}); // @ts-ignore
+      const parseOne = new ParseNode(source, {a: 'time'});
       const parseTwo = new ParseNode(source, {b: 'number'});
       const parseThree = new ParseNode(parseTwo, {a: 'number'});
       // @ts-ignore

--- a/test/compile/data/optimize.test.ts
+++ b/test/compile/data/optimize.test.ts
@@ -1,9 +1,12 @@
 /* tslint:disable:quotemark */
 
 import {assert} from 'chai';
-import {DataFlowNode} from '../../../src/compile/data/dataflow';
+import {DataFlowNode, OutputNode} from '../../../src/compile/data/dataflow';
 import {ParseNode} from '../../../src/compile/data/formatparse';
-import {mergeParse} from '../../../src/compile/data/optimize';
+import {mergeParse, optimizeDataflow} from '../../../src/compile/data/optimize';
+import {moveParseUp} from '../../../src/compile/data/optimizers';
+import {SourceNode} from '../../../src/compile/data/source';
+import {TimeUnitNode} from '../../../src/compile/data/timeunit';
 
 describe('compile/data/optimize', () => {
   describe('mergeParse', () => {
@@ -33,6 +36,62 @@ describe('compile/data/optimize', () => {
       const children = mergedParseNode.children as [ParseNode];
       assert.deepEqual(children[0].parse, {a: 'number'});
       assert.deepEqual(children[1].parse, {a: 'boolean'});
+    });
+  });
+  describe('optimizeDataFlow', () => {
+    it('should push up common parse', () => {
+      const source = new SourceNode(null);
+      // @ts-ignore
+      const parseOne = new ParseNode(source, {a: 'time', b: 'number'});
+      // @ts-ignore
+      const parseTwo = new ParseNode(source, {a: 'time', b: 'date'});
+      // @ts-ignore
+      const outputOne = new OutputNode(parseOne, 'foo', null, {foo: 1});
+      // @ts-ignore
+      const outputTwo = new OutputNode(parseTwo, 'bar', null, {bar: 1});
+
+      optimizeDataflow({sources: {source: source}} as any);
+
+      expect(source.children.length).toEqual(1);
+      expect(source.children[0]).toBeInstanceOf(ParseNode);
+
+      const commonParse = source.children[0] as ParseNode;
+      expect(commonParse.parse).toEqual({a: 'time'});
+      expect(commonParse.children.length).toEqual(2);
+
+      expect(commonParse.children[0]).toBeInstanceOf(ParseNode);
+      expect(commonParse.children[0]).toMatchObject(parseOne);
+
+      expect(commonParse.children[1]).toBeInstanceOf(ParseNode);
+      expect(commonParse.children[1]).toMatchObject(parseTwo);
+    });
+    it('should push parse up from lowest level first to avoid conflicting common parse', () => {
+      const source = new SourceNode(null);
+      const parseOne = new ParseNode(source, {a: 'time'}); // @ts-ignore
+      const parseTwo = new ParseNode(source, {b: 'number'});
+      const parseThree = new ParseNode(parseTwo, {a: 'number'});
+      // @ts-ignore
+      const outputOne = new OutputNode(parseOne, 'foo', null, {foo: 1});
+      // @ts-ignore
+      const outputTwo = new OutputNode(parseThree, 'bar', null, {bar: 1});
+
+      optimizeDataflow({sources: {source: source}} as any);
+
+      expect(source.children.length).toEqual(1);
+      expect(source.children[0]).toBeInstanceOf(ParseNode);
+
+      const commonParse = source.children[0] as ParseNode;
+      expect(commonParse.parse).toEqual({b: 'number'});
+
+      expect(commonParse.children.length).toEqual(2);
+      expect(commonParse.children[0]).toBeInstanceOf(ParseNode);
+      expect(commonParse.children[1]).toBeInstanceOf(ParseNode);
+
+      const p1 = commonParse.children[0] as ParseNode;
+      const p2 = commonParse.children[0] as ParseNode;
+
+      expect(p1.parse).toEqual({a: 'time'});
+      expect(p2.parse).toEqual({a: 'number'});
     });
   });
 });

--- a/test/compile/data/optimize.test.ts
+++ b/test/compile/data/optimize.test.ts
@@ -4,9 +4,7 @@ import {assert} from 'chai';
 import {DataFlowNode, OutputNode} from '../../../src/compile/data/dataflow';
 import {ParseNode} from '../../../src/compile/data/formatparse';
 import {mergeParse, optimizeDataflow} from '../../../src/compile/data/optimize';
-import {moveParseUp} from '../../../src/compile/data/optimizers';
 import {SourceNode} from '../../../src/compile/data/source';
-import {TimeUnitNode} from '../../../src/compile/data/timeunit';
 
 describe('compile/data/optimize', () => {
   describe('mergeParse', () => {


### PR DESCRIPTION
Added a couple of tests for optimizeDataFlow. One simply checks to see if a common parse node is being generated in a simple case where to adjacent ParseNodes have one common parse and one conflicting parse. This test passes. 

The second case showcases what I believe to be a bug with the current implementation of moveParse. This test demonstrates how in some cases a common parse node is added above two adjacent ParseNodes even though this parse node conflicts with another ParseNode that exists at a lower level of the DataFlow tree.

I believe the solution to this involves changing the order in which we move up ParseNodes such that the nodes at lower levels are moved up first before merging nodes that exist further up in the tree.