### PR TITLE
Fix overwritten transform in composite mark

### DIFF
--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -186,7 +186,7 @@ export function normalizeBoxPlot(
   }
   return {
     ...outerSpec,
-    transform,
+    transform: (outerSpec.transform || []).concat(transform),
     layer: boxLayer
   };
 }

--- a/src/compositemark/errorbar.ts
+++ b/src/compositemark/errorbar.ts
@@ -211,6 +211,7 @@ export function errorBarParams<
 
   return {
     transform: [
+      ...(outerSpec.transform || []),
       ...bins,
       ...timeUnits,
       ...(!aggregate.length ? [] : [{aggregate, groupby}]),

--- a/test/compositemark/boxplot.test.ts
+++ b/test/compositemark/boxplot.test.ts
@@ -3,6 +3,7 @@ import {assert} from 'chai';
 
 import * as log from '../../src/log';
 import {normalize} from '../../src/spec';
+import {Transform} from '../../src/transform';
 import {defaultConfig} from '.././../src/config';
 
 describe('normalizeBoxMinMax', () => {
@@ -1554,6 +1555,26 @@ describe('normalizeBoxMinMax', () => {
         ]
       }
     );
+  });
+
+  it("should not overwrite transform with boxplot's transfroms", () => {
+    const outputSpec = normalize(
+      {
+        data: {url: 'data/population.json'},
+        mark: {
+          type: 'boxplot',
+          extent: 'min-max'
+        },
+        transform: [{calculate: 'age * 2', as: 'age2'}],
+        encoding: {x: {field: 'age', type: 'ordinal'}, y: {field: 'people', type: 'quantitative', title: 'population'}}
+      },
+      defaultConfig
+    );
+
+    const transforms: Transform[] = outputSpec.transform;
+    expect(transforms).toBeDefined();
+    expect(transforms).not.toHaveLength(0);
+    expect(transforms[0]).toEqual({calculate: 'age * 2', as: 'age2'});
   });
 });
 

--- a/test/compositemark/errorbar.test.ts
+++ b/test/compositemark/errorbar.test.ts
@@ -471,6 +471,23 @@ describe('normalizeErrorBar with raw data input', () => {
       assert.fail(!layer, false, 'layer should be a part of the spec');
     }
   });
+
+  it("should not overwrite transform with errorbar's transfroms", () => {
+    const outputSpec = normalize(
+      {
+        data: {url: 'data/population.json'},
+        mark: 'errorbar',
+        transform: [{calculate: 'age * 2', as: 'age2'}],
+        encoding: {x: {field: 'age', type: 'ordinal'}, y: {field: 'people', type: 'quantitative', title: 'population'}}
+      },
+      defaultConfig
+    );
+
+    const transforms: Transform[] = outputSpec.transform;
+    expect(transforms).toBeDefined();
+    expect(transforms).not.toHaveLength(0);
+    expect(transforms[0]).toEqual({calculate: 'age * 2', as: 'age2'});
+  });
 });
 
 describe('normalizeErrorBar for all possible extents and centers with raw data input', () => {


### PR DESCRIPTION
combine transform from outer spec with transform from composite mark before return to prevent overwriting.
issue #4140