### PR TITLE
Fix "Conditional Encodings" example in selection documentation

### DIFF
--- a/site/docs/selection/selection.md
+++ b/site/docs/selection/selection.md
@@ -91,12 +91,12 @@ Vega-Lite provides a number of selection _transformations_ to further customize 
 
 Selections can be used to conditionally specify visual encodings -- encode data values one way if they fall within the selection, and another if they do not. For instance, in the first two examples on this page, rectangles are colored based on whether or not their data values fall within the `pts` selection. If they do, they are colored by the number of records; and, if they do not, they are left grey.
 
-In this example, a selection (named `paintbrush`) is used to resize the points in the scatterplot on hover. This example is also useful for understanding the difference when empty selections are set to contain <select onchange="changeSpec('paintbrush_simple', 'paintbrush_simple_' + this.value)">
+In this example, a selection (named `paintbrush`) is used to resize the points in the scatterplot on hover. This example is also useful for understanding the difference when empty selections are set to contain <select onchange="changeSpec('interactive_paintbrush_simple', 'interactive_paintbrush_simple_' + this.value)">
   <option>all</option>
   <option>none</option>
 </select> of the data values.
 
-<div class="vl-example" id="paintbrush_simple" data-name="interactive_paintbrush_simple_all"></div>
+<div class="vl-example" id="interactive_paintbrush_simple" data-name="interactive_paintbrush_simple_all"></div>
 
 See the [`condition`](condition.html) documentation for more information.
 


### PR DESCRIPTION
Documentation fix.

Current behavior:
- changing the selector from "all" to "none" does not change the example visualization
https://vega.github.io/vega-lite/docs/selection.html#conditional-encodings
- console error: `GET https://vega.github.io/vega-lite/examples/specs/paintbrush_simple_none.vl.json 404`

Expected behavior:
the spec is reloaded to point to interactive_paintbrush_simple_none.vl.json instead of interactive_paintbrush_simple_all.vl.json

It looks like the source file was renamed at some point and was not updated in the markdown. This change updates the links.