### PR TITLE
Only run all tests and scripts in the latest node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,36 +6,38 @@ language: node_js
 node_js:
   - "6"
   - "8"
+  - "10"
+env:
+  LATEST=false
+matrix:
+    include:
+       - node_js: "10"
+         env: LATEST=true
 
-before_install:
+before_install: |
   # Minimal installation as desdcribed in https://github.com/martinda/gnu-parallel
-  - wget http://git.savannah.gnu.org/cgit/parallel.git/plain/src/parallel
-  - chmod +x parallel
-  - cp parallel sem
-  - sudo mv parallel sem /usr/local/bin
+  wget http://git.savannah.gnu.org/cgit/parallel.git/plain/src/parallel
+  chmod +x parallel
+  cp parallel sem
+  sudo mv parallel sem /usr/local/bin
 
-script:
-  - yarn data
-  - yarn build
-  - yarn jest test/ --collectCoverage=true
-  - yarn codecov
-  - yarn jest examples/
-  - yarn test:runtime
-  - ./scripts/check-schema.sh
-  - ./scripts/check-and-fix.sh
-  - yarn lint
+script: |
+  yarn data
+  if [ $LATEST ]; then
+    yarn build
+    yarn jest test/ --collectCoverage=true
+    yarn codecov
+    yarn jest examples/
+    yarn test:runtime
+    ./scripts/check-schema.sh
+    ./scripts/check-and-fix.sh
+    yarn lint
+  else
+    yarn build:only
+    yarn jest
+    yarn test:runtime
+  fi
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 
 cache: yarn
-
-notifications:
-  email: never
-  slack:
-    rooms:
-      - vega-js:eJe5JNgxfucTVcTMbeplKX3v
-    on_success: never
-    on_failure: always
-env:
-  global:
-    secure: I9sReagJiE7B0154AnU3t8WcdPtmZm86vMp+6umKegvzYr46jbypPAmlWW50A09fw4AmTaGOtwpYtvglf0JikkR6saXY0rRquDnO70DRmbdrO2o2WMjjCzkYID58SkGvqsqVJ4HXcu0HdJp6o5L7v7JMdzji6abYKxtsnw2ouk0=

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install: |
 
 script: |
   yarn data
-  if [ $LATEST ]; then
+  if [ $LATEST = true ]; then
     yarn build
     yarn jest test/ --collectCoverage=true
     yarn codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,12 @@ language: node_js
 node_js:
   - "6"
   - "8"
-  - "10"
 env:
   LATEST=false
 matrix:
-    include:
-       - node_js: "10"
-         env: LATEST=true
+  include:
+    - node_js: "10"
+      env: LATEST=true
 
 before_install: |
   # Minimal installation as desdcribed in https://github.com/martinda/gnu-parallel

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       env: LATEST=true
 
 before_install: |
-  # Minimal installation as desdcribed in https://github.com/martinda/gnu-parallel
+  # Minimal installation as described in https://github.com/martinda/gnu-parallel
   wget http://git.savannah.gnu.org/cgit/parallel.git/plain/src/parallel
   chmod +x parallel
   cp parallel sem


### PR DESCRIPTION
We are now testing Node 6, 8, and 10. We only run linting, check and fix, and coverage reports on node 10 since there is no need to do this for all node versions. I also removed the slack integration. 