### PR TITLE
Don’t warn about using ordinal with shape.

### DIFF
--- a/src/fielddef.ts
+++ b/src/fielddef.ts
@@ -723,10 +723,10 @@ export function channelCompatibility(
       return COMPATIBLE;
 
     case 'shape':
-      if (fieldDef.type !== 'nominal' && fieldDef.type !== 'geojson') {
+      if (!contains(['ordinal', 'nominal', 'geojson'], fieldDef.type)) {
         return {
           compatible: false,
-          warning: 'Shape channel should be used with only either nominal or geojson data'
+          warning: 'Shape channel should be used with only either discrete or geojson data.'
         };
       }
       return COMPATIBLE;

--- a/test/fielddef.test.ts
+++ b/test/fielddef.test.ts
@@ -159,8 +159,8 @@ describe('fieldDef', () => {
       it('is compatible with nominal field', () => {
         assert(channelCompatibility({field: 'a', type: 'nominal'}, 'shape').compatible);
       });
-      it('is incompatible with ordinal field', () => {
-        assert(!channelCompatibility({field: 'a', type: 'ordinal'}, 'shape').compatible);
+      it('is compatible with ordinal field', () => {
+        assert(channelCompatibility({field: 'a', type: 'ordinal'}, 'shape').compatible);
       });
       it('is incompatible with quantitative field', () => {
         assert(!channelCompatibility({field: 'a', type: 'quantitative'}, 'shape').compatible);


### PR DESCRIPTION
We already show Using discrete channel "shape" to encode "ordinal" field can be misleading as it does not encode order. Ref #3208