### PR TITLE
Fix axis customization issue of composite mark

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -4,6 +4,7 @@ import {isBinning} from './bin';
 import {Channel, CHANNELS, isChannel, supportMark} from './channel';
 import {Config} from './config';
 import {FacetMapping} from './facet';
+import {isPositionFieldDef} from './fielddef';
 import {
   ChannelDef,
   Field,
@@ -228,7 +229,8 @@ export function extractTransformsFromEncoding(oldEncoding: Encoding<string>, con
       encoding[channel] = {
         field: vgField(channelDef),
         type: channelDef.type,
-        title: title(channelDef, config, {allowDisabling: true})
+        title: title(channelDef, config, {allowDisabling: true}),
+        ...(isPositionFieldDef(channelDef) ? {axis: channelDef.axis} : {})
       };
     } else {
       // For value def, just copy

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -1,5 +1,7 @@
 import {assert} from 'chai';
-import {normalizeEncoding} from '../src/encoding';
+import {defaultConfig} from '../src/config';
+import {extractTransformsFromEncoding, normalizeEncoding} from '../src/encoding';
+import {isPositionFieldDef} from '../src/fielddef';
 import * as log from '../src/log';
 
 describe('encoding', () => {
@@ -39,5 +41,26 @@ describe('encoding', () => {
         assert.equal(logger.warns[0], log.message.droppingColor('encoding', {stroke: true}));
       })
     );
+  });
+
+  describe('extractTransformsFromEncoding', () => {
+    it('should indlude axis in extracted encoding', () => {
+      const encoding = extractTransformsFromEncoding(
+        {
+          x: {field: 'dose', type: 'ordinal', axis: {labelAngle: 15}},
+          y: {field: 'response', type: 'quantitative'}
+        },
+        defaultConfig
+      ).encoding;
+
+      const x = encoding.x;
+      expect(x).toBeDefined();
+      if (isPositionFieldDef(x)) {
+        expect(x.axis).toBeDefined();
+        expect(x.axis.labelAngle).toEqual(15);
+      } else {
+        assert.fail(null, null, 'encoding x is not PositionFieldDef');
+      }
+    });
   });
 });


### PR DESCRIPTION
From this issue #4188 

Problem: extractTransformFromEncoding drops axis after extracting encoding.