### PR TITLE
Drop falsy title when merge

### DIFF
--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -222,9 +222,16 @@ export function mergeTitleFieldDefs(f1: FieldDefBase<string>[], f2: FieldDefBase
 }
 
 export function mergeTitle(title1: string, title2: string) {
-  return title1 === title2
-    ? title1 // if title is the same just use one of them
-    : title1 + ', ' + title2; // join title with comma if different
+  if (title1 === title2 || !title2) {
+    // if titles are the same or title2 is falsy
+    return title1;
+  } else if (!title1) {
+    // if title1 is falsy
+    return title2;
+  } else {
+    // join title with comma if they are different
+    return title1 + ', ' + title2;
+  }
 }
 
 export function mergeTitleComponent(v1: Explicit<AxisTitleComponent>, v2: Explicit<AxisTitleComponent>) {

--- a/test/compile/common.test.ts
+++ b/test/compile/common.test.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:quotemark */
 
-import {numberFormat, timeFormatExpression} from '../../src/compile/common';
+import {mergeTitle, numberFormat, timeFormatExpression} from '../../src/compile/common';
 import {defaultConfig} from '../../src/config';
 import {vgField} from '../../src/fielddef';
 import {TimeUnit} from '../../src/timeunit';
@@ -113,6 +113,22 @@ describe('Common', () => {
     it('should not use number format for temporal scale', () => {
       expect(numberFormat({bin: true, field: 'a', type: TEMPORAL}, undefined, {})).toBeUndefined();
       expect(numberFormat({bin: true, field: 'a', type: ORDINAL, timeUnit: 'month'}, undefined, {})).toBeUndefined();
+    });
+  });
+
+  describe('mergeTitle()', () => {
+    it('should drop falsy title(s) when merged', () => {
+      expect(mergeTitle('title', null)).toBe('title');
+      expect(mergeTitle(null, 'title')).toBe('title');
+      expect(mergeTitle(null, null)).toBe(null);
+    });
+
+    it('should drop one title when both are the same', () => {
+      expect(mergeTitle('title', 'title')).toBe('title');
+    });
+
+    it('should join 2 titles with comma when both titles are not falsy and difference', () => {
+      expect(mergeTitle('title1', 'title2')).toBe('title1, title2');
     });
   });
 });


### PR DESCRIPTION
Fixes #4195
 
Drop `{"title" : null}` when merging titles