### PR TITLE
Don't explicitly set title in during transformation extraction if channel has title in other layer 

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -12,7 +12,6 @@ import {
   FieldDefWithCondition,
   FieldDefWithoutScale,
   getFieldDef,
-  getGuide,
   hasConditionalFieldDef,
   isConditionalDef,
   isFieldDef,
@@ -34,7 +33,7 @@ import {Mark} from './mark';
 import {getDateTimeComponents} from './timeunit';
 import {AggregatedFieldDef, BinTransform, TimeUnitTransform} from './transform';
 import {Type} from './type';
-import {keys, some} from './util';
+import {keys, some, StringSet} from './util';
 
 export interface Encoding<F> {
   /**
@@ -198,7 +197,11 @@ export function isAggregate(encoding: EncodingWithFacet<Field>) {
     return false;
   });
 }
-export function extractTransformsFromEncoding(oldEncoding: Encoding<string | RepeatRef>, config: Config) {
+export function extractTransformsFromEncoding(
+  oldEncoding: Encoding<string | RepeatRef>,
+  config: Config,
+  channelsWithTitles: StringSet = {}
+) {
   const groupby: string[] = [];
   const bins: BinTransform[] = [];
   const timeUnits: TimeUnitTransform[] = [];
@@ -209,9 +212,9 @@ export function extractTransformsFromEncoding(oldEncoding: Encoding<string | Rep
     // Extract potential embedded transformations along with remaining properties
     const {field, aggregate: aggOp, timeUnit, bin, ...remaining} = channelDef;
     if (isFieldDef(channelDef) && (aggOp || timeUnit || bin)) {
-      const guide = getGuide(channelDef);
-      const isTitleDefined = guide && guide.title;
       const newField = vgField(channelDef, {forAs: true});
+      const isTitleDefined = channelsWithTitles[channel];
+
       const newChannelDef = {
         // Only add title if it doesn't exist
         ...(isTitleDefined ? [] : {title: title(channelDef, config, {allowDisabling: true})}),

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -392,3 +392,33 @@ function usedFieldsLayered(spec: NormalizedLayerSpec): string[] {
 function usedFieldsSingle(spec: NormalizedFacetSpec | NormalizedRepeatSpec): string[] {
   return usedFields(spec.spec);
 }
+
+export function forEachUnitSpec(spec: NormalizedSpec, f: (unitSpec: NormalizedUnitSpec) => void): void {
+  if (isFacetSpec(spec) || isRepeatSpec(spec)) {
+    forEachUnitSpec(spec.spec, f);
+    return;
+  }
+  if (isLayerSpec(spec)) {
+    spec.layer.map(subspec => {
+      forEachUnitSpec(subspec, f);
+    });
+    return;
+  }
+  if (isUnitSpec(spec)) {
+    f(spec);
+    return;
+  }
+  if (isVConcatSpec(spec)) {
+    spec.vconcat.map(subspec => {
+      forEachUnitSpec(subspec, f);
+    });
+    return;
+  }
+  if (isHConcatSpec(spec)) {
+    spec.hconcat.map(subspec => {
+      forEachUnitSpec(subspec, f);
+    });
+    return;
+  }
+  throw new Error(log.message.INVALID_SPEC);
+}

--- a/src/transformextract.ts
+++ b/src/transformextract.ts
@@ -1,7 +1,9 @@
 import {Config} from './config';
-import {extractTransformsFromEncoding} from './encoding';
+import {extractTransformsFromEncoding, forEach} from './encoding';
+import {getGuide} from './fielddef';
 import * as log from './log';
 import {
+  forEachUnitSpec,
   GenericHConcatSpec,
   GenericVConcatSpec,
   isFacetSpec,
@@ -17,35 +19,45 @@ import {
   NormalizedSpec,
   NormalizedUnitSpec
 } from './spec';
+import {StringSet} from './util';
 
 /**
  * Modifies spec extracting transformations from encoding and moving them to the transforms array
  */
 export function extractTransforms(spec: NormalizedSpec, config: Config): NormalizedSpec {
+  return doExtractTransforms(spec, config, getChannelsWithTitles(spec));
+}
+
+function doExtractTransforms(spec: NormalizedSpec, config: Config, channelsWithTitles: StringSet): NormalizedSpec {
   if (isFacetSpec(spec) || isRepeatSpec(spec)) {
-    return extractTransformsSingle(spec, config);
+    return extractTransformsSingle(spec, config, channelsWithTitles);
   }
   if (isLayerSpec(spec)) {
-    return extractTransformsLayered(spec, config);
+    return extractTransformsLayered(spec, config, channelsWithTitles);
   }
   if (isUnitSpec(spec)) {
-    return extractTransformsUnit(spec, config);
+    return extractTransformsUnit(spec, config, channelsWithTitles);
   }
   if (isVConcatSpec(spec)) {
-    return extractTransformsVConcat(spec, config);
+    return extractTransformsVConcat(spec, config, channelsWithTitles);
   }
   if (isHConcatSpec(spec)) {
-    return extractTransformsHConcat(spec, config);
+    return extractTransformsHConcat(spec, config, channelsWithTitles);
   }
   throw new Error(log.message.INVALID_SPEC);
 }
 
-function extractTransformsUnit(spec: NormalizedUnitSpec, config: Config): NormalizedUnitSpec {
+function extractTransformsUnit(
+  spec: NormalizedUnitSpec,
+  config: Config,
+  channelsWithTitles: StringSet = {}
+): NormalizedUnitSpec {
   if (spec.encoding) {
     const {encoding: oldEncoding, transform: oldTransforms, ...rest} = spec;
     const {bins, timeUnits, aggregate, groupby, encoding: newEncoding} = extractTransformsFromEncoding(
       oldEncoding,
-      config
+      config,
+      channelsWithTitles
     );
     return {
       transform: [
@@ -64,47 +76,69 @@ function extractTransformsUnit(spec: NormalizedUnitSpec, config: Config): Normal
 
 function extractTransformsSingle(
   spec: NormalizedFacetSpec | NormalizedRepeatSpec,
-  config: Config
+  config: Config,
+  channelsWithTitles: StringSet = {}
 ): NormalizedFacetSpec | NormalizedRepeatSpec {
   const {spec: subspec, ...rest} = spec;
   return {
     ...rest,
-    spec: extractTransforms(subspec, config) as any
+    spec: doExtractTransforms(subspec, config, channelsWithTitles) as any
   };
 }
 
-function extractTransformsLayered(spec: NormalizedLayerSpec, config: Config): NormalizedLayerSpec {
+function extractTransformsLayered(
+  spec: NormalizedLayerSpec,
+  config: Config,
+  channelsWithTitles: StringSet = {}
+): NormalizedLayerSpec {
   const {layer, ...rest} = spec;
   return {
     ...rest,
     layer: layer.map(subspec => {
-      return extractTransforms(subspec, config) as any;
+      return doExtractTransforms(subspec, config, channelsWithTitles) as any;
     })
   };
 }
 
 function extractTransformsVConcat(
   spec: GenericVConcatSpec<NormalizedUnitSpec, NormalizedLayerSpec>,
-  config: Config
+  config: Config,
+  channelsWithTitles: StringSet = {}
 ): NormalizedConcatSpec {
   const {vconcat, ...rest} = spec;
   return {
     ...rest,
     vconcat: vconcat.map(subspec => {
-      return extractTransforms(subspec, config) as any;
+      return doExtractTransforms(subspec, config, channelsWithTitles) as any;
     })
   };
 }
 
 function extractTransformsHConcat(
   spec: GenericHConcatSpec<NormalizedUnitSpec, NormalizedLayerSpec>,
-  config: Config
+  config: Config,
+  channelsWithTitles: StringSet = {}
 ): NormalizedConcatSpec {
   const {hconcat, ...rest} = spec;
   return {
     ...rest,
     hconcat: hconcat.map(subspec => {
-      return extractTransforms(subspec, config) as any;
+      return doExtractTransforms(subspec, config, channelsWithTitles) as any;
     })
   };
+}
+
+export function getChannelsWithTitles(spec: NormalizedSpec): StringSet {
+  const channelsWithTitles: StringSet = {};
+  forEachUnitSpec(spec, (unit: NormalizedUnitSpec) => {
+    if (unit.encoding) {
+      forEach(unit.encoding, (channelDef, channel) => {
+        const guide = getGuide(channelDef);
+        if (channelDef.title || (guide && guide.title !== undefined)) {
+          channelsWithTitles[channel] = true;
+        }
+      });
+    }
+  });
+  return channelsWithTitles;
 }

--- a/src/transformextract.ts
+++ b/src/transformextract.ts
@@ -128,7 +128,7 @@ function extractTransformsHConcat(
   };
 }
 
-export function getChannelsWithTitles(spec: NormalizedSpec): StringSet {
+function getChannelsWithTitles(spec: NormalizedSpec): StringSet {
   const channelsWithTitles: StringSet = {};
   forEachUnitSpec(spec, (unit: NormalizedUnitSpec) => {
     if (unit.encoding) {


### PR DESCRIPTION
Prior to this PR extractTransforms would explicitly set the title of channels where a title isn't explicitly defined within the channel in order to match the default titles generated with embedded transformations. 

This PR makes extractTransforms also check to see if a title for the channel is defined in any other layer, if so, a title will not be set.
