### PR TITLE
Allow titles of type FieldDefBase to be used with TitleMixins [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "deploy:gh": "scripts/deploy-gh.sh",
     "deploy:schema": "scripts/deploy-schema.sh",
     "preschema": "npm run prebuild",
-    "schema": "node --stack-size=1800 ./node_modules/.bin/ts-json-schema-generator --no-type-check --path tsconfig.json --type TopLevelSpec > build/vega-lite-schema.json && npm run renameschema && cp build/vega-lite-schema.json _data/",
+    "schema": "node --stack-size=1900 ./node_modules/.bin/ts-json-schema-generator --no-type-check --path tsconfig.json --type TopLevelSpec > build/vega-lite-schema.json && npm run renameschema && cp build/vega-lite-schema.json _data/",
     "renameschema": "scripts/rename-schema.sh",
     "presite": "npm run prebuild && npm run data && npm run build:site && npm run build:toc && npm run build:versions && scripts/create-example-pages",
     "site": "bundle exec jekyll serve --incremental",

--- a/src/compile/axis/assemble.ts
+++ b/src/compile/axis/assemble.ts
@@ -6,7 +6,7 @@ import {defaultTitle, FieldDefBase} from '../../fielddef';
 import {getFirstDefined, keys} from '../../util';
 import {AxisComponent, AxisComponentIndex} from './component';
 
-function assembleTitle(title: string | FieldDefBase<string>[], config: Config) {
+export function assembleTitle(title: string | FieldDefBase<string>[], config: Config) {
   if (isArray(title)) {
     return title.map(fieldDef => defaultTitle(fieldDef, config)).join(', ');
   }

--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -206,6 +206,19 @@ export function sortParams(
 
 export type AxisTitleComponent = AxisComponentProps['title'];
 
+export function mergeTitleStrings(title1: string, title2: string): string {
+  if (title1 === title2 || !title2) {
+    // if titles are the same or title2 is falsy
+    return title1;
+  } else if (!title1) {
+    // if title1 is falsy
+    return title2;
+  } else {
+    // join title with comma if they are different
+    return title1 + ', ' + title2;
+  }
+}
+
 export function mergeTitleFieldDefs(f1: FieldDefBase<string>[], f2: FieldDefBase<string>[]) {
   const merged = [...f1];
 
@@ -221,33 +234,20 @@ export function mergeTitleFieldDefs(f1: FieldDefBase<string>[], f2: FieldDefBase
   return merged;
 }
 
-export function mergeTitle(title1: string, title2: string) {
-  if (title1 === title2 || !title2) {
-    // if titles are the same or title2 is falsy
-    return title1;
-  } else if (!title1) {
-    // if title1 is falsy
-    return title2;
-  } else {
-    // join title with comma if they are different
-    return title1 + ', ' + title2;
+export function mergeTitle(title1: string | FieldDefBase<string>[], title2: string | FieldDefBase<string>[]) {
+  if (isArray(title1) && isArray(title2)) {
+    return mergeTitleFieldDefs(title1, title2);
+  } else if (!isArray(title1) && !isArray(title2)) {
+    return mergeTitleStrings(title1, title2);
   }
+  throw new Error('It should never reach here');
 }
 
 export function mergeTitleComponent(v1: Explicit<AxisTitleComponent>, v2: Explicit<AxisTitleComponent>) {
-  if (isArray(v1.value) && isArray(v2.value)) {
-    return {
-      explicit: v1.explicit,
-      value: mergeTitleFieldDefs(v1.value, v2.value)
-    };
-  } else if (!isArray(v1.value) && !isArray(v2.value)) {
-    return {
-      explicit: v1.explicit, // keep the old explicit
-      value: mergeTitle(v1.value, v2.value)
-    };
-  }
-  /* istanbul ignore next: Condition should not happen -- only for warning in development. */
-  throw new Error('It should never reach here');
+  return {
+    explicit: v1.explicit,
+    value: mergeTitle(v1.value, v2.value)
+  };
 }
 
 /**

--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -237,8 +237,15 @@ export function mergeTitleFieldDefs(f1: FieldDefBase<string>[], f2: FieldDefBase
 export function mergeTitle(title1: string | FieldDefBase<string>[], title2: string | FieldDefBase<string>[]) {
   if (isArray(title1) && isArray(title2)) {
     return mergeTitleFieldDefs(title1, title2);
-  } else if (!isArray(title1) && !isArray(title2)) {
+  }
+  if (!isArray(title1) && !isArray(title2)) {
     return mergeTitleStrings(title1, title2);
+  }
+  if (!isArray(title1)) {
+    return title1;
+  }
+  if (!isArray(title2)) {
+    return title2;
   }
   throw new Error('It should never reach here');
 }

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -4,22 +4,14 @@ import {Channel, COLUMN, ROW, ScaleChannel} from '../channel';
 import {Config} from '../config';
 import {reduce} from '../encoding';
 import {FacetFieldDef, FacetMapping} from '../facet';
-import {
-  defaultTitle,
-  FieldDef,
-  FieldDefBase,
-  FieldRefOption,
-  normalize,
-  title as fieldDefTitle,
-  vgField
-} from '../fielddef';
+import {FieldDef, FieldRefOption, normalize, title as fieldDefTitle, vgField} from '../fielddef';
 import * as log from '../log';
 import {hasDiscreteDomain} from '../scale';
 import {EncodingSortField, isSortField, SortOrder} from '../sort';
 import {NormalizedFacetSpec} from '../spec';
 import {contains} from '../util';
 import {isVgRangeStep, VgData, VgLayout, VgMarkGroup, VgSignal} from '../vega.schema';
-import {assembleAxis} from './axis/assemble';
+import {assembleAxis, assembleTitle} from './axis/assemble';
 import {buildModel} from './buildmodel';
 import {assembleFacetData} from './data/assemble';
 import {sortArrayIndexField} from './data/calculate';
@@ -31,13 +23,6 @@ import {RepeaterValue, replaceRepeaterInFacet} from './repeater';
 import {parseGuideResolve} from './resolve';
 import {assembleDomain, getFieldFromDomain} from './scale/domain';
 import {assembleFacetSignals} from './selection/selection';
-
-function assembleTitle(title: string | FieldDefBase<string>[], config: Config) {
-  if (isArray(title)) {
-    return title.map(fieldDef => defaultTitle(fieldDef, config)).join(', ');
-  }
-  return title;
-}
 
 export function facetSortFieldName(
   fieldDef: FacetFieldDef<string>,

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -4,7 +4,15 @@ import {Channel, COLUMN, ROW, ScaleChannel} from '../channel';
 import {Config} from '../config';
 import {reduce} from '../encoding';
 import {FacetFieldDef, FacetMapping} from '../facet';
-import {FieldDef, FieldRefOption, normalize, title as fieldDefTitle, vgField} from '../fielddef';
+import {
+  defaultTitle,
+  FieldDef,
+  FieldDefBase,
+  FieldRefOption,
+  normalize,
+  title as fieldDefTitle,
+  vgField
+} from '../fielddef';
 import * as log from '../log';
 import {hasDiscreteDomain} from '../scale';
 import {EncodingSortField, isSortField, SortOrder} from '../sort';
@@ -23,6 +31,13 @@ import {RepeaterValue, replaceRepeaterInFacet} from './repeater';
 import {parseGuideResolve} from './resolve';
 import {assembleDomain, getFieldFromDomain} from './scale/domain';
 import {assembleFacetSignals} from './selection/selection';
+
+function assembleTitle(title: string | FieldDefBase<string>[], config: Config) {
+  if (isArray(title)) {
+    return title.map(fieldDef => defaultTitle(fieldDef, config)).join(', ');
+  }
+  return title;
+}
 
 export function facetSortFieldName(
   fieldDef: FacetFieldDef<string>,
@@ -132,7 +147,7 @@ export class FacetModel extends ModelWithField {
       }
 
       this.component.layoutHeaders[channel] = {
-        title,
+        title: assembleTitle(title, this.config),
         facetFieldDef: fieldDef,
         // TODO: support adding label to footer as well
         header: [this.makeHeaderComponent(channel, true)]

--- a/src/compile/legend/parse.ts
+++ b/src/compile/legend/parse.ts
@@ -15,6 +15,7 @@ import {FieldDef, isFieldDef, title as fieldDefTitle} from '../../fielddef';
 import {Legend, LEGEND_PROPERTIES, VG_LEGEND_PROPERTIES} from '../../legend';
 import {GEOJSON} from '../../type';
 import {deleteNestedProperty, getFirstDefined, keys} from '../../util';
+import {assembleTitle} from '../axis/assemble';
 import {guideEncodeEntry, mergeTitleComponent, numberFormat} from '../common';
 import {isUnitModel, Model} from '../model';
 import {parseGuideResolve} from '../resolve';
@@ -139,7 +140,7 @@ function getProperty<K extends keyof VgLegend>(
       // We don't include temporal field here as we apply format in encode block
       return numberFormat(fieldDef, specifiedLegend.format, model.config);
     case 'title':
-      return fieldDefTitle(fieldDef, model.config, {allowDisabling: true}) || undefined;
+      return assembleTitle(fieldDefTitle(fieldDef, model.config, {allowDisabling: true}), model.config) || undefined;
 
     // TODO: enable when https://github.com/vega/vega/issues/1351 is fixed
     // case 'clipHeight':

--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -25,6 +25,7 @@ import {StackProperties} from '../../stack';
 import {QUANTITATIVE} from '../../type';
 import {contains, keys, some, StringSet} from '../../util';
 import {VgValueRef} from '../../vega.schema';
+import {assembleTitle} from '../axis/assemble';
 import {binRequiresRange, formatSignalRef} from '../common';
 import {ScaleComponent} from '../scale/component';
 
@@ -207,7 +208,7 @@ export function midPoint(
 export function tooltipForChannelDefs(channelDefs: FieldDef<string>[], config: Config) {
   const keyValues: StringSet = {};
   for (const fieldDef of channelDefs) {
-    const key = title(fieldDef, config, {allowDisabling: false});
+    const key = assembleTitle(title(fieldDef, config, {allowDisabling: false}), config);
     const value = text(fieldDef, config).signal;
     keyValues[`${stringValue(key)}: ${value}`] = true;
   }

--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -23,7 +23,7 @@ import {Mark, MarkDef} from '../../mark';
 import {hasDiscreteDomain, ScaleType} from '../../scale';
 import {StackProperties} from '../../stack';
 import {QUANTITATIVE} from '../../type';
-import {contains, some} from '../../util';
+import {contains, keys, some, StringSet} from '../../util';
 import {VgValueRef} from '../../vega.schema';
 import {binRequiresRange, formatSignalRef} from '../common';
 import {ScaleComponent} from '../scale/component';
@@ -205,17 +205,13 @@ export function midPoint(
 }
 
 export function tooltipForChannelDefs(channelDefs: FieldDef<string>[], config: Config) {
-  const keyValues: string[] = [];
-  const usedKey = {};
+  const keyValues: StringSet = {};
   for (const fieldDef of channelDefs) {
     const key = title(fieldDef, config, {allowDisabling: false});
     const value = text(fieldDef, config).signal;
-    if (!usedKey[key]) {
-      keyValues.push(`${stringValue(key)}: ${value}`);
-    }
-    usedKey[key] = true;
+    keyValues[`${stringValue(key)}: ${value}`] = true;
   }
-  return keyValues.length ? {signal: `{${keyValues.join(', ')}}`} : undefined;
+  return keys(keyValues).length ? {signal: `{${keys(keyValues).join(', ')}}`} : undefined;
 }
 
 export function text(channelDef: ChannelDefWithCondition<TextFieldDef<string>>, config: Config): VgValueRef {

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -5,6 +5,7 @@ import {Channel, CHANNELS, isChannel, isNonPositionScaleChannel, supportMark} fr
 import {binRequiresRange} from './compile/common';
 import {Config} from './config';
 import {FacetMapping} from './facet';
+import {toFieldDefBase} from './fielddef';
 import {
   ChannelDef,
   Field,
@@ -24,7 +25,6 @@ import {
   PositionFieldDef,
   RepeatRef,
   TextFieldDef,
-  title,
   ValueDef,
   ValueDefWithCondition,
   vgField
@@ -234,7 +234,7 @@ export function extractTransformsFromEncoding(oldEncoding: Encoding<string | Rep
       const newField = vgField(channelDef, {forAs: true});
       const newChannelDef = {
         // Only add title if it doesn't exist
-        ...(isTitleDefined ? [] : {title: title(channelDef, config, {allowDisabling: true})}),
+        ...(isTitleDefined ? [] : {title: [toFieldDefBase(channelDef)]}),
         ...remaining,
         // Always overwrite field
         field: newField

--- a/src/guide.ts
+++ b/src/guide.ts
@@ -1,4 +1,4 @@
-import {ConditionValueDefMixins, ValueDef} from './fielddef';
+import {ConditionValueDefMixins, FieldDefBase, ValueDef} from './fielddef';
 import {VgEncodeChannel} from './vega.schema';
 
 export interface TitleMixins {
@@ -13,7 +13,7 @@ export interface TitleMixins {
    *
    * 2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.
    */
-  title?: string | null;
+  title?: string | FieldDefBase<string>[];
 }
 
 export interface Guide extends TitleMixins {

--- a/test/compositemark/boxplot.test.ts
+++ b/test/compositemark/boxplot.test.ts
@@ -2091,7 +2091,12 @@ describe('normalizeBoxIQR', () => {
                 },
                 color: {
                   field: 'mean_people',
-                  title: 'Mean of people',
+                  title: [
+                    {
+                      field: 'people',
+                      aggregate: 'mean'
+                    }
+                  ],
                   type: 'quantitative'
                 }
               }

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -82,7 +82,12 @@ describe('encoding', () => {
           x: {
             field: 'yearmonthdatehoursminutes_a',
             type: 'temporal',
-            title: 'a (year-month-date-hours-minutes)',
+            title: [
+              {
+                field: 'a',
+                timeUnit: 'yearmonthdatehoursminutes'
+              }
+            ],
             axis: {format: '%b %d, %Y %H:%M'}
           },
           y: {field: 'b', type: 'quantitative'}
@@ -104,7 +109,7 @@ describe('encoding', () => {
         ),
         defaultConfig
       );
-      assert.deepEqual(output, {
+      expect(output).toEqual({
         bins: [],
         timeUnits: [],
         aggregate: [{op: 'max', field: 'b', as: 'max_b'}],
@@ -114,7 +119,12 @@ describe('encoding', () => {
           y: {
             field: 'max_b',
             type: 'quantitative',
-            title: 'Max of b'
+            title: [
+              {
+                field: 'b',
+                aggregate: 'max'
+              }
+            ]
           }
         }
       });
@@ -130,15 +140,20 @@ describe('encoding', () => {
         ),
         defaultConfig
       );
-      assert.deepEqual(output, {
+      expect(output).toEqual({
         bins: [{bin: {maxbins: 10}, field: 'a', as: 'bin_maxbins_10_a'}],
         timeUnits: [],
         aggregate: [{op: 'count', as: 'count_*'}],
         groupby: ['bin_maxbins_10_a_end', 'bin_maxbins_10_a_range', 'bin_maxbins_10_a'],
         encoding: {
-          x: {field: 'bin_maxbins_10_a', type: 'quantitative', title: 'a (binned)', bin: 'binned'},
+          x: {
+            field: 'bin_maxbins_10_a',
+            type: 'quantitative',
+            title: [{field: 'a', bin: {maxbins: 10}}],
+            bin: 'binned'
+          },
           x2: {field: 'bin_maxbins_10_a_end', type: 'quantitative'},
-          y: {field: 'count_*', type: 'quantitative', title: 'Number of Records'}
+          y: {field: 'count_*', type: 'quantitative', title: [{aggregate: 'count'}]}
         }
       });
     });

--- a/test/transformextract.test.ts
+++ b/test/transformextract.test.ts
@@ -162,7 +162,7 @@ describe('extractTransforms()', () => {
           height: 234,
           encoding: {
             x: {field: 'Worldwide_Gross', type: 'quantitative'},
-            y: {field: 'count_*', type: 'quantitative', title: 'Number of Records'}
+            y: {field: 'count_*', type: 'quantitative', title: [{aggregate: 'count'}]}
           }
         }
       });
@@ -234,13 +234,23 @@ describe('extractTransforms()', () => {
                   x: {
                     field: 'month_date',
                     type: 'ordinal',
-                    title: 'date (month)',
+                    title: [
+                      {
+                        field: 'date',
+                        timeUnit: 'month'
+                      }
+                    ],
                     axis: {format: '%b'}
                   },
                   y: {
                     field: 'mean_precipitation',
                     type: 'quantitative',
-                    title: 'Mean of precipitation',
+                    title: [
+                      {
+                        field: 'precipitation',
+                        aggregate: 'mean'
+                      }
+                    ],
                     axis: {
                       grid: false
                     }
@@ -260,13 +270,23 @@ describe('extractTransforms()', () => {
                   x: {
                     field: 'month_date',
                     type: 'ordinal',
-                    title: 'date (month)',
+                    title: [
+                      {
+                        field: 'date',
+                        timeUnit: 'month'
+                      }
+                    ],
                     axis: {format: '%b'}
                   },
                   y: {
                     field: 'mean_temp_max',
                     type: 'quantitative',
-                    title: 'Mean of temp_max',
+                    title: [
+                      {
+                        field: 'temp_max',
+                        aggregate: 'mean'
+                      }
+                    ],
                     axis: {
                       grid: false
                     },

--- a/test/transformextract.test.ts
+++ b/test/transformextract.test.ts
@@ -62,7 +62,6 @@ describe('extractTransforms()', () => {
     'layer_point_errorbar_stdev.vl.json': true,
     'layer_precipitation_mean.vl.json': true,
     'layer_rect_extent.vl.json': true,
-    'layer_scatter_errorband_1D_stdev_global_mean.vl.json': true,
     'line_calculate.vl.json': true,
     'line_color_binned.vl.json': true,
     'line_max_year.vl.json': true,
@@ -98,11 +97,8 @@ describe('extractTransforms()', () => {
     'trellis_barley.vl.json': true,
     'trellis_barley_layer_median.vl.json': true,
     'trellis_column_year.vl.json': true,
-    'trellis_cross_sort.vl.json': true,
-    'trellis_cross_sort_array.vl.json': true,
     'trellis_line_quarter.vl.json': true,
-    'vconcat_weather.vl.json': true,
-    'window_mean_difference.vl.json': true
+    'vconcat_weather.vl.json': true
   };
   for (const file of fs.readdirSync(specsDir)) {
     const filepath = specsDir + file;


### PR DESCRIPTION
As mentioned by @kanitw in #4254 a cleaner approach to fixing the problem of differing title behavior between specs which have had extracted transformations and those without is to allow the `title` field in `TitleMixins` to be of type `string | FieldDefBase<string>[]` where the latter type is used to define the correct implicit title.
