### PR TITLE
Refactor selection code paths

### DIFF
--- a/examples/compiled/interactive_bar_select_highlight.vg.json
+++ b/examples/compiled/interactive_bar_select_highlight.vg.json
@@ -55,7 +55,7 @@
     },
     {
       "name": "highlight_tuple_fields",
-      "value": [{"field": "_vgsid_", "type": "E"}]
+      "value": [{"type": "E", "field": "_vgsid_"}]
     },
     {
       "name": "highlight_modify",
@@ -73,7 +73,7 @@
     },
     {
       "name": "select_tuple_fields",
-      "value": [{"field": "_vgsid_", "type": "E"}]
+      "value": [{"type": "E", "field": "_vgsid_"}]
     },
     {
       "name": "select_toggle",

--- a/examples/compiled/interactive_multi_line_tooltip.vg.json
+++ b/examples/compiled/interactive_multi_line_tooltip.vg.json
@@ -58,7 +58,7 @@
     },
     {
       "name": "hover_tuple_fields",
-      "value": [{"field": "_vgsid_", "type": "E"}]
+      "value": [{"type": "E", "field": "_vgsid_"}]
     },
     {
       "name": "hover_modify",

--- a/examples/compiled/interactive_paintbrush.vg.json
+++ b/examples/compiled/interactive_paintbrush.vg.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "paintbrush_tuple_fields",
-      "value": [{"field": "_vgsid_", "type": "E"}]
+      "value": [{"type": "E", "field": "_vgsid_"}]
     },
     {
       "name": "paintbrush_toggle",

--- a/examples/compiled/interactive_paintbrush_color.vg.json
+++ b/examples/compiled/interactive_paintbrush_color.vg.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "paintbrush_tuple_fields",
-      "value": [{"field": "_vgsid_", "type": "E"}]
+      "value": [{"type": "E", "field": "_vgsid_"}]
     },
     {
       "name": "paintbrush_toggle",

--- a/examples/compiled/interactive_paintbrush_color_nearest.vg.json
+++ b/examples/compiled/interactive_paintbrush_color_nearest.vg.json
@@ -39,7 +39,7 @@
     },
     {
       "name": "paintbrush_tuple_fields",
-      "value": [{"field": "_vgsid_", "type": "E"}]
+      "value": [{"type": "E", "field": "_vgsid_"}]
     },
     {
       "name": "paintbrush_toggle",

--- a/examples/compiled/interactive_paintbrush_simple_all.vg.json
+++ b/examples/compiled/interactive_paintbrush_simple_all.vg.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "paintbrush_tuple_fields",
-      "value": [{"field": "_vgsid_", "type": "E"}]
+      "value": [{"type": "E", "field": "_vgsid_"}]
     },
     {
       "name": "paintbrush_toggle",

--- a/examples/compiled/interactive_paintbrush_simple_none.vg.json
+++ b/examples/compiled/interactive_paintbrush_simple_none.vg.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "paintbrush_tuple_fields",
-      "value": [{"field": "_vgsid_", "type": "E"}]
+      "value": [{"type": "E", "field": "_vgsid_"}]
     },
     {
       "name": "paintbrush_toggle",

--- a/examples/compiled/interactive_query_widgets.vg.json
+++ b/examples/compiled/interactive_query_widgets.vg.json
@@ -69,8 +69,8 @@
     {
       "name": "CylYr_tuple_fields",
       "value": [
-        {"field": "Cylinders", "type": "E"},
-        {"field": "Year", "type": "E"}
+        {"type": "E", "field": "Cylinders"},
+        {"type": "E", "field": "Year"}
       ]
     },
     {

--- a/examples/compiled/selection_bind_cylyr.vg.json
+++ b/examples/compiled/selection_bind_cylyr.vg.json
@@ -54,8 +54,8 @@
     {
       "name": "CylYr_tuple_fields",
       "value": [
-        {"field": "Cylinders", "type": "E"},
-        {"field": "Year", "type": "E"}
+        {"type": "E", "field": "Cylinders"},
+        {"type": "E", "field": "Year"}
       ]
     },
     {

--- a/examples/compiled/selection_bind_origin.vg.json
+++ b/examples/compiled/selection_bind_origin.vg.json
@@ -33,7 +33,7 @@
       "name": "org_tuple",
       "update": "org_Origin !== null ? {fields: org_tuple_fields, values: [org_Origin]} : null"
     },
-    {"name": "org_tuple_fields", "value": [{"field": "Origin", "type": "E"}]},
+    {"name": "org_tuple_fields", "value": [{"type": "E", "field": "Origin"}]},
     {"name": "org_modify", "update": "modify(\"org_store\", org_tuple, true)"}
   ],
   "marks": [

--- a/examples/compiled/selection_insert.vg.json
+++ b/examples/compiled/selection_insert.vg.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "paintbrush_tuple_fields",
-      "value": [{"field": "_vgsid_", "type": "E"}]
+      "value": [{"type": "E", "field": "_vgsid_"}]
     },
     {
       "name": "paintbrush_modify",

--- a/examples/compiled/selection_multi_condition.vg.json
+++ b/examples/compiled/selection_multi_condition.vg.json
@@ -247,7 +247,7 @@
     },
     {
       "name": "hoverbrush_tuple_fields",
-      "value": [{"field": "_vgsid_", "type": "E"}]
+      "value": [{"type": "E", "field": "_vgsid_"}]
     },
     {
       "name": "hoverbrush_toggle",

--- a/examples/compiled/selection_project_multi.vg.json
+++ b/examples/compiled/selection_project_multi.vg.json
@@ -33,7 +33,7 @@
         }
       ]
     },
-    {"name": "pts_tuple_fields", "value": [{"field": "_vgsid_", "type": "E"}]},
+    {"name": "pts_tuple_fields", "value": [{"type": "E", "field": "_vgsid_"}]},
     {
       "name": "pts_toggle",
       "value": false,

--- a/examples/compiled/selection_project_multi_cylinders.vg.json
+++ b/examples/compiled/selection_project_multi_cylinders.vg.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "pts_tuple_fields",
-      "value": [{"field": "Cylinders", "type": "E"}]
+      "value": [{"type": "E", "field": "Cylinders"}]
     },
     {
       "name": "pts_toggle",

--- a/examples/compiled/selection_project_multi_cylinders_origin.vg.json
+++ b/examples/compiled/selection_project_multi_cylinders_origin.vg.json
@@ -31,8 +31,8 @@
     {
       "name": "pts_tuple_fields",
       "value": [
-        {"field": "Cylinders", "type": "E"},
-        {"field": "Origin", "type": "E"}
+        {"type": "E", "field": "Cylinders"},
+        {"type": "E", "field": "Origin"}
       ]
     },
     {

--- a/examples/compiled/selection_project_multi_origin.vg.json
+++ b/examples/compiled/selection_project_multi_origin.vg.json
@@ -28,7 +28,7 @@
         }
       ]
     },
-    {"name": "pts_tuple_fields", "value": [{"field": "Origin", "type": "E"}]},
+    {"name": "pts_tuple_fields", "value": [{"type": "E", "field": "Origin"}]},
     {
       "name": "pts_toggle",
       "value": false,

--- a/examples/compiled/selection_project_single.vg.json
+++ b/examples/compiled/selection_project_single.vg.json
@@ -33,7 +33,7 @@
         }
       ]
     },
-    {"name": "pts_tuple_fields", "value": [{"field": "_vgsid_", "type": "E"}]},
+    {"name": "pts_tuple_fields", "value": [{"type": "E", "field": "_vgsid_"}]},
     {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
   ],
   "marks": [

--- a/examples/compiled/selection_project_single_cylinders.vg.json
+++ b/examples/compiled/selection_project_single_cylinders.vg.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "pts_tuple_fields",
-      "value": [{"field": "Cylinders", "type": "E"}]
+      "value": [{"type": "E", "field": "Cylinders"}]
     },
     {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
   ],

--- a/examples/compiled/selection_project_single_cylinders_origin.vg.json
+++ b/examples/compiled/selection_project_single_cylinders_origin.vg.json
@@ -31,8 +31,8 @@
     {
       "name": "pts_tuple_fields",
       "value": [
-        {"field": "Cylinders", "type": "E"},
-        {"field": "Origin", "type": "E"}
+        {"type": "E", "field": "Cylinders"},
+        {"type": "E", "field": "Origin"}
       ]
     },
     {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}

--- a/examples/compiled/selection_project_single_origin.vg.json
+++ b/examples/compiled/selection_project_single_origin.vg.json
@@ -28,7 +28,7 @@
         }
       ]
     },
-    {"name": "pts_tuple_fields", "value": [{"field": "Origin", "type": "E"}]},
+    {"name": "pts_tuple_fields", "value": [{"type": "E", "field": "Origin"}]},
     {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
   ],
   "marks": [

--- a/examples/compiled/selection_toggle_altKey.vg.json
+++ b/examples/compiled/selection_toggle_altKey.vg.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "paintbrush_tuple_fields",
-      "value": [{"field": "_vgsid_", "type": "E"}]
+      "value": [{"type": "E", "field": "_vgsid_"}]
     },
     {
       "name": "paintbrush_toggle",

--- a/examples/compiled/selection_toggle_altKey_shiftKey.vg.json
+++ b/examples/compiled/selection_toggle_altKey_shiftKey.vg.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "paintbrush_tuple_fields",
-      "value": [{"field": "_vgsid_", "type": "E"}]
+      "value": [{"type": "E", "field": "_vgsid_"}]
     },
     {
       "name": "paintbrush_toggle",

--- a/examples/compiled/selection_toggle_shiftKey.vg.json
+++ b/examples/compiled/selection_toggle_shiftKey.vg.json
@@ -38,7 +38,7 @@
     },
     {
       "name": "paintbrush_tuple_fields",
-      "value": [{"field": "_vgsid_", "type": "E"}]
+      "value": [{"type": "E", "field": "_vgsid_"}]
     },
     {
       "name": "paintbrush_toggle",

--- a/examples/compiled/selection_type_multi.vg.json
+++ b/examples/compiled/selection_type_multi.vg.json
@@ -48,7 +48,7 @@
         }
       ]
     },
-    {"name": "pts_tuple_fields", "value": [{"field": "_vgsid_", "type": "E"}]},
+    {"name": "pts_tuple_fields", "value": [{"type": "E", "field": "_vgsid_"}]},
     {
       "name": "pts_toggle",
       "value": false,

--- a/examples/compiled/selection_type_single.vg.json
+++ b/examples/compiled/selection_type_single.vg.json
@@ -48,7 +48,7 @@
         }
       ]
     },
-    {"name": "pts_tuple_fields", "value": [{"field": "_vgsid_", "type": "E"}]},
+    {"name": "pts_tuple_fields", "value": [{"type": "E", "field": "_vgsid_"}]},
     {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
   ],
   "marks": [

--- a/examples/compiled/selection_type_single_dblclick.vg.json
+++ b/examples/compiled/selection_type_single_dblclick.vg.json
@@ -48,7 +48,7 @@
         }
       ]
     },
-    {"name": "pts_tuple_fields", "value": [{"field": "_vgsid_", "type": "E"}]},
+    {"name": "pts_tuple_fields", "value": [{"type": "E", "field": "_vgsid_"}]},
     {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
   ],
   "marks": [

--- a/examples/compiled/trellis_selections.vg.json
+++ b/examples/compiled/trellis_selections.vg.json
@@ -399,7 +399,7 @@
           "name": "xenc_tuple",
           "update": "xenc_X !== null ? {fields: xenc_tuple_fields, values: [xenc_X]} : null"
         },
-        {"name": "xenc_tuple_fields", "value": [{"field": "X", "type": "E"}]},
+        {"name": "xenc_tuple_fields", "value": [{"type": "E", "field": "X"}]},
         {
           "name": "xenc_modify",
           "update": "modify(\"xenc_store\", xenc_tuple, true)"

--- a/examples/compiled/vconcat_flatten.vg.json
+++ b/examples/compiled/vconcat_flatten.vg.json
@@ -104,7 +104,7 @@
             }
           ]
         },
-        {"name": "pts_tuple_fields", "value": [{"field": "id", "type": "E"}]},
+        {"name": "pts_tuple_fields", "value": [{"type": "E", "field": "id"}]},
         {
           "name": "pts_toggle",
           "value": false,

--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -17,7 +17,7 @@ import {
 } from '../../transform';
 import {deepEqual, mergeDeep} from '../../util';
 import {isFacetModel, isLayerModel, isUnitModel, Model} from '../model';
-import {requiresSelectionId} from '../selection/selection';
+import {requiresSelectionId} from '../selection';
 import {AggregateNode} from './aggregate';
 import {BinNode} from './bin';
 import {CalculateNode} from './calculate';

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -21,7 +21,7 @@ import {parseChildrenLayoutSize} from './layoutsize/parse';
 import {Model, ModelWithField} from './model';
 import {RepeaterValue, replaceRepeaterInFacet} from './repeater';
 import {assembleDomain, getFieldFromDomain} from './scale/domain';
-import {assembleFacetSignals} from './selection/selection';
+import {assembleFacetSignals} from './selection/assemble';
 
 export function facetSortFieldName(
   fieldDef: FacetFieldDef<string>,

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -12,7 +12,7 @@ import {parseLayerLayoutSize} from './layoutsize/parse';
 import {assembleLegends} from './legend/assemble';
 import {Model} from './model';
 import {RepeaterValue} from './repeater';
-import {assembleLayerSelectionMarks} from './selection/selection';
+import {assembleLayerSelectionMarks} from './selection/assemble';
 import {UnitModel} from './unit';
 
 export class LayerModel extends Model {

--- a/src/compile/mark/mixins.ts
+++ b/src/compile/mark/mixins.ts
@@ -18,7 +18,7 @@ import {contains, Dict, getFirstDefined, keys} from '../../util';
 import {VG_MARK_CONFIGS, VgEncodeEntry, VgValueRef} from '../../vega.schema';
 import {getMarkConfig} from '../common';
 import {expression} from '../predicate';
-import {selectionPredicate} from '../selection/selection';
+import {assembleSelectionPredicate} from '../selection/assemble';
 import {UnitModel} from '../unit';
 import * as ref from './valueref';
 import {fieldInvalidPredicate} from './valueref';
@@ -244,7 +244,9 @@ export function wrapCondition(
     const conditions = isArray(condition) ? condition : [condition];
     const vgConditions = conditions.map(c => {
       const conditionValueRef = refFn(c);
-      const test = isConditionalSelection(c) ? selectionPredicate(model, c.selection) : expression(model, c.test);
+      const test = isConditionalSelection(c)
+        ? assembleSelectionPredicate(model, c.selection)
+        : expression(model, c.test);
       return {
         test,
         ...conditionValueRef

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -37,7 +37,7 @@ import {assembleScales} from './scale/assemble';
 import {ScaleComponent, ScaleComponentIndex} from './scale/component';
 import {assembleDomain, getFieldFromDomain} from './scale/domain';
 import {parseScales} from './scale/parse';
-import {SelectionComponent} from './selection/selection';
+import {SelectionComponent} from './selection';
 import {Split} from './split';
 import {UnitModel} from './unit';
 

--- a/src/compile/predicate.ts
+++ b/src/compile/predicate.ts
@@ -4,7 +4,7 @@ import {fieldFilterExpression, isSelectionPredicate, Predicate} from '../predica
 import {logicalExpr} from '../util';
 import {DataFlowNode} from './data/dataflow';
 import {Model} from './model';
-import {selectionPredicate} from './selection/selection';
+import {assembleSelectionPredicate} from './selection/assemble';
 
 /**
  * Converts a predicate into an expression.
@@ -15,7 +15,7 @@ export function expression(model: Model, filterOp: LogicalOperand<Predicate>, no
     if (isString(predicate)) {
       return predicate;
     } else if (isSelectionPredicate(predicate)) {
-      return selectionPredicate(model, predicate.selection, node);
+      return assembleSelectionPredicate(model, predicate.selection, node);
     } else {
       // Filter Object
       return fieldFilterExpression(predicate);

--- a/src/compile/scale/assemble.ts
+++ b/src/compile/scale/assemble.ts
@@ -2,7 +2,8 @@ import {Channel, ScaleChannel} from '../../channel';
 import {keys} from '../../util';
 import {isVgRangeStep, VgRange, VgScale} from '../../vega.schema';
 import {isConcatModel, isLayerModel, isRepeatModel, Model} from '../model';
-import {isRawSelectionDomain, selectionScaleDomain} from '../selection/selection';
+import {isRawSelectionDomain} from '../selection';
+import {assembleSelectionScaleDomain} from '../selection/assemble';
 import {assembleDomain} from './domain';
 
 export function assembleScales(model: Model): VgScale[] {
@@ -40,7 +41,7 @@ export function assembleScalesForModel(model: Model): VgScale[] {
       // is set, and replace it with the correct domainRaw signal.
       // For more information, see isRawSelectionDomain in selection.ts.
       if (domainRaw && isRawSelectionDomain(domainRaw)) {
-        domainRaw = selectionScaleDomain(model, domainRaw);
+        domainRaw = assembleSelectionScaleDomain(model, domainRaw);
       }
 
       const domain = assembleDomain(model, channel);

--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -26,7 +26,7 @@ import {
 import {sortArrayIndexField} from '../data/calculate';
 import {FACET_SCALE_PREFIX} from '../data/optimize';
 import {isFacetModel, isUnitModel, Model} from '../model';
-import {SELECTION_DOMAIN} from '../selection/selection';
+import {SELECTION_DOMAIN} from '../selection';
 import {UnitModel} from '../unit';
 import {ScaleComponentIndex} from './component';
 

--- a/src/compile/selection/index.ts
+++ b/src/compile/selection/index.ts
@@ -1,0 +1,113 @@
+import {Binding, NewSignal, SignalRef} from 'vega';
+import {stringValue} from 'vega-util';
+import {FACET_CHANNELS} from '../../channel';
+import {
+  BrushConfig,
+  SELECTION_ID,
+  SelectionInit,
+  SelectionInitArray,
+  SelectionResolution,
+  SelectionType
+} from '../../selection';
+import {accessPathWithDatum, Dict} from '../../util';
+import {EventStream} from '../../vega.schema';
+import {FacetModel} from '../facet';
+import {isFacetModel, Model} from '../model';
+import {UnitModel} from '../unit';
+import interval from './interval';
+import multi from './multi';
+import single from './single';
+import {SelectionProjection, SelectionProjectionComponent} from './transforms/project';
+
+export const STORE = '_store';
+export const TUPLE = '_tuple';
+export const MODIFY = '_modify';
+export const SELECTION_DOMAIN = '_selection_domain_';
+export const VL_SELECTION_RESOLVE = 'vlSelectionResolve';
+
+export interface SelectionComponent<T extends SelectionType = SelectionType> {
+  name: string;
+  type: T;
+
+  // Use conditional typing (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-8.html)
+  // so we have stricter type of init (as the type of init depends on selection type)
+  init?: (T extends 'interval'
+    ? SelectionInitArray //
+    : T extends 'single'
+    ? SelectionInit
+    : SelectionInit | SelectionInit[])[]; // multi
+  events: EventStream;
+  // predicate?: string;
+  bind?: 'scales' | Binding | Dict<Binding>;
+  resolve: SelectionResolution;
+  empty: 'all' | 'none';
+  mark?: BrushConfig;
+
+  // Transforms
+  project?: SelectionProjectionComponent;
+  scales?: SelectionProjection[];
+  toggle?: any;
+  translate?: any;
+  zoom?: any;
+  nearest?: any;
+}
+
+export interface SelectionCompiler<T extends SelectionType = SelectionType> {
+  signals: (model: UnitModel, selCmpt: SelectionComponent<T>) => NewSignal[];
+  topLevelSignals?: (model: Model, selCmpt: SelectionComponent<T>, signals: NewSignal[]) => NewSignal[];
+  modifyExpr: (model: UnitModel, selCmpt: SelectionComponent<T>) => string;
+  marks?: (model: UnitModel, selCmpt: SelectionComponent<T>, marks: any[]) => any[];
+}
+
+const compilers: Dict<SelectionCompiler> = {single, multi, interval};
+
+export function forEachSelection(
+  model: Model,
+  cb: (selCmpt: SelectionComponent, selCompiler: SelectionCompiler) => void
+) {
+  const selections = model.component.selection;
+  for (const name in selections) {
+    if (selections.hasOwnProperty(name)) {
+      const sel = selections[name];
+      cb(sel, compilers[sel.type]);
+    }
+  }
+}
+
+function getFacetModel(model: Model): FacetModel {
+  let parent = model.parent;
+  while (parent) {
+    if (isFacetModel(parent)) {
+      break;
+    }
+    parent = parent.parent;
+  }
+
+  return parent as FacetModel;
+}
+
+export function unitName(model: Model) {
+  let name = stringValue(model.name);
+  const facetModel = getFacetModel(model);
+  if (facetModel) {
+    const {facet} = facetModel;
+    for (const channel of FACET_CHANNELS) {
+      if (facet[channel]) {
+        name += ` + '__facet_${channel}_' + (${accessPathWithDatum(facetModel.vgField(channel), 'facet')})`;
+      }
+    }
+  }
+  return name;
+}
+
+export function requiresSelectionId(model: Model) {
+  let identifier = false;
+  forEachSelection(model, selCmpt => {
+    identifier = identifier || selCmpt.project.some(proj => proj.field === SELECTION_ID);
+  });
+  return identifier;
+}
+
+export function isRawSelectionDomain(domainRaw: SignalRef) {
+  return domainRaw.signal.indexOf(SELECTION_DOMAIN) >= 0;
+}

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -1,21 +1,13 @@
 import {stringValue} from 'vega-util';
-import {X, Y} from '../../channel';
+import {ScaleChannel, X, Y} from '../../channel';
 import {warn} from '../../log';
 import {hasContinuousDomain} from '../../scale';
+import {SelectionInitArray} from '../../selection';
 import {keys} from '../../util';
 import {EventStream} from '../../vega.schema';
 import {UnitModel} from '../unit';
-import {
-  assembleInit,
-  channelSignalName,
-  positionalProjections,
-  SelectionCompiler,
-  SelectionComponent,
-  STORE,
-  TUPLE,
-  unitName
-} from './selection';
-import {TUPLE_FIELDS} from './transforms/project';
+import {assembleInit, SelectionCompiler, SelectionComponent, STORE, TUPLE, unitName} from './selection';
+import {SelectionProjection, TUPLE_FIELDS} from './transforms/project';
 import scales from './transforms/scales';
 
 export const BRUSH = '_brush';
@@ -24,7 +16,7 @@ export const SCALE_TRIGGER = '_scale_trigger';
 const interval: SelectionCompiler<'interval'> = {
   signals: (model, selCmpt) => {
     const name = selCmpt.name;
-    const fieldsSg = name + TUPLE + TUPLE_FIELDS;
+    const fieldsSg = name + TUPLE_FIELDS;
     const hasScales = scales.has(selCmpt);
     const signals: any[] = [];
     const dataSignals: string[] = [];
@@ -40,17 +32,18 @@ const interval: SelectionCompiler<'interval'> = {
       });
     }
 
-    selCmpt.project.forEach((p, i) => {
-      const channel = p.channel;
+    selCmpt.project.forEach((proj, i) => {
+      const channel = proj.channel;
       if (channel !== X && channel !== Y) {
         warn('Interval selections only support x and y encoding channels.');
         return;
       }
 
-      const cs = channelSignals(model, selCmpt, channel, i);
-      const dname = channelSignalName(selCmpt, channel, 'data');
-      const vname = channelSignalName(selCmpt, channel, 'visual');
-      const scaleStr = stringValue(model.scaleName(channel));
+      const init = selCmpt.init ? selCmpt.init[i] : null;
+      const cs = channelSignals(model, selCmpt, proj, init);
+      const dname = proj.signals.data;
+      const vname = proj.signals.visual;
+      const scaleName = stringValue(model.scaleName(channel));
       const scaleType = model.getScaleComponent(channel).get('type');
       const toNum = hasContinuousDomain(scaleType) ? '+' : '';
 
@@ -61,8 +54,8 @@ const interval: SelectionCompiler<'interval'> = {
         scaleName: model.scaleName(channel),
         expr:
           `(!isArray(${dname}) || ` +
-          `(${toNum}invert(${scaleStr}, ${vname})[0] === ${toNum}${dname}[0] && ` +
-          `${toNum}invert(${scaleStr}, ${vname})[1] === ${toNum}${dname}[1]))`
+          `(${toNum}invert(${scaleName}, ${vname})[0] === ${toNum}${dname}[0] && ` +
+          `${toNum}invert(${scaleName}, ${vname})[1] === ${toNum}${dname}[1]))`
       });
     });
 
@@ -99,7 +92,7 @@ const interval: SelectionCompiler<'interval'> = {
 
   marks: (model, selCmpt, marks) => {
     const name = selCmpt.name;
-    const {xi, yi} = positionalProjections(selCmpt);
+    const {x, y} = selCmpt.project.has;
     const store = `data(${stringValue(selCmpt.name + STORE)})`;
 
     // Do not add a brush if we're binding to scales.
@@ -108,10 +101,10 @@ const interval: SelectionCompiler<'interval'> = {
     }
 
     const update: any = {
-      x: xi !== null ? {signal: `${name}_x[0]`} : {value: 0},
-      y: yi !== null ? {signal: `${name}_y[0]`} : {value: 0},
-      x2: xi !== null ? {signal: `${name}_x[1]`} : {field: {group: 'width'}},
-      y2: yi !== null ? {signal: `${name}_y[1]`} : {field: {group: 'height'}}
+      x: x !== undefined ? {signal: `${name}_x[0]`} : {value: 0},
+      y: y !== undefined ? {signal: `${name}_y[0]`} : {value: 0},
+      x2: x !== undefined ? {signal: `${name}_x[1]`} : {field: {group: 'width'}},
+      y2: y !== undefined ? {signal: `${name}_y[1]`} : {field: {group: 'height'}}
     };
 
     // If the selection is resolved to global, only a single interval is in
@@ -137,8 +130,8 @@ const interval: SelectionCompiler<'interval'> = {
     const vgStroke = keys(stroke).reduce((def, k) => {
       def[k] = [
         {
-          test: [xi !== null && `${name}_x[0] !== ${name}_x[1]`, yi != null && `${name}_y[0] !== ${name}_y[1]`]
-            .filter(x => x)
+          test: [x !== undefined && `${name}_x[0] !== ${name}_x[1]`, y !== undefined && `${name}_y[0] !== ${name}_y[1]`]
+            .filter(t => t)
             .join(' && '),
           value: stroke[k]
         },
@@ -183,15 +176,15 @@ export default interval;
 function channelSignals(
   model: UnitModel,
   selCmpt: SelectionComponent<'interval'>,
-  channel: 'x' | 'y',
-  idx: number
+  proj: SelectionProjection,
+  init?: SelectionInitArray
 ): any {
-  const vname = channelSignalName(selCmpt, channel, 'visual');
-  const dname = channelSignalName(selCmpt, channel, 'data');
-  const init = selCmpt.init && selCmpt.init[idx];
+  const channel = proj.channel;
+  const vname = proj.signals.visual;
+  const dname = proj.signals.data;
   const hasScales = scales.has(selCmpt);
   const scaleName = stringValue(model.scaleName(channel));
-  const scale = model.getScaleComponent(channel);
+  const scale = model.getScaleComponent(channel as ScaleChannel);
   const scaleType = scale ? scale.get('type') : undefined;
   const scaled = (str: string) => `scale(${scaleName}, ${str})`;
   const size = model.getSizeSignalRef(channel === X ? 'width' : 'height').signal;

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -1,4 +1,5 @@
 import {stringValue} from 'vega-util';
+import {SelectionCompiler, SelectionComponent, STORE, TUPLE, unitName} from '.';
 import {ScaleChannel, X, Y} from '../../channel';
 import {warn} from '../../log';
 import {hasContinuousDomain} from '../../scale';
@@ -6,7 +7,7 @@ import {SelectionInitArray} from '../../selection';
 import {keys} from '../../util';
 import {EventStream} from '../../vega.schema';
 import {UnitModel} from '../unit';
-import {assembleInit, SelectionCompiler, SelectionComponent, STORE, TUPLE, unitName} from './selection';
+import {assembleInit} from './assemble';
 import {SelectionProjection, TUPLE_FIELDS} from './transforms/project';
 import scales from './transforms/scales';
 

--- a/src/compile/selection/multi.ts
+++ b/src/compile/selection/multi.ts
@@ -1,8 +1,9 @@
 import {stringValue} from 'vega-util';
+import {SelectionCompiler, SelectionComponent, STORE, TUPLE, unitName} from '.';
 import {SelectionInit} from '../../selection';
 import {accessPathWithDatum} from '../../util';
 import {UnitModel} from '../unit';
-import {assembleInit, SelectionCompiler, SelectionComponent, STORE, TUPLE, unitName} from './selection';
+import {assembleInit} from './assemble';
 import {TUPLE_FIELDS} from './transforms/project';
 
 export function singleOrMultiSignals(model: UnitModel, selCmpt: SelectionComponent<'single' | 'multi'>) {

--- a/src/compile/selection/multi.ts
+++ b/src/compile/selection/multi.ts
@@ -7,7 +7,7 @@ import {TUPLE_FIELDS} from './transforms/project';
 
 export function singleOrMultiSignals(model: UnitModel, selCmpt: SelectionComponent<'single' | 'multi'>) {
   const name = selCmpt.name;
-  const fieldsSg = name + TUPLE + TUPLE_FIELDS;
+  const fieldsSg = name + TUPLE_FIELDS;
   const proj = selCmpt.project;
   const datum = '(item().isVoronoi ? datum.datum : datum)';
   const values = proj

--- a/src/compile/selection/parse.ts
+++ b/src/compile/selection/parse.ts
@@ -1,0 +1,60 @@
+import {selector as parseSelector} from 'vega-event-selector';
+import {isString} from 'vega-util';
+import {SelectionComponent} from '.';
+import {SelectionDef} from '../../selection';
+import {Dict, duplicate, varName} from '../../util';
+import {UnitModel} from '../unit';
+import {forEachTransform} from './transforms/transforms';
+
+export function parseUnitSelection(model: UnitModel, selDefs: Dict<SelectionDef>) {
+  const selCmpts: Dict<SelectionComponent<any /* this has to be "any" so typing won't fail in test files*/>> = {};
+  const selectionConfig = model.config.selection;
+
+  if (selDefs) {
+    selDefs = duplicate(selDefs); // duplicate to avoid side effects to original spec
+  }
+
+  for (let name in selDefs) {
+    if (!selDefs.hasOwnProperty(name)) {
+      continue;
+    }
+
+    const selDef = selDefs[name];
+    const cfg = selectionConfig[selDef.type];
+
+    // Set default values from config if a property hasn't been specified,
+    // or if it is true. E.g., "translate": true should use the default
+    // event handlers for translate. However, true may be a valid value for
+    // a property (e.g., "nearest": true).
+    for (const key in cfg) {
+      // A selection should contain either `encodings` or `fields`, only use
+      // default values for these two values if neither of them is specified.
+      if ((key === 'encodings' && selDef.fields) || (key === 'fields' && selDef.encodings)) {
+        continue;
+      }
+
+      if (key === 'mark') {
+        selDef[key] = {...cfg[key], ...selDef[key]};
+      }
+
+      if (selDef[key] === undefined || selDef[key] === true) {
+        selDef[key] = cfg[key] || selDef[key];
+      }
+    }
+
+    name = varName(name);
+    const selCmpt = (selCmpts[name] = {
+      ...selDef,
+      name: name,
+      events: isString(selDef.on) ? parseSelector(selDef.on, 'scope') : selDef.on
+    } as any);
+
+    forEachTransform(selCmpt, txCompiler => {
+      if (txCompiler.parse) {
+        txCompiler.parse(model, selDef, selCmpt);
+      }
+    });
+  }
+
+  return selCmpts;
+}

--- a/src/compile/selection/single.ts
+++ b/src/compile/selection/single.ts
@@ -1,5 +1,5 @@
+import {SelectionCompiler, TUPLE, unitName} from '.';
 import {singleOrMultiSignals} from './multi';
-import {SelectionCompiler, TUPLE, unitName} from './selection';
 
 const single: SelectionCompiler<'single'> = {
   signals: singleOrMultiSignals,

--- a/src/compile/selection/transforms/inputs.ts
+++ b/src/compile/selection/transforms/inputs.ts
@@ -1,5 +1,6 @@
+import {TUPLE} from '..';
 import {accessPathWithDatum, varName} from '../../../util';
-import {assembleInit, TUPLE} from '../selection';
+import {assembleInit} from '../assemble';
 import nearest from './nearest';
 import {TUPLE_FIELDS} from './project';
 import {TransformCompiler} from './transforms';

--- a/src/compile/selection/transforms/inputs.ts
+++ b/src/compile/selection/transforms/inputs.ts
@@ -41,7 +41,7 @@ const inputBindings: TransformCompiler = {
     const name = selCmpt.name;
     const proj = selCmpt.project;
     const signal = signals.filter(s => s.name === name + TUPLE)[0];
-    const fields = name + TUPLE + TUPLE_FIELDS;
+    const fields = name + TUPLE_FIELDS;
     const values = proj.map(p => varName(`${name}_${p.field}`));
     const valid = values.map(v => `${v} !== null`).join(' && ');
 

--- a/src/compile/selection/transforms/nearest.ts
+++ b/src/compile/selection/transforms/nearest.ts
@@ -1,6 +1,5 @@
 import * as log from '../../../log';
 import {isPathMark} from '../../../mark';
-import {positionalProjections} from '../selection';
 import {TransformCompiler} from './transforms';
 
 const VORONOI = 'voronoi';
@@ -11,7 +10,7 @@ const nearest: TransformCompiler = {
   },
 
   marks: (model, selCmpt, marks) => {
-    const {x, y} = positionalProjections(selCmpt);
+    const {x, y} = selCmpt.project.has;
     const markType = model.mark;
     if (isPathMark(markType)) {
       log.warn(log.message.nearestNotSupportForContinuous(markType));

--- a/src/compile/selection/transforms/project.ts
+++ b/src/compile/selection/transforms/project.ts
@@ -129,14 +129,17 @@ const project: TransformCompiler = {
     }
   },
 
-  signals: (model, selCmpt, signals) => {
+  signals: (model, selCmpt, allSignals) => {
     const name = selCmpt.name + TUPLE_FIELDS;
-    const hasSignal = signals.filter(s => s.name === name);
+    const hasSignal = allSignals.filter(s => s.name === name);
     return hasSignal.length
-      ? signals
-      : signals.concat({
+      ? allSignals
+      : allSignals.concat({
           name,
-          value: selCmpt.project
+          value: selCmpt.project.map(proj => {
+            const {signals, ...rest} = proj;
+            return rest;
+          })
         });
   }
 };

--- a/src/compile/selection/transforms/project.ts
+++ b/src/compile/selection/transforms/project.ts
@@ -1,11 +1,11 @@
 import {isArray} from 'vega-util';
+import {SelectionComponent} from '..';
 import {ScaleChannel, SingleDefChannel} from '../../../channel';
 import * as log from '../../../log';
 import {hasContinuousDomain} from '../../../scale';
 import {isIntervalSelection, SelectionDef, SelectionInitArrayMapping, SelectionInitMapping} from '../../../selection';
 import {Dict, keys, varName} from '../../../util';
 import {TimeUnitComponent, TimeUnitNode} from '../../data/timeunit';
-import {SelectionComponent} from '../selection';
 import scales from './scales';
 import {TransformCompiler} from './transforms';
 

--- a/src/compile/selection/transforms/project.ts
+++ b/src/compile/selection/transforms/project.ts
@@ -1,15 +1,38 @@
 import {isArray} from 'vega-util';
-import {ScaleChannel} from '../../../channel';
+import {ScaleChannel, SingleDefChannel} from '../../../channel';
 import * as log from '../../../log';
 import {hasContinuousDomain} from '../../../scale';
 import {isIntervalSelection, SelectionDef, SelectionInitArrayMapping, SelectionInitMapping} from '../../../selection';
-import {Dict, keys} from '../../../util';
+import {Dict, keys, varName} from '../../../util';
 import {TimeUnitComponent, TimeUnitNode} from '../../data/timeunit';
-import {ProjectSelectionComponent, SelectionComponent, TUPLE, TupleStoreType} from '../selection';
+import {SelectionComponent} from '../selection';
 import scales from './scales';
 import {TransformCompiler} from './transforms';
 
-export const TUPLE_FIELDS = '_fields';
+export const TUPLE_FIELDS = '_tuple_fields';
+
+/**
+ * Do the selection tuples hold enumerated or ranged values for a field?
+ * Ranged values can be left-right inclusive (R) or left-inclusive, right-exclusive (R-LE).
+ */
+export type TupleStoreType = 'E' | 'R' | 'R-RE';
+
+export interface SelectionProjection {
+  type: TupleStoreType;
+  field: string;
+  channel?: SingleDefChannel;
+  signals?: {data?: string; visual?: string};
+}
+
+export class SelectionProjectionComponent extends Array<SelectionProjection> {
+  public has: {[key in SingleDefChannel]?: SelectionProjection};
+  public timeUnit?: TimeUnitNode;
+  constructor(...items: SelectionProjection[]) {
+    super(...items);
+    (this as any).__proto__ = SelectionProjectionComponent.prototype;
+    this.has = {};
+  }
+}
 
 const project: TransformCompiler = {
   has: (selDef: SelectionComponent | SelectionDef) => {
@@ -18,16 +41,26 @@ const project: TransformCompiler = {
   },
 
   parse: (model, selDef, selCmpt) => {
+    const name = selCmpt.name;
+    const proj = selCmpt.project || (selCmpt.project = new SelectionProjectionComponent());
+    const parsed: Dict<SelectionProjection> = {};
     const timeUnits: Dict<TimeUnitComponent> = {};
-    const f: Dict<ProjectSelectionComponent> = {};
 
-    // Selection component may already have a projection from the config. (Interval selection will have `encodings: ['x', 'y'].)
-    const proj = selCmpt.project || (selCmpt.project = []);
-    selCmpt.fields = {};
+    const signals = {};
+    const signalName = (p: SelectionProjection, range: 'data' | 'visual') => {
+      const suffix = range === 'visual' ? p.channel : p.field;
+      let sg = varName(`${name}_${suffix}`);
+      for (let counter = 1; signals[sg]; counter++) {
+        sg = varName(`${name}_${suffix}_${counter}`);
+      }
+      return {[range]: signals[sg] = sg};
+    };
 
     // TODO: find a possible channel mapping for these fields.
-    if (selDef.fields) {
-      proj.push(...selDef.fields.map<ProjectSelectionComponent>(field => ({field, type: 'E'})));
+    for (const field of selDef.fields || []) {
+      const p: SelectionProjection = {type: 'E', field};
+      p.signals = {...signalName(p, 'data')};
+      proj.push(p);
     }
 
     for (const channel of selDef.encodings || []) {
@@ -50,7 +83,7 @@ const project: TransformCompiler = {
 
         // Prevent duplicate projections on the same field.
         // TODO: what if the same field is bound to multiple channels (e.g., SPLOM diag).
-        if (!f[field]) {
+        if (!parsed[field]) {
           // Determine whether the tuple will store enumerated or ranged values.
           // Interval selections store ranges for continuous scales, and enumerations otherwise.
           // Single/multi selections store ranges for binned fields, and enumerations otherwise.
@@ -64,10 +97,11 @@ const project: TransformCompiler = {
             type = 'R-RE';
           }
 
-          proj.push((f[field] = {field, channel, type}));
+          const p: SelectionProjection = {field, channel, type};
+          p.signals = {...signalName(p, 'data'), ...signalName(p, 'visual')};
+          proj.push((parsed[field] = p));
+          proj.has[channel] = parsed[field];
         }
-
-        selCmpt.fields[channel] = field;
       } else {
         log.warn(log.message.cannotProjectOnChannelWithoutField(channel));
       }
@@ -91,12 +125,12 @@ const project: TransformCompiler = {
     }
 
     if (keys(timeUnits).length) {
-      selCmpt.timeUnit = new TimeUnitNode(null, timeUnits);
+      proj.timeUnit = new TimeUnitNode(null, timeUnits);
     }
   },
 
   signals: (model, selCmpt, signals) => {
-    const name = selCmpt.name + TUPLE + TUPLE_FIELDS;
+    const name = selCmpt.name + TUPLE_FIELDS;
     const hasSignal = signals.filter(s => s.name === name);
     return hasSignal.length
       ? signals

--- a/src/compile/selection/transforms/scales.ts
+++ b/src/compile/selection/transforms/scales.ts
@@ -4,7 +4,8 @@ import * as log from '../../../log';
 import {hasContinuousDomain} from '../../../scale';
 import {accessPathWithDatum, varName} from '../../../util';
 import {UnitModel} from '../../unit';
-import {channelSignalName, VL_SELECTION_RESOLVE} from '../selection';
+import {VL_SELECTION_RESOLVE} from '../selection';
+import {SelectionProjection} from './project';
 import {TransformCompiler} from './transforms';
 
 const scaleBindings: TransformCompiler = {
@@ -14,10 +15,10 @@ const scaleBindings: TransformCompiler = {
 
   parse: (model, selDef, selCmpt) => {
     const name = varName(selCmpt.name);
-    const bound: Channel[] = (selCmpt.scales = []);
+    const bound: SelectionProjection[] = (selCmpt.scales = []);
 
-    for (const p of selCmpt.project) {
-      const channel = p.channel;
+    for (const proj of selCmpt.project) {
+      const channel = proj.channel;
 
       if (!isScaleChannel(channel)) {
         continue;
@@ -31,29 +32,23 @@ const scaleBindings: TransformCompiler = {
         continue;
       }
 
-      scale.set('domainRaw', {signal: accessPathWithDatum(p.field, name)}, true);
-      bound.push(channel);
+      scale.set('domainRaw', {signal: accessPathWithDatum(proj.field, name)}, true);
+      bound.push(proj);
 
       // Bind both x/y for diag plot of repeated views.
       if (model.repeater && model.repeater.row === model.repeater.column) {
         const scale2 = model.getScaleComponent(channel === X ? Y : X);
-        scale2.set('domainRaw', {signal: accessPathWithDatum(p.field, name)}, true);
+        scale2.set('domainRaw', {signal: accessPathWithDatum(proj.field, name)}, true);
       }
     }
   },
 
   topLevelSignals: (model, selCmpt, signals) => {
-    const channelSignals = selCmpt.scales
-      .filter(channel => {
-        return !signals.filter(s => s.name === channelSignalName(selCmpt, channel, 'data')).length;
-      })
-      .map(channel => {
-        return {channel, signal: channelSignalName(selCmpt, channel, 'data')};
-      });
+    const bound = selCmpt.scales.filter(proj => !signals.filter(s => s.name === proj.signals.data).length);
 
     // Top-level signals are only needed for multiview displays and if this
     // view's top-level signals haven't already been generated.
-    if (!model.parent || !channelSignals.length) {
+    if (!model.parent || !bound.length) {
       return signals;
     }
 
@@ -66,27 +61,24 @@ const scaleBindings: TransformCompiler = {
     const namedSg = signals.filter(s => s.name === selCmpt.name)[0];
     const update = namedSg.update;
     if (update.indexOf(VL_SELECTION_RESOLVE) >= 0) {
-      namedSg.update =
-        '{' + channelSignals.map(cs => `${stringValue(selCmpt.fields[cs.channel])}: ${cs.signal}`).join(', ') + '}';
+      namedSg.update = `{${bound.map(proj => `${stringValue(proj.field)}: ${proj.signals.data}`).join(', ')}}`;
     } else {
-      for (const cs of channelSignals) {
-        const mapping = `, ${stringValue(selCmpt.fields[cs.channel])}: ${cs.signal}`;
+      for (const proj of bound) {
+        const mapping = `, ${stringValue(proj.field)}: ${proj.signals.data}`;
         if (update.indexOf(mapping) < 0) {
           namedSg.update = update.substring(0, update.length - 1) + mapping + '}';
         }
       }
     }
 
-    return signals.concat(channelSignals.map(cs => ({name: cs.signal})));
+    return signals.concat(bound.map(proj => ({name: proj.signals.data})));
   },
 
   signals: (model, selCmpt, signals) => {
     // Nested signals need only push to top-level signals with multiview displays.
     if (model.parent) {
-      for (const channel of selCmpt.scales) {
-        const signal: any = signals.filter(s => s.name === channelSignalName(selCmpt, channel, 'data'))[0];
-
-        // convert to PushSignal
+      for (const proj of selCmpt.scales) {
+        const signal: any = signals.filter(s => s.name === proj.signals.data)[0];
         signal.push = 'outer';
         delete signal.value;
         delete signal.update;

--- a/src/compile/selection/transforms/scales.ts
+++ b/src/compile/selection/transforms/scales.ts
@@ -1,10 +1,10 @@
 import {stringValue} from 'vega-util';
+import {VL_SELECTION_RESOLVE} from '..';
 import {Channel, isScaleChannel, X, Y} from '../../../channel';
 import * as log from '../../../log';
 import {hasContinuousDomain} from '../../../scale';
 import {accessPathWithDatum, varName} from '../../../util';
 import {UnitModel} from '../../unit';
-import {VL_SELECTION_RESOLVE} from '../selection';
 import {SelectionProjection} from './project';
 import {TransformCompiler} from './transforms';
 

--- a/src/compile/selection/transforms/toggle.ts
+++ b/src/compile/selection/transforms/toggle.ts
@@ -1,4 +1,4 @@
-import {TUPLE, unitName} from '../selection';
+import {TUPLE, unitName} from '..';
 import {TransformCompiler} from './transforms';
 
 const TOGGLE = '_toggle';

--- a/src/compile/selection/transforms/transforms.ts
+++ b/src/compile/selection/transforms/transforms.ts
@@ -1,9 +1,9 @@
 import {NewSignal, Signal} from 'vega';
+import {SelectionComponent} from '..';
 import {SelectionDef} from '../../../selection';
 import {Dict} from '../../../util';
 import {Model} from '../../model';
 import {UnitModel} from '../../unit';
-import {SelectionComponent} from '../selection';
 import inputs from './inputs';
 import nearest from './nearest';
 import project from './project';

--- a/src/compile/selection/transforms/translate.ts
+++ b/src/compile/selection/transforms/translate.ts
@@ -1,9 +1,9 @@
 import {NewSignal} from 'vega';
 import {selector as parseSelector} from 'vega-event-selector';
+import {SelectionComponent} from '..';
 import {ScaleChannel, X, Y} from '../../../channel';
 import {UnitModel} from '../../unit';
 import {BRUSH as INTERVAL_BRUSH} from '../interval';
-import {SelectionComponent} from '../selection';
 import {SelectionProjection} from './project';
 import scalesCompiler, {domain} from './scales';
 import {TransformCompiler} from './transforms';

--- a/src/compile/selection/transforms/translate.ts
+++ b/src/compile/selection/transforms/translate.ts
@@ -3,7 +3,8 @@ import {selector as parseSelector} from 'vega-event-selector';
 import {ScaleChannel, X, Y} from '../../../channel';
 import {UnitModel} from '../../unit';
 import {BRUSH as INTERVAL_BRUSH} from '../interval';
-import {channelSignalName, positionalProjections, SelectionComponent} from '../selection';
+import {SelectionComponent} from '../selection';
+import {SelectionProjection} from './project';
 import scalesCompiler, {domain} from './scales';
 import {TransformCompiler} from './transforms';
 
@@ -19,7 +20,7 @@ const translate: TransformCompiler = {
     const name = selCmpt.name;
     const hasScales = scalesCompiler.has(selCmpt);
     const anchor = name + ANCHOR;
-    const {x, y} = positionalProjections(selCmpt);
+    const {x, y} = selCmpt.project.has;
     let events = parseSelector(selCmpt.translate, 'scope');
 
     if (!hasScales) {
@@ -35,14 +36,8 @@ const translate: TransformCompiler = {
             events: events.map(e => e.between[0]),
             update:
               '{x: x(unit), y: y(unit)' +
-              (x !== null
-                ? ', extent_x: ' +
-                  (hasScales ? domain(model, X) : `slice(${channelSignalName(selCmpt, 'x', 'visual')})`)
-                : '') +
-              (y !== null
-                ? ', extent_y: ' +
-                  (hasScales ? domain(model, Y) : `slice(${channelSignalName(selCmpt, 'y', 'visual')})`)
-                : '') +
+              (x !== undefined ? ', extent_x: ' + (hasScales ? domain(model, X) : `slice(${x.signals.visual})`) : '') +
+              (y !== undefined ? ', extent_y: ' + (hasScales ? domain(model, Y) : `slice(${y.signals.visual})`) : '') +
               '}'
           }
         ]
@@ -59,12 +54,12 @@ const translate: TransformCompiler = {
       }
     );
 
-    if (x !== null) {
-      onDelta(model, selCmpt, X, 'width', signals);
+    if (x !== undefined) {
+      onDelta(model, selCmpt, x, 'width', signals);
     }
 
-    if (y !== null) {
-      onDelta(model, selCmpt, Y, 'height', signals);
+    if (y !== undefined) {
+      onDelta(model, selCmpt, y, 'height', signals);
     }
 
     return signals;
@@ -76,17 +71,16 @@ export default translate;
 function onDelta(
   model: UnitModel,
   selCmpt: SelectionComponent,
-  channel: ScaleChannel,
+  proj: SelectionProjection,
   size: 'width' | 'height',
   signals: NewSignal[]
 ) {
   const name = selCmpt.name;
-  const hasScales = scalesCompiler.has(selCmpt);
-  const signal = signals.filter(s => {
-    return s.name === channelSignalName(selCmpt, channel, hasScales ? 'data' : 'visual');
-  })[0];
   const anchor = name + ANCHOR;
   const delta = name + DELTA;
+  const channel = proj.channel as ScaleChannel;
+  const hasScales = scalesCompiler.has(selCmpt);
+  const signal = signals.filter(s => s.name === proj.signals[hasScales ? 'data' : 'visual'])[0];
   const sizeSg = model.getSizeSignalRef(size).signal;
   const scaleCmpt = model.getScaleComponent(channel);
   const scaleType = scaleCmpt.get('type');

--- a/src/compile/selection/transforms/zoom.ts
+++ b/src/compile/selection/transforms/zoom.ts
@@ -1,10 +1,10 @@
 import {NewSignal} from 'vega';
 import {selector as parseSelector} from 'vega-event-selector';
 import {stringValue} from 'vega-util';
+import {SelectionComponent} from '..';
 import {ScaleChannel, X, Y} from '../../../channel';
 import {UnitModel} from '../../unit';
 import {BRUSH as INTERVAL_BRUSH} from '../interval';
-import {SelectionComponent} from '../selection';
 import {SelectionProjection} from './project';
 import {default as scalesCompiler, domain} from './scales';
 import {TransformCompiler} from './transforms';

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -40,9 +40,9 @@ import {
   assembleTopLevelSignals,
   assembleUnitSelectionData,
   assembleUnitSelectionMarks,
-  assembleUnitSelectionSignals,
-  parseUnitSelection
-} from './selection/selection';
+  assembleUnitSelectionSignals
+} from './selection/assemble';
+import {parseUnitSelection} from './selection/parse';
 
 /**
  * Internal model of Vega-Lite specification for the compiler.

--- a/test/compile/scale/parse.test.ts
+++ b/test/compile/scale/parse.test.ts
@@ -2,7 +2,7 @@
 
 import {toSet} from 'vega-util';
 import {parseScaleCore, parseScales} from '../../../src/compile/scale/parse';
-import {SELECTION_DOMAIN} from '../../../src/compile/selection/selection';
+import {SELECTION_DOMAIN} from '../../../src/compile/selection';
 import * as log from '../../../src/log';
 import {NON_TYPE_DOMAIN_RANGE_VEGA_SCALE_PROPERTIES, SCALE_PROPERTIES} from '../../../src/scale';
 import {without} from '../../../src/util';

--- a/test/compile/selection/facets.test.ts
+++ b/test/compile/selection/facets.test.ts
@@ -1,7 +1,8 @@
 /* tslint:disable quotemark */
 
 import {FacetModel} from '../../../src/compile/facet';
-import * as selection from '../../../src/compile/selection/selection';
+import {unitName} from '../../../src/compile/selection';
+import {assembleFacetSignals} from '../../../src/compile/selection/assemble';
 import {UnitModel} from '../../../src/compile/unit';
 import {parseModel} from '../../util';
 
@@ -37,7 +38,7 @@ describe('Faceted Selections', () => {
   const unit = model.children[0].children[1] as UnitModel;
 
   it('should assemble a facet signal', () => {
-    expect(selection.assembleFacetSignals(model as FacetModel, [])).toContainEqual({
+    expect(assembleFacetSignals(model as FacetModel, [])).toContainEqual({
       name: 'facet',
       value: {},
       on: [
@@ -50,7 +51,7 @@ describe('Faceted Selections', () => {
   });
 
   it('should name the unit with the facet keys', () => {
-    expect(selection.unitName(unit)).toEqual(
+    expect(unitName(unit)).toEqual(
       `"child_layer_1" + '__facet_row_' + (facet["bin_maxbins_6_X"]) + '__facet_column_' + (facet["Series"])`
     );
   });

--- a/test/compile/selection/inputs.test.ts
+++ b/test/compile/selection/inputs.test.ts
@@ -1,6 +1,7 @@
 /* tslint:disable quotemark */
 
-import * as selection from '../../../src/compile/selection/selection';
+import {assembleTopLevelSignals, assembleUnitSelectionSignals} from '../../../src/compile/selection/assemble';
+import {parseUnitSelection} from '../../../src/compile/selection/parse';
 import inputs from '../../../src/compile/selection/transforms/inputs';
 import {parseUnitModel} from '../../util';
 
@@ -15,7 +16,7 @@ describe('Inputs Selection Transform', () => {
   });
 
   model.parseScale();
-  const selCmpts = selection.parseUnitSelection(model, {
+  const selCmpts = parseUnitSelection(model, {
     one: {
       type: 'single',
       bind: {input: 'range', min: 0, max: 10, step: 1}
@@ -65,12 +66,12 @@ describe('Inputs Selection Transform', () => {
 
   it('adds widget binding for default projection', () => {
     model.component.selection = {one: selCmpts['one']};
-    expect(selection.assembleUnitSelectionSignals(model, [])).toContainEqual({
+    expect(assembleUnitSelectionSignals(model, [])).toContainEqual({
       name: 'one_tuple',
       update: 'one__vgsid_ !== null ? {fields: one_tuple_fields, values: [one__vgsid_]} : null'
     });
 
-    expect(selection.assembleTopLevelSignals(model, [])).toContainEqual({
+    expect(assembleTopLevelSignals(model, [])).toContainEqual({
       name: 'one__vgsid_',
       value: null,
       on: [
@@ -85,13 +86,13 @@ describe('Inputs Selection Transform', () => {
 
   it('adds single widget binding for compound projection', () => {
     model.component.selection = {two: selCmpts['two']};
-    expect(selection.assembleUnitSelectionSignals(model, [])).toContainEqual({
+    expect(assembleUnitSelectionSignals(model, [])).toContainEqual({
       name: 'two_tuple',
       update:
         'two_Cylinders !== null && two_Horsepower !== null ? {fields: two_tuple_fields, values: [two_Cylinders, two_Horsepower]} : null'
     });
 
-    expect(selection.assembleTopLevelSignals(model, [])).toEqual(
+    expect(assembleTopLevelSignals(model, [])).toEqual(
       expect.arrayContaining([
         {
           name: 'two_Horsepower',
@@ -121,13 +122,13 @@ describe('Inputs Selection Transform', () => {
 
   it('adds projection-specific widget bindings', () => {
     model.component.selection = {three: selCmpts['three']};
-    expect(selection.assembleUnitSelectionSignals(model, [])).toContainEqual({
+    expect(assembleUnitSelectionSignals(model, [])).toContainEqual({
       name: 'three_tuple',
       update:
         'three_Cylinders !== null && three_Origin !== null ? {fields: three_tuple_fields, values: [three_Cylinders, three_Origin]} : null'
     });
 
-    expect(selection.assembleTopLevelSignals(model, [])).toEqual(
+    expect(assembleTopLevelSignals(model, [])).toEqual(
       expect.arrayContaining([
         {
           name: 'three_Origin',
@@ -168,7 +169,7 @@ describe('Inputs Selection Transform', () => {
 
   it('respects initialization', () => {
     model.component.selection = {seven: selCmpts['seven']};
-    expect(selection.assembleUnitSelectionSignals(model, [])).toEqual(
+    expect(assembleUnitSelectionSignals(model, [])).toEqual(
       expect.arrayContaining([
         {
           name: 'seven_tuple',
@@ -177,7 +178,7 @@ describe('Inputs Selection Transform', () => {
       ])
     );
 
-    expect(selection.assembleTopLevelSignals(model, [])).toEqual(
+    expect(assembleTopLevelSignals(model, [])).toEqual(
       expect.arrayContaining([
         {
           name: 'seven_Year',

--- a/test/compile/selection/interval.test.ts
+++ b/test/compile/selection/interval.test.ts
@@ -1,9 +1,9 @@
 /* tslint:disable quotemark */
 
 import {selector as parseSelector} from 'vega-event-selector';
-
+import {assembleUnitSelectionSignals} from '../../../src/compile/selection/assemble';
 import interval from '../../../src/compile/selection/interval';
-import * as selection from '../../../src/compile/selection/selection';
+import {parseUnitSelection} from '../../../src/compile/selection/parse';
 import {parseUnitModel} from '../../util';
 
 describe('Interval Selections', () => {
@@ -17,7 +17,7 @@ describe('Interval Selections', () => {
   });
   model.parseScale();
 
-  const selCmpts = (model.component.selection = selection.parseUnitSelection(model, {
+  const selCmpts = (model.component.selection = parseUnitSelection(model, {
     one: {type: 'interval', encodings: ['x'], translate: false, zoom: false},
     two: {
       type: 'interval',
@@ -411,7 +411,7 @@ describe('Interval Selections', () => {
 
       model2.parseScale();
 
-      const selCmpts2 = (model2.component.selection = selection.parseUnitSelection(model2, {
+      const selCmpts2 = (model2.component.selection = parseUnitSelection(model2, {
         one: {
           type: 'interval',
           encodings: ['x'],
@@ -436,7 +436,7 @@ describe('Interval Selections', () => {
     const threeExpr = interval.modifyExpr(model, selCmpts['thr_ee']);
     expect(threeExpr).toEqual('thr_ee_tuple, {unit: ""}');
 
-    const signals = selection.assembleUnitSelectionSignals(model, []);
+    const signals = assembleUnitSelectionSignals(model, []);
     expect(signals).toEqual(
       expect.arrayContaining([
         {

--- a/test/compile/selection/interval.test.ts
+++ b/test/compile/selection/interval.test.ts
@@ -421,8 +421,8 @@ describe('Interval Selections', () => {
       }));
 
       const sg = interval.signals(model, selCmpts2['one']);
-      expect(sg[0].name).toEqual('one_x');
-      expect(sg[1].name).toEqual('one_x_1');
+      expect(sg[0].name).toEqual('one_x_1');
+      expect(sg[1].name).toEqual('one_x');
     });
   });
 

--- a/test/compile/selection/layers.test.ts
+++ b/test/compile/selection/layers.test.ts
@@ -1,6 +1,6 @@
 /* tslint:disable quotemark */
 
-import * as selection from '../../../src/compile/selection/selection';
+import * as selection from '../../../src/compile/selection';
 import {UnitModel} from '../../../src/compile/unit';
 import {parseLayerModel} from '../../util';
 

--- a/test/compile/selection/multi.test.ts
+++ b/test/compile/selection/multi.test.ts
@@ -1,6 +1,11 @@
 /* tslint:disable quotemark */
+import {
+  assembleUnitSelectionData,
+  assembleUnitSelectionMarks,
+  assembleUnitSelectionSignals
+} from '../../../src/compile/selection/assemble';
 import multi from '../../../src/compile/selection/multi';
-import * as selection from '../../../src/compile/selection/selection';
+import {parseUnitSelection} from '../../../src/compile/selection/parse';
 import {parseUnitModelWithScale} from '../../util';
 
 describe('Multi Selection', () => {
@@ -13,7 +18,7 @@ describe('Multi Selection', () => {
     }
   });
 
-  const selCmpts = (model.component.selection = selection.parseUnitSelection(model, {
+  const selCmpts = (model.component.selection = parseUnitSelection(model, {
     one: {type: 'multi'},
     two: {
       type: 'multi',
@@ -137,13 +142,13 @@ describe('Multi Selection', () => {
       }
     ]);
 
-    const signals = selection.assembleUnitSelectionSignals(model, []);
+    const signals = assembleUnitSelectionSignals(model, []);
     expect(signals).toEqual(expect.arrayContaining([...oneSg, ...twoSg, ...threeSg, ...fourSg, ...fiveSg]));
   });
 
   it('builds unit datasets', () => {
     const data: any[] = [];
-    expect(selection.assembleUnitSelectionData(model, data)).toEqual([
+    expect(assembleUnitSelectionData(model, data)).toEqual([
       {name: 'one_store'},
       {name: 'two_store'},
       {name: 'thr_ee_store'},
@@ -155,6 +160,6 @@ describe('Multi Selection', () => {
   it('leaves marks alone', () => {
     const marks: any[] = [];
     model.component.selection = {one: selCmpts['one']};
-    expect(selection.assembleUnitSelectionMarks(model, marks)).toEqual(marks);
+    expect(assembleUnitSelectionMarks(model, marks)).toEqual(marks);
   });
 });

--- a/test/compile/selection/nearest.test.ts
+++ b/test/compile/selection/nearest.test.ts
@@ -1,6 +1,6 @@
 /* tslint:disable quotemark */
 
-import * as selection from '../../../src/compile/selection/selection';
+import {parseUnitSelection} from '../../../src/compile/selection/parse';
 import nearest from '../../../src/compile/selection/transforms/nearest';
 import * as log from '../../../src/log';
 import {duplicate} from '../../../src/util';
@@ -17,7 +17,7 @@ function getModel(markType: any) {
   });
   model.parseScale();
   model.parseMarkGroup();
-  model.component.selection = selection.parseUnitSelection(model, {
+  model.component.selection = parseUnitSelection(model, {
     one: {type: 'single', nearest: true},
     two: {type: 'multi', nearest: true},
     three: {type: 'interval'},

--- a/test/compile/selection/parse.test.ts
+++ b/test/compile/selection/parse.test.ts
@@ -1,7 +1,7 @@
 /* tslint:disable quotemark */
 
 import {selector as parseSelector} from 'vega-event-selector';
-import * as selection from '../../../src/compile/selection/selection';
+import {parseUnitSelection} from '../../../src/compile/selection/parse';
 import {SelectionProjectionComponent} from '../../../src/compile/selection/transforms/project';
 import {keys} from '../../../src/util';
 import {parseUnitModel} from '../../util';
@@ -19,7 +19,7 @@ describe('Selection', () => {
   model.parseScale();
 
   it('parses default selection definitions', () => {
-    const component = selection.parseUnitSelection(model, {
+    const component = parseUnitSelection(model, {
       one: {type: 'single'},
       two: {type: 'multi'},
       three: {type: 'interval'}
@@ -63,7 +63,7 @@ describe('Selection', () => {
   });
 
   it('supports inline default overrides', () => {
-    const component = selection.parseUnitSelection(model, {
+    const component = parseUnitSelection(model, {
       one: {
         type: 'single',
         on: 'dblclick',
@@ -133,7 +133,7 @@ describe('Selection', () => {
       }
     };
 
-    const component = selection.parseUnitSelection(model, {
+    const component = parseUnitSelection(model, {
       one: {type: 'single'},
       two: {type: 'multi'},
       three: {type: 'interval'}
@@ -189,7 +189,7 @@ describe('Selection', () => {
 
       m.parseScale();
 
-      let c = selection.parseUnitSelection(m, {
+      let c = parseUnitSelection(m, {
         one: {type: 'interval', encodings: ['x']}
       });
 
@@ -209,7 +209,7 @@ describe('Selection', () => {
 
       m.parseScale();
 
-      c = selection.parseUnitSelection(m, {
+      c = parseUnitSelection(m, {
         one: {type: 'interval', encodings: ['x']}
       });
 
@@ -231,7 +231,7 @@ describe('Selection', () => {
 
       m.parseScale();
 
-      let c = selection.parseUnitSelection(m, {
+      let c = parseUnitSelection(m, {
         one: {type: 'single', encodings: ['x']}
       });
 
@@ -251,7 +251,7 @@ describe('Selection', () => {
 
       m.parseScale();
 
-      c = selection.parseUnitSelection(m, {
+      c = parseUnitSelection(m, {
         one: {type: 'multi', encodings: ['x']}
       });
 

--- a/test/compile/selection/parse.test.ts
+++ b/test/compile/selection/parse.test.ts
@@ -2,6 +2,7 @@
 
 import {selector as parseSelector} from 'vega-event-selector';
 import * as selection from '../../../src/compile/selection/selection';
+import {SelectionProjectionComponent} from '../../../src/compile/selection/transforms/project';
 import {keys} from '../../../src/util';
 import {parseUnitModel} from '../../util';
 
@@ -28,23 +29,32 @@ describe('Selection', () => {
 
     expect(component.one.name).toBe('one');
     expect(component.one.type).toBe('single');
-    expect(component['one'].project).toEqual([{field: '_vgsid_', type: 'E'}]);
+    expect<SelectionProjectionComponent>(component['one'].project).toEqual(
+      expect.arrayContaining([{field: '_vgsid_', type: 'E', signals: {data: 'one__vgsid_'}}])
+    );
     expect(component['one'].events).toEqual(parseSelector('click', 'scope'));
 
     expect(component.two.name).toBe('two');
     expect(component.two.type).toBe('multi');
     expect(component.two.toggle).toEqual('event.shiftKey');
-    expect(component['two'].project).toEqual([{field: '_vgsid_', type: 'E'}]);
+    expect<SelectionProjectionComponent>(component['two'].project).toEqual(
+      expect.arrayContaining([{field: '_vgsid_', type: 'E', signals: {data: 'two__vgsid_'}}])
+    );
     expect(component['two'].events).toEqual(parseSelector('click', 'scope'));
 
     expect(component.three.name).toBe('three');
     expect(component.three.type).toBe('interval');
     expect(component.three.translate).toEqual('[mousedown, window:mouseup] > window:mousemove!');
     expect(component.three.zoom).toEqual('wheel!');
-    expect(component['three'].project).toEqual(
+    expect<SelectionProjectionComponent>(component['three'].project).toEqual(
       expect.arrayContaining([
-        {field: 'Horsepower', channel: 'x', type: 'R'},
-        {field: 'Miles_per_Gallon', channel: 'y', type: 'R'}
+        {field: 'Horsepower', channel: 'x', type: 'R', signals: {data: 'three_Horsepower', visual: 'three_x'}},
+        {
+          field: 'Miles_per_Gallon',
+          channel: 'y',
+          type: 'R',
+          signals: {data: 'three_Miles_per_Gallon', visual: 'three_y'}
+        }
       ])
     );
     expect(component['three'].events).toEqual(
@@ -78,21 +88,34 @@ describe('Selection', () => {
 
     expect(component.one.name).toBe('one');
     expect(component.one.type).toBe('single');
-    expect(component['one'].project).toEqual([{field: 'Cylinders', type: 'E'}]);
+    expect<SelectionProjectionComponent>(component['one'].project).toEqual(
+      expect.arrayContaining([{field: 'Cylinders', type: 'E', signals: {data: 'one_Cylinders'}}])
+    );
     expect(component['one'].events).toEqual(parseSelector('dblclick', 'scope'));
 
     expect(component.two.name).toBe('two');
     expect(component.two.type).toBe('multi');
     expect(component.two.toggle).toEqual('event.ctrlKey');
-    expect(component['two'].project).toEqual(expect.arrayContaining([{field: 'Origin', channel: 'color', type: 'E'}]));
+    expect<SelectionProjectionComponent>(component['two'].project).toEqual(
+      expect.arrayContaining([
+        {field: 'Origin', channel: 'color', type: 'E', signals: {data: 'two_Origin', visual: 'two_color'}}
+      ])
+    );
     expect(component['two'].events).toEqual(parseSelector('mouseover', 'scope'));
 
     expect(component.three.name).toBe('three');
     expect(component.three.type).toBe('interval');
     expect(component.three.translate).toEqual(false);
     expect(component.three.zoom).toEqual('wheel[event.altKey]');
-    expect(component['three'].project).toEqual(
-      expect.arrayContaining([{field: 'Miles_per_Gallon', channel: 'y', type: 'R'}])
+    expect<SelectionProjectionComponent>(component['three'].project).toEqual(
+      expect.arrayContaining([
+        {
+          field: 'Miles_per_Gallon',
+          channel: 'y',
+          type: 'R',
+          signals: {data: 'three_Miles_per_Gallon', visual: 'three_y'}
+        }
+      ])
     );
     expect(component['three'].events).toEqual(
       parseSelector('[mousedown[!event.shiftKey], mouseup] > mousemove', 'scope')
@@ -120,21 +143,34 @@ describe('Selection', () => {
 
     expect(component.one.name).toBe('one');
     expect(component.one.type).toBe('single');
-    expect(component['one'].project).toEqual([{field: 'Cylinders', type: 'E'}]);
+    expect<SelectionProjectionComponent>(component['one'].project).toEqual(
+      expect.arrayContaining([{field: 'Cylinders', type: 'E', signals: {data: 'one_Cylinders'}}])
+    );
     expect(component['one'].events).toEqual(parseSelector('dblclick', 'scope'));
 
     expect(component.two.name).toBe('two');
     expect(component.two.type).toBe('multi');
     expect(component.two.toggle).toEqual('event.ctrlKey');
-    expect(component['two'].project).toEqual(expect.arrayContaining([{field: 'Origin', channel: 'color', type: 'E'}]));
+    expect<SelectionProjectionComponent>(component['two'].project).toEqual(
+      expect.arrayContaining([
+        {field: 'Origin', channel: 'color', type: 'E', signals: {data: 'two_Origin', visual: 'two_color'}}
+      ])
+    );
     expect(component['two'].events).toEqual(parseSelector('mouseover', 'scope'));
 
     expect(component.three.name).toBe('three');
     expect(component.three.type).toBe('interval');
     expect(!component.three.translate).toBeTruthy();
     expect(component.three.zoom).toEqual('wheel[event.altKey]');
-    expect(component['three'].project).toEqual(
-      expect.arrayContaining([{field: 'Miles_per_Gallon', channel: 'y', type: 'R'}])
+    expect<SelectionProjectionComponent>(component['three'].project).toEqual(
+      expect.arrayContaining([
+        {
+          field: 'Miles_per_Gallon',
+          channel: 'y',
+          type: 'R',
+          signals: {data: 'three_Miles_per_Gallon', visual: 'three_y'}
+        }
+      ])
     );
     expect(component['three'].events).toEqual(
       parseSelector('[mousedown[!event.shiftKey], mouseup] > mousemove', 'scope')
@@ -157,7 +193,11 @@ describe('Selection', () => {
         one: {type: 'interval', encodings: ['x']}
       });
 
-      expect(c['one'].project).toEqual([{field: 'Origin', channel: 'x', type: 'E'}]);
+      expect<SelectionProjectionComponent>(c['one'].project).toEqual(
+        expect.arrayContaining([
+          {field: 'Origin', channel: 'x', type: 'E', signals: {data: 'one_Origin', visual: 'one_x'}}
+        ])
+      );
 
       m = parseUnitModel({
         mark: 'bar',
@@ -173,7 +213,11 @@ describe('Selection', () => {
         one: {type: 'interval', encodings: ['x']}
       });
 
-      expect(c['one'].project).toEqual([{field: 'Origin', channel: 'x', type: 'E'}]);
+      expect<SelectionProjectionComponent>(c['one'].project).toEqual(
+        expect.arrayContaining([
+          {field: 'Origin', channel: 'x', type: 'E', signals: {data: 'one_Origin', visual: 'one_x'}}
+        ])
+      );
     });
 
     it('uses ranged types for single/multi selections', () => {
@@ -191,7 +235,11 @@ describe('Selection', () => {
         one: {type: 'single', encodings: ['x']}
       });
 
-      expect(c['one'].project).toEqual([{field: 'Acceleration', channel: 'x', type: 'R-RE'}]);
+      expect<SelectionProjectionComponent>(c['one'].project).toEqual(
+        expect.arrayContaining([
+          {field: 'Acceleration', channel: 'x', type: 'R-RE', signals: {data: 'one_Acceleration', visual: 'one_x'}}
+        ])
+      );
 
       m = parseUnitModel({
         mark: 'bar',
@@ -207,7 +255,11 @@ describe('Selection', () => {
         one: {type: 'multi', encodings: ['x']}
       });
 
-      expect(c['one'].project).toEqual([{field: 'Acceleration', channel: 'x', type: 'R-RE'}]);
+      expect<SelectionProjectionComponent>(c['one'].project).toEqual(
+        expect.arrayContaining([
+          {field: 'Acceleration', channel: 'x', type: 'R-RE', signals: {data: 'one_Acceleration', visual: 'one_x'}}
+        ])
+      );
     });
   });
 });

--- a/test/compile/selection/predicate.test.ts
+++ b/test/compile/selection/predicate.test.ts
@@ -2,10 +2,9 @@
 
 import {nonPosition} from '../../../src/compile/mark/mixins';
 import {expression} from '../../../src/compile/predicate';
-import * as selection from '../../../src/compile/selection/selection';
+import {assembleSelectionPredicate as predicate} from '../../../src/compile/selection/assemble';
+import {parseUnitSelection} from '../../../src/compile/selection/parse';
 import {parseUnitModel} from '../../util';
-
-const predicate = selection.selectionPredicate;
 
 describe('Selection Predicate', () => {
   const model = parseUnitModel({
@@ -34,7 +33,7 @@ describe('Selection Predicate', () => {
 
   model.parseScale();
 
-  model.component.selection = selection.parseUnitSelection(model, {
+  model.component.selection = parseUnitSelection(model, {
     one: {type: 'single'},
     two: {type: 'multi', resolve: 'union'},
     'thr-ee': {type: 'interval', resolve: 'intersect'},

--- a/test/compile/selection/scales.test.ts
+++ b/test/compile/selection/scales.test.ts
@@ -2,7 +2,7 @@
 
 import {X} from '../../../src/channel';
 import {assembleScalesForModel} from '../../../src/compile/scale/assemble';
-import {assembleTopLevelSignals, assembleUnitSelectionSignals} from '../../../src/compile/selection/selection';
+import {assembleTopLevelSignals, assembleUnitSelectionSignals} from '../../../src/compile/selection/assemble';
 import {UnitModel} from '../../../src/compile/unit';
 import * as log from '../../../src/log';
 import {Domain} from '../../../src/scale';

--- a/test/compile/selection/single.test.ts
+++ b/test/compile/selection/single.test.ts
@@ -1,5 +1,11 @@
 /* tslint:disable quotemark */
-import * as selection from '../../../src/compile/selection/selection';
+import {
+  assembleTopLevelSignals,
+  assembleUnitSelectionData,
+  assembleUnitSelectionMarks,
+  assembleUnitSelectionSignals
+} from '../../../src/compile/selection/assemble';
+import {parseUnitSelection} from '../../../src/compile/selection/parse';
 import single from '../../../src/compile/selection/single';
 import {parseUnitModelWithScale} from '../../util';
 
@@ -15,7 +21,7 @@ describe('Single Selection', () => {
 
   model.parseScale();
 
-  const selCmpts = (model.component.selection = selection.parseUnitSelection(model, {
+  const selCmpts = (model.component.selection = parseUnitSelection(model, {
     one: {type: 'single'},
     two: {
       type: 'single',
@@ -105,7 +111,7 @@ describe('Single Selection', () => {
       }
     ]);
 
-    const signals = selection.assembleUnitSelectionSignals(model, []);
+    const signals = assembleUnitSelectionSignals(model, []);
     expect(signals).toEqual(expect.arrayContaining([...oneSg, ...twoSg, ...threeSg, ...fourSg]));
   });
 
@@ -116,7 +122,7 @@ describe('Single Selection', () => {
     const twoExpr = single.modifyExpr(model, selCmpts['two']);
     expect(twoExpr).toEqual('two_tuple, {unit: ""}');
 
-    const signals = selection.assembleUnitSelectionSignals(model, []);
+    const signals = assembleUnitSelectionSignals(model, []);
     expect(signals).toEqual(
       expect.arrayContaining([
         {
@@ -132,7 +138,7 @@ describe('Single Selection', () => {
   });
 
   it('builds top-level signals', () => {
-    const signals = selection.assembleTopLevelSignals(model, []);
+    const signals = assembleTopLevelSignals(model, []);
     expect(signals).toEqual(
       expect.arrayContaining([
         {
@@ -154,7 +160,7 @@ describe('Single Selection', () => {
 
   it('builds unit datasets', () => {
     const data: any[] = [];
-    expect(selection.assembleUnitSelectionData(model, data)).toEqual([
+    expect(assembleUnitSelectionData(model, data)).toEqual([
       {name: 'one_store'},
       {name: 'two_store'},
       {name: 'thr_ee_store'},
@@ -165,6 +171,6 @@ describe('Single Selection', () => {
   it('leaves marks alone', () => {
     const marks: any[] = [];
     model.component.selection = {one: selCmpts['one']};
-    expect(selection.assembleUnitSelectionMarks(model, marks)).toEqual(marks);
+    expect(assembleUnitSelectionMarks(model, marks)).toEqual(marks);
   });
 });

--- a/test/compile/selection/timeunit.test.ts
+++ b/test/compile/selection/timeunit.test.ts
@@ -4,7 +4,7 @@ import {assembleRootData} from '../../../src/compile/data/assemble';
 import {optimizeDataflow} from '../../../src/compile/data/optimize';
 import {TimeUnitNode} from '../../../src/compile/data/timeunit';
 import {Model} from '../../../src/compile/model';
-import * as selection from '../../../src/compile/selection/selection';
+import {parseUnitSelection} from '../../../src/compile/selection/parse';
 import {NormalizedUnitSpec} from '../../../src/spec';
 import {parseModel, parseUnitModel} from '../../util';
 
@@ -55,7 +55,7 @@ describe('Selection time unit', () => {
         y: {field: 'date', type: 'temporal', timeUnit: 'minutes'}
       }
     });
-    const selCmpts = (model.component.selection = selection.parseUnitSelection(model, {
+    const selCmpts = (model.component.selection = parseUnitSelection(model, {
       one: {type: 'single'},
       two: {type: 'single', encodings: ['x', 'y']}
     }));

--- a/test/compile/selection/timeunit.test.ts
+++ b/test/compile/selection/timeunit.test.ts
@@ -60,10 +60,10 @@ describe('Selection time unit', () => {
       two: {type: 'single', encodings: ['x', 'y']}
     }));
 
-    expect(selCmpts['one'].timeUnit).not.toBeDefined();
-    expect(selCmpts['two'].timeUnit).toBeInstanceOf(TimeUnitNode);
+    expect(selCmpts['one'].project.timeUnit).not.toBeDefined();
+    expect(selCmpts['two'].project.timeUnit).toBeInstanceOf(TimeUnitNode);
 
-    const as = selCmpts['two'].timeUnit.assemble().map(tx => tx.as);
+    const as = selCmpts['two'].project.timeUnit.assemble().map(tx => tx.as);
     expect(as).toEqual(['seconds_date', 'minutes_date']);
   });
 

--- a/test/compile/selection/toggle.test.ts
+++ b/test/compile/selection/toggle.test.ts
@@ -1,6 +1,7 @@
 /* tslint:disable quotemark */
 
-import * as selection from '../../../src/compile/selection/selection';
+import {assembleUnitSelectionSignals} from '../../../src/compile/selection/assemble';
+import {parseUnitSelection} from '../../../src/compile/selection/parse';
 import toggle from '../../../src/compile/selection/transforms/toggle';
 import {parseUnitModel} from '../../util';
 
@@ -15,7 +16,7 @@ describe('Toggle Selection Transform', () => {
   });
 
   model.parseScale();
-  const selCmpts = (model.component.selection = selection.parseUnitSelection(model, {
+  const selCmpts = (model.component.selection = parseUnitSelection(model, {
     one: {type: 'multi'},
     two: {
       type: 'multi',
@@ -68,7 +69,7 @@ describe('Toggle Selection Transform', () => {
       }
     ]);
 
-    const signals = selection.assembleUnitSelectionSignals(model, []);
+    const signals = assembleUnitSelectionSignals(model, []);
     expect(signals).toEqual(expect.arrayContaining([...oneSg, ...twoSg]));
   });
 
@@ -81,7 +82,7 @@ describe('Toggle Selection Transform', () => {
       'two_toggle ? null : two_tuple, two_toggle ? null : {unit: ""}, two_toggle ? two_tuple : null'
     );
 
-    const signals = selection.assembleUnitSelectionSignals(model, []);
+    const signals = assembleUnitSelectionSignals(model, []);
     expect(signals).toEqual(
       expect.arrayContaining([
         {

--- a/test/compile/selection/translate.test.ts
+++ b/test/compile/selection/translate.test.ts
@@ -1,7 +1,8 @@
 /* tslint:disable quotemark */
 
 import {selector as parseSelector} from 'vega-event-selector';
-import * as selection from '../../../src/compile/selection/selection';
+import {assembleUnitSelectionSignals} from '../../../src/compile/selection/assemble';
+import {parseUnitSelection} from '../../../src/compile/selection/parse';
 import translate from '../../../src/compile/selection/transforms/translate';
 import {ScaleType} from '../../../src/scale';
 import {parseUnitModel} from '../../util';
@@ -17,7 +18,7 @@ function getModel(xscale?: ScaleType, yscale?: ScaleType) {
   });
 
   model.parseScale();
-  const selCmpts = selection.parseUnitSelection(model, {
+  const selCmpts = parseUnitSelection(model, {
     one: {
       type: 'single'
     },
@@ -65,7 +66,7 @@ describe('Translate Selection Transform', () => {
 
     it('builds them for default invocation', () => {
       model.component.selection = {four: selCmpts['four']};
-      const signals = selection.assembleUnitSelectionSignals(model, []);
+      const signals = assembleUnitSelectionSignals(model, []);
       expect(signals).toEqual(
         expect.arrayContaining([
           {
@@ -94,7 +95,7 @@ describe('Translate Selection Transform', () => {
 
     it('builds them for custom events', () => {
       model.component.selection = {five: selCmpts['five']};
-      const signals = selection.assembleUnitSelectionSignals(model, []);
+      const signals = assembleUnitSelectionSignals(model, []);
       expect(signals).toEqual(
         expect.arrayContaining([
           {
@@ -126,7 +127,7 @@ describe('Translate Selection Transform', () => {
 
     it('builds them for scale-bound intervals', () => {
       model.component.selection = {six: selCmpts['six']};
-      const signals = selection.assembleUnitSelectionSignals(model, []);
+      const signals = assembleUnitSelectionSignals(model, []);
       expect(signals).toEqual(
         expect.arrayContaining([
           {
@@ -158,7 +159,7 @@ describe('Translate Selection Transform', () => {
     it('always builds panLinear exprs for brushes', () => {
       const {model, selCmpts} = getModel();
       model.component.selection = {four: selCmpts['four']};
-      let signals = selection.assembleUnitSelectionSignals(model, []);
+      let signals = assembleUnitSelectionSignals(model, []);
       expect(signals.filter(s => s.name === 'four_x')[0].on).toContainEqual({
         events: {signal: 'four_translate_delta'},
         update:
@@ -173,7 +174,7 @@ describe('Translate Selection Transform', () => {
 
       const model2 = getModel('log', 'pow').model;
       model2.component.selection = {four: selCmpts['four']};
-      signals = selection.assembleUnitSelectionSignals(model2, []);
+      signals = assembleUnitSelectionSignals(model2, []);
       expect(signals.filter(s => s.name === 'four_x')[0].on).toContainEqual({
         events: {signal: 'four_translate_delta'},
         update:
@@ -190,7 +191,7 @@ describe('Translate Selection Transform', () => {
     it('builds panLinear exprs for scale-bound intervals', () => {
       const {model, selCmpts} = getModel();
       model.component.selection = {six: selCmpts['six']};
-      const signals = selection.assembleUnitSelectionSignals(model, []);
+      const signals = assembleUnitSelectionSignals(model, []);
 
       expect(signals.filter(s => s.name === 'six_Horsepower')[0].on).toContainEqual({
         events: {signal: 'six_translate_delta'},
@@ -206,7 +207,7 @@ describe('Translate Selection Transform', () => {
     it('builds panLog/panPow exprs for scale-bound intervals', () => {
       const {model, selCmpts} = getModel('log', 'pow');
       model.component.selection = {six: selCmpts['six']};
-      const signals = selection.assembleUnitSelectionSignals(model, []);
+      const signals = assembleUnitSelectionSignals(model, []);
 
       expect(signals.filter(s => s.name === 'six_Horsepower')[0].on).toContainEqual({
         events: {signal: 'six_translate_delta'},

--- a/test/compile/selection/zoom.test.ts
+++ b/test/compile/selection/zoom.test.ts
@@ -1,7 +1,8 @@
 /* tslint:disable quotemark */
 
 import {selector as parseSelector} from 'vega-event-selector';
-import * as selection from '../../../src/compile/selection/selection';
+import {assembleUnitSelectionSignals} from '../../../src/compile/selection/assemble';
+import {parseUnitSelection} from '../../../src/compile/selection/parse';
 import zoom from '../../../src/compile/selection/transforms/zoom';
 import {ScaleType} from '../../../src/scale';
 import {parseUnitModel} from '../../util';
@@ -17,7 +18,7 @@ function getModel(xscale?: ScaleType, yscale?: ScaleType) {
   });
 
   model.parseScale();
-  const selCmpts = selection.parseUnitSelection(model, {
+  const selCmpts = parseUnitSelection(model, {
     one: {
       type: 'single'
     },
@@ -64,7 +65,7 @@ describe('Zoom Selection Transform', () => {
     it('builds then for default invocation', () => {
       const {model, selCmpts} = getModel();
       model.component.selection = {four: selCmpts['four']};
-      const signals = selection.assembleUnitSelectionSignals(model, []);
+      const signals = assembleUnitSelectionSignals(model, []);
       expect(signals).toEqual(
         expect.arrayContaining([
           {
@@ -93,7 +94,7 @@ describe('Zoom Selection Transform', () => {
     it('builds them for custom events', () => {
       const {model, selCmpts} = getModel();
       model.component.selection = {five: selCmpts['five']};
-      const signals = selection.assembleUnitSelectionSignals(model, []);
+      const signals = assembleUnitSelectionSignals(model, []);
       expect(signals).toEqual(
         expect.arrayContaining([
           {
@@ -122,7 +123,7 @@ describe('Zoom Selection Transform', () => {
     it('builds them for scale-bound zoom', () => {
       const {model, selCmpts} = getModel();
       model.component.selection = {six: selCmpts['six']};
-      const signals = selection.assembleUnitSelectionSignals(model, []);
+      const signals = assembleUnitSelectionSignals(model, []);
       expect(signals).toEqual(
         expect.arrayContaining([
           {
@@ -153,7 +154,7 @@ describe('Zoom Selection Transform', () => {
     it('always builds zoomLinear exprs for brushes', () => {
       const {model, selCmpts} = getModel();
       model.component.selection = {four: selCmpts['four']};
-      let signals = selection.assembleUnitSelectionSignals(model, []);
+      let signals = assembleUnitSelectionSignals(model, []);
 
       expect(signals.filter(s => s.name === 'four_x')[0].on).toContainEqual({
         events: {signal: 'four_zoom_delta'},
@@ -167,7 +168,7 @@ describe('Zoom Selection Transform', () => {
 
       const model2 = getModel('log', 'pow').model;
       model2.component.selection = {four: selCmpts['four']};
-      signals = selection.assembleUnitSelectionSignals(model2, []);
+      signals = assembleUnitSelectionSignals(model2, []);
       expect(signals.filter(s => s.name === 'four_x')[0].on).toContainEqual({
         events: {signal: 'four_zoom_delta'},
         update: 'clampRange(zoomLinear(four_x, four_zoom_anchor.x, four_zoom_delta), 0, width)'
@@ -182,7 +183,7 @@ describe('Zoom Selection Transform', () => {
     it('builds zoomLinear exprs for scale-bound zoom', () => {
       const {model, selCmpts} = getModel();
       model.component.selection = {six: selCmpts['six']};
-      const signals = selection.assembleUnitSelectionSignals(model, []);
+      const signals = assembleUnitSelectionSignals(model, []);
 
       expect(signals.filter(s => s.name === 'six_Horsepower')[0].on).toContainEqual({
         events: {signal: 'six_zoom_delta'},
@@ -198,7 +199,7 @@ describe('Zoom Selection Transform', () => {
     it('builds zoomLog/Pow exprs for scale-bound zoom', () => {
       const {model, selCmpts} = getModel('log', 'pow');
       model.component.selection = {six: selCmpts['six']};
-      const signals = selection.assembleUnitSelectionSignals(model, []);
+      const signals = assembleUnitSelectionSignals(model, []);
 
       expect(signals.filter(s => s.name === 'six_Horsepower')[0].on).toContainEqual({
         events: {signal: 'six_zoom_delta'},


### PR DESCRIPTION
Please merge after #4139. 

This PR cleans up the selection code paths into more manageable `parse` and `assemble` modules that mimic the structure elsewhere. It also reintroduces a `compile/selection/index.ts` as per #1966 to hold the definitions needed on the compiler side