### PR TITLE
Don't import util from vega directly.  Otherwise our users can no longer use `vega-lib`.

### DIFF
--- a/src/compile/data/aggregate.ts
+++ b/src/compile/data/aggregate.ts
@@ -1,4 +1,5 @@
-import {AggregateOp, extend} from 'vega';
+import {AggregateOp} from 'vega';
+import {extend} from 'vega-util';
 import {isBinning} from '../../bin';
 import {Channel, isScaleChannel} from '../../channel';
 import {FieldDef, vgField} from '../../fielddef';


### PR DESCRIPTION
cc: @Saba9 @domoritz @arvind 

We should do #4322 to prevent this.  