### PR TITLE
Make default tooltip respect the order of channels in `encoding`

### DIFF
--- a/examples/compiled/bar_aggregate.vg.json
+++ b/examples/compiled/bar_aggregate.vg.json
@@ -45,7 +45,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "sum_people"},
           "x2": {"scale": "x", "value": 0},

--- a/examples/compiled/bar_aggregate_format.vg.json
+++ b/examples/compiled/bar_aggregate_format.vg.json
@@ -45,7 +45,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"sum_people\"], \".2e\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \".2e\")}"
           },
           "x": {"scale": "x", "field": "sum_people"},
           "x2": {"scale": "x", "value": 0},

--- a/examples/compiled/bar_aggregate_size.vg.json
+++ b/examples/compiled/bar_aggregate_size.vg.json
@@ -45,7 +45,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "xc": {"scale": "x", "field": "age", "band": 0.5},
           "width": {"value": 10},

--- a/examples/compiled/bar_binned_data.vg.json
+++ b/examples/compiled/bar_binned_data.vg.json
@@ -36,7 +36,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"bin_start\": format(datum[\"bin_start\"], \"\"), \"count\": format(datum[\"count\"], \"\"), \"bin_end\": format(datum[\"bin_end\"], \"\")}"
+            "signal": "{\"bin_start\": format(datum[\"bin_start\"], \"\"), \"bin_end\": format(datum[\"bin_end\"], \"\"), \"count\": format(datum[\"count\"], \"\")}"
           },
           "x2": {"scale": "x", "field": "bin_start", "offset": 1},
           "x": {"scale": "x", "field": "bin_end", "offset": 0},

--- a/examples/compiled/bar_diverging_stack_transform.vg.json
+++ b/examples/compiled/bar_diverging_stack_transform.vg.json
@@ -311,7 +311,7 @@
             {"scale": "color", "field": "type"}
           ],
           "tooltip": {
-            "signal": "{\"Percentage\": format(datum[\"nx\"], \"\"), \"Question\": ''+datum[\"question\"], \"nx2\": format(datum[\"nx2\"], \"\"), \"Response\": ''+datum[\"type\"]}"
+            "signal": "{\"Percentage\": format(datum[\"nx\"], \"\"), \"nx2\": format(datum[\"nx2\"], \"\"), \"Question\": ''+datum[\"question\"], \"Response\": ''+datum[\"type\"]}"
           },
           "x": {"scale": "x", "field": "nx"},
           "x2": {"scale": "x", "field": "nx2"},

--- a/examples/compiled/bar_filter_calc.vg.json
+++ b/examples/compiled/bar_filter_calc.vg.json
@@ -52,7 +52,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"a\": ''+datum[\"a\"], \"b2\": format(datum[\"b2\"], \"\")}"
+            "signal": "{\"b2\": format(datum[\"b2\"], \"\"), \"a\": ''+datum[\"a\"]}"
           },
           "x": {"scale": "x", "field": "a"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/bar_gantt.vg.json
+++ b/examples/compiled/bar_gantt.vg.json
@@ -38,7 +38,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"start\": format(datum[\"start\"], \"\"), \"task\": ''+datum[\"task\"], \"end\": format(datum[\"end\"], \"\")}"
+            "signal": "{\"task\": ''+datum[\"task\"], \"start\": format(datum[\"start\"], \"\"), \"end\": format(datum[\"end\"], \"\")}"
           },
           "x": {"scale": "x", "field": "start"},
           "x2": {"scale": "x", "field": "end"},

--- a/examples/compiled/bar_grouped.vg.json
+++ b/examples/compiled/bar_grouped.vg.json
@@ -131,7 +131,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"gender\": ''+datum[\"gender\"], \"population\": format(datum[\"sum_people\"], \"\")}"
+                "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "x", "field": "gender"},
               "width": {"scale": "x", "band": true},

--- a/examples/compiled/bar_layered_weather.vg.json
+++ b/examples/compiled/bar_layered_weather.vg.json
@@ -89,7 +89,7 @@
             {"value": "#ccc"}
           ],
           "tooltip": {
-            "signal": "{\"Day\": ''+datum[\"id\"], \"Temperature (F)\": format(datum[\"record.low\"], \"\"), \"record.high\": format(datum[\"record.high\"], \"\")}"
+            "signal": "{\"Temperature (F)\": format(datum[\"record.low\"], \"\"), \"record.high\": format(datum[\"record.high\"], \"\"), \"Day\": ''+datum[\"id\"]}"
           },
           "xc": {"scale": "x", "field": "id", "band": 0.5},
           "width": {"value": 20},
@@ -113,7 +113,7 @@
             {"value": "#999"}
           ],
           "tooltip": {
-            "signal": "{\"id\": ''+datum[\"id\"], \"normal.low\": format(datum[\"normal.low\"], \"\"), \"normal.high\": format(datum[\"normal.high\"], \"\")}"
+            "signal": "{\"normal.low\": format(datum[\"normal.low\"], \"\"), \"normal.high\": format(datum[\"normal.high\"], \"\"), \"id\": ''+datum[\"id\"]}"
           },
           "xc": {"scale": "x", "field": "id", "band": 0.5},
           "width": {"value": 20},
@@ -137,7 +137,7 @@
             {"value": "#000"}
           ],
           "tooltip": {
-            "signal": "{\"id\": ''+datum[\"id\"], \"actual.low\": format(datum[\"actual.low\"], \"\"), \"actual.high\": format(datum[\"actual.high\"], \"\")}"
+            "signal": "{\"actual.low\": format(datum[\"actual.low\"], \"\"), \"actual.high\": format(datum[\"actual.high\"], \"\"), \"id\": ''+datum[\"id\"]}"
           },
           "xc": {"scale": "x", "field": "id", "band": 0.5},
           "width": {"value": 12},
@@ -161,7 +161,7 @@
             {"value": "#000"}
           ],
           "tooltip": {
-            "signal": "{\"id\": ''+datum[\"id\"], \"forecast.low.low\": format(datum[\"forecast.low.low\"], \"\"), \"forecast.low.high\": format(datum[\"forecast.low.high\"], \"\")}"
+            "signal": "{\"forecast.low.low\": format(datum[\"forecast.low.low\"], \"\"), \"forecast.low.high\": format(datum[\"forecast.low.high\"], \"\"), \"id\": ''+datum[\"id\"]}"
           },
           "xc": {"scale": "x", "field": "id", "band": 0.5},
           "width": {"value": 12},
@@ -185,7 +185,7 @@
             {"value": "#000"}
           ],
           "tooltip": {
-            "signal": "{\"id\": ''+datum[\"id\"], \"forecast.low.high\": format(datum[\"forecast.low.high\"], \"\"), \"forecast.high.low\": format(datum[\"forecast.high.low\"], \"\")}"
+            "signal": "{\"forecast.low.high\": format(datum[\"forecast.low.high\"], \"\"), \"forecast.high.low\": format(datum[\"forecast.high.low\"], \"\"), \"id\": ''+datum[\"id\"]}"
           },
           "xc": {"scale": "x", "field": "id", "band": 0.5},
           "width": {"value": 3},
@@ -209,7 +209,7 @@
             {"value": "#000"}
           ],
           "tooltip": {
-            "signal": "{\"id\": ''+datum[\"id\"], \"forecast.high.low\": format(datum[\"forecast.high.low\"], \"\"), \"forecast.high.high\": format(datum[\"forecast.high.high\"], \"\")}"
+            "signal": "{\"forecast.high.low\": format(datum[\"forecast.high.low\"], \"\"), \"forecast.high.high\": format(datum[\"forecast.high.high\"], \"\"), \"id\": ''+datum[\"id\"]}"
           },
           "xc": {"scale": "x", "field": "id", "band": 0.5},
           "width": {"value": 12},

--- a/examples/compiled/bar_swap_axes.vg.json
+++ b/examples/compiled/bar_swap_axes.vg.json
@@ -56,7 +56,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"Average of b\": format(datum[\"average_b\"], \"\"), \"a\": ''+datum[\"a\"]}"
+            "signal": "{\"a\": ''+datum[\"a\"], \"Average of b\": format(datum[\"average_b\"], \"\")}"
           },
           "x": {"scale": "x", "field": "average_b"},
           "x2": {"scale": "x", "value": 0},

--- a/examples/compiled/bar_swap_custom.vg.json
+++ b/examples/compiled/bar_swap_custom.vg.json
@@ -56,7 +56,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"Average of b\": format(datum[\"average_b\"], \"\"), \"a\": ''+datum[\"a\"]}"
+            "signal": "{\"a\": ''+datum[\"a\"], \"Average of b\": format(datum[\"average_b\"], \"\")}"
           },
           "x": {"scale": "x", "field": "average_b"},
           "x2": {"scale": "x", "value": 0},

--- a/examples/compiled/boxplot_2D_horizontal.vg.json
+++ b/examples/compiled/boxplot_2D_horizontal.vg.json
@@ -89,7 +89,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "lower_whisker_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -112,7 +112,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "upper_box_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -135,7 +135,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "lower_box_people"},
           "x2": {"scale": "x", "field": "upper_box_people"},

--- a/examples/compiled/boxplot_2D_horizontal_color_size.vg.json
+++ b/examples/compiled/boxplot_2D_horizontal_color_size.vg.json
@@ -89,7 +89,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "lower_whisker_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -112,7 +112,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "upper_box_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -135,7 +135,7 @@
             {"value": "blue"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "lower_box_people"},
           "x2": {"scale": "x", "field": "upper_box_people"},

--- a/examples/compiled/boxplot_2D_horizontal_explicit_aggregate.vg.json
+++ b/examples/compiled/boxplot_2D_horizontal_explicit_aggregate.vg.json
@@ -89,7 +89,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "lower_whisker_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -112,7 +112,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "upper_box_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -135,7 +135,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "lower_box_people"},
           "x2": {"scale": "x", "field": "upper_box_people"},

--- a/examples/compiled/boxplot_2D_vertical.vg.json
+++ b/examples/compiled/boxplot_2D_vertical.vg.json
@@ -89,7 +89,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "age", "band": 0.5},
           "y": {"scale": "y", "field": "lower_whisker_people"},
@@ -112,7 +112,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "age", "band": 0.5},
           "y": {"scale": "y", "field": "upper_box_people"},
@@ -135,7 +135,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "xc": {"scale": "x", "field": "age", "band": 0.5},
           "width": {"value": 5},
@@ -160,7 +160,7 @@
             {"value": "white"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"mid_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"mid_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "xc": {"scale": "x", "field": "age", "band": 0.5},
           "yc": {"scale": "y", "field": "mid_box_people"},
@@ -192,7 +192,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"people\": format(datum[\"people\"], \"\")}"
+            "signal": "{\"people\": format(datum[\"people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "age", "band": 0.5},
           "y": {"scale": "y", "field": "people"}

--- a/examples/compiled/boxplot_minmax_2D_horizontal.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_horizontal.vg.json
@@ -50,7 +50,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "lower_whisker_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -73,7 +73,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "upper_box_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -96,7 +96,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "lower_box_people"},
           "x2": {"scale": "x", "field": "upper_box_people"},

--- a/examples/compiled/boxplot_minmax_2D_horizontal_custom_midtick_color.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_horizontal_custom_midtick_color.vg.json
@@ -50,7 +50,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "lower_whisker_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -73,7 +73,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "upper_box_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -96,7 +96,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "lower_box_people"},
           "x2": {"scale": "x", "field": "upper_box_people"},

--- a/examples/compiled/boxplot_minmax_2D_vertical.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_vertical.vg.json
@@ -50,7 +50,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "age", "band": 0.5},
           "y": {"scale": "y", "field": "lower_whisker_people"},
@@ -73,7 +73,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "age", "band": 0.5},
           "y": {"scale": "y", "field": "upper_box_people"},
@@ -96,7 +96,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "xc": {"scale": "x", "field": "age", "band": 0.5},
           "width": {"value": 14},
@@ -121,7 +121,7 @@
             {"value": "white"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"mid_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"mid_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "xc": {"scale": "x", "field": "age", "band": 0.5},
           "yc": {"scale": "y", "field": "mid_box_people"},

--- a/examples/compiled/circle_bubble_health_income.vg.json
+++ b/examples/compiled/circle_bubble_health_income.vg.json
@@ -139,7 +139,7 @@
             {"value": "#000"}
           ],
           "tooltip": {
-            "signal": "{\"income\": format(datum[\"income\"], \"\"), \"health\": format(datum[\"health\"], \"\"), \"population\": format(datum[\"population\"], \"\")}"
+            "signal": "{\"health\": format(datum[\"health\"], \"\"), \"income\": format(datum[\"income\"], \"\"), \"population\": format(datum[\"population\"], \"\")}"
           },
           "x": {"scale": "x", "field": "income"},
           "y": {"scale": "y", "field": "health"},

--- a/examples/compiled/circle_github_punchcard.vg.json
+++ b/examples/compiled/circle_github_punchcard.vg.json
@@ -69,7 +69,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"time (hours)\": timeFormat(datum[\"hours_time\"], '%H'), \"time (day)\": timeFormat(datum[\"day_time\"], '%A'), \"Sum of count\": format(datum[\"sum_count\"], \"\")}"
+            "signal": "{\"time (day)\": timeFormat(datum[\"day_time\"], '%A'), \"time (hours)\": timeFormat(datum[\"hours_time\"], '%H'), \"Sum of count\": format(datum[\"sum_count\"], \"\")}"
           },
           "x": {"scale": "x", "field": "hours_time"},
           "y": {"scale": "y", "field": "day_time"},

--- a/examples/compiled/concat_layer_voyager_result_future.vg.json
+++ b/examples/compiled/concat_layer_voyager_result_future.vg.json
@@ -97,7 +97,7 @@
                 {"value": "black"}
               ],
               "tooltip": {
-                "signal": "{\"lo\": format(datum[\"lo\"], \"\"), \"study\": ''+datum[\"study\"], \"hi\": format(datum[\"hi\"], \"\")}"
+                "signal": "{\"study\": ''+datum[\"study\"], \"lo\": format(datum[\"lo\"], \"\"), \"hi\": format(datum[\"hi\"], \"\")}"
               },
               "x": {"scale": "concat_0_x", "field": "lo"},
               "y": {"scale": "concat_0_y", "field": "study", "band": 0.5},
@@ -128,7 +128,7 @@
                 {"scale": "color", "field": "measure"}
               ],
               "tooltip": {
-                "signal": "{\"mean\": format(datum[\"mean\"], \"\"), \"study\": ''+datum[\"study\"], \"measure\": ''+datum[\"measure\"]}"
+                "signal": "{\"study\": ''+datum[\"study\"], \"mean\": format(datum[\"mean\"], \"\"), \"measure\": ''+datum[\"measure\"]}"
               },
               "x": {"scale": "concat_0_x", "field": "mean"},
               "y": {"scale": "concat_0_y", "field": "study", "band": 0.5},

--- a/examples/compiled/concat_marginal_histograms.vg.json
+++ b/examples/compiled/concat_marginal_histograms.vg.json
@@ -308,7 +308,7 @@
                     {"value": "#4c78a8"}
                   ],
                   "tooltip": {
-                    "signal": "{\"Number of Records\": format(datum[\"count_*\"], \"\"), \"Rotten_Tomatoes_Rating (binned)\": datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_end\"], \"\")}"
+                    "signal": "{\"Rotten_Tomatoes_Rating (binned)\": datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"] === null || isNaN(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"]) ? \"null\" : format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating\"], \"\") + \" - \" + format(datum[\"bin_maxbins_10_Rotten_Tomatoes_Rating_end\"], \"\"), \"Number of Records\": format(datum[\"count_*\"], \"\")}"
                   },
                   "x": {"scale": "concat_1_concat_1_x", "field": "count_*"},
                   "x2": {"scale": "concat_1_concat_1_x", "value": 0},

--- a/examples/compiled/concat_population_pyramid.vg.json
+++ b/examples/compiled/concat_population_pyramid.vg.json
@@ -115,7 +115,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "concat_0_x", "field": "sum_people_end"},
               "x2": {"scale": "concat_0_x", "field": "sum_people_start"},
@@ -207,7 +207,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "concat_2_x", "field": "sum_people_end"},
               "x2": {"scale": "concat_2_x", "field": "sum_people_start"},

--- a/examples/compiled/errorband_2d_horizontal_color_encoding.vg.json
+++ b/examples/compiled/errorband_2d_horizontal_color_encoding.vg.json
@@ -39,7 +39,7 @@
           "orient": {"value": "vertical"},
           "fill": {"value": "black"},
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\"), \"upper_Miles_per_Gallon\": format(datum[\"upper_Miles_per_Gallon\"], \"\")}"
+            "signal": "{\"Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\"), \"upper_Miles_per_Gallon\": format(datum[\"upper_Miles_per_Gallon\"], \"\"), \"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y')}"
           },
           "x": {"scale": "x", "field": "year_Year"},
           "y": {"scale": "y", "field": "lower_Miles_per_Gallon"},
@@ -60,7 +60,7 @@
         "update": {
           "stroke": {"value": "black"},
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\")}"
+            "signal": "{\"Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\"), \"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y')}"
           },
           "x": {"scale": "x", "field": "year_Year"},
           "y": {"scale": "y", "field": "lower_Miles_per_Gallon"},
@@ -80,7 +80,7 @@
         "update": {
           "stroke": {"value": "black"},
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Miles per Gallon (95% CIs)\": format(datum[\"upper_Miles_per_Gallon\"], \"\")}"
+            "signal": "{\"Miles per Gallon (95% CIs)\": format(datum[\"upper_Miles_per_Gallon\"], \"\"), \"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y')}"
           },
           "x": {"scale": "x", "field": "year_Year"},
           "y": {"scale": "y", "field": "upper_Miles_per_Gallon"},

--- a/examples/compiled/errorband_2d_vertical_borders.vg.json
+++ b/examples/compiled/errorband_2d_vertical_borders.vg.json
@@ -39,7 +39,7 @@
           "orient": {"value": "vertical"},
           "fill": {"value": "#4c78a8"},
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\"), \"upper_Miles_per_Gallon\": format(datum[\"upper_Miles_per_Gallon\"], \"\")}"
+            "signal": "{\"Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\"), \"upper_Miles_per_Gallon\": format(datum[\"upper_Miles_per_Gallon\"], \"\"), \"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y')}"
           },
           "x": {"scale": "x", "field": "year_Year"},
           "y": {"scale": "y", "field": "lower_Miles_per_Gallon"},
@@ -60,7 +60,7 @@
         "update": {
           "stroke": {"value": "#4c78a8"},
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\")}"
+            "signal": "{\"Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\"), \"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y')}"
           },
           "x": {"scale": "x", "field": "year_Year"},
           "y": {"scale": "y", "field": "lower_Miles_per_Gallon"},
@@ -80,7 +80,7 @@
         "update": {
           "stroke": {"value": "#4c78a8"},
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Miles per Gallon (95% CIs)\": format(datum[\"upper_Miles_per_Gallon\"], \"\")}"
+            "signal": "{\"Miles per Gallon (95% CIs)\": format(datum[\"upper_Miles_per_Gallon\"], \"\"), \"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y')}"
           },
           "x": {"scale": "x", "field": "year_Year"},
           "y": {"scale": "y", "field": "upper_Miles_per_Gallon"},

--- a/examples/compiled/errorbar_2d_vertical_ticks.vg.json
+++ b/examples/compiled/errorbar_2d_vertical_ticks.vg.json
@@ -43,7 +43,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\")}"
+            "signal": "{\"Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\"), \"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y')}"
           },
           "xc": {"scale": "x", "field": "year_Year"},
           "yc": {"scale": "y", "field": "lower_Miles_per_Gallon"},
@@ -68,7 +68,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Miles per Gallon (95% CIs)\": format(datum[\"upper_Miles_per_Gallon\"], \"\")}"
+            "signal": "{\"Miles per Gallon (95% CIs)\": format(datum[\"upper_Miles_per_Gallon\"], \"\"), \"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y')}"
           },
           "xc": {"scale": "x", "field": "year_Year"},
           "yc": {"scale": "y", "field": "upper_Miles_per_Gallon"},
@@ -92,7 +92,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\"), \"upper_Miles_per_Gallon\": format(datum[\"upper_Miles_per_Gallon\"], \"\")}"
+            "signal": "{\"Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\"), \"upper_Miles_per_Gallon\": format(datum[\"upper_Miles_per_Gallon\"], \"\"), \"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y')}"
           },
           "x": {"scale": "x", "field": "year_Year"},
           "y": {"scale": "y", "field": "lower_Miles_per_Gallon"},

--- a/examples/compiled/errorbar_horizontal_aggregate.vg.json
+++ b/examples/compiled/errorbar_horizontal_aggregate.vg.json
@@ -67,7 +67,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"min_people\"], \"\"), \"age\": ''+datum[\"age\"], \"Max of people\": format(datum[\"max_people\"], \"\")}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"min_people\"], \"\"), \"Max of people\": format(datum[\"max_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "min_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -90,7 +90,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"min_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"min_people\"], \"\")}"
           },
           "xc": {"scale": "x", "field": "min_people"},
           "yc": {"scale": "y", "field": "age", "band": 0.5},
@@ -114,7 +114,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"max_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"max_people\"], \"\")}"
           },
           "xc": {"scale": "x", "field": "max_people"},
           "yc": {"scale": "y", "field": "age", "band": 0.5},
@@ -145,7 +145,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"mean_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"mean_people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "mean_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},

--- a/examples/compiled/facet_cross_independent_scale.vg.json
+++ b/examples/compiled/facet_cross_independent_scale.vg.json
@@ -162,7 +162,7 @@
             "update": {
               "fill": {"value": "#4c78a8"},
               "tooltip": {
-                "signal": "{\"a\": ''+datum[\"a\"], \"b\": ''+datum[\"b\"]}"
+                "signal": "{\"b\": ''+datum[\"b\"], \"a\": ''+datum[\"a\"]}"
               },
               "x": {"scale": "child_x", "field": "a"},
               "width": {"scale": "child_x", "band": true},

--- a/examples/compiled/facet_custom.vg.json
+++ b/examples/compiled/facet_custom.vg.json
@@ -148,7 +148,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "x", "field": "age"},
               "width": {"scale": "x", "band": true},

--- a/examples/compiled/facet_custom_header.vg.json
+++ b/examples/compiled/facet_custom_header.vg.json
@@ -148,7 +148,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "x", "field": "age"},
               "width": {"scale": "x", "band": true},

--- a/examples/compiled/facet_independent_scale.vg.json
+++ b/examples/compiled/facet_independent_scale.vg.json
@@ -142,7 +142,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "child_x", "field": "age"},
               "width": {"scale": "child_x", "band": true},

--- a/examples/compiled/facet_independent_scale_layer_broken.vg.json
+++ b/examples/compiled/facet_independent_scale_layer_broken.vg.json
@@ -146,7 +146,7 @@
                 "update": {
                   "stroke": {"scale": "color", "field": "gender"},
                   "tooltip": {
-                    "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+                    "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
                   },
                   "x": {"scale": "child_x", "field": "age"},
                   "y": {"scale": "y", "field": "sum_people"},
@@ -180,7 +180,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "child_x", "field": "age"},
               "y": {"scale": "y", "field": "sum_people"}

--- a/examples/compiled/geo_repeat.vg.json
+++ b/examples/compiled/geo_repeat.vg.json
@@ -111,7 +111,7 @@
                 {"scale": "child_population_color", "field": "population"}
               ],
               "tooltip": {
-                "signal": "{\"population\": format(datum[\"population\"], \"\"), \"geo\": ''+datum[\"geo\"]}"
+                "signal": "{\"geo\": ''+datum[\"geo\"], \"population\": format(datum[\"population\"], \"\")}"
               }
             }
           },
@@ -155,7 +155,7 @@
                 {"scale": "child_engineers_color", "field": "engineers"}
               ],
               "tooltip": {
-                "signal": "{\"engineers\": format(datum[\"engineers\"], \"\"), \"geo\": ''+datum[\"geo\"]}"
+                "signal": "{\"geo\": ''+datum[\"geo\"], \"engineers\": format(datum[\"engineers\"], \"\")}"
               }
             }
           },
@@ -199,7 +199,7 @@
                 {"scale": "child_hurricanes_color", "field": "hurricanes"}
               ],
               "tooltip": {
-                "signal": "{\"hurricanes\": format(datum[\"hurricanes\"], \"\"), \"geo\": ''+datum[\"geo\"]}"
+                "signal": "{\"geo\": ''+datum[\"geo\"], \"hurricanes\": format(datum[\"hurricanes\"], \"\")}"
               }
             }
           },

--- a/examples/compiled/geo_rule.vg.json
+++ b/examples/compiled/geo_rule.vg.json
@@ -125,7 +125,7 @@
         "update": {
           "stroke": {"value": "black"},
           "tooltip": {
-            "signal": "{\"origin_longitude\": format(datum[\"origin_longitude\"], \"\"), \"dest_longitude\": format(datum[\"dest_longitude\"], \"\"), \"origin_latitude\": format(datum[\"origin_latitude\"], \"\"), \"dest_latitude\": format(datum[\"dest_latitude\"], \"\")}"
+            "signal": "{\"origin_longitude\": format(datum[\"origin_longitude\"], \"\"), \"origin_latitude\": format(datum[\"origin_latitude\"], \"\"), \"dest_longitude\": format(datum[\"dest_longitude\"], \"\"), \"dest_latitude\": format(datum[\"dest_latitude\"], \"\")}"
           },
           "x": {"field": "layer_2_x"},
           "y": {"field": "layer_2_y"},

--- a/examples/compiled/geo_trellis.vg.json
+++ b/examples/compiled/geo_trellis.vg.json
@@ -105,7 +105,7 @@
                 {"scale": "color", "field": "pct"}
               ],
               "tooltip": {
-                "signal": "{\"pct\": format(datum[\"pct\"], \"\"), \"geo\": ''+datum[\"geo\"]}"
+                "signal": "{\"geo\": ''+datum[\"geo\"], \"pct\": format(datum[\"pct\"], \"\")}"
               }
             }
           },

--- a/examples/compiled/histogram_bin_transform.vg.json
+++ b/examples/compiled/histogram_bin_transform.vg.json
@@ -50,7 +50,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"IMDB_Rating (binned)\": format(datum[\"bin_IMDB_Rating\"], \"\"), \"Number of Records\": format(datum[\"count_*\"], \"\"), \"bin_IMDB_Rating_end\": format(datum[\"bin_IMDB_Rating_end\"], \"\")}"
+            "signal": "{\"IMDB_Rating (binned)\": format(datum[\"bin_IMDB_Rating\"], \"\"), \"bin_IMDB_Rating_end\": format(datum[\"bin_IMDB_Rating_end\"], \"\"), \"Number of Records\": format(datum[\"count_*\"], \"\")}"
           },
           "x2": {"scale": "x", "field": "bin_IMDB_Rating", "offset": 1},
           "x": {"scale": "x", "field": "bin_IMDB_Rating_end", "offset": 0},

--- a/examples/compiled/histogram_sort_mean.vg.json
+++ b/examples/compiled/histogram_sort_mean.vg.json
@@ -43,7 +43,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"Mean of Horsepower\": format(datum[\"mean_Horsepower\"], \"\"), \"Origin\": ''+datum[\"Origin\"]}"
+            "signal": "{\"Origin\": ''+datum[\"Origin\"], \"Mean of Horsepower\": format(datum[\"mean_Horsepower\"], \"\")}"
           },
           "x": {"scale": "x", "field": "mean_Horsepower"},
           "x2": {"scale": "x", "value": 0},

--- a/examples/compiled/interactive_dashboard_europe_pop.vg.json
+++ b/examples/compiled/interactive_dashboard_europe_pop.vg.json
@@ -556,7 +556,7 @@
                 {"value": "goldenrod"}
               ],
               "tooltip": {
-                "signal": "{\"Population_ages_15_64_of_total\": format(datum[\"Population_ages_15_64_of_total\"], \"\"), \"Country\": ''+datum[\"Country\"]}"
+                "signal": "{\"Country\": ''+datum[\"Country\"], \"Population_ages_15_64_of_total\": format(datum[\"Population_ages_15_64_of_total\"], \"\")}"
               },
               "x": {
                 "scale": "concat_0_x",
@@ -869,7 +869,7 @@
                 {"value": "goldenrod"}
               ],
               "tooltip": {
-                "signal": "{\"Population_ages_65_and_above_of_total\": format(datum[\"Population_ages_65_and_above_of_total\"], \"\"), \"Country\": ''+datum[\"Country\"]}"
+                "signal": "{\"Country\": ''+datum[\"Country\"], \"Population_ages_65_and_above_of_total\": format(datum[\"Population_ages_65_and_above_of_total\"], \"\")}"
               },
               "x": {
                 "scale": "concat_1_x",
@@ -1251,7 +1251,7 @@
                 {"value": "goldenrod"}
               ],
               "tooltip": {
-                "signal": "{\"Population_ages_65_and_above_of_total\": format(datum[\"Population_ages_65_and_above_of_total\"], \"\"), \"Population_ages_15_64_of_total\": format(datum[\"Population_ages_15_64_of_total\"], \"\")}"
+                "signal": "{\"Population_ages_15_64_of_total\": format(datum[\"Population_ages_15_64_of_total\"], \"\"), \"Population_ages_65_and_above_of_total\": format(datum[\"Population_ages_65_and_above_of_total\"], \"\")}"
               },
               "x": {
                 "scale": "concat_2_x",

--- a/examples/compiled/interactive_multi_line_label.vg.json
+++ b/examples/compiled/interactive_multi_line_label.vg.json
@@ -190,7 +190,7 @@
           "dx": {"value": 5},
           "dy": {"value": -5},
           "tooltip": {
-            "signal": "{\"date\": timeFormat(datum[\"date\"], '%b %d, %Y'), \"price\": format(datum[\"price\"], \"\")}"
+            "signal": "{\"price\": format(datum[\"price\"], \"\"), \"date\": timeFormat(datum[\"date\"], '%b %d, %Y')}"
           },
           "x": {"scale": "x", "field": "date"},
           "y": {"scale": "y", "field": "price"},
@@ -216,7 +216,7 @@
             {"scale": "fill", "field": "symbol"}
           ],
           "tooltip": {
-            "signal": "{\"date\": timeFormat(datum[\"date\"], '%b %d, %Y'), \"price\": format(datum[\"price\"], \"\"), \"symbol\": ''+datum[\"symbol\"]}"
+            "signal": "{\"price\": format(datum[\"price\"], \"\"), \"date\": timeFormat(datum[\"date\"], '%b %d, %Y'), \"symbol\": ''+datum[\"symbol\"]}"
           },
           "x": {"scale": "x", "field": "date"},
           "y": {"scale": "y", "field": "price"},

--- a/examples/compiled/interactive_seattle_weather.vg.json
+++ b/examples/compiled/interactive_seattle_weather.vg.json
@@ -311,7 +311,7 @@
                 {"value": "lightgray"}
               ],
               "tooltip": {
-                "signal": "{\"Date\": timeFormat(datum[\"monthdate_date\"], '%b'), \"Maximum Daily Temperature (C)\": format(datum[\"temp_max\"], \"\"), \"weather\": ''+datum[\"weather\"], \"precipitation\": format(datum[\"precipitation\"], \"\")}"
+                "signal": "{\"weather\": ''+datum[\"weather\"], \"precipitation\": format(datum[\"precipitation\"], \"\"), \"Date\": timeFormat(datum[\"monthdate_date\"], '%b'), \"Maximum Daily Temperature (C)\": format(datum[\"temp_max\"], \"\")}"
               },
               "x": {"scale": "concat_0_x", "field": "monthdate_date"},
               "y": {"scale": "concat_0_y", "field": "temp_max"},
@@ -482,7 +482,7 @@
                 {"value": "lightgray"}
               ],
               "tooltip": {
-                "signal": "{\"Number of Records\": format(datum[\"count_*\"], \"\"), \"weather\": ''+datum[\"weather\"], \"Weather\": ''+datum[\"weather\"]}"
+                "signal": "{\"Weather\": ''+datum[\"weather\"], \"Number of Records\": format(datum[\"count_*\"], \"\"), \"weather\": ''+datum[\"weather\"]}"
               },
               "x": {"scale": "concat_1_x", "field": "count_*"},
               "x2": {"scale": "concat_1_x", "value": 0},

--- a/examples/compiled/layer_bar_labels.vg.json
+++ b/examples/compiled/layer_bar_labels.vg.json
@@ -34,7 +34,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"b\": format(datum[\"b\"], \"\"), \"a\": ''+datum[\"a\"]}"
+            "signal": "{\"a\": ''+datum[\"a\"], \"b\": format(datum[\"b\"], \"\")}"
           },
           "x": {"scale": "x", "field": "b"},
           "x2": {"scale": "x", "value": 0},
@@ -61,7 +61,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"b\": format(datum[\"b\"], \"\"), \"a\": ''+datum[\"a\"]}"
+            "signal": "{\"a\": ''+datum[\"a\"], \"b\": format(datum[\"b\"], \"\")}"
           },
           "x": {"scale": "x", "field": "b"},
           "y": {"scale": "y", "field": "a", "band": 0.5},

--- a/examples/compiled/layer_bar_labels_style.vg.json
+++ b/examples/compiled/layer_bar_labels_style.vg.json
@@ -34,7 +34,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"b\": format(datum[\"b\"], \"\"), \"a\": ''+datum[\"a\"]}"
+            "signal": "{\"a\": ''+datum[\"a\"], \"b\": format(datum[\"b\"], \"\")}"
           },
           "x": {"scale": "x", "field": "b"},
           "x2": {"scale": "x", "value": 0},
@@ -58,7 +58,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"b\": format(datum[\"b\"], \"\"), \"a\": ''+datum[\"a\"]}"
+            "signal": "{\"a\": ''+datum[\"a\"], \"b\": format(datum[\"b\"], \"\")}"
           },
           "x": {"scale": "x", "field": "b"},
           "y": {"scale": "y", "field": "a", "band": 0.5},

--- a/examples/compiled/layer_boxplot_circle.vg.json
+++ b/examples/compiled/layer_boxplot_circle.vg.json
@@ -69,7 +69,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"], \"lower_box_people\": format(datum[\"lower_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_whisker_people\"], \"\"), \"lower_box_people\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "lower_whisker_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -92,7 +92,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"upper_box_people\"], \"\"), \"upper_whisker_people\": format(datum[\"upper_whisker_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "upper_box_people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},
@@ -115,7 +115,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"age\": ''+datum[\"age\"], \"upper_box_people\": format(datum[\"upper_box_people\"], \"\")}"
+            "signal": "{\"population\": format(datum[\"lower_box_people\"], \"\"), \"upper_box_people\": format(datum[\"upper_box_people\"], \"\"), \"age\": ''+datum[\"age\"]}"
           },
           "x": {"scale": "x", "field": "lower_box_people"},
           "x2": {"scale": "x", "field": "upper_box_people"},
@@ -165,7 +165,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"population\": format(datum[\"people\"], \"\"), \"age\": ''+datum[\"age\"]}"
+            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"people\"], \"\")}"
           },
           "x": {"scale": "x", "field": "people"},
           "y": {"scale": "y", "field": "age", "band": 0.5},

--- a/examples/compiled/layer_cumulative_histogram.vg.json
+++ b/examples/compiled/layer_cumulative_histogram.vg.json
@@ -60,7 +60,7 @@
             {"value": "#4c78a8"}
           ],
           "tooltip": {
-            "signal": "{\"IMDB Rating\": format(datum[\"bin_IMDB_Rating\"], \"\"), \"cumulative_count\": format(datum[\"cumulative_count\"], \"\"), \"bin_IMDB_Rating_end\": format(datum[\"bin_IMDB_Rating_end\"], \"\")}"
+            "signal": "{\"IMDB Rating\": format(datum[\"bin_IMDB_Rating\"], \"\"), \"bin_IMDB_Rating_end\": format(datum[\"bin_IMDB_Rating_end\"], \"\"), \"cumulative_count\": format(datum[\"cumulative_count\"], \"\")}"
           },
           "x": {"scale": "x", "field": "bin_IMDB_Rating"},
           "x2": {"scale": "x", "field": "bin_IMDB_Rating_end"},
@@ -85,7 +85,7 @@
             {"value": "yellow"}
           ],
           "tooltip": {
-            "signal": "{\"IMDB Rating\": format(datum[\"bin_IMDB_Rating\"], \"\"), \"count\": format(datum[\"count\"], \"\"), \"bin_IMDB_Rating_end\": format(datum[\"bin_IMDB_Rating_end\"], \"\")}"
+            "signal": "{\"IMDB Rating\": format(datum[\"bin_IMDB_Rating\"], \"\"), \"bin_IMDB_Rating_end\": format(datum[\"bin_IMDB_Rating_end\"], \"\"), \"count\": format(datum[\"count\"], \"\")}"
           },
           "x": {"scale": "x", "field": "bin_IMDB_Rating"},
           "x2": {"scale": "x", "field": "bin_IMDB_Rating_end"},

--- a/examples/compiled/layer_line_errorband_2d_horizontal_borders_strokedash.vg.json
+++ b/examples/compiled/layer_line_errorband_2d_horizontal_borders_strokedash.vg.json
@@ -61,7 +61,7 @@
           "orient": {"value": "vertical"},
           "fill": {"value": "#4c78a8"},
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\"), \"upper_Miles_per_Gallon\": format(datum[\"upper_Miles_per_Gallon\"], \"\")}"
+            "signal": "{\"Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\"), \"upper_Miles_per_Gallon\": format(datum[\"upper_Miles_per_Gallon\"], \"\"), \"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y')}"
           },
           "x": {"scale": "x", "field": "year_Year"},
           "y": {"scale": "y", "field": "lower_Miles_per_Gallon"},
@@ -84,7 +84,7 @@
           "strokeDash": {"value": [6, 4]},
           "stroke": {"value": "#4c78a8"},
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\")}"
+            "signal": "{\"Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\"), \"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y')}"
           },
           "x": {"scale": "x", "field": "year_Year"},
           "y": {"scale": "y", "field": "lower_Miles_per_Gallon"},
@@ -106,7 +106,7 @@
           "strokeDash": {"value": [6, 4]},
           "stroke": {"value": "#4c78a8"},
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Miles per Gallon (95% CIs)\": format(datum[\"upper_Miles_per_Gallon\"], \"\")}"
+            "signal": "{\"Miles per Gallon (95% CIs)\": format(datum[\"upper_Miles_per_Gallon\"], \"\"), \"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y')}"
           },
           "x": {"scale": "x", "field": "year_Year"},
           "y": {"scale": "y", "field": "upper_Miles_per_Gallon"},
@@ -126,7 +126,7 @@
         "update": {
           "stroke": {"value": "#4c78a8"},
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Mean of Miles_per_Gallon\": format(datum[\"mean_Miles_per_Gallon\"], \"\")}"
+            "signal": "{\"Mean of Miles_per_Gallon\": format(datum[\"mean_Miles_per_Gallon\"], \"\"), \"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y')}"
           },
           "x": {"scale": "x", "field": "year_Year"},
           "y": {"scale": "y", "field": "mean_Miles_per_Gallon"},

--- a/examples/compiled/layer_line_errorband_ci.vg.json
+++ b/examples/compiled/layer_line_errorband_ci.vg.json
@@ -61,7 +61,7 @@
           "orient": {"value": "vertical"},
           "fill": {"value": "#4c78a8"},
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Mean of Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\"), \"upper_Miles_per_Gallon\": format(datum[\"upper_Miles_per_Gallon\"], \"\")}"
+            "signal": "{\"Mean of Miles per Gallon (95% CIs)\": format(datum[\"lower_Miles_per_Gallon\"], \"\"), \"upper_Miles_per_Gallon\": format(datum[\"upper_Miles_per_Gallon\"], \"\"), \"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y')}"
           },
           "x": {"scale": "x", "field": "year_Year"},
           "y": {"scale": "y", "field": "lower_Miles_per_Gallon"},

--- a/examples/compiled/layer_line_errorband_pre_aggregated.vg.json
+++ b/examples/compiled/layer_line_errorband_pre_aggregated.vg.json
@@ -80,7 +80,7 @@
           "orient": {"value": "vertical"},
           "fill": {"value": "#4c78a8"},
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"Mean of Miles per Gallon (95% CIs)\": format(datum[\"lower_ci1\"], \"\"), \"upper_ci1\": format(datum[\"upper_ci1\"], \"\")}"
+            "signal": "{\"Mean of Miles per Gallon (95% CIs)\": format(datum[\"lower_ci1\"], \"\"), \"upper_ci1\": format(datum[\"upper_ci1\"], \"\"), \"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y')}"
           },
           "x": {"scale": "x", "field": "year_Year"},
           "y": {"scale": "y", "field": "lower_ci1"},
@@ -101,7 +101,7 @@
         "update": {
           "stroke": {"value": "#4c78a8"},
           "tooltip": {
-            "signal": "{\"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y'), \"center\": format(datum[\"center\"], \"\")}"
+            "signal": "{\"center\": format(datum[\"center\"], \"\"), \"Year (year)\": timeFormat(datum[\"year_Year\"], '%Y')}"
           },
           "x": {"scale": "x", "field": "year_Year"},
           "y": {"scale": "y", "field": "center"},

--- a/examples/compiled/layer_point_errorbar_2d_horizontal.vg.json
+++ b/examples/compiled/layer_point_errorbar_2d_horizontal.vg.json
@@ -59,7 +59,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"yield\": format(datum[\"lower_yield\"], \"\"), \"variety\": ''+datum[\"variety\"], \"upper_yield\": format(datum[\"upper_yield\"], \"\")}"
+            "signal": "{\"yield\": format(datum[\"lower_yield\"], \"\"), \"upper_yield\": format(datum[\"upper_yield\"], \"\"), \"variety\": ''+datum[\"variety\"]}"
           },
           "x": {"scale": "x", "field": "lower_yield"},
           "y": {"scale": "y", "field": "variety", "band": 0.5},

--- a/examples/compiled/layer_point_errorbar_2d_horizontal_ci.vg.json
+++ b/examples/compiled/layer_point_errorbar_2d_horizontal_ci.vg.json
@@ -43,7 +43,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"yield\": format(datum[\"lower_yield\"], \"\"), \"variety\": ''+datum[\"variety\"], \"upper_yield\": format(datum[\"upper_yield\"], \"\")}"
+            "signal": "{\"yield\": format(datum[\"lower_yield\"], \"\"), \"upper_yield\": format(datum[\"upper_yield\"], \"\"), \"variety\": ''+datum[\"variety\"]}"
           },
           "x": {"scale": "x", "field": "lower_yield"},
           "y": {"scale": "y", "field": "variety", "band": 0.5},

--- a/examples/compiled/layer_point_errorbar_2d_horizontal_color_encoding.vg.json
+++ b/examples/compiled/layer_point_errorbar_2d_horizontal_color_encoding.vg.json
@@ -109,7 +109,7 @@
             {"value": "#4682b4"}
           ],
           "tooltip": {
-            "signal": "{\"yield\": format(datum[\"lower_yield\"], \"\"), \"variety\": ''+datum[\"variety\"], \"upper_yield\": format(datum[\"upper_yield\"], \"\")}"
+            "signal": "{\"yield\": format(datum[\"lower_yield\"], \"\"), \"upper_yield\": format(datum[\"upper_yield\"], \"\"), \"variety\": ''+datum[\"variety\"]}"
           },
           "x": {"scale": "x", "field": "lower_yield"},
           "y": {"scale": "y", "field": "variety", "band": 0.5},

--- a/examples/compiled/layer_point_errorbar_2d_horizontal_custom_ticks.vg.json
+++ b/examples/compiled/layer_point_errorbar_2d_horizontal_custom_ticks.vg.json
@@ -109,7 +109,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"yield\": format(datum[\"lower_yield\"], \"\"), \"variety\": ''+datum[\"variety\"], \"upper_yield\": format(datum[\"upper_yield\"], \"\")}"
+            "signal": "{\"yield\": format(datum[\"lower_yield\"], \"\"), \"upper_yield\": format(datum[\"upper_yield\"], \"\"), \"variety\": ''+datum[\"variety\"]}"
           },
           "x": {"scale": "x", "field": "lower_yield"},
           "y": {"scale": "y", "field": "variety", "band": 0.5},

--- a/examples/compiled/layer_point_errorbar_2d_horizontal_iqr.vg.json
+++ b/examples/compiled/layer_point_errorbar_2d_horizontal_iqr.vg.json
@@ -43,7 +43,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"yield\": format(datum[\"lower_yield\"], \"\"), \"variety\": ''+datum[\"variety\"], \"upper_yield\": format(datum[\"upper_yield\"], \"\")}"
+            "signal": "{\"yield\": format(datum[\"lower_yield\"], \"\"), \"upper_yield\": format(datum[\"upper_yield\"], \"\"), \"variety\": ''+datum[\"variety\"]}"
           },
           "x": {"scale": "x", "field": "lower_yield"},
           "y": {"scale": "y", "field": "variety", "band": 0.5},

--- a/examples/compiled/layer_point_errorbar_2d_horizontal_pre_aggregated.vg.json
+++ b/examples/compiled/layer_point_errorbar_2d_horizontal_pre_aggregated.vg.json
@@ -74,7 +74,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"yield\": format(datum[\"lower_upper_yield\"], \"\"), \"variety\": ''+datum[\"variety\"], \"upper_upper_yield\": format(datum[\"upper_upper_yield\"], \"\")}"
+            "signal": "{\"yield\": format(datum[\"lower_upper_yield\"], \"\"), \"upper_upper_yield\": format(datum[\"upper_upper_yield\"], \"\"), \"variety\": ''+datum[\"variety\"]}"
           },
           "x": {"scale": "x", "field": "lower_upper_yield"},
           "y": {"scale": "y", "field": "variety", "band": 0.5},

--- a/examples/compiled/layer_point_errorbar_2d_horizontal_pre_aggregated_error_asymmetric.vg.json
+++ b/examples/compiled/layer_point_errorbar_2d_horizontal_pre_aggregated_error_asymmetric.vg.json
@@ -74,7 +74,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"yield\": format(datum[\"lower_yield_center\"], \"\"), \"variety\": ''+datum[\"variety\"], \"upper_yield_center\": format(datum[\"upper_yield_center\"], \"\")}"
+            "signal": "{\"yield\": format(datum[\"lower_yield_center\"], \"\"), \"upper_yield_center\": format(datum[\"upper_yield_center\"], \"\"), \"variety\": ''+datum[\"variety\"]}"
           },
           "x": {"scale": "x", "field": "lower_yield_center"},
           "y": {"scale": "y", "field": "variety", "band": 0.5},

--- a/examples/compiled/layer_point_errorbar_2d_horizontal_pre_aggregated_error_symmetric.vg.json
+++ b/examples/compiled/layer_point_errorbar_2d_horizontal_pre_aggregated_error_symmetric.vg.json
@@ -62,7 +62,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"yield\": format(datum[\"lower_yield_center\"], \"\"), \"variety\": ''+datum[\"variety\"], \"upper_yield_center\": format(datum[\"upper_yield_center\"], \"\")}"
+            "signal": "{\"yield\": format(datum[\"lower_yield_center\"], \"\"), \"upper_yield_center\": format(datum[\"upper_yield_center\"], \"\"), \"variety\": ''+datum[\"variety\"]}"
           },
           "x": {"scale": "x", "field": "lower_yield_center"},
           "y": {"scale": "y", "field": "variety", "band": 0.5},

--- a/examples/compiled/layer_point_errorbar_2d_horizontal_stdev.vg.json
+++ b/examples/compiled/layer_point_errorbar_2d_horizontal_stdev.vg.json
@@ -59,7 +59,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"yield\": format(datum[\"lower_yield\"], \"\"), \"variety\": ''+datum[\"variety\"], \"upper_yield\": format(datum[\"upper_yield\"], \"\")}"
+            "signal": "{\"yield\": format(datum[\"lower_yield\"], \"\"), \"upper_yield\": format(datum[\"upper_yield\"], \"\"), \"variety\": ''+datum[\"variety\"]}"
           },
           "x": {"scale": "x", "field": "lower_yield"},
           "y": {"scale": "y", "field": "variety", "band": 0.5},

--- a/examples/compiled/layer_point_errorbar_2d_vertical.vg.json
+++ b/examples/compiled/layer_point_errorbar_2d_vertical.vg.json
@@ -59,7 +59,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"variety\": ''+datum[\"variety\"], \"yield\": format(datum[\"lower_yield\"], \"\"), \"upper_yield\": format(datum[\"upper_yield\"], \"\")}"
+            "signal": "{\"yield\": format(datum[\"lower_yield\"], \"\"), \"upper_yield\": format(datum[\"upper_yield\"], \"\"), \"variety\": ''+datum[\"variety\"]}"
           },
           "x": {"scale": "x", "field": "variety", "band": 0.5},
           "y": {"scale": "y", "field": "lower_yield"},
@@ -82,7 +82,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"variety\": ''+datum[\"variety\"], \"Mean of yield\": format(datum[\"mean_yield\"], \"\")}"
+            "signal": "{\"Mean of yield\": format(datum[\"mean_yield\"], \"\"), \"variety\": ''+datum[\"variety\"]}"
           },
           "x": {"scale": "x", "field": "variety", "band": 0.5},
           "y": {"scale": "y", "field": "mean_yield"}

--- a/examples/compiled/layer_point_errorbar_ci.vg.json
+++ b/examples/compiled/layer_point_errorbar_ci.vg.json
@@ -43,7 +43,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"Barley Yield\": format(datum[\"mean_yield\"], \"\"), \"variety\": ''+datum[\"variety\"]}"
+            "signal": "{\"variety\": ''+datum[\"variety\"], \"Barley Yield\": format(datum[\"mean_yield\"], \"\")}"
           },
           "x": {"scale": "x", "field": "mean_yield"},
           "y": {"scale": "y", "field": "variety", "band": 0.5}
@@ -65,7 +65,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"Barley Yield\": format(datum[\"lower_yield\"], \"\"), \"variety\": ''+datum[\"variety\"], \"upper_yield\": format(datum[\"upper_yield\"], \"\")}"
+            "signal": "{\"Barley Yield\": format(datum[\"lower_yield\"], \"\"), \"upper_yield\": format(datum[\"upper_yield\"], \"\"), \"variety\": ''+datum[\"variety\"]}"
           },
           "x": {"scale": "x", "field": "lower_yield"},
           "y": {"scale": "y", "field": "variety", "band": 0.5},

--- a/examples/compiled/layer_point_errorbar_stdev.vg.json
+++ b/examples/compiled/layer_point_errorbar_stdev.vg.json
@@ -59,7 +59,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"Barley Yield\": format(datum[\"mean_yield\"], \"\"), \"variety\": ''+datum[\"variety\"]}"
+            "signal": "{\"variety\": ''+datum[\"variety\"], \"Barley Yield\": format(datum[\"mean_yield\"], \"\")}"
           },
           "x": {"scale": "x", "field": "mean_yield"},
           "y": {"scale": "y", "field": "variety", "band": 0.5}
@@ -81,7 +81,7 @@
             {"value": "black"}
           ],
           "tooltip": {
-            "signal": "{\"Barley Yield\": format(datum[\"lower_yield\"], \"\"), \"variety\": ''+datum[\"variety\"], \"upper_yield\": format(datum[\"upper_yield\"], \"\")}"
+            "signal": "{\"Barley Yield\": format(datum[\"lower_yield\"], \"\"), \"upper_yield\": format(datum[\"upper_yield\"], \"\"), \"variety\": ''+datum[\"variety\"]}"
           },
           "x": {"scale": "x", "field": "lower_yield"},
           "y": {"scale": "y", "field": "variety", "band": 0.5},

--- a/examples/compiled/layer_text_heatmap.vg.json
+++ b/examples/compiled/layer_text_heatmap.vg.json
@@ -41,7 +41,7 @@
             {"scale": "color", "field": "count_*"}
           ],
           "tooltip": {
-            "signal": "{\"Cylinders\": ''+datum[\"Cylinders\"], \"Origin\": ''+datum[\"Origin\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+            "signal": "{\"Origin\": ''+datum[\"Origin\"], \"Cylinders\": ''+datum[\"Cylinders\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Cylinders"},
           "width": {"scale": "x", "band": true},
@@ -62,7 +62,7 @@
             {"value": "white"}
           ],
           "tooltip": {
-            "signal": "{\"Cylinders\": ''+datum[\"Cylinders\"], \"Origin\": ''+datum[\"Origin\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+            "signal": "{\"Origin\": ''+datum[\"Origin\"], \"Cylinders\": ''+datum[\"Cylinders\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Cylinders", "band": 0.5},
           "y": {"scale": "y", "field": "Origin", "band": 0.5},

--- a/examples/compiled/line_color_binned.vg.json
+++ b/examples/compiled/line_color_binned.vg.json
@@ -73,7 +73,7 @@
                 "field": "bin_maxbins_6_Acceleration"
               },
               "tooltip": {
-                "signal": "{\"Year\": timeFormat(datum[\"Year\"], '%b %d, %Y'), \"Mean of Horsepower\": format(datum[\"mean_Horsepower\"], \"\"), \"Acceleration (binned)\": datum[\"bin_maxbins_6_Acceleration\"] === null || isNaN(datum[\"bin_maxbins_6_Acceleration\"]) ? \"null\" : format(datum[\"bin_maxbins_6_Acceleration\"], \"\") + \" - \" + format(datum[\"bin_maxbins_6_Acceleration_end\"], \"\")}"
+                "signal": "{\"Mean of Horsepower\": format(datum[\"mean_Horsepower\"], \"\"), \"Year\": timeFormat(datum[\"Year\"], '%b %d, %Y'), \"Acceleration (binned)\": datum[\"bin_maxbins_6_Acceleration\"] === null || isNaN(datum[\"bin_maxbins_6_Acceleration\"]) ? \"null\" : format(datum[\"bin_maxbins_6_Acceleration\"], \"\") + \" - \" + format(datum[\"bin_maxbins_6_Acceleration_end\"], \"\")}"
               },
               "x": {"scale": "x", "field": "Year"},
               "y": {"scale": "y", "field": "mean_Horsepower"},

--- a/examples/compiled/point_dot_timeunit_color.vg.json
+++ b/examples/compiled/point_dot_timeunit_color.vg.json
@@ -49,7 +49,7 @@
             {"scale": "color", "field": "yearmonth_date"}
           ],
           "tooltip": {
-            "signal": "{\"Mean of temp\": format(datum[\"mean_temp\"], \"\"), \"date (year-month)\": timeFormat(datum[\"yearmonth_date\"], '%b %Y')}"
+            "signal": "{\"date (year-month)\": timeFormat(datum[\"yearmonth_date\"], '%b %Y'), \"Mean of temp\": format(datum[\"mean_temp\"], \"\")}"
           },
           "x": {"scale": "x", "field": "mean_temp"},
           "y": {"signal": "height", "mult": 0.5}

--- a/examples/compiled/rect_heatmap.vg.json
+++ b/examples/compiled/rect_heatmap.vg.json
@@ -47,7 +47,7 @@
             {"scale": "color", "field": "mean_Horsepower"}
           ],
           "tooltip": {
-            "signal": "{\"Cylinders\": ''+datum[\"Cylinders\"], \"Origin\": ''+datum[\"Origin\"], \"Mean of Horsepower\": format(datum[\"mean_Horsepower\"], \"\")}"
+            "signal": "{\"Origin\": ''+datum[\"Origin\"], \"Cylinders\": ''+datum[\"Cylinders\"], \"Mean of Horsepower\": format(datum[\"mean_Horsepower\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Cylinders"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/rect_lasagna_future.vg.json
+++ b/examples/compiled/rect_lasagna_future.vg.json
@@ -43,7 +43,7 @@
             {"scale": "color", "field": "sum_price"}
           ],
           "tooltip": {
-            "signal": "{\"Time\": timeFormat(datum[\"yearmonthdate_date\"], '%Y'), \"symbol\": ''+datum[\"symbol\"], \"Price\": format(datum[\"sum_price\"], \"\")}"
+            "signal": "{\"Time\": timeFormat(datum[\"yearmonthdate_date\"], '%Y'), \"Price\": format(datum[\"sum_price\"], \"\"), \"symbol\": ''+datum[\"symbol\"]}"
           },
           "x": {"scale": "x", "field": "yearmonthdate_date"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/repeat_layer.vg.json
+++ b/examples/compiled/repeat_layer.vg.json
@@ -115,7 +115,7 @@
                   "stroke": {"scale": "color", "field": "location"},
                   "opacity": {"value": 0.2},
                   "tooltip": {
-                    "signal": "{\"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"Mean of temp_max\": format(datum[\"mean_temp_max\"], \"\"), \"location\": ''+datum[\"location\"], \"date (year)\": timeFormat(datum[\"year_date\"], '%Y')}"
+                    "signal": "{\"Mean of temp_max\": format(datum[\"mean_temp_max\"], \"\"), \"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"date (year)\": timeFormat(datum[\"year_date\"], '%Y'), \"location\": ''+datum[\"location\"]}"
                   },
                   "x": {"scale": "child_temp_max_x", "field": "month_date"},
                   "y": {"scale": "child_temp_max_y", "field": "mean_temp_max"},
@@ -154,7 +154,7 @@
                 "update": {
                   "stroke": {"scale": "color", "field": "location"},
                   "tooltip": {
-                    "signal": "{\"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"Mean of temp_max\": format(datum[\"mean_temp_max\"], \"\"), \"location\": ''+datum[\"location\"]}"
+                    "signal": "{\"Mean of temp_max\": format(datum[\"mean_temp_max\"], \"\"), \"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"location\": ''+datum[\"location\"]}"
                   },
                   "x": {"scale": "child_temp_max_x", "field": "month_date"},
                   "y": {"scale": "child_temp_max_y", "field": "mean_temp_max"},
@@ -247,7 +247,7 @@
                   "stroke": {"scale": "color", "field": "location"},
                   "opacity": {"value": 0.2},
                   "tooltip": {
-                    "signal": "{\"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"Mean of precipitation\": format(datum[\"mean_precipitation\"], \"\"), \"location\": ''+datum[\"location\"], \"date (year)\": timeFormat(datum[\"year_date\"], '%Y')}"
+                    "signal": "{\"Mean of precipitation\": format(datum[\"mean_precipitation\"], \"\"), \"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"date (year)\": timeFormat(datum[\"year_date\"], '%Y'), \"location\": ''+datum[\"location\"]}"
                   },
                   "x": {
                     "scale": "child_precipitation_x",
@@ -292,7 +292,7 @@
                 "update": {
                   "stroke": {"scale": "color", "field": "location"},
                   "tooltip": {
-                    "signal": "{\"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"Mean of precipitation\": format(datum[\"mean_precipitation\"], \"\"), \"location\": ''+datum[\"location\"]}"
+                    "signal": "{\"Mean of precipitation\": format(datum[\"mean_precipitation\"], \"\"), \"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"location\": ''+datum[\"location\"]}"
                   },
                   "x": {
                     "scale": "child_precipitation_x",
@@ -391,7 +391,7 @@
                   "stroke": {"scale": "color", "field": "location"},
                   "opacity": {"value": 0.2},
                   "tooltip": {
-                    "signal": "{\"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"Mean of wind\": format(datum[\"mean_wind\"], \"\"), \"location\": ''+datum[\"location\"], \"date (year)\": timeFormat(datum[\"year_date\"], '%Y')}"
+                    "signal": "{\"Mean of wind\": format(datum[\"mean_wind\"], \"\"), \"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"date (year)\": timeFormat(datum[\"year_date\"], '%Y'), \"location\": ''+datum[\"location\"]}"
                   },
                   "x": {"scale": "child_wind_x", "field": "month_date"},
                   "y": {"scale": "child_wind_y", "field": "mean_wind"},
@@ -430,7 +430,7 @@
                 "update": {
                   "stroke": {"scale": "color", "field": "location"},
                   "tooltip": {
-                    "signal": "{\"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"Mean of wind\": format(datum[\"mean_wind\"], \"\"), \"location\": ''+datum[\"location\"]}"
+                    "signal": "{\"Mean of wind\": format(datum[\"mean_wind\"], \"\"), \"date (month)\": timeFormat(datum[\"month_date\"], '%b'), \"location\": ''+datum[\"location\"]}"
                   },
                   "x": {"scale": "child_wind_x", "field": "month_date"},
                   "y": {"scale": "child_wind_y", "field": "mean_wind"},

--- a/examples/compiled/selection_composition_and.vg.json
+++ b/examples/compiled/selection_composition_and.vg.json
@@ -554,7 +554,7 @@
             {"value": "grey"}
           ],
           "tooltip": {
-            "signal": "{\"Cylinders\": ''+datum[\"Cylinders\"], \"Origin\": ''+datum[\"Origin\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+            "signal": "{\"Origin\": ''+datum[\"Origin\"], \"Cylinders\": ''+datum[\"Cylinders\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Cylinders"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/selection_composition_or.vg.json
+++ b/examples/compiled/selection_composition_or.vg.json
@@ -554,7 +554,7 @@
             {"value": "grey"}
           ],
           "tooltip": {
-            "signal": "{\"Cylinders\": ''+datum[\"Cylinders\"], \"Origin\": ''+datum[\"Origin\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+            "signal": "{\"Origin\": ''+datum[\"Origin\"], \"Cylinders\": ''+datum[\"Cylinders\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Cylinders"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/selection_interval_mark_style.vg.json
+++ b/examples/compiled/selection_interval_mark_style.vg.json
@@ -549,7 +549,7 @@
             {"scale": "color", "field": "count_*"}
           ],
           "tooltip": {
-            "signal": "{\"Cylinders\": ''+datum[\"Cylinders\"], \"Origin\": ''+datum[\"Origin\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+            "signal": "{\"Origin\": ''+datum[\"Origin\"], \"Cylinders\": ''+datum[\"Cylinders\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Cylinders"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/selection_project_interval.vg.json
+++ b/examples/compiled/selection_project_interval.vg.json
@@ -294,7 +294,7 @@
             {"value": "grey"}
           ],
           "tooltip": {
-            "signal": "{\"Cylinders\": ''+datum[\"Cylinders\"], \"Origin\": ''+datum[\"Origin\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+            "signal": "{\"Origin\": ''+datum[\"Origin\"], \"Cylinders\": ''+datum[\"Cylinders\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Cylinders"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/selection_project_interval_x.vg.json
+++ b/examples/compiled/selection_project_interval_x.vg.json
@@ -244,7 +244,7 @@
             {"value": "grey"}
           ],
           "tooltip": {
-            "signal": "{\"Cylinders\": ''+datum[\"Cylinders\"], \"Origin\": ''+datum[\"Origin\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+            "signal": "{\"Origin\": ''+datum[\"Origin\"], \"Cylinders\": ''+datum[\"Cylinders\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Cylinders"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/selection_project_interval_x_y.vg.json
+++ b/examples/compiled/selection_project_interval_x_y.vg.json
@@ -294,7 +294,7 @@
             {"value": "grey"}
           ],
           "tooltip": {
-            "signal": "{\"Cylinders\": ''+datum[\"Cylinders\"], \"Origin\": ''+datum[\"Origin\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+            "signal": "{\"Origin\": ''+datum[\"Origin\"], \"Cylinders\": ''+datum[\"Cylinders\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Cylinders"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/selection_project_interval_y.vg.json
+++ b/examples/compiled/selection_project_interval_y.vg.json
@@ -244,7 +244,7 @@
             {"value": "grey"}
           ],
           "tooltip": {
-            "signal": "{\"Cylinders\": ''+datum[\"Cylinders\"], \"Origin\": ''+datum[\"Origin\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+            "signal": "{\"Origin\": ''+datum[\"Origin\"], \"Cylinders\": ''+datum[\"Cylinders\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Cylinders"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/selection_translate_brush_drag.vg.json
+++ b/examples/compiled/selection_translate_brush_drag.vg.json
@@ -288,7 +288,7 @@
             {"value": "grey"}
           ],
           "tooltip": {
-            "signal": "{\"Horsepower\": format(datum[\"Horsepower\"], \"\"), \"Miles_per_Gallon\": format(datum[\"Miles_per_Gallon\"], \"\"), \"Origin\": ''+datum[\"Origin\"], \"Cylinders\": format(datum[\"Cylinders\"], \"\")}"
+            "signal": "{\"Horsepower\": format(datum[\"Horsepower\"], \"\"), \"Miles_per_Gallon\": format(datum[\"Miles_per_Gallon\"], \"\"), \"Cylinders\": format(datum[\"Cylinders\"], \"\"), \"Origin\": ''+datum[\"Origin\"]}"
           },
           "x": {"scale": "x", "field": "Horsepower"},
           "y": {"scale": "y", "field": "Miles_per_Gallon"},

--- a/examples/compiled/selection_translate_brush_shift-drag.vg.json
+++ b/examples/compiled/selection_translate_brush_shift-drag.vg.json
@@ -294,7 +294,7 @@
             {"value": "grey"}
           ],
           "tooltip": {
-            "signal": "{\"Horsepower\": format(datum[\"Horsepower\"], \"\"), \"Miles_per_Gallon\": format(datum[\"Miles_per_Gallon\"], \"\"), \"Origin\": ''+datum[\"Origin\"], \"Cylinders\": format(datum[\"Cylinders\"], \"\")}"
+            "signal": "{\"Horsepower\": format(datum[\"Horsepower\"], \"\"), \"Miles_per_Gallon\": format(datum[\"Miles_per_Gallon\"], \"\"), \"Cylinders\": format(datum[\"Cylinders\"], \"\"), \"Origin\": ''+datum[\"Origin\"]}"
           },
           "x": {"scale": "x", "field": "Horsepower"},
           "y": {"scale": "y", "field": "Miles_per_Gallon"},

--- a/examples/compiled/selection_type_interval.vg.json
+++ b/examples/compiled/selection_type_interval.vg.json
@@ -294,7 +294,7 @@
             {"value": "grey"}
           ],
           "tooltip": {
-            "signal": "{\"Cylinders\": ''+datum[\"Cylinders\"], \"Origin\": ''+datum[\"Origin\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+            "signal": "{\"Origin\": ''+datum[\"Origin\"], \"Cylinders\": ''+datum[\"Cylinders\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Cylinders"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/selection_type_interval_invert.vg.json
+++ b/examples/compiled/selection_type_interval_invert.vg.json
@@ -293,7 +293,7 @@
             {"scale": "color", "field": "count_*"}
           ],
           "tooltip": {
-            "signal": "{\"Cylinders\": ''+datum[\"Cylinders\"], \"Origin\": ''+datum[\"Origin\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+            "signal": "{\"Origin\": ''+datum[\"Origin\"], \"Cylinders\": ''+datum[\"Cylinders\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Cylinders"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/selection_type_multi.vg.json
+++ b/examples/compiled/selection_type_multi.vg.json
@@ -97,7 +97,7 @@
             {"value": "grey"}
           ],
           "tooltip": {
-            "signal": "{\"Cylinders\": ''+datum[\"Cylinders\"], \"Origin\": ''+datum[\"Origin\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+            "signal": "{\"Origin\": ''+datum[\"Origin\"], \"Cylinders\": ''+datum[\"Cylinders\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Cylinders"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/selection_type_single.vg.json
+++ b/examples/compiled/selection_type_single.vg.json
@@ -87,7 +87,7 @@
             {"value": "grey"}
           ],
           "tooltip": {
-            "signal": "{\"Cylinders\": ''+datum[\"Cylinders\"], \"Origin\": ''+datum[\"Origin\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+            "signal": "{\"Origin\": ''+datum[\"Origin\"], \"Cylinders\": ''+datum[\"Cylinders\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Cylinders"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/selection_type_single_dblclick.vg.json
+++ b/examples/compiled/selection_type_single_dblclick.vg.json
@@ -87,7 +87,7 @@
             {"value": "grey"}
           ],
           "tooltip": {
-            "signal": "{\"Cylinders\": ''+datum[\"Cylinders\"], \"Origin\": ''+datum[\"Origin\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
+            "signal": "{\"Origin\": ''+datum[\"Origin\"], \"Cylinders\": ''+datum[\"Cylinders\"], \"Number of Records\": format(datum[\"count_*\"], \"\")}"
           },
           "x": {"scale": "x", "field": "Cylinders"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/selection_zoom_brush_shift-wheel.vg.json
+++ b/examples/compiled/selection_zoom_brush_shift-wheel.vg.json
@@ -290,7 +290,7 @@
             {"value": "grey"}
           ],
           "tooltip": {
-            "signal": "{\"Horsepower\": format(datum[\"Horsepower\"], \"\"), \"Miles_per_Gallon\": format(datum[\"Miles_per_Gallon\"], \"\"), \"Origin\": ''+datum[\"Origin\"], \"Cylinders\": format(datum[\"Cylinders\"], \"\")}"
+            "signal": "{\"Horsepower\": format(datum[\"Horsepower\"], \"\"), \"Miles_per_Gallon\": format(datum[\"Miles_per_Gallon\"], \"\"), \"Cylinders\": format(datum[\"Cylinders\"], \"\"), \"Origin\": ''+datum[\"Origin\"]}"
           },
           "x": {"scale": "x", "field": "Horsepower"},
           "y": {"scale": "y", "field": "Miles_per_Gallon"},

--- a/examples/compiled/selection_zoom_brush_wheel.vg.json
+++ b/examples/compiled/selection_zoom_brush_wheel.vg.json
@@ -288,7 +288,7 @@
             {"value": "grey"}
           ],
           "tooltip": {
-            "signal": "{\"Horsepower\": format(datum[\"Horsepower\"], \"\"), \"Miles_per_Gallon\": format(datum[\"Miles_per_Gallon\"], \"\"), \"Origin\": ''+datum[\"Origin\"], \"Cylinders\": format(datum[\"Cylinders\"], \"\")}"
+            "signal": "{\"Horsepower\": format(datum[\"Horsepower\"], \"\"), \"Miles_per_Gallon\": format(datum[\"Miles_per_Gallon\"], \"\"), \"Cylinders\": format(datum[\"Cylinders\"], \"\"), \"Origin\": ''+datum[\"Origin\"]}"
           },
           "x": {"scale": "x", "field": "Horsepower"},
           "y": {"scale": "y", "field": "Miles_per_Gallon"},

--- a/examples/compiled/stacked_area_overlay.vg.json
+++ b/examples/compiled/stacked_area_overlay.vg.json
@@ -79,7 +79,7 @@
               "orient": {"value": "vertical"},
               "fill": {"scale": "color", "field": "gender"},
               "tooltip": {
-                "signal": "{\"age\": ''+datum[\"age\"], \"Sum of people\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"Sum of people\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "x", "field": "age"},
               "y": {"scale": "y", "field": "sum_people_end"},
@@ -120,7 +120,7 @@
               "stroke": {"scale": "color", "field": "gender"},
               "opacity": {"value": 0.7},
               "tooltip": {
-                "signal": "{\"age\": ''+datum[\"age\"], \"Sum of people\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"Sum of people\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "x", "field": "age"},
               "y": {"scale": "y", "field": "sum_people_end"},

--- a/examples/compiled/stacked_bar_normalize.vg.json
+++ b/examples/compiled/stacked_bar_normalize.vg.json
@@ -57,7 +57,7 @@
             {"scale": "color", "field": "gender"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+            "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
           },
           "x": {"scale": "x", "field": "age"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/stacked_bar_population.vg.json
+++ b/examples/compiled/stacked_bar_population.vg.json
@@ -58,7 +58,7 @@
             {"scale": "color", "field": "gender"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+            "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
           },
           "x": {"scale": "x", "field": "age"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/stacked_bar_population_transform.vg.json
+++ b/examples/compiled/stacked_bar_population_transform.vg.json
@@ -51,7 +51,7 @@
             {"scale": "color", "field": "gender"}
           ],
           "tooltip": {
-            "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"v1\"], \"\"), \"v2\": format(datum[\"v2\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+            "signal": "{\"population\": format(datum[\"v1\"], \"\"), \"v2\": format(datum[\"v2\"], \"\"), \"age\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
           },
           "x": {"scale": "x", "field": "age"},
           "width": {"scale": "x", "band": true},

--- a/examples/compiled/test_aggregate_nested.vg.json
+++ b/examples/compiled/test_aggregate_nested.vg.json
@@ -88,7 +88,7 @@
             {"scale": "color", "field": "properties\\.site"}
           ],
           "tooltip": {
-            "signal": "{\"Sum of properties.yield\": format(datum[\"sum_properties.yield\"], \"\"), \"properties.variety\": ''+datum[\"properties.variety\"], \"site\": ''+datum[\"properties.site\"]}"
+            "signal": "{\"properties.variety\": ''+datum[\"properties.variety\"], \"Sum of properties.yield\": format(datum[\"sum_properties.yield\"], \"\"), \"site\": ''+datum[\"properties.site\"]}"
           },
           "x": {"scale": "x", "field": "sum_properties\\.yield_end"},
           "x2": {"scale": "x", "field": "sum_properties\\.yield_start"},

--- a/examples/compiled/trellis_bar.vg.json
+++ b/examples/compiled/trellis_bar.vg.json
@@ -140,7 +140,7 @@
                 {"scale": "color", "field": "gender"}
               ],
               "tooltip": {
-                "signal": "{\"age\": ''+datum[\"age\"], \"population\": format(datum[\"sum_people\"], \"\"), \"gender\": ''+datum[\"gender\"]}"
+                "signal": "{\"population\": format(datum[\"sum_people\"], \"\"), \"age\": ''+datum[\"age\"], \"gender\": ''+datum[\"gender\"]}"
               },
               "x": {"scale": "x", "field": "age"},
               "width": {"scale": "x", "band": true},

--- a/examples/compiled/window_sum_waterfall_chart.vg.json
+++ b/examples/compiled/window_sum_waterfall_chart.vg.json
@@ -130,7 +130,7 @@
             {"value": "#404040"}
           ],
           "tooltip": {
-            "signal": "{\"Months\": ''+datum[\"label\"], \"sum\": format(datum[\"sum\"], \"\"), \"lead\": ''+datum[\"lead\"]}"
+            "signal": "{\"Months\": ''+datum[\"label\"], \"lead\": ''+datum[\"lead\"], \"sum\": format(datum[\"sum\"], \"\")}"
           },
           "x": {"scale": "x", "field": "label", "band": 0.5, "offset": -22.5},
           "y": {"scale": "y", "field": "sum"},

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -388,7 +388,7 @@ export function isRanged(encoding: EncodingWithFacet<any>) {
 
 export function fieldDefs<T>(encoding: EncodingWithFacet<T>): FieldDef<T>[] {
   const arr: FieldDef<T>[] = [];
-  CHANNELS.forEach(channel => {
+  for (const channel of keys(encoding)) {
     if (channelHasField(encoding, channel)) {
       const channelDef = encoding[channel];
       (isArray(channelDef) ? channelDef : [channelDef]).forEach(def => {
@@ -399,7 +399,7 @@ export function fieldDefs<T>(encoding: EncodingWithFacet<T>): FieldDef<T>[] {
         }
       });
     }
-  });
+  }
   return arr;
 }
 


### PR DESCRIPTION
By simply using `for..of` in `fieldDefs()` that default tooltip generator depends on. 