### PR TITLE
Make `build-example` throw `exit 1` when there is an empty SVG

### DIFF
--- a/scripts/build-examples.sh
+++ b/scripts/build-examples.sh
@@ -36,9 +36,24 @@ rm -f $dir/*.vg.json
 echo "Using parallel to generate vega specs from examples in parallel."
 ls examples/specs/*.vl.json | parallel --env skipnormalize --env forcesvg --env nopatch --eta --no-notice --plus --halt 1 "./scripts/build-example.sh {/..}"
 
+
+echo "Build normalized examples."
 scripts/build-normalized-examples
 
+echo "Clean up outdated SVG files."
 # Clean up outdated svg files (This has to be done by checking files as we do not always regenerate svgs)
 ls examples/compiled/*.svg | parallel --eta --no-notice --plus --halt 1 "[ -f examples/specs/{/..}.vl.json ] || rm -f examples/compiled/{/..}.svg"
 
+echo "Check if there is any empty SVG file."
+# Throw exit 1 if there is an SVG file.
+for file in examples/specs/*.vl.json; do
+  filename=$(basename "$file")
+  name="${filename%.vl.json}"
 
+  # [[ -s file ]] --> Checks if file has size greater than 0
+  # Here we check if there is an empty SVG file.
+  if [ ! -s "examples/compiled/$name.svg" ]; then
+    echo " examples/compiled/$name.svg empty "
+    exit 1
+  fi
+done


### PR DESCRIPTION
by modifying `build-examples.sh`