### PR TITLE
Add `view` as a property for Layer and Unit specs for customizing view background

### DIFF
--- a/_data/link.yml
+++ b/_data/link.yml
@@ -4,6 +4,8 @@
 CompositeUnitSpec:
   name: SingleViewSpec
   link: "spec.html#single"
+ViewBackground:
+  name: "spec.html#view-background"
 LayerSpec:
   link: "layer.html"
 AutoSizeParams:

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -2734,7 +2734,7 @@
           "description": "Y-axis specific config."
         },
         "background": {
-          "description": "CSS color property to use as the background of visualization.\n\n__Default value:__ none (transparent)",
+          "description": "CSS color property to use as the background of the whole Vega-Lite view\n\n__Default value:__ none (transparent)",
           "type": "string"
         },
         "bar": {
@@ -3987,6 +3987,10 @@
             "$ref": "#/definitions/Transform"
           },
           "type": "array"
+        },
+        "view": {
+          "$ref": "#/definitions/ViewBackground",
+          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
         },
         "width": {
           "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
@@ -5370,6 +5374,10 @@
           },
           "type": "array"
         },
+        "view": {
+          "$ref": "#/definitions/ViewBackground",
+          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
+        },
         "width": {
           "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
           "type": "number"
@@ -5436,6 +5444,10 @@
             "$ref": "#/definitions/Transform"
           },
           "type": "array"
+        },
+        "view": {
+          "$ref": "#/definitions/ViewBackground",
+          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
         },
         "width": {
           "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
@@ -10074,7 +10086,7 @@
           "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
         },
         "background": {
-          "description": "CSS color property to use as the background of visualization.\n\n__Default value:__ none (transparent)",
+          "description": "CSS color property to use as the background of the entire view.\n\n__Default value:__ none (transparent)",
           "type": "string"
         },
         "config": {
@@ -10153,6 +10165,10 @@
           "description": "Optional metadata that will be passed to Vega.\nThis object is completely ignored by Vega and Vega-Lite and can be used for custom metadata.",
           "type": "object"
         },
+        "view": {
+          "$ref": "#/definitions/ViewBackground",
+          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
+        },
         "width": {
           "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
           "type": "number"
@@ -10183,7 +10199,7 @@
           "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
         },
         "background": {
-          "description": "CSS color property to use as the background of visualization.\n\n__Default value:__ none (transparent)",
+          "description": "CSS color property to use as the background of the entire view.\n\n__Default value:__ none (transparent)",
           "type": "string"
         },
         "bounds": {
@@ -10296,7 +10312,7 @@
           "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
         },
         "background": {
-          "description": "CSS color property to use as the background of visualization.\n\n__Default value:__ none (transparent)",
+          "description": "CSS color property to use as the background of the entire view.\n\n__Default value:__ none (transparent)",
           "type": "string"
         },
         "bounds": {
@@ -10413,7 +10429,7 @@
           "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
         },
         "background": {
-          "description": "CSS color property to use as the background of visualization.\n\n__Default value:__ none (transparent)",
+          "description": "CSS color property to use as the background of the entire view.\n\n__Default value:__ none (transparent)",
           "type": "string"
         },
         "bounds": {
@@ -10526,7 +10542,7 @@
           "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
         },
         "background": {
-          "description": "CSS color property to use as the background of visualization.\n\n__Default value:__ none (transparent)",
+          "description": "CSS color property to use as the background of the entire view.\n\n__Default value:__ none (transparent)",
           "type": "string"
         },
         "bounds": {
@@ -10652,7 +10668,7 @@
           "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
         },
         "background": {
-          "description": "CSS color property to use as the background of visualization.\n\n__Default value:__ none (transparent)",
+          "description": "CSS color property to use as the background of the entire view.\n\n__Default value:__ none (transparent)",
           "type": "string"
         },
         "config": {
@@ -10723,6 +10739,10 @@
         "usermeta": {
           "description": "Optional metadata that will be passed to Vega.\nThis object is completely ignored by Vega and Vega-Lite and can be used for custom metadata.",
           "type": "object"
+        },
+        "view": {
+          "$ref": "#/definitions/ViewBackground",
+          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
         },
         "width": {
           "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
@@ -11382,6 +11402,70 @@
       ],
       "type": "object"
     },
+    "ViewBackground": {
+      "additionalProperties": false,
+      "properties": {
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners.\n\n__Default value:__ `0`",
+          "type": "number"
+        },
+        "fill": {
+          "description": "The fill color.\n\n__Default value:__ `undefined`",
+          "type": "string"
+        },
+        "fillOpacity": {
+          "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "opacity": {
+          "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "stroke": {
+          "description": "The stroke color.\n\n__Default value:__ `undefined`",
+          "type": "string"
+        },
+        "strokeCap": {
+          "$ref": "#/definitions/StrokeCap",
+          "description": "The stroke cap for line ending style. One of `\"butt\"`, `\"round\"`, or `\"square\"`.\n\n__Default value:__ `\"square\"`"
+        },
+        "strokeDash": {
+          "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "strokeDashOffset": {
+          "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
+          "type": "number"
+        },
+        "strokeJoin": {
+          "$ref": "#/definitions/StrokeJoin",
+          "description": "The stroke line join method. One of `\"miter\"`, `\"round\"` or `\"bevel\"`.\n\n__Default value:__ `\"miter\"`"
+        },
+        "strokeMiterLimit": {
+          "description": "The miter limit at which to bevel a line join.",
+          "type": "number"
+        },
+        "strokeOpacity": {
+          "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
+        "strokeWidth": {
+          "description": "The stroke width, in pixels.",
+          "minimum": 0,
+          "type": "number"
+        }
+      },
+      "type": "object"
+    },
     "ViewConfig": {
       "additionalProperties": false,
       "properties": {
@@ -11389,47 +11473,66 @@
           "description": "Whether the view should be clipped.",
           "type": "boolean"
         },
+        "cornerRadius": {
+          "description": "The radius in pixels of rounded rectangle corners.\n\n__Default value:__ `0`",
+          "type": "number"
+        },
         "fill": {
-          "description": "The fill color.\n\n__Default value:__ (none)",
+          "description": "The fill color.\n\n__Default value:__ `undefined`",
           "type": "string"
         },
         "fillOpacity": {
-          "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ (none)",
+          "description": "The fill opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
           "type": "number"
         },
         "height": {
           "description": "The default height of the single plot or each plot in a trellis plot when the visualization has a continuous (non-ordinal) y-scale with `rangeStep` = `null`.\n\n__Default value:__ `200`",
           "type": "number"
         },
+        "opacity": {
+          "description": "The overall opacity (value between [0,1]).\n\n__Default value:__ `0.7` for non-aggregate plots with `point`, `tick`, `circle`, or `square` marks or layered `bar` charts and `1` otherwise.",
+          "maximum": 1,
+          "minimum": 0,
+          "type": "number"
+        },
         "stroke": {
-          "description": "The stroke color.\n\n__Default value:__ (none)",
+          "description": "The stroke color.\n\n__Default value:__ `undefined`",
           "type": "string"
         },
+        "strokeCap": {
+          "$ref": "#/definitions/StrokeCap",
+          "description": "The stroke cap for line ending style. One of `\"butt\"`, `\"round\"`, or `\"square\"`.\n\n__Default value:__ `\"square\"`"
+        },
         "strokeDash": {
-          "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.\n\n__Default value:__ (none)",
+          "description": "An array of alternating stroke, space lengths for creating dashed or dotted lines.",
           "items": {
             "type": "number"
           },
           "type": "array"
         },
         "strokeDashOffset": {
-          "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.\n\n__Default value:__ (none)",
+          "description": "The offset (in pixels) into which to begin drawing with the stroke dash array.",
           "type": "number"
         },
         "strokeJoin": {
           "$ref": "#/definitions/StrokeJoin",
-          "description": "The stroke line join method. One of miter (default), round or bevel.\n\n__Default value:__ 'miter'"
+          "description": "The stroke line join method. One of `\"miter\"`, `\"round\"` or `\"bevel\"`.\n\n__Default value:__ `\"miter\"`"
         },
         "strokeMiterLimit": {
-          "description": "The stroke line join method. One of miter (default), round or bevel.\n\n__Default value:__ 'miter'",
+          "description": "The miter limit at which to bevel a line join.",
           "type": "number"
         },
         "strokeOpacity": {
-          "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ (none)",
+          "description": "The stroke opacity (value between [0,1]).\n\n__Default value:__ `1`",
+          "maximum": 1,
+          "minimum": 0,
           "type": "number"
         },
         "strokeWidth": {
-          "description": "The stroke width, in pixels.\n\n__Default value:__ (none)",
+          "description": "The stroke width, in pixels.",
+          "minimum": 0,
           "type": "number"
         },
         "width": {

--- a/site/docs/composition/layer.md
+++ b/site/docs/composition/layer.md
@@ -19,7 +19,7 @@ Sometimes, it's useful to superimpose one chart on top of another. You can accom
 
 In addition to [common properties of a view specification](spec.html#common), a layer specification has the following properties:
 
-{% include table.html props="layer,width,height,encoding,projection,resolve" source="LayerSpec" %}
+{% include table.html props="layer,width,height,view,encoding,projection,resolve" source="LayerSpec" %}
 
 Please note that you can _only layer single or layered views_ to guarantee that the combined views have a compatible layout. For instance, it is not clear how a composed view with two views side-by-side could be layered on top of a single view.
 

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -78,7 +78,15 @@ As it is designed for analysis, Vega-Lite also supports data transformation such
 
 To summarize, a single-view specification in Vega-Lite can have the following properties (in addition to [common properties of a specification](#common)):
 
-{% include table.html props="width,height,selection,projection,mark,encoding" source="TopLevelFacetedUnitSpec" %}
+{% include table.html props="mark,encoding,width,height,view,selection,projection" source="TopLevelFacetedUnitSpec" %}
+
+{:#view-background}
+
+### View Background
+
+The `view` property of a single-view or [layer](layer.html) specification can define the background of the view with the following properties:
+
+{% include table.html props="cornerRadius,fill,fillOpacity,opacity,stroke,strokeCap,strokeDash,strokeDashOffset,strokeJoin,strokeMiterLimit,strokeOpacity,strokeWidth" source="ViewBackground" %}
 
 ## Layered and Multi-view Specifications
 
@@ -106,16 +114,10 @@ To create layered and multi-view graphics, please refer to the following pages:
 }
 ```
 
-The style of a single view visualization can be customized by specifying the `view` property of the `config` object.
+The style of a single view visualization can be customized by specifying the `view` property of the `config` object. The view config support all [view background properties](#view-background).
 
-### Default View Size
-
-The `width` and `height` properties of the `view` configuration determine the width of a single view with a continuous x-scale and the height of a single view with a continuous y-scale respectively.
+In addition, the `width` and `height` properties of the `view` configuration determine the width of a single view with a continuous x-scale and the height of a single view with a continuous y-scale respectively.
 
 {% include table.html props="width,height" source="ViewConfig" %}
 
 **For more information about view size, please see the [size](size.html) documentation.**
-
-### View Styles
-
-{% include table.html props="clip,fill,fillOpacity,stroke,strokeOpacity,strokeWidth,strokeDash,strokeDashOffset" source="ViewConfig" %}

--- a/src/compile/baseconcat.ts
+++ b/src/compile/baseconcat.ts
@@ -78,19 +78,14 @@ export abstract class BaseConcatModel extends Model {
     return this.children.map(child => {
       const title = child.assembleTitle();
       const style = child.assembleGroupStyle();
-      const layoutSizeEncodeEntry = child.assembleLayoutSize();
+      const encodeEntry = child.assembleGroupEncodeEntry(false);
+
       return {
         type: 'group',
         name: child.getName('group'),
         ...(title ? {title} : {}),
         ...(style ? {style} : {}),
-        ...(layoutSizeEncodeEntry
-          ? {
-              encode: {
-                update: layoutSizeEncodeEntry
-              }
-            }
-          : {}),
+        ...(encodeEntry ? {encode: {update: encodeEntry}} : {}),
         ...child.assembleGroup()
       };
     });

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -149,6 +149,7 @@ function assembleTopLevelModel(
   const projections = model.assembleProjections();
   const title = model.assembleTitle();
   const style = model.assembleGroupStyle();
+  const encodeEntry = model.assembleGroupEncodeEntry(true);
 
   let layoutSignals = model.assembleLayoutSignals();
 
@@ -167,7 +168,8 @@ function assembleTopLevelModel(
     ...topLevelProperties,
     ...(title ? {title} : {}),
     ...(style ? {style} : {}),
-    data: data,
+    ...(encodeEntry ? {encode: {update: encodeEntry}} : {}),
+    data,
     ...(projections.length > 0 ? {projections: projections} : {}),
     ...model.assembleGroup([...layoutSignals, ...model.assembleSelectionTopLevelSignals([])]),
     ...(vgConfig ? {config: vgConfig} : {}),

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -390,12 +390,13 @@ export class FacetModel extends ModelWithField {
 
   public assembleMarks(): VgMarkGroup[] {
     const {child} = this;
-    const facetRoot = this.component.data.facetRoot;
-    const data = assembleFacetData(facetRoot);
 
     // If we facet by two dimensions, we need to add a cross operator to the aggregation
     // so that we create all groups
-    const layoutSizeEncodeEntry = child.assembleLayoutSize();
+    const facetRoot = this.component.data.facetRoot;
+    const data = assembleFacetData(facetRoot);
+
+    const encodeEntry = child.assembleGroupEncodeEntry(false);
 
     const title = child.assembleTitle();
     const style = child.assembleGroupStyle();
@@ -414,7 +415,7 @@ export class FacetModel extends ModelWithField {
         order: [...this.headerSortOrder('row'), ...this.headerSortOrder('column')]
       },
       ...(data.length > 0 ? {data: data} : {}),
-      ...(layoutSizeEncodeEntry ? {encode: {update: layoutSizeEncodeEntry}} : {}),
+      ...(encodeEntry ? {encode: {update: encodeEntry}} : {}),
       ...child.assembleGroup(assembleFacetSignals(this, []))
     };
 

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -30,7 +30,7 @@ export class LayerModel extends Model {
     config: Config,
     fit: boolean
   ) {
-    super(spec, parent, parentGivenName, config, repeater, spec.resolve);
+    super(spec, parent, parentGivenName, config, repeater, spec.resolve, spec.view);
 
     const layoutSize = {
       ...parentGivenSize,

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -9,6 +9,7 @@ import * as log from '../log';
 import {Resolve} from '../resolve';
 import {hasDiscreteDomain} from '../scale';
 import {BaseSpec, isFacetSpec, isLayerSpec, isUnitSpec, TopLevelFacetSpec} from '../spec';
+import {ViewBackground} from '../spec/base';
 import {extractCompositionLayout, GenericCompositionLayout} from '../spec/toplevel';
 import {extractTitleConfig, TitleParams} from '../title';
 import {normalizeTransform, Transform} from '../transform';
@@ -134,7 +135,6 @@ export function isLayerModel(model: Model): model is LayerModel {
 
 export abstract class Model {
   public abstract readonly type: 'unit' | 'facet' | 'layer' | 'concat' | 'repeat';
-  public readonly parent: Model;
   public readonly name: string;
 
   public readonly title: TitleParams;
@@ -153,21 +153,18 @@ export abstract class Model {
   /** Name map for signals, which can be renamed by a model's parent. */
   protected signalNameMap: NameMapInterface;
 
-  public readonly repeater: RepeaterValue;
-
-  public readonly config: Config;
-
   public readonly component: Component;
 
   public abstract readonly children: Model[] = [];
 
   constructor(
     spec: BaseSpec,
-    parent: Model,
+    public readonly parent: Model,
     parentGivenName: string,
-    config: Config,
-    repeater: RepeaterValue,
-    resolve: Resolve
+    public readonly config: Config,
+    public readonly repeater: RepeaterValue,
+    resolve: Resolve,
+    public readonly view?: ViewBackground
   ) {
     this.parent = parent;
     this.config = config;
@@ -295,14 +292,37 @@ export abstract class Model {
     return undefined;
   }
 
-  public assembleLayoutSize(): VgEncodeEntry {
-    if (this.type === 'unit' || this.type === 'layer') {
-      return {
-        width: this.getSizeSignalRef('width'),
-        height: this.getSizeSignalRef('height')
-      };
+  private assembleEncodeFromView(view: ViewBackground): VgEncodeEntry {
+    const e = {};
+    for (const property in view) {
+      if (view.hasOwnProperty(property)) {
+        const value = view[property];
+        if (value !== undefined) {
+          e[property] = {value};
+        }
+      }
     }
-    return undefined;
+    return e;
+  }
+
+  public assembleGroupEncodeEntry(isTopLevel: boolean): VgEncodeEntry {
+    let encodeEntry: VgEncodeEntry = undefined;
+    if (this.view) {
+      encodeEntry = this.assembleEncodeFromView(this.view);
+    }
+    if (!isTopLevel) {
+      // For top-level spec, we can set the global width and height signal to adjust the group size.
+      // For other child specs, we have to manually set width and height in the encode entry.
+      if (this.type === 'unit' || this.type === 'layer') {
+        return {
+          width: this.getSizeSignalRef('width'),
+          height: this.getSizeSignalRef('height'),
+          ...(encodeEntry || {})
+        };
+      }
+    }
+
+    return encodeEntry;
   }
 
   public assembleLayout(): VgLayout {

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -22,7 +22,7 @@ import {SelectionDef} from '../selection';
 import {LayoutSizeMixins, NormalizedUnitSpec} from '../spec';
 import {stack, StackProperties} from '../stack';
 import {Dict, duplicate} from '../util';
-import {VgData, VgEncodeEntry, VgLayout} from '../vega.schema';
+import {VgData, VgLayout} from '../vega.schema';
 import {AxisIndex} from './axis/component';
 import {parseUnitAxis} from './axis/parse';
 import {parseData} from './data/parse';
@@ -72,7 +72,8 @@ export class UnitModel extends ModelWithField {
     config: Config,
     public fit: boolean
   ) {
-    super(spec, parent, parentGivenName, config, repeater, undefined);
+    super(spec, parent, parentGivenName, config, repeater, undefined, spec.view);
+
     this.initSize({
       ...parentGivenSize,
       ...(spec.width ? {width: spec.width} : {}),
@@ -241,13 +242,6 @@ export class UnitModel extends ModelWithField {
     }
 
     return marks.map(this.correctDataNames);
-  }
-
-  public assembleLayoutSize(): VgEncodeEntry {
-    return {
-      width: this.getSizeSignalRef('width'),
-      height: this.getSizeSignalRef('height')
-    };
   }
 
   protected getMapping() {

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,13 +15,14 @@ import {
 import {ProjectionConfig} from './projection';
 import {defaultScaleConfig, ScaleConfig} from './scale';
 import {defaultConfig as defaultSelectionConfig, SelectionConfig} from './selection';
+import {ViewBackground} from './spec/base';
 import {TopLevelProperties} from './spec/toplevel';
 import {StackOffset} from './stack';
 import {extractTitleConfig, TitleConfig} from './title';
 import {duplicate, keys, mergeDeep} from './util';
-import {StrokeJoin, VgMarkConfig, VgScheme} from './vega.schema';
+import {VgMarkConfig, VgScheme} from './vega.schema';
 
-export interface ViewConfig {
+export interface ViewConfig extends ViewBackground {
   /**
    * The default width of the single plot or each plot in a trellis plot when the visualization has a continuous (non-ordinal) x-scale or ordinal x-scale with `rangeStep` = `null`.
    *
@@ -42,79 +43,6 @@ export interface ViewConfig {
    * Whether the view should be clipped.
    */
   clip?: boolean;
-
-  // FILL_STROKE_CONFIG
-  /**
-   * The fill color.
-   *
-   * __Default value:__ (none)
-   *
-   */
-  fill?: string;
-
-  /**
-   * The fill opacity (value between [0,1]).
-   *
-   * __Default value:__ (none)
-   *
-   */
-  fillOpacity?: number;
-
-  /**
-   * The stroke color.
-   *
-   * __Default value:__ (none)
-   *
-   */
-  stroke?: string;
-
-  /**
-   * The stroke opacity (value between [0,1]).
-   *
-   * __Default value:__ (none)
-   *
-   */
-  strokeOpacity?: number;
-
-  /**
-   * The stroke width, in pixels.
-   *
-   * __Default value:__ (none)
-   *
-   */
-  strokeWidth?: number;
-
-  /**
-   * An array of alternating stroke, space lengths for creating dashed or dotted lines.
-   *
-   * __Default value:__ (none)
-   *
-   */
-  strokeDash?: number[];
-
-  /**
-   * The offset (in pixels) into which to begin drawing with the stroke dash array.
-   *
-   * __Default value:__ (none)
-   *
-   */
-  strokeDashOffset?: number;
-
-  /**
-   * The stroke line join method. One of miter (default), round or bevel.
-   *
-   * __Default value:__ 'miter'
-   *
-   */
-  strokeJoin?: StrokeJoin;
-
-  /**
-   * The stroke line join method. One of miter (default), round or bevel.
-   *
-   * __Default value:__ 'miter'
-   *
-   */
-  strokeMiterLimit?: number;
 }
 
 export const defaultViewConfig: ViewConfig = {
@@ -225,6 +153,13 @@ export interface Config
     MarkConfigMixins,
     CompositeMarkConfigMixins,
     AxisConfigMixins {
+  /**
+   * CSS color property to use as the background of the whole Vega-Lite view
+   *
+   * __Default value:__ none (transparent)
+   */
+  background?: string;
+
   /**
    * An object hash that defines default range arrays or schemes for using with scales.
    * For a full list of scale range configuration options, please see the [corresponding section of the scale documentation](https://vega.github.io/vega-lite/docs/scale.html#config).

--- a/src/spec/base.ts
+++ b/src/spec/base.ts
@@ -1,6 +1,7 @@
 import {Data} from '../data';
 import {TitleParams} from '../title';
 import {Transform} from '../transform';
+import {VgMarkConfig} from '../vega.schema';
 
 export {normalizeTopLevelSpec as normalize} from '../normalize';
 export {TopLevel} from './toplevel';
@@ -75,4 +76,45 @@ export interface LayoutSizeMixins {
    * __See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.
    */
   height?: number;
+}
+
+export interface LayerUnitMixins extends LayoutSizeMixins {
+  /**
+   * An object defining the view background's fill and stroke.
+   *
+   * __Default value:__ none (transparent)
+   */
+  view?: ViewBackground;
+}
+
+export interface ViewBackground
+  extends Partial<
+    Pick<
+      VgMarkConfig,
+      | 'cornerRadius'
+      | 'fillOpacity'
+      | 'opacity'
+      | 'strokeCap'
+      | 'strokeDash'
+      | 'strokeDashOffset'
+      | 'strokeJoin'
+      | 'strokeMiterLimit'
+      | 'strokeOpacity'
+      | 'strokeWidth'
+    >
+  > {
+  // Override documentations for fill and stroke
+  /**
+   * The fill color.
+   *
+   * __Default value:__ `undefined`
+   */
+  fill?: string;
+
+  /**
+   * The stroke color.
+   *
+   * __Default value:__ `undefined`
+   */
+  stroke?: string;
 }

--- a/src/spec/layer.ts
+++ b/src/spec/layer.ts
@@ -2,13 +2,13 @@ import {Encoding} from '../encoding';
 import {RepeatRef} from '../fielddef';
 import {Projection} from '../projection';
 import {Resolve} from '../resolve';
-import {BaseSpec, LayoutSizeMixins} from './base';
+import {BaseSpec, LayerUnitMixins} from './base';
 import {CompositeUnitSpec, GenericUnitSpec, NormalizedUnitSpec} from './unit';
 
 /**
  * Base interface for a layer specification.
  */
-export interface GenericLayerSpec<U extends GenericUnitSpec<any, any>> extends BaseSpec, LayoutSizeMixins {
+export interface GenericLayerSpec<U extends GenericUnitSpec<any, any>> extends BaseSpec, LayerUnitMixins {
   /**
    * Layer or single view specifications to be layered.
    *

--- a/src/spec/toplevel.ts
+++ b/src/spec/toplevel.ts
@@ -42,7 +42,7 @@ export type TopLevel<S extends BaseSpec> = S &
 
 export interface TopLevelProperties {
   /**
-   * CSS color property to use as the background of visualization.
+   * CSS color property to use as the background of the entire view.
    *
    * __Default value:__ none (transparent)
    */

--- a/src/spec/unit.ts
+++ b/src/spec/unit.ts
@@ -3,7 +3,7 @@ import {RepeatRef} from '../fielddef';
 import {AnyMark, Mark, MarkDef} from '../mark';
 import {Projection} from '../projection';
 import {SelectionDef} from '../selection';
-import {BaseSpec, LayoutSizeMixins} from './base';
+import {BaseSpec, LayerUnitMixins} from './base';
 
 export {normalizeTopLevelSpec as normalize} from '../normalize';
 export {BaseSpec, DataMixins, LayoutSizeMixins} from './base';
@@ -12,7 +12,7 @@ export {TopLevel} from './toplevel';
 /**
  * Base interface for a unit (single-view) specification.
  */
-export interface GenericUnitSpec<E extends Encoding<any>, M> extends BaseSpec, LayoutSizeMixins {
+export interface GenericUnitSpec<E extends Encoding<any>, M> extends BaseSpec, LayerUnitMixins {
   /**
    * A string describing the mark type (one of `"bar"`, `"circle"`, `"square"`, `"tick"`, `"line"`,
    * `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def).


### PR DESCRIPTION
Fix https://github.com/vega/vega-lite/issues/4025

Note that we can't add `view` to concat/facet/repeat yet due to https://github.com/vega/vega/issues/1523

Also:
- Remove redundant `assembleLayoutSize` in `unit.ts`
- Update & improve docs

