### PR TITLE
Make sort op optional and make `"mean"` the default op

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -3566,7 +3566,7 @@
         },
         "op": {
           "$ref": "#/definitions/AggregateOp",
-          "description": "An [aggregate operation](https://vega.github.io/vega-lite/docs/aggregate.html#ops) to perform on the field prior to sorting (e.g., `\"count\"`, `\"mean\"` and `\"median\"`).\nThis property is required in cases there are multiple values of the sort field for each encoded data field.\nThe input data objects will be aggregated, grouped by the encoded data field.\n\nFor a full list of operations, please see the documentation for [aggregate](https://vega.github.io/vega-lite/docs/aggregate.html#ops).\n\n__Default value:__ `\"mean\"`"
+          "description": "An [aggregate operation](https://vega.github.io/vega-lite/docs/aggregate.html#ops) to perform on the field prior to sorting (e.g., `\"count\"`, `\"mean\"` and `\"median\"`).\nThis property is required in cases there are multiple values of the sort field for each encoded data field.\nThe input data objects will be aggregated, grouped by the encoded data field.\n\nFor a full list of operations, please see the documentation for [aggregate](https://vega.github.io/vega-lite/docs/aggregate.html#ops).\n\n__Default value:__ `\"sum\"` for stacked plots. Otherwise, `\"mean\"`."
         },
         "order": {
           "anyOf": [

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -3566,7 +3566,7 @@
         },
         "op": {
           "$ref": "#/definitions/AggregateOp",
-          "description": "An [aggregate operation](https://vega.github.io/vega-lite/docs/aggregate.html#ops) to perform on the field prior to sorting (e.g., `\"count\"`, `\"mean\"` and `\"median\"`).\nThis property is required in cases where the sort field and the data reference field do not match.\nThe input data objects will be aggregated, grouped by the encoded data field.\n\nFor a full list of operations, please see the documentation for [aggregate](https://vega.github.io/vega-lite/docs/aggregate.html#ops)."
+          "description": "An [aggregate operation](https://vega.github.io/vega-lite/docs/aggregate.html#ops) to perform on the field prior to sorting (e.g., `\"count\"`, `\"mean\"` and `\"median\"`).\nThis property is required in cases there are multiple values of the sort field for each encoded data field.\nThe input data objects will be aggregated, grouped by the encoded data field.\n\nFor a full list of operations, please see the documentation for [aggregate](https://vega.github.io/vega-lite/docs/aggregate.html#ops).\n\n__Default value:__ `\"mean\"`"
         },
         "order": {
           "anyOf": [
@@ -3580,9 +3580,6 @@
           "description": "The sort order. One of `\"ascending\"` (default), `\"descending\"`, or `null` (no not sort)."
         }
       },
-      "required": [
-        "op"
-      ],
       "type": "object"
     },
     "EncodingWithFacet": {

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -3566,7 +3566,7 @@
         },
         "op": {
           "$ref": "#/definitions/AggregateOp",
-          "description": "An [aggregate operation](https://vega.github.io/vega-lite/docs/aggregate.html#ops) to perform on the field prior to sorting (e.g., `\"count\"`, `\"mean\"` and `\"median\"`).\nThis property is required in cases there are multiple values of the sort field for each encoded data field.\nThe input data objects will be aggregated, grouped by the encoded data field.\n\nFor a full list of operations, please see the documentation for [aggregate](https://vega.github.io/vega-lite/docs/aggregate.html#ops).\n\n__Default value:__ `\"sum\"` for stacked plots. Otherwise, `\"mean\"`."
+          "description": "An [aggregate operation](https://vega.github.io/vega-lite/docs/aggregate.html#ops) to perform on the field prior to sorting (e.g., `\"count\"`, `\"mean\"` and `\"median\"`).\nAn aggregation is required when there are multiple values of the sort field for each encoded data field.\nThe input data objects will be aggregated, grouped by the encoded data field.\n\nFor a full list of operations, please see the documentation for [aggregate](https://vega.github.io/vega-lite/docs/aggregate.html#ops).\n\n__Default value:__ `\"sum\"` for stacked plots. Otherwise, `\"mean\"`."
         },
         "order": {
           "anyOf": [

--- a/examples/compiled/trellis_barley.vg.json
+++ b/examples/compiled/trellis_barley.vg.json
@@ -208,7 +208,7 @@
       "domain": {
         "data": "source_0",
         "field": "variety",
-        "sort": {"field": "yield", "op": "median", "order": "descending"}
+        "sort": {"op": "median", "field": "yield", "order": "descending"}
       },
       "range": {"step": {"signal": "trellis_barley_y_step"}},
       "padding": 0.5

--- a/examples/compiled/trellis_barley_layer_median.vg.json
+++ b/examples/compiled/trellis_barley_layer_median.vg.json
@@ -262,7 +262,7 @@
       "domain": {
         "data": "source_0",
         "field": "variety",
-        "sort": {"field": "yield", "op": "median", "order": "descending"}
+        "sort": {"op": "median", "field": "yield", "order": "descending"}
       },
       "range": {"step": {"signal": "trellis_barley_y_step"}},
       "padding": 0.5

--- a/examples/compiled/window_top_k.vg.json
+++ b/examples/compiled/window_top_k.vg.json
@@ -97,7 +97,7 @@
       "domain": {
         "data": "data_0",
         "field": "student",
-        "sort": {"field": "score", "op": "average", "order": "descending"}
+        "sort": {"op": "average", "field": "score", "order": "descending"}
       },
       "range": {"step": {"signal": "y_step"}},
       "paddingInner": 0.1,

--- a/src/compile/data/facet.ts
+++ b/src/compile/data/facet.ts
@@ -5,7 +5,7 @@ import {COLUMN, ROW, ScaleChannel} from '../../channel';
 import {vgField} from '../../fielddef';
 import * as log from '../../log';
 import {hasDiscreteDomain} from '../../scale';
-import {EncodingSortField, isSortField} from '../../sort';
+import {DEFAULT_SORT_OP, EncodingSortField, isSortField} from '../../sort';
 import {hash} from '../../util';
 import {isVgRangeStep, VgData} from '../../vega.schema';
 import {FacetModel} from '../facet';
@@ -145,7 +145,7 @@ export class FacetNode extends DataFlowNode {
 
     const {sortField, sortIndexField} = this[channel];
     if (sortField) {
-      const {op, field} = sortField;
+      const {op = DEFAULT_SORT_OP, field} = sortField;
       fields.push(field);
       ops.push(op);
       as.push(vgField(sortField, {forAs: true}));

--- a/src/compile/data/windowfacet.ts
+++ b/src/compile/data/windowfacet.ts
@@ -1,5 +1,5 @@
 import {vgField} from '../../fielddef';
-import {isSortField} from '../../sort';
+import {DEFAULT_SORT_OP, isSortField} from '../../sort';
 import {FacetMapping} from '../../spec/facet';
 import {facetSortFieldName} from '../facet';
 import {DataFlowNode} from './dataflow';
@@ -12,7 +12,7 @@ export function makeWindowFromFacet(parent: DataFlowNode, facet: FacetMapping<st
     // only need to make one for crossed facet
     for (const fieldDef of [row, column]) {
       if (isSortField(fieldDef.sort)) {
-        const {field, op} = fieldDef.sort;
+        const {field, op = DEFAULT_SORT_OP} = fieldDef.sort;
         parent = newParent = new WindowTransformNode(parent, {
           window: [
             {

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -6,7 +6,7 @@ import {reduce} from '../encoding';
 import {FieldRefOption, normalize, title as fieldDefTitle, TypedFieldDef, vgField} from '../fielddef';
 import * as log from '../log';
 import {hasDiscreteDomain} from '../scale';
-import {EncodingSortField, isSortField, SortOrder} from '../sort';
+import {DEFAULT_SORT_OP, EncodingSortField, isSortField, SortOrder} from '../sort';
 import {NormalizedFacetSpec} from '../spec';
 import {FacetFieldDef, FacetMapping} from '../spec/facet';
 import {contains} from '../util';
@@ -322,7 +322,7 @@ export class FacetModel extends ModelWithField {
         groupby.push(vgField(fieldDef));
         const {sort} = fieldDef;
         if (isSortField(sort)) {
-          const {field, op} = sort;
+          const {field, op = DEFAULT_SORT_OP} = sort;
           const outputName = facetSortFieldName(fieldDef, sort);
           if (row && column) {
             // For crossed facet, use pre-calculate field as it requires a different groupby

--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -347,9 +347,10 @@ export function domainSort(
 
   // Sorted based on an aggregate calculation over a specified sort field (only for ordinal scale)
   if (isSortField(sort)) {
+    const isStacked = model.stack !== null;
     // flatten nested fields
     return {
-      op: DEFAULT_SORT_OP,
+      op: isStacked ? 'sum' : DEFAULT_SORT_OP,
       ...sort,
       ...(sort.field ? {field: util.replacePathInField(sort.field)} : {})
     };

--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -1,4 +1,4 @@
-import {isString} from 'vega-util';
+import {isObject, isString} from 'vega-util';
 import {SHARED_DOMAIN_OP_INDEX} from '../../aggregate';
 import {binToString, isBinning, isBinParams} from '../../bin';
 import {isScaleChannel, ScaleChannel} from '../../channel';
@@ -7,7 +7,7 @@ import {DateTime} from '../../datetime';
 import {binRequiresRange, ScaleFieldDef, TypedFieldDef, valueExpr, vgField} from '../../fielddef';
 import * as log from '../../log';
 import {Domain, hasDiscreteDomain, isBinScale, isSelectionDomain, ScaleConfig, ScaleType} from '../../scale';
-import {EncodingSortField, isSortArray, isSortField} from '../../sort';
+import {DEFAULT_SORT_OP, isSortArray, isSortField} from '../../sort';
 import {TimeUnit} from '../../timeunit';
 import {Type} from '../../type';
 import * as util from '../../util';
@@ -231,7 +231,9 @@ function parseSingleChannelDomain(
     ];
   }
 
-  const sort = isScaleChannel(channel) ? domainSort(model, channel, scaleType) : undefined;
+  const sort: undefined | true | VgSortField = isScaleChannel(channel)
+    ? domainSort(model, channel, scaleType)
+    : undefined;
 
   if (domain === 'unaggregated') {
     const data = model.requestDataName(MAIN);
@@ -265,7 +267,7 @@ function parseSingleChannelDomain(
           field: model.vgField(channel, binRequiresRange(fieldDef, channel) ? {binSuffix: 'range'} : {}),
           // we have to use a sort object if sort = true to make the sort correct by bin start
           sort:
-            sort === true || !isSortField(sort)
+            sort === true || !isObject(sort)
               ? {
                   field: model.vgField(channel, {}),
                   op: 'min' // min or max doesn't matter since we sort by the start of the bin range
@@ -325,7 +327,7 @@ export function domainSort(
   model: UnitModel,
   channel: ScaleChannel,
   scaleType: ScaleType
-): true | EncodingSortField<string> {
+): undefined | true | VgSortField {
   if (!hasDiscreteDomain(scaleType)) {
     return undefined;
   }
@@ -347,6 +349,7 @@ export function domainSort(
   if (isSortField(sort)) {
     // flatten nested fields
     return {
+      op: DEFAULT_SORT_OP,
       ...sort,
       ...(sort.field ? {field: util.replacePathInField(sort.field)} : {})
     };

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -39,7 +39,6 @@ export interface EncodingSortField<F> {
   field?: F;
   /**
    * An [aggregate operation](https://vega.github.io/vega-lite/docs/aggregate.html#ops) to perform on the field prior to sorting (e.g., `"count"`, `"mean"` and `"median"`).
-   * This property is required in cases there are multiple values of the sort field for each encoded data field.
    * The input data objects will be aggregated, grouped by the encoded data field.
    *
    * For a full list of operations, please see the documentation for [aggregate](https://vega.github.io/vega-lite/docs/aggregate.html#ops).

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -44,7 +44,7 @@ export interface EncodingSortField<F> {
    *
    * For a full list of operations, please see the documentation for [aggregate](https://vega.github.io/vega-lite/docs/aggregate.html#ops).
    *
-   * __Default value:__ `"mean"`
+   * __Default value:__ `"sum"` for stacked plots. Otherwise, `"mean"`.
    */
   op?: AggregateOp;
 

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -39,6 +39,7 @@ export interface EncodingSortField<F> {
   field?: F;
   /**
    * An [aggregate operation](https://vega.github.io/vega-lite/docs/aggregate.html#ops) to perform on the field prior to sorting (e.g., `"count"`, `"mean"` and `"median"`).
+   * An aggregation is required when there are multiple values of the sort field for each encoded data field.
    * The input data objects will be aggregated, grouped by the encoded data field.
    *
    * For a full list of operations, please see the documentation for [aggregate](https://vega.github.io/vega-lite/docs/aggregate.html#ops).

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -24,6 +24,8 @@ export interface SortFields {
   order?: (SortOrder)[];
 }
 
+export const DEFAULT_SORT_OP = 'mean';
+
 /**
  * A sort definition for sorting a discrete scale in an encoding field definition.
  */
@@ -37,12 +39,14 @@ export interface EncodingSortField<F> {
   field?: F;
   /**
    * An [aggregate operation](https://vega.github.io/vega-lite/docs/aggregate.html#ops) to perform on the field prior to sorting (e.g., `"count"`, `"mean"` and `"median"`).
-   * This property is required in cases where the sort field and the data reference field do not match.
+   * This property is required in cases there are multiple values of the sort field for each encoded data field.
    * The input data objects will be aggregated, grouped by the encoded data field.
    *
    * For a full list of operations, please see the documentation for [aggregate](https://vega.github.io/vega-lite/docs/aggregate.html#ops).
+   *
+   * __Default value:__ `"mean"`
    */
-  op: AggregateOp;
+  op?: AggregateOp;
 
   /**
    * The sort order. One of `"ascending"` (default), `"descending"`, or `null` (no not sort).
@@ -53,7 +57,7 @@ export interface EncodingSortField<F> {
 export type Sort<F> = number[] | string[] | boolean[] | DateTime[] | SortOrder | EncodingSortField<F> | null;
 
 export function isSortField<F>(sort: Sort<F>): sort is EncodingSortField<F> {
-  return !!sort && (sort['op'] === 'count' || !!sort['field']) && !!sort['op'];
+  return !!sort && (sort['op'] === 'count' || !!sort['field']);
 }
 
 export function isSortArray<F>(sort: Sort<F>): sort is number[] | string[] | boolean[] | DateTime[] {

--- a/test/compile/data/facet.test.ts
+++ b/test/compile/data/facet.test.ts
@@ -189,7 +189,7 @@ describe('compile/data/facet', () => {
         },
         facet: {
           row: {field: 'r', type: 'nominal', sort: {op: 'median', field: 'b'}},
-          column: {field: 'c', type: 'nominal', sort: {op: 'median', field: 'a'}}
+          column: {field: 'c', type: 'nominal', sort: {field: 'a'}}
         },
         spec: {
           mark: 'rect',
@@ -211,8 +211,8 @@ describe('compile/data/facet', () => {
             type: 'aggregate',
             groupby: ['c'],
             fields: ['a'],
-            ops: ['median'],
-            as: ['median_a']
+            ops: ['mean'],
+            as: ['a']
           }
         ]
       });

--- a/test/compile/scale/domain.test.ts
+++ b/test/compile/scale/domain.test.ts
@@ -395,6 +395,39 @@ describe('compile/scale', () => {
         ]);
       });
 
+      it('should return the correct domain for month O when specify sort does not have op and the plot is stacked', () => {
+        const sortDef: EncodingSortField<string> = {field: 'precipitation', order: 'descending'};
+        const model = parseUnitModel({
+          mark: 'bar',
+          encoding: {
+            x: {
+              timeUnit: 'month',
+              field: 'date',
+              type: 'ordinal',
+              sort: sortDef
+            },
+            y: {
+              aggregate: 'sum',
+              field: 'precipitation',
+              type: 'quantitative'
+            },
+            color: {
+              field: 'weather_type',
+              type: 'nominal'
+            }
+          }
+        });
+        const _domain = testParseDomainForChannel(model, 'x');
+
+        expect(_domain).toEqual([
+          {
+            data: 'raw',
+            field: 'month_date',
+            sort: {...sortDef, op: 'sum'}
+          }
+        ]);
+      });
+
       it('should return the right custom domain with DateTime objects', () => {
         const model = parseUnitModel({
           mark: 'point',

--- a/test/compile/scale/domain.test.ts
+++ b/test/compile/scale/domain.test.ts
@@ -366,6 +366,35 @@ describe('compile/scale', () => {
         ]);
       });
 
+      it('should return the correct domain for month O when specify sort does not have op', () => {
+        const sortDef: EncodingSortField<string> = {field: 'precipitation', order: 'descending'};
+        const model = parseUnitModel({
+          mark: 'bar',
+          encoding: {
+            x: {
+              timeUnit: 'month',
+              field: 'date',
+              type: 'ordinal',
+              sort: sortDef
+            },
+            y: {
+              aggregate: 'mean',
+              field: 'precipitation',
+              type: 'quantitative'
+            }
+          }
+        });
+        const _domain = testParseDomainForChannel(model, 'x');
+
+        expect(_domain).toEqual([
+          {
+            data: 'raw',
+            field: 'month_date',
+            sort: {...sortDef, op: 'mean'}
+          }
+        ]);
+      });
+
       it('should return the right custom domain with DateTime objects', () => {
         const model = parseUnitModel({
           mark: 'point',


### PR DESCRIPTION
Fix https://github.com/vega/vega-lite/issues/1489

I think this will resolve a common error that many novice users run into.  While this may introduce a slightly different problem (namely that people may not specify op: 'mean' even when they want to), I think the benefits outweight the cons in this case. 

FWIW, the lack of default sort op has confused so many users already.

