### PR TITLE
Support nested row of row facet. We previously returned a signal `unk…

### DIFF
--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -224,7 +224,7 @@ export class FacetModel extends ModelWithField {
     return {
       ...this.getHeaderLayoutMixins(),
 
-      columns,
+      ...(columns ? {columns} : {}),
       bounds: 'full',
       align: 'all'
     };

--- a/test/compile/data/source.test.ts
+++ b/test/compile/data/source.test.ts
@@ -19,7 +19,7 @@ describe('compile/data/source', () => {
       });
 
       it('should have no source.format.type', () => {
-        expect(source.data.format).toEqual(undefined);
+        expect(source.data).not.toHaveProperty('format');
       });
     });
 

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -21,7 +21,7 @@ describe('FacetModel', () => {
             encoding: {}
           }
         });
-        expect(model.facet['shape']).toEqual(undefined);
+        expect(model.facet).not.toHaveProperty('shape');
         expect(localLogger.warns[0]).toEqual(log.message.incompatibleChannel(SHAPE, 'facet'));
       })
     );
@@ -38,7 +38,7 @@ describe('FacetModel', () => {
             encoding: {}
           }
         });
-        expect(model.facet.row).toEqual(undefined);
+        expect(model.facet).not.toHaveProperty('row');
         expect(localLogger.warns[0]).toEqual(log.message.emptyFieldDef({type: ORDINAL}, ROW));
       })
     );
@@ -265,7 +265,7 @@ describe('FacetModel', () => {
         // TODO: remove "any" once we support all facet listed in https://github.com/vega/vega-lite/issues/2760
       } as any);
       const layout = model.child.assembleLayout();
-      expect(layout.columns).toEqual(undefined);
+      expect(layout).not.toHaveProperty('columns');
     });
 
     it('returns a layout with header band if child spec is also a facet', () => {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -55,7 +55,7 @@ describe('config', () => {
     });
 
     it('should redirect config.title to config.style.group-title and rename color to fill', () => {
-      expect(output.title).toEqual(undefined);
+      expect(output).not.toHaveProperty('title');
       expect(output.style['group-title'].fontWeight).toEqual('bold');
       expect(output.style['group-title'].fill).toEqual('red');
     });


### PR DESCRIPTION
…nown` for columns.

Now this works

```
{
  "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
  "data": {"url": "data/cars.json"},
  "facet": {
    "column": {"field": "Cylinders","type": "ordinal"}
  },
  "spec": {
    "facet": {
      "column": {"field": "Origin","type": "ordinal"}
    },
    "spec": {
      "mark": "point",
      "encoding": {    
        "x": {"field": "Displacement","type": "quantitative"},
        "y": {"field": "Horsepower","type": "quantitative"}
      }
    }
  }
}
```