### PR TITLE
Do not align when scales are independent

### DIFF
--- a/examples/compiled/facet_independent_scale.vg.json
+++ b/examples/compiled/facet_independent_scale.vg.json
@@ -55,7 +55,7 @@
     "offset": {"columnTitle": 10},
     "columns": {"signal": "length(data('column_domain'))"},
     "bounds": "full",
-    "align": "all"
+    "align": "none"
   },
   "marks": [
     {

--- a/examples/compiled/facet_independent_scale_layer_broken.vg.json
+++ b/examples/compiled/facet_independent_scale_layer_broken.vg.json
@@ -47,7 +47,7 @@
     "offset": {"columnTitle": 10},
     "columns": {"signal": "length(data('column_domain'))"},
     "bounds": "full",
-    "align": "all"
+    "align": "none"
   },
   "marks": [
     {

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -221,8 +221,8 @@ export class FacetModel extends ModelWithField {
 
     let align: LayoutAlign = 'all';
 
-    // Do not align the cells if the scale corresponding to teh directin is indepent.
-    // We always align when we facet into row and column.
+    // Do not align the cells if the scale corresponding to the directin is indepent.
+    // We always align when we facet into both row and column.
     if (!this.channelHasField('row') && this.component.resolve.scale.x === 'independent') {
       align = 'none';
     } else if (!this.channelHasField('column') && this.component.resolve.scale.y === 'independent') {

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -1,4 +1,4 @@
-import {AggregateOp, NewSignal} from 'vega';
+import {AggregateOp, LayoutAlign, NewSignal} from 'vega';
 import {isArray} from 'vega-util';
 import {Channel, COLUMN, ROW, ScaleChannel} from '../channel';
 import {Config} from '../config';
@@ -219,14 +219,22 @@ export class FacetModel extends ModelWithField {
   protected assembleDefaultLayout(): VgLayout {
     const columns = this.channelHasField('column') ? this.columnDistinctSignal() : 1;
 
-    // TODO: determine default align based on shared / independent scales
+    let align: LayoutAlign = 'all';
+
+    // Do not align the cells if the scale corresponding to teh directin is indepent.
+    // We always align when we facet into row and column.
+    if (!this.channelHasField('row') && this.component.resolve.scale.x === 'independent') {
+      align = 'none';
+    } else if (!this.channelHasField('column') && this.component.resolve.scale.y === 'independent') {
+      align = 'none';
+    }
 
     return {
       ...this.getHeaderLayoutMixins(),
 
       columns,
       bounds: 'full',
-      align: 'all'
+      align
     };
   }
 

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -137,7 +137,7 @@ describe('FacetModel', () => {
     it('should correctly set scale component for a model', () => {
       const model = parseFacetModelWithScale({
         facet: {
-          row: {field: 'a', type: 'quantitative'}
+          row: {field: 'a', type: 'ordinal'}
         },
         spec: {
           mark: 'point',
@@ -153,7 +153,7 @@ describe('FacetModel', () => {
     it('should create independent scales if resolve is set to independent', () => {
       const model = parseFacetModelWithScale({
         facet: {
-          row: {field: 'a', type: 'quantitative'}
+          row: {field: 'a', type: 'ordinal'}
         },
         spec: {
           mark: 'point',
@@ -176,7 +176,7 @@ describe('FacetModel', () => {
     it('should sort headers in ascending order', () => {
       const model = parseFacetModelWithScale({
         facet: {
-          column: {field: 'a', type: 'quantitative', format: 'd'}
+          column: {field: 'a', type: 'ordinal', format: 'd'}
         },
         spec: {
           mark: 'point',
@@ -201,11 +201,11 @@ describe('FacetModel', () => {
     it('includes a columns fields in the encode block for facet with column that parent is also a facet.', () => {
       const model = parseFacetModelWithScale({
         facet: {
-          column: {field: 'a', type: 'quantitative'}
+          column: {field: 'a', type: 'ordinal'}
         },
         spec: {
           facet: {
-            column: {field: 'c', type: 'quantitative'}
+            column: {field: 'c', type: 'ordinal'}
           },
           spec: {
             mark: 'point',
@@ -226,7 +226,7 @@ describe('FacetModel', () => {
     it('returns a layout with a column signal for facet with column', () => {
       const model = parseFacetModelWithScale({
         facet: {
-          column: {field: 'a', type: 'quantitative'}
+          column: {field: 'a', type: 'ordinal'}
         },
         spec: {
           mark: 'point',
@@ -246,15 +246,15 @@ describe('FacetModel', () => {
       });
     });
 
-    it('should not align independent scales', () => {
+    it('should not align independent scales for column', () => {
       const model = parseFacetModelWithScale({
         facet: {
-          column: {field: 'a', type: 'quantitative'}
+          column: {field: 'a', type: 'ordinal'}
         },
         spec: {
           mark: 'point',
           encoding: {
-            x: {field: 'b', type: 'quantitative'}
+            x: {field: 'b', type: 'ordinal'}
           }
         },
         resolve: {
@@ -274,14 +274,40 @@ describe('FacetModel', () => {
       });
     });
 
+    it('should not align independent scales for row', () => {
+      const model = parseFacetModelWithScale({
+        facet: {
+          row: {field: 'a', type: 'ordinal'}
+        },
+        spec: {
+          mark: 'point',
+          encoding: {
+            y: {field: 'b', type: 'ordinal'}
+          }
+        },
+        resolve: {
+          scale: {
+            y: 'independent'
+          }
+        }
+      });
+      const layout = model.assembleLayout();
+      expect(layout).toEqual({
+        padding: {row: 10, column: 10},
+        columns: 1,
+        bounds: 'full',
+        align: 'none'
+      });
+    });
+
     it('returns a layout without a column signal for facet with column that parent is also a facet.', () => {
       const model = parseFacetModelWithScale({
         facet: {
-          column: {field: 'a', type: 'quantitative'}
+          column: {field: 'a', type: 'ordinal'}
         },
         spec: {
           facet: {
-            column: {field: 'c', type: 'quantitative'}
+            column: {field: 'c', type: 'ordinal'}
           },
           spec: {
             mark: 'point',

--- a/test/compile/facet.test.ts
+++ b/test/compile/facet.test.ts
@@ -246,6 +246,34 @@ describe('FacetModel', () => {
       });
     });
 
+    it('should not align independent scales', () => {
+      const model = parseFacetModelWithScale({
+        facet: {
+          column: {field: 'a', type: 'quantitative'}
+        },
+        spec: {
+          mark: 'point',
+          encoding: {
+            x: {field: 'b', type: 'quantitative'}
+          }
+        },
+        resolve: {
+          scale: {
+            x: 'independent'
+          }
+        }
+      });
+      const layout = model.assembleLayout();
+      expect(layout).toEqual({
+        padding: {row: 10, column: 10},
+        columns: {
+          signal: "length(data('column_domain'))"
+        },
+        bounds: 'full',
+        align: 'none'
+      });
+    });
+
     it('returns a layout without a column signal for facet with column that parent is also a facet.', () => {
       const model = parseFacetModelWithScale({
         facet: {


### PR DESCRIPTION
```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
  "data": {"url": "data/cars.json"},
  "facet": {
    "row": {"field": "Cylinders","type": "ordinal"}
  },
  "spec": {
    "mark": "bar",
    "encoding": {    
      "y": {"field": "Origin","type": "ordinal"},
      "x": {"aggregate": "count","type": "quantitative"}
    }
  },
  "resolve": {
    "scale": {
      "y": "independent"
    }
  }
}
```

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
  "data": {"url": "data/cars.json"},
  "facet": {
    "column": {"field": "Cylinders","type": "ordinal"}
  },
  "spec": {
    "mark": "bar",
    "encoding": {    
      "x": {"field": "Origin","type": "ordinal"},
      "y": {"aggregate": "count","type": "quantitative"}
    }
  },
  "resolve": {
    "scale": {
      "x": "independent"
    }
  }
}
```

@jheer this should make the layout in your example from today better by default. 