### PR TITLE
BUG: Selection dropdown html is broken

### DIFF
--- a/site/docs/selection/selection.md
+++ b/site/docs/selection/selection.md
@@ -39,8 +39,9 @@ Selections are defined within single views, and their simplest definition consis
 | :------- | :----: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | type     | String | _**Required.**_ Determines the default event processing and data query for the selection. Vega-Lite currently supports three selection types: <br/>`single` -- to select a single discrete data value on `click`. <br/>`multi` -- to select multiple discrete data value; the first value is selected on `click` and additional values toggled on shift-`click`. <br/>`interval` -- to select a continuous range of data values on `drag`. |
 
-For example, try the different types against the example selection (named `pts`) below: <select onchange="changeSpec('selection_type', 'selection_type_' + this.value)">
+For example, try the different types against the example selection (named `pts`) below: 
 
+<select onchange="changeSpec('selection_type', 'selection_type_' + this.value)">
   <option>single</option>
   <option>multi</option>
   <option>interval</option>


### PR DESCRIPTION
https://vega.github.io/vega-lite/docs/selection.html select dropdown is broken due to newline between html content in markdown. This patch removes it.
