### PR TITLE
Allow scheme config with only count or only extent.

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -9064,9 +9064,6 @@
           "type": "string"
         }
       },
-      "required": [
-        "name"
-      ],
       "type": "object"
     },
     "SecondaryFieldDef": {

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -200,16 +200,12 @@ export function parseRangeForChannel(
   );
 }
 
-function parseScheme(scheme: Scheme) {
+function parseScheme(scheme: Scheme): SchemeConfig {
   if (isExtendedScheme(scheme)) {
-    const r: SchemeConfig = {scheme: scheme.name};
-    if (scheme.count) {
-      r.count = scheme.count;
-    }
-    if (scheme.extent) {
-      r.extent = scheme.extent;
-    }
-    return r;
+    return {
+      scheme: scheme.name || 'blues',
+      ...util.omit(scheme, ['name'])
+    };
   }
   return {scheme: scheme};
 }

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -1,4 +1,4 @@
-import {toSet} from 'vega-util';
+import {isObject, toSet} from 'vega-util';
 import {BinParams} from './bin';
 import {Channel, CHANNELS, isColorChannel} from './channel';
 import {DateTime} from './datetime';
@@ -438,7 +438,7 @@ export interface SchemeParams {
    *
    * For the full list of supported schemes, please refer to the [Vega Scheme](https://vega.github.io/vega/docs/schemes/#reference) reference.
    */
-  name: string;
+  name?: string;
 
   /**
    * For sequential and diverging schemes only, determines the extent of the color range to use. For example `[0.2, 1]` will rescale the color scheme such that color values in the range _[0, 0.2)_ are excluded from the scheme.
@@ -479,7 +479,7 @@ export type Domain = number[] | string[] | boolean[] | DateTime[] | 'unaggregate
 export type Scheme = string | SchemeParams;
 
 export function isExtendedScheme(scheme: string | SchemeParams): scheme is SchemeParams {
-  return scheme && !!scheme['name'];
+  return isObject(scheme);
 }
 
 export function isSelectionDomain(domain: Domain): domain is SelectionDomain {

--- a/test/compile/scale/range.test.ts
+++ b/test/compile/scale/range.test.ts
@@ -377,6 +377,23 @@ describe('compile/scale', () => {
         ).toEqual(makeExplicit({scheme: 'viridis', count: 3}));
       });
 
+      it('should use the specified count for a quantitative color field.', () => {
+        expect(
+          parseRangeForChannel(
+            'color',
+            'ordinal',
+            QUANTITATIVE,
+            {scheme: {count: 3}},
+            defaultConfig,
+            undefined,
+            'point',
+            false,
+            'plot_width',
+            []
+          )
+        ).toEqual(makeExplicit({scheme: 'blues', count: 3}));
+      });
+
       it('should use default ordinal range for quantile/quantize scales', () => {
         const scales: ScaleType[] = ['quantile', 'quantize'];
         scales.forEach(discretizingScale => {


### PR DESCRIPTION
We now support

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
  "data": {"url": "data/movies.json"},
  "transform": [{
    "filter": {"and": [
      {"field": "IMDB_Rating", "valid": true},
      {"field": "Rotten_Tomatoes_Rating", "valid": true}
    ]}
  }],
  "mark": "rect",
  "width": 300,
  "height": 200,
  "encoding": {
    "x": {
      "bin": {"maxbins":60},
      "field": "IMDB_Rating",
      "type": "quantitative"
    },
    "y": {
      "bin": {"maxbins": 40},
      "field": "Rotten_Tomatoes_Rating",
      "type": "quantitative"
    },
    "color": {
      "aggregate": "count",
      "type": "quantitative",
      "scale": {
        "type": "quantize",
        "scheme": {
          "count": 5
        }
      }
    }
  },
  "config": {
    "range": {
      "heatmap": {
        "scheme": "greenblue"
      }
    },
    "view": {
      "stroke": "transparent"
    }
  }
}
```