### PR TITLE
Suppress all errors in JSON syntax highlighting

### DIFF
--- a/site/docs/composition/concat.md
+++ b/site/docs/composition/concat.md
@@ -21,8 +21,6 @@ If you concatenate similar views where the only difference is the field that is 
 
 Put multiple views into a row by putting the specs for each view into an array and assign it to the `hconcat` property.
 
-{: .suppress-error}
-
 ```json
 {
   "hconcat": [
@@ -42,8 +40,6 @@ In addition to [common properties of a view specification](spec.html#common), a 
 ## Vertical Concatenation
 
 Put multiple views into a column by putting the specs for each view into an array and assign it to the `vconcat` property.
-
-{: .suppress-error}
 
 ```json
 {

--- a/site/docs/composition/facet.md
+++ b/site/docs/composition/facet.md
@@ -25,8 +25,6 @@ Second, as a shortcut you can use the [`column` or `row` encoding channels](#fac
 
 To create a faceted view, define how the data should be faceted in `facet` and how each facet should be displayed in the `spec`.
 
-{: .suppress-error}
-
 ```json
 {
   "facet": {

--- a/site/docs/composition/layer.md
+++ b/site/docs/composition/layer.md
@@ -7,8 +7,6 @@ permalink: /docs/layer.html
 
 Sometimes, it's useful to superimpose one chart on top of another. You can accomplish this by using the `layer` operator. This operator is one of Vega-Lite's [view composition operators](composition.html). To define a layered chart, put multiple specifications into an array under the `layer` property.
 
-{: .suppress-error}
-
 ```json
 {
   "layer": [

--- a/site/docs/composition/repeat.md
+++ b/site/docs/composition/repeat.md
@@ -19,8 +19,6 @@ The `repeat` operator is part of Vega-Lite's [view composition](composition.html
 
 To repeat a view, define what fields should be used for each entry in the row or columns. Then define the repeated view in `spec` with a reference to a repeated field (`{"repeat": ...}`).
 
-{: .suppress-error}
-
 ```json
 {
   "repeat": {
@@ -35,8 +33,6 @@ For instance, you can use this operator to quickly create an overview over the t
 <span class="vl-example" data-name="repeat_line_weather"></span>
 
 Note how the field for the y channel refers to a repeated field.
-
-{: .suppress-error}
 
 ```json
 "y": {

--- a/site/docs/composition/resolve.md
+++ b/site/docs/composition/resolve.md
@@ -7,8 +7,6 @@ permalink: /docs/resolve.html
 
 Vega-Lite determines whether scale domains should be unioned. If the scale domain is unioned, axes and legends can be merged. Otherwise they have to be independent.
 
-{: .suppress-error}
-
 ```json
 {
   "resolve": {

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -5,8 +5,6 @@ title: Configuration
 permalink: /docs/config.html
 ---
 
-{: .suppress-error}
-
 ```json
 {
   ...,

--- a/site/docs/data.md
+++ b/site/docs/data.md
@@ -67,8 +67,6 @@ Here is a list of all properties describing a named `data` source:
 
 For example, to create a data source named `myData`, use the following data
 
-{: .suppress-error}
-
 ```json
 {
   "name": "myData"
@@ -124,8 +122,6 @@ Load a JavaScript Object Notation (JSON) file using the TopoJSON format. The inp
 ## Datasets
 
 Vega-Lite supports a top-level `datasets` property. This can be useful when the same data should be inlined in different places in the spec. Instead of setting values inline, specify datasets at the top level and then refer to the [named](#named) datasource in the rest of the spec. `datasets` is a mapping from name to an [inline](#inline) dataset.
-
-{: .suppress-error}
 
 ```json
     "datasets": {

--- a/site/docs/encoding.md
+++ b/site/docs/encoding.md
@@ -7,8 +7,6 @@ permalink: /docs/encoding.html
 
 An integral part of the data visualization process is encoding data with visual properties of graphical marks. The `encoding` property of a single view specification represents the mapping between [encoding channels](#channels) (such as `x`, `y`, or `color`) and [data fields](#field-def) or [constant values](#value-def).
 
-{: .suppress-error}
-
 ```json
 // Specification of a Single View
 {
@@ -83,8 +81,6 @@ Each channel definition object is either a [field definition](<(#field-def)>), w
 
 ### Field Definition
 
-{: .suppress-error}
-
 ```json
 // Specification of a Single View
 {
@@ -128,8 +124,6 @@ To see a list of additional properties for each type of encoding channels, pleas
 {:#value-def}
 
 ### Value Definition
-
-{: .suppress-error}
 
 ```json
 // Specification of a Single View

--- a/site/docs/encoding/axis.md
+++ b/site/docs/encoding/axis.md
@@ -21,8 +21,6 @@ Besides `axis` property of a field definition, the configuration object ([`confi
 
 ## Axis Properties
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -102,8 +100,6 @@ For example, the following plot has a customized x-axis title.
 {:#config}
 
 ## Axis Config
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/encoding/condition.md
+++ b/site/docs/encoding/condition.md
@@ -28,8 +28,6 @@ In addition, there are two ways to encode the data that satisfy the specified co
 
 ## Conditional Field Definition
 
-{: .suppress-error}
-
 ```json
 // Specification of a Single View
 {
@@ -63,8 +61,6 @@ For example, in the following plot, the color of `rect` marks is driven by a con
 {:#value}
 
 ## Conditional Value Definition
-
-{: .suppress-error}
 
 ```json
 // Specification of a Single View

--- a/site/docs/encoding/field.md
+++ b/site/docs/encoding/field.md
@@ -4,8 +4,6 @@ title: Field
 permalink: /docs/field.html
 ---
 
-{: .suppress-error}
-
 ```json
 // Specification of a Single View
 {

--- a/site/docs/encoding/header.md
+++ b/site/docs/encoding/header.md
@@ -21,8 +21,6 @@ In addition to the `header` property of a row- or column-field definition, users
 
 ## Header Properties
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -75,8 +73,6 @@ This example uses header properties to change the font size of this faceted plot
 {:#config}
 
 ## Header Config
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/encoding/legend.md
+++ b/site/docs/encoding/legend.md
@@ -33,8 +33,6 @@ If multiple channels encode the same fields, Vega-lite automatically combines th
 
 ## Legend Properties
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -95,8 +93,6 @@ _See also:_ This [interactive article](https://beta.observablehq.com/@jheer/a-gu
 {:#config}
 
 ## Legend Config
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/encoding/scale.md
+++ b/site/docs/encoding/scale.md
@@ -9,8 +9,6 @@ Scales are functions that transform a domain of data values (numbers, dates, str
 
 Vega-Lite automatically creates scales for fields that are mapped to [position](encoding.html#position) and [mark property](encoding.html#mark-prop) channels. To customize the scale of a field, users can provide a `scale` object as a part of the [field definition](encoding.html#field) to customize scale properties (e.g., [type](#type), [domain](#domain), and [range](#range)).
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -374,8 +372,6 @@ For example, the follow bar chart directly encodes color names in the data.
 {:#config}
 
 ## Configuration
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/encoding/sort.md
+++ b/site/docs/encoding/sort.md
@@ -4,8 +4,6 @@ title: Sorting
 permalink: /docs/sort.html
 ---
 
-{: .suppress-error}
-
 ```json
 {
   "data": ... ,

--- a/site/docs/encoding/value.md
+++ b/site/docs/encoding/value.md
@@ -4,8 +4,6 @@ title: Value
 permalink: /docs/value.html
 ---
 
-{: .suppress-error}
-
 ```json
 // Specification of a Single View
 {

--- a/site/docs/mark/area.md
+++ b/site/docs/mark/area.md
@@ -5,8 +5,6 @@ title: Area
 permalink: /docs/area.html
 ---
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -28,8 +26,6 @@ permalink: /docs/area.html
 {:#properties}
 
 ## Area Mark Properties
-
-{: .suppress-error}
 
 ```json
 // Single View Specification
@@ -91,8 +87,6 @@ Specifying `x2` or `y2` for the quantitative axis of area marks produce ranged a
 {:#config}
 
 ## Area Config
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/mark/bar.md
+++ b/site/docs/mark/bar.md
@@ -5,8 +5,6 @@ title: Bar
 permalink: /docs/bar.html
 ---
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -30,8 +28,6 @@ Bar marks are useful in many visualizations, including bar charts, [stacked bar 
 {:#properties}
 
 ## Bar Mark Properties
-
-{: .suppress-error}
 
 ```json
 // Single View Specification
@@ -123,8 +119,6 @@ Specifying `x2` or `y2` for the quantitative axis of bar marks creates ranged ba
 {:#config}
 
 ## Bar Config
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/mark/boxplot.md
+++ b/site/docs/mark/boxplot.md
@@ -5,8 +5,6 @@ title: Box Plot
 permalink: /docs/boxplot.html
 ---
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -108,8 +106,6 @@ An example of a `boxplot` where the `size` encoding channel is specified.
 {:#config}
 
 ## Mark Config
-
-{: .suppress-error}
 
 ```json
 {

--- a/site/docs/mark/circle.md
+++ b/site/docs/mark/circle.md
@@ -5,8 +5,6 @@ title: Circle
 permalink: /docs/circle.html
 ---
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -22,8 +20,6 @@ permalink: /docs/circle.html
 {:#properties}
 
 ## Circle Mark Properties
-
-{: .suppress-error}
 
 ```json
 // Single View Specification
@@ -53,8 +49,6 @@ Here is an example scatter plot with `circle` marks:
 {:#config}
 
 ## Circle Config
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/mark/errorband.md
+++ b/site/docs/mark/errorband.md
@@ -5,8 +5,6 @@ title: Error Band
 permalink: /docs/errorband.html
 ---
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -112,8 +110,6 @@ Here is an example of a `errorband` with the `color` encoding channel set to `{"
 {:#config}
 
 ## Mark Config
-
-{: .suppress-error}
 
 ```json
 {

--- a/site/docs/mark/errorbar.md
+++ b/site/docs/mark/errorbar.md
@@ -5,8 +5,6 @@ title: Error Bar
 permalink: /docs/errorbar.html
 ---
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -132,8 +130,6 @@ Here is an example of a `errorbar` with the `color` encoding channel set to `{"v
 {:#config}
 
 ## Mark Config
-
-{: .suppress-error}
 
 ```json
 {

--- a/site/docs/mark/geoshape.md
+++ b/site/docs/mark/geoshape.md
@@ -5,8 +5,6 @@ title: Geoshape
 permalink: /docs/geoshape.html
 ---
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -26,8 +24,6 @@ Here are an example choropleth making use of `geoshape` marks:
 {:#config}
 
 ## Geoshape Config
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/mark/line.md
+++ b/site/docs/mark/line.md
@@ -5,8 +5,6 @@ title: Line
 permalink: /docs/line.html
 ---
 
-{: .suppress-error}
-
 ```json
 {
   "data": ... ,
@@ -31,8 +29,6 @@ The `line` mark represents the data points stored in a field with a line connect
 {:#properties}
 
 ## Line Mark Properties
-
-{: .suppress-error}
 
 ```json
 // Single View Specification
@@ -144,8 +140,6 @@ By mapping geographic coordinate data to `longitude` and `latitude` channels of 
 {:#config}
 
 ## Line Config
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/mark/mark.md
+++ b/site/docs/mark/mark.md
@@ -11,8 +11,6 @@ The `mark` property of a [single view specification](spec.html#single) can eithe
 
 <!-- why mark-based approach over chart typology + but we support variety of chart types -->
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -46,8 +44,6 @@ For example, a bar chart has `mark` as a simple string `"bar"`.
 {:#mark-def}
 
 ## Mark Definition Object
-
-{: .suppress-error}
 
 ```json
 // Single View Specification
@@ -105,8 +101,6 @@ Marks can act as hyperlinks when the `href` property or [channel](encoding.html#
 
 ## Mark Style Config
 
-{: .suppress-error}
-
 ```json
 {
   // Top Level Specification
@@ -124,8 +118,6 @@ In addition to the default mark properties above, default values can be further 
 {% include table.html props="style" source="Config" %}
 
 For example, to set a default shape and stroke width for `point` marks with a style named `"triangle"`:
-
-{: .suppress-error}
 
 ```json
 {
@@ -156,8 +148,6 @@ See also: [a similar example that uses mark definition to configure offset, alig
 {:#config}
 
 ## Mark Config
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/mark/point.md
+++ b/site/docs/mark/point.md
@@ -5,8 +5,6 @@ title: Point
 permalink: /docs/point.html
 ---
 
-{: .suppress-error}
-
 ```json
 {
   "data": ... ,
@@ -29,8 +27,6 @@ permalink: /docs/point.html
 {:#properties}
 
 ## Point Mark Properties
-
-{: .suppress-error}
 
 ```json
 // Single View Specification
@@ -90,8 +86,6 @@ By mapping geographic coordinate data to `longitude` and `latitude` channels of 
 {:#config}
 
 ## Point Config
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/mark/rect.md
+++ b/site/docs/mark/rect.md
@@ -5,8 +5,6 @@ title: Rect
 permalink: /docs/rect.html
 ---
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -29,8 +27,6 @@ The `rect` mark represents an arbitrary rectangle.
 {:#properties}
 
 ## Rect Mark Properties
-
-{: .suppress-error}
 
 ```json
 // Single View Specification
@@ -78,8 +74,6 @@ We can also use `rect` to show a band covering one standard deviation over and b
 {:#config}
 
 ## Rect Config
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/mark/rule.md
+++ b/site/docs/mark/rule.md
@@ -5,8 +5,6 @@ title: Rule
 permalink: /docs/rule.html
 ---
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -30,8 +28,6 @@ The `rule` mark represents each data point as a line segment. It can be used in 
 {:#properties}
 
 ## Rule Mark Properties
-
-{: .suppress-error}
 
 ```json
 // Single View Specification
@@ -87,8 +83,6 @@ Alternatively, we can create error bars showing one standard deviation (`stdev`)
 {:#config}
 
 ## Rule Config
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/mark/square.md
+++ b/site/docs/mark/square.md
@@ -5,8 +5,6 @@ title: Square
 permalink: /docs/square.html
 ---
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -36,8 +34,6 @@ Here are an example scatter plot with `square` marks:
 {:#config}
 
 ## Square Config
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/mark/text.md
+++ b/site/docs/mark/text.md
@@ -5,8 +5,6 @@ title: Text
 permalink: /docs/text.html
 ---
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -30,8 +28,6 @@ permalink: /docs/text.html
 {:#properties}
 
 ## Text Mark Properties
-
-{: .suppress-error}
 
 ```json
 // Single View Specification
@@ -77,8 +73,6 @@ By mapping geographic coordinate data to `longitude` and `latitude` channels of 
 {:#config}
 
 ## Text Config
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/mark/tick.md
+++ b/site/docs/mark/tick.md
@@ -5,8 +5,6 @@ title: Tick
 permalink: /docs/tick.html
 ---
 
-{: .suppress-error}
-
 ```json
 // Single View Specification
 {
@@ -56,8 +54,6 @@ The following strip-plot use `tick` mark to represent its data.
 {:#config}
 
 ## Tick Config
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/mark/trail.md
+++ b/site/docs/mark/trail.md
@@ -5,8 +5,6 @@ title: Trail
 permalink: /docs/trail.html
 ---
 
-{: .suppress-error}
-
 ```json
 {
   "data": ... ,
@@ -29,8 +27,6 @@ The `trail` mark represents the data points stored in a field with a line connec
 {:#properties}
 
 ## Trail Mark Properties
-
-{: .suppress-error}
 
 ```json
 // Single View Specification
@@ -58,8 +54,6 @@ A trail mark definition can contain any [standard mark properties](mark.html#mar
 {:#config}
 
 ## Trail Config
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/projection.md
+++ b/site/docs/projection.md
@@ -51,8 +51,6 @@ Vega-lite includes all cartographic projections provided by the [d3-geo](https:/
 
 ## Projection Configuration
 
-{: .suppress-error}
-
 ```json
 // Top-level View Specification
 {

--- a/site/docs/selection/selection.md
+++ b/site/docs/selection/selection.md
@@ -5,8 +5,6 @@ title: Interactive Plots with Selections
 permalink: /docs/selection.html
 ---
 
-{: .suppress-error}
-
 ```json
 // Specification of a Single View
 {
@@ -121,8 +119,6 @@ With multiview displays, selections can also be used to determine the domains of
 
 An alternate way to construct this technique would be to filter out the input data to the top (detail) view like so:
 
-{: .suppress-error}
-
 ```json
 {
   "vconcat": [{
@@ -185,8 +181,6 @@ The aptly named `resolve` property addresses this ambiguity, and can be set to o
 {:#config}
 
 ## Selection Configuration
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/spec.md
+++ b/site/docs/spec.md
@@ -37,8 +37,6 @@ In addition to the [common properties](#common), any kind of top-level specifica
 
 ## Single View Specifications
 
-{: .suppress-error}
-
 ```json
 {
   // Properties for top-level specification (e.g., standalone single view specifications)
@@ -106,8 +104,6 @@ To create layered and multi-view graphics, please refer to the following pages:
 {:#config}
 
 ## View Configuration
-
-{: .suppress-error}
 
 ```json
 // Top-level View Specification

--- a/site/docs/transform/aggregate.md
+++ b/site/docs/transform/aggregate.md
@@ -20,8 +20,6 @@ To aggregate data in Vega-Lite, users can either use the `aggregate` property of
 
 <!-- TODO why aggregation -->
 
-{: .suppress-error}
-
 ```json
 // A Single View Specification
 {
@@ -58,8 +56,6 @@ The `detail` channel can be used to specify additional summary and group-by fiel
 {:#transform}
 
 ## Aggregate Transform
-
-{: .suppress-error}
 
 ```json
 // A View Specification

--- a/site/docs/transform/bin.md
+++ b/site/docs/transform/bin.md
@@ -20,8 +20,6 @@ There are two ways to define binning in Vega-Lite: [the `bin` property in encodi
 
 ## Binning in Encoding Field Definition
 
-{: .suppress-error}
-
 ```json
 // A Single View Specification
 {
@@ -78,8 +76,6 @@ If you have data that is already binned outside of Vega-Lite, setting the `bin` 
 {:#transform}
 
 ## Bin Transform
-
-{: .suppress-error}
 
 ```json
 // Any View Specification

--- a/site/docs/transform/calculate.md
+++ b/site/docs/transform/calculate.md
@@ -7,8 +7,6 @@ permalink: /docs/calculate.html
 
 The formula transform extends data objects with new fields (columns) according to an [expression](types.html#expression).
 
-{: .suppress-error}
-
 ```json
 {
   ...

--- a/site/docs/transform/filter.md
+++ b/site/docs/transform/filter.md
@@ -7,8 +7,6 @@ permalink: /docs/filter.html
 
 The filter transform removes objects from a data stream based on a provided filter expression or filter object.
 
-{: .suppress-error}
-
 ```json
 {
   ...
@@ -42,8 +40,6 @@ For a field predicate, a `field` must be provided along with one of the predicat
 
 For example, to check if the `car_color` field's value is equal to `"red"`, we can use the following filter:
 
-{: .suppress-error}
-
 ```json
 {"filter": {"field": "car_color", "equal": "red"}}
 ```
@@ -55,8 +51,6 @@ For example, to check if the `car_color` field's value is equal to `"red"`, we c
 {% include table.html props="lt" source="FieldLTPredicate" %}
 
 For example, to check if the `height` field's value is less than `180`, we can use the following filter:
-
-{: .suppress-error}
 
 ```json
 {"filter": {"field": "height", "lt": 180}}
@@ -70,8 +64,6 @@ For example, to check if the `height` field's value is less than `180`, we can u
 
 For example, to check if the `Year` field's value is less than or equals to `"2000"`, we can use the following filter:
 
-{: .suppress-error}
-
 ```json
 {"filter": {"timeUnit": "year", "field": "Year", "lte": "2000"}}
 ```
@@ -84,8 +76,6 @@ For example, to check if the `Year` field's value is less than or equals to `"20
 
 To check if the `state` field's value is greater than `"Arizona"` by string comparison, we can use the following filter: (Note: Standard Javascript string comparison is done, ie., "A" < "B", but "B" < "a")
 
-{: .suppress-error}
-
 ```json
 {"filter": {"field": "state", "gt": "Arizona"}}
 ```
@@ -97,8 +87,6 @@ To check if the `state` field's value is greater than `"Arizona"` by string comp
 {% include table.html props="gte" source="FieldGTEPredicate" %}
 
 For example, to check if the `height` field's value is greater than or equals to `0`, we can use the following filter:
-
-{: .suppress-error}
 
 ```json
 {"filter": {"field": "height", "gte": 0}}

--- a/site/docs/transform/impute.md
+++ b/site/docs/transform/impute.md
@@ -20,8 +20,6 @@ The impute transform groups data and determines missing values of the `key` fiel
 
 ## Impute in Encoding Field Definition
 
-{: .suppress-error}
-
 ```json
 // A Single View Specification
 {
@@ -84,8 +82,6 @@ Alternatively, the `keyvals` property can be an [object](#sequence-def) defining
 ## Impute Transform
 
 An impute transform can also be specified as a part of the `transform` array.
-
-{: .suppress-error}
 
 ```json
 // A View Specification

--- a/site/docs/transform/lookup.md
+++ b/site/docs/transform/lookup.md
@@ -7,8 +7,6 @@ permalink: /docs/lookup.html
 
 The lookup transform extends a primary data source by looking up values from another data source. It is similar to a one sided join.
 
-{: .suppress-error}
-
 ```json
 {
   ...

--- a/site/docs/transform/stack.md
+++ b/site/docs/transform/stack.md
@@ -18,8 +18,6 @@ To stack fields in Vega-Lite, users can either use the `stack` property of an [e
 
 ## Stack in Encoding Field Definition
 
-{: .suppress-error}
-
 ```json
 // Specification of a Single View
 {
@@ -112,8 +110,6 @@ Since `line` marks are not stacked by default, to layer lines on top of stacked 
 {:#transform}
 
 ## Stack Transform
-
-{: .suppress-error}
 
 ```json
 // A View Specification

--- a/site/docs/transform/timeunit.md
+++ b/site/docs/transform/timeunit.md
@@ -32,8 +32,6 @@ By default, all time units represent date time using local time. To use UTC time
 
 ## Time Unit in Encoding Field Definition
 
-{: .suppress-error}
-
 ```json
 {
   "data": ... ,
@@ -69,8 +67,6 @@ If you want to use a discrete scale instead, you can cast the field to have an `
 {: #transform}
 
 ## Time Unit Transform
-
-{: .suppress-error}
 
 ```json
 {

--- a/site/docs/transform/transform.md
+++ b/site/docs/transform/transform.md
@@ -11,8 +11,6 @@ When both types of transforms are specified, the view-level `transform`s are exe
 
 ## View-level Transform Property
 
-{: .suppress-error}
-
 ```json
 {
   "data": ... ,

--- a/site/docs/transform/window.md
+++ b/site/docs/transform/window.md
@@ -17,8 +17,6 @@ The window transform performs calculations over sorted groups of data objects. T
 
 ## Window Field Definition
 
-{: .suppress-error}
-
 ```json
 // A View Specification
 {

--- a/site/docs/view/title.md
+++ b/site/docs/view/title.md
@@ -23,8 +23,6 @@ For example, we can customize the `anchor` of the title of a bar chart.
 
 <span class="vl-example" data-name="bar_title_start"></span>
 
-{: .suppress-error}
-
 ```json
 // Top-level View Specification
 {

--- a/site/static/syntax.css
+++ b/site/static/syntax.css
@@ -209,7 +209,7 @@
 
 /* Allow json example with errors */
 
-.suppress-error .highlight .err {
+.language-json .highlight .err {
   color: #000;
   background-color: transparent;
 }

--- a/site/tutorials/explore.md
+++ b/site/tutorials/explore.md
@@ -11,8 +11,6 @@ For this tutorial, we will create visualizations to explore weather data for Sea
 
 To load the CSV file with Vega-Lite, we need to provide a URL and set the format type in the data section of the specification.
 
-{: .suppress-error}
-
 ```json
 "data": {"url": "data/seattle-weather.csv"}
 ```

--- a/site/tutorials/getting_started.md
+++ b/site/tutorials/getting_started.md
@@ -85,8 +85,6 @@ Now, it looks like we get a point. In fact, Vega-Lite renders one point for each
 
 To visually separate the points, data variables can be mapped to visual properties of a mark. For example, we can [_encode_]({{site.baseurl}}/docs/encoding.html) the variable `a` of the data with `x` channel, which represents the x-position of the points. We can do that by adding an `encoding` object with its key `x` mapped to a channel definition that describes variable `a`.
 
-{: .suppress-error}
-
 ```json
 ...
 "encoding": {
@@ -100,8 +98,6 @@ To visually separate the points, data variables can be mapped to visual properti
 The [`encoding`]({{site.baseurl}}/docs/encoding.html) object is a key-value mapping between encoding channels (such as `x`, `y`) and definitions of the mapped data fields. The channel definition describes the field's name (`field`) and its [data type]({{site.baseurl}}/docs/encoding.html#type) (`type`). In this example, we map the values for field `a` to the _encoding channel_ `x` (the x-location of the points) and set `a`'s data type to `nominal`, since it represents categories. (See [the documentation for more information about data types]({{site.baseurl}}/docs/encoding.html#type).)
 
 In the visualization above, Vega-Lite automatically adds an axis with labels for the different categories as well as an axis title. However, 3 points in each category are still overlapping. So far, we have only defined a visual encoding for the field `a`. We can also map the field `b` to the `y` channel.
-
-{: .suppress-error}
 
 ```json
 ...

--- a/site/tutorials/streaming.md
+++ b/site/tutorials/streaming.md
@@ -13,8 +13,6 @@ We will be using the `View` API from the Vega, where we update data via the [`ch
 
 To use `view.change`, you have to first specify the name of the data source you are updating: `view.change('data', ... )`. The name needs to be specified in the original spec, as described [here]({{site.baseurl}}/docs/data.html#named). As the second parameter to the `view.change` method, you should specify what data to add, and what data to remove. To add data, simply supply the array of data entries matching previous schemas, for the example here, it is:
 
-{: .suppress-error}
-
 ```json
 {
   "x": number,


### PR DESCRIPTION
I saw an error on the config page and decided to just hide all errors. 

<img width="845" alt="screen shot 2019-01-28 at 17 26 12" src="https://user-images.githubusercontent.com/589034/51877890-98260700-2322-11e9-83d9-d679cd98fa76.png">
