### PR TITLE
Fix Customize your Visualization section of tutorial

### DIFF
--- a/examples/specs/bar_swap_custom.vl.json
+++ b/examples/specs/bar_swap_custom.vl.json
@@ -12,7 +12,7 @@
     "y": {"field": "a", "type": "nominal"},
     "x": {
       "aggregate": "average", "field": "b", "type": "quantitative",
-      "axis": {"title": "Average of b"}
+      "axis": {"title": "Mean of b"}
     }
   }
 }

--- a/site/tutorials/getting_started.md
+++ b/site/tutorials/getting_started.md
@@ -138,7 +138,7 @@ Since the quantitative value is on y, you automatically get a vertical bar chart
 
 <!-- TODO need to find a way to talk about conciseness here somehow. -->
 
-Vega-Lite automatically provides default properties for the visualization. You can further customize these values by adding more properties. For example, to change the title of the x-axis from `MEAN(b)` to `Average of b`, we can set the title property of the axis in the `x` channel.
+Vega-Lite automatically provides default properties for the visualization. You can further customize these values by adding more properties. For example, to change the title of the x-axis from `Average of b` to `Mean of b`, we can set the title property of the axis in the `x` channel.
 
 <div class="vl-example" data-name="bar_swap_custom"></div>
 


### PR DESCRIPTION
The default title for average aggregate was `MEAN(b)`. Now it's `Average of b`. With the new title, the [Customize your Visualization section](https://vega.github.io/vega-lite/tutorials/getting_started.html#customize-your-visualization) needs to be updated.

Before:
![before](https://user-images.githubusercontent.com/10929390/52450616-ac22f300-2af0-11e9-895c-ca50ccb956d2.png)

After:
![after](https://user-images.githubusercontent.com/10929390/52450654-e096af00-2af0-11e9-8f00-9b56e6b09cc4.png)

With `yarn test`, `toggle.test.ts` fails. But it also fails at head, so I assume I can ignore.