### PR TITLE
Don't include extra encoding for composite mark in the main `Encoding`

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -85,6 +85,22 @@
       ],
       "type": "string"
     },
+    "AnyMark": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/CompositeMark"
+        },
+        {
+          "$ref": "#/definitions/CompositeMarkDef"
+        },
+        {
+          "$ref": "#/definitions/Mark"
+        },
+        {
+          "$ref": "#/definitions/MarkDef"
+        }
+      ]
+    },
     "AreaConfig": {
       "additionalProperties": false,
       "properties": {
@@ -1660,12 +1676,6 @@
       ],
       "type": "object"
     },
-    "BoxPlotUnitSpec": {
-      "$ref": "#/definitions/GenericUnitSpec<(BoxPlotEncoding),(BoxPlot|BoxPlotDef)>"
-    },
-    "BoxPlotUnitSpecWithFacet": {
-      "$ref": "#/definitions/GenericUnitSpec<(BoxPlotEncodingWithFacet),(BoxPlot|BoxPlotDef)>"
-    },
     "BrushConfig": {
       "additionalProperties": false,
       "properties": {
@@ -1730,31 +1740,321 @@
     "ColorValueDefWithCondition": {
       "$ref": "#/definitions/ValueDefWithCondition<MarkPropFieldDef,(string|null)>"
     },
-    "CompositeMarkUnitSpec": {
+    "Encoding": {
+      "additionalProperties": false,
+      "properties": {
+        "color": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ColorFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/ColorValueDefWithCondition"
+            }
+          ],
+          "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
+        },
+        "detail": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FieldDef"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDef"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
+        },
+        "fill": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ColorFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/ColorValueDefWithCondition"
+            }
+          ],
+          "description": "Fill color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `fill` channel, `color ` channel will be ignored. To customize both fill and stroke, please use `fill` and `stroke` channels (not `fill` and `color`)."
+        },
+        "fillOpacity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NumericFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/NumericValueDefWithCondition"
+            }
+          ],
+          "description": "Fill opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `fillOpacity` property."
+        },
+        "href": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/StringValueDefWithCondition"
+            }
+          ],
+          "description": "A URL to load upon mouse click."
+        },
+        "key": {
+          "$ref": "#/definitions/FieldDef",
+          "description": "A data field to use as a unique key for data binding. When a visualization’s data is updated, the key value will be used to match data elements to existing mark instances. Use a key channel to enable object constancy for transitions over dynamic data."
+        },
+        "latitude": {
+          "$ref": "#/definitions/LatLongFieldDef",
+          "description": "Latitude position of geographically projected marks."
+        },
+        "latitude2": {
+          "$ref": "#/definitions/SecondaryFieldDef",
+          "description": "Latitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+        },
+        "longitude": {
+          "$ref": "#/definitions/LatLongFieldDef",
+          "description": "Longitude position of geographically projected marks."
+        },
+        "longitude2": {
+          "$ref": "#/definitions/SecondaryFieldDef",
+          "description": "Longitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+        },
+        "opacity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NumericFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/NumericValueDefWithCondition"
+            }
+          ],
+          "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
+        },
+        "order": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OrderFieldDef"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/OrderFieldDef"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/NumberValueDef"
+            }
+          ],
+          "description": "Order of the marks.\n- For stacked marks, this `order` channel encodes [stack order](https://vega.github.io/vega-lite/docs/stack.html#order).\n- For line and trail marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/connected_scatterplot.html).  Setting `order` to `{\"value\": null}` makes the line marks use the original order in the data sources.\n- Otherwise, this `order` channel encodes layer order of the marks.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
+        },
+        "shape": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ShapeFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/ShapeValueDefWithCondition"
+            }
+          ],
+          "description": "For `point` marks the supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string.\nFor `geoshape` marks it should be a field definition of the geojson data\n\n__Default value:__ If undefined, the default shape depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape` property."
+        },
+        "size": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NumericFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/NumericValueDefWithCondition"
+            }
+          ],
+          "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
+        },
+        "stroke": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ColorFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/ColorValueDefWithCondition"
+            }
+          ],
+          "description": "Stroke color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `stroke` channel, `color ` channel will be ignored. To customize both stroke and fill, please use `stroke` and `fill` channels (not `stroke` and `color`)."
+        },
+        "strokeOpacity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NumericFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/NumericValueDefWithCondition"
+            }
+          ],
+          "description": "Stroke opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeOpacity` property."
+        },
+        "strokeWidth": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NumericFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/NumericValueDefWithCondition"
+            }
+          ],
+          "description": "Stroke width of the marks.\n\n__Default value:__ If undefined, the default stroke width depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeWidth` property."
+        },
+        "text": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/TextValueDefWithCondition"
+            }
+          ],
+          "description": "Text of the `text` mark."
+        },
+        "tooltip": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/TextValueDefWithCondition"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/TextFieldDef"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The tooltip text to show upon mouse hover."
+        },
+        "x": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PositionFieldDef"
+            },
+            {
+              "$ref": "#/definitions/XValueDef"
+            }
+          ],
+          "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+        },
+        "x2": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SecondaryFieldDef"
+            },
+            {
+              "$ref": "#/definitions/XValueDef"
+            }
+          ],
+          "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+        },
+        "xError": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SecondaryFieldDef"
+            },
+            {
+              "$ref": "#/definitions/NumberValueDef"
+            }
+          ],
+          "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+        },
+        "xError2": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SecondaryFieldDef"
+            },
+            {
+              "$ref": "#/definitions/NumberValueDef"
+            }
+          ],
+          "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+        },
+        "y": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PositionFieldDef"
+            },
+            {
+              "$ref": "#/definitions/YValueDef"
+            }
+          ],
+          "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+        },
+        "y2": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SecondaryFieldDef"
+            },
+            {
+              "$ref": "#/definitions/YValueDef"
+            }
+          ],
+          "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+        },
+        "yError": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SecondaryFieldDef"
+            },
+            {
+              "$ref": "#/definitions/NumberValueDef"
+            }
+          ],
+          "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+        },
+        "yError2": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SecondaryFieldDef"
+            },
+            {
+              "$ref": "#/definitions/NumberValueDef"
+            }
+          ],
+          "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+        }
+      },
+      "type": "object"
+    },
+    "CompositeMark": {
       "anyOf": [
         {
-          "$ref": "#/definitions/ErrorBarUnitSpec"
+          "$ref": "#/definitions/BoxPlot"
         },
         {
-          "$ref": "#/definitions/ErrorBandUnitSpec"
+          "$ref": "#/definitions/ErrorBar"
         },
         {
-          "$ref": "#/definitions/BoxPlotUnitSpec"
+          "$ref": "#/definitions/ErrorBand"
         }
       ]
     },
-    "CompositeMarkUnitSpecWithFacet": {
+    "CompositeMarkDef": {
       "anyOf": [
         {
-          "$ref": "#/definitions/ErrorBarUnitSpecWithFacet"
+          "$ref": "#/definitions/BoxPlotDef"
         },
         {
-          "$ref": "#/definitions/ErrorBandUnitSpecWithFacet"
+          "$ref": "#/definitions/ErrorBarDef"
         },
         {
-          "$ref": "#/definitions/BoxPlotUnitSpecWithFacet"
+          "$ref": "#/definitions/ErrorBandDef"
         }
       ]
+    },
+    "CompositeUnitSpec": {
+      "$ref": "#/definitions/GenericUnitSpec<Encoding,AnyMark>",
+      "description": "Unit spec that can be normalized/expanded into a layer spec or another unit spec."
     },
     "ConditionOnlyDef<MarkPropFieldDef<\"nominal\">>": {
       "additionalProperties": false,
@@ -3193,248 +3493,6 @@
     "Element": {
       "type": "string"
     },
-    "Encoding": {
-      "additionalProperties": false,
-      "properties": {
-        "color": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ColorFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/ColorValueDefWithCondition"
-            }
-          ],
-          "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
-        },
-        "detail": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/FieldDef"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/FieldDef"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
-        },
-        "fill": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ColorFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/ColorValueDefWithCondition"
-            }
-          ],
-          "description": "Fill color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `fill` channel, `color ` channel will be ignored. To customize both fill and stroke, please use `fill` and `stroke` channels (not `fill` and `color`)."
-        },
-        "fillOpacity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/NumericFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/NumericValueDefWithCondition"
-            }
-          ],
-          "description": "Fill opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `fillOpacity` property."
-        },
-        "href": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/StringFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/StringValueDefWithCondition"
-            }
-          ],
-          "description": "A URL to load upon mouse click."
-        },
-        "key": {
-          "$ref": "#/definitions/FieldDef",
-          "description": "A data field to use as a unique key for data binding. When a visualization’s data is updated, the key value will be used to match data elements to existing mark instances. Use a key channel to enable object constancy for transitions over dynamic data."
-        },
-        "latitude": {
-          "$ref": "#/definitions/LatLongFieldDef",
-          "description": "Latitude position of geographically projected marks."
-        },
-        "latitude2": {
-          "$ref": "#/definitions/SecondaryFieldDef",
-          "description": "Latitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
-        },
-        "longitude": {
-          "$ref": "#/definitions/LatLongFieldDef",
-          "description": "Longitude position of geographically projected marks."
-        },
-        "longitude2": {
-          "$ref": "#/definitions/SecondaryFieldDef",
-          "description": "Longitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
-        },
-        "opacity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/NumericFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/NumericValueDefWithCondition"
-            }
-          ],
-          "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
-        },
-        "order": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/OrderFieldDef"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/OrderFieldDef"
-              },
-              "type": "array"
-            },
-            {
-              "$ref": "#/definitions/NumberValueDef"
-            }
-          ],
-          "description": "Order of the marks.\n- For stacked marks, this `order` channel encodes [stack order](https://vega.github.io/vega-lite/docs/stack.html#order).\n- For line and trail marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/connected_scatterplot.html).  Setting `order` to `{\"value\": null}` makes the line marks use the original order in the data sources.\n- Otherwise, this `order` channel encodes layer order of the marks.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
-        },
-        "shape": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ShapeFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/ShapeValueDefWithCondition"
-            }
-          ],
-          "description": "For `point` marks the supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string.\nFor `geoshape` marks it should be a field definition of the geojson data\n\n__Default value:__ If undefined, the default shape depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape` property."
-        },
-        "size": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/NumericFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/NumericValueDefWithCondition"
-            }
-          ],
-          "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
-        },
-        "stroke": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ColorFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/ColorValueDefWithCondition"
-            }
-          ],
-          "description": "Stroke color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `stroke` channel, `color ` channel will be ignored. To customize both stroke and fill, please use `stroke` and `fill` channels (not `stroke` and `color`)."
-        },
-        "strokeOpacity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/NumericFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/NumericValueDefWithCondition"
-            }
-          ],
-          "description": "Stroke opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeOpacity` property."
-        },
-        "strokeWidth": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/NumericFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/NumericValueDefWithCondition"
-            }
-          ],
-          "description": "Stroke width of the marks.\n\n__Default value:__ If undefined, the default stroke width depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeWidth` property."
-        },
-        "text": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TextFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/TextValueDefWithCondition"
-            }
-          ],
-          "description": "Text of the `text` mark."
-        },
-        "tooltip": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TextFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/TextValueDefWithCondition"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/TextFieldDef"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "The tooltip text to show upon mouse hover."
-        },
-        "x": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PositionFieldDef"
-            },
-            {
-              "$ref": "#/definitions/XValueDef"
-            }
-          ],
-          "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-        },
-        "x2": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SecondaryFieldDef"
-            },
-            {
-              "$ref": "#/definitions/XValueDef"
-            }
-          ],
-          "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-        },
-        "y": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PositionFieldDef"
-            },
-            {
-              "$ref": "#/definitions/YValueDef"
-            }
-          ],
-          "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-        },
-        "y2": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SecondaryFieldDef"
-            },
-            {
-              "$ref": "#/definitions/YValueDef"
-            }
-          ],
-          "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-        }
-      },
-      "type": "object"
-    },
     "EncodingSortField": {
       "additionalProperties": false,
       "description": "A sort definition for sorting a discrete scale in an encoding field definition.",
@@ -3570,12 +3628,6 @@
       ],
       "type": "object"
     },
-    "ErrorBandUnitSpec": {
-      "$ref": "#/definitions/GenericUnitSpec<(ErrorEncoding),(ErrorBand|ErrorBandDef)>"
-    },
-    "ErrorBandUnitSpecWithFacet": {
-      "$ref": "#/definitions/GenericUnitSpec<(ErrorEncodingWithFacet),(ErrorBand|ErrorBandDef)>"
-    },
     "ErrorBar": {
       "enum": [
         "errorbar"
@@ -3674,12 +3726,6 @@
       ],
       "type": "string"
     },
-    "ErrorBarUnitSpec": {
-      "$ref": "#/definitions/GenericUnitSpec<(ErrorEncoding),(ErrorBar|ErrorBarDef)>"
-    },
-    "ErrorBarUnitSpecWithFacet": {
-      "$ref": "#/definitions/GenericUnitSpec<(ErrorEncodingWithFacet),(ErrorBar|ErrorBarDef)>"
-    },
     "EventStream": {
     },
     "LayerSpec": {
@@ -3710,7 +3756,7 @@
                 "$ref": "#/definitions/LayerSpec"
               },
               {
-                "$ref": "#/definitions/ExtendedUnitSpec"
+                "$ref": "#/definitions/CompositeUnitSpec"
               }
             ]
           },
@@ -3759,28 +3805,6 @@
         "layer"
       ],
       "type": "object"
-    },
-    "ExtendedUnitSpec": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/NormalizedUnitSpec"
-        },
-        {
-          "$ref": "#/definitions/CompositeMarkUnitSpec"
-        }
-      ],
-      "description": "Unit spec that can be normalized/expanded into a layer spec or another unit spec."
-    },
-    "ExtendedUnitSpecWithFacet": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/NormalizedUnitSpecWithFacet"
-        },
-        {
-          "$ref": "#/definitions/CompositeMarkUnitSpecWithFacet"
-        }
-      ],
-      "description": "Unit spec that can be normalized/expanded into a layer spec or another unit spec."
     },
     "FacetFieldDef": {
       "additionalProperties": false,
@@ -3869,8 +3893,302 @@
       },
       "type": "object"
     },
-    "FacetedExtendedUnitSpec": {
-      "$ref": "#/definitions/ExtendedUnitSpecWithFacet",
+    "FacetedEncoding": {
+      "additionalProperties": false,
+      "properties": {
+        "color": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ColorFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/ColorValueDefWithCondition"
+            }
+          ],
+          "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
+        },
+        "column": {
+          "$ref": "#/definitions/FacetFieldDef",
+          "description": "Horizontal facets for trellis plots."
+        },
+        "detail": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FieldDef"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDef"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
+        },
+        "fill": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ColorFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/ColorValueDefWithCondition"
+            }
+          ],
+          "description": "Fill color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `fill` channel, `color ` channel will be ignored. To customize both fill and stroke, please use `fill` and `stroke` channels (not `fill` and `color`)."
+        },
+        "fillOpacity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NumericFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/NumericValueDefWithCondition"
+            }
+          ],
+          "description": "Fill opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `fillOpacity` property."
+        },
+        "href": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/StringFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/StringValueDefWithCondition"
+            }
+          ],
+          "description": "A URL to load upon mouse click."
+        },
+        "key": {
+          "$ref": "#/definitions/FieldDef",
+          "description": "A data field to use as a unique key for data binding. When a visualization’s data is updated, the key value will be used to match data elements to existing mark instances. Use a key channel to enable object constancy for transitions over dynamic data."
+        },
+        "latitude": {
+          "$ref": "#/definitions/LatLongFieldDef",
+          "description": "Latitude position of geographically projected marks."
+        },
+        "latitude2": {
+          "$ref": "#/definitions/SecondaryFieldDef",
+          "description": "Latitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+        },
+        "longitude": {
+          "$ref": "#/definitions/LatLongFieldDef",
+          "description": "Longitude position of geographically projected marks."
+        },
+        "longitude2": {
+          "$ref": "#/definitions/SecondaryFieldDef",
+          "description": "Longitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+        },
+        "opacity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NumericFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/NumericValueDefWithCondition"
+            }
+          ],
+          "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
+        },
+        "order": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OrderFieldDef"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/OrderFieldDef"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/NumberValueDef"
+            }
+          ],
+          "description": "Order of the marks.\n- For stacked marks, this `order` channel encodes [stack order](https://vega.github.io/vega-lite/docs/stack.html#order).\n- For line and trail marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/connected_scatterplot.html).  Setting `order` to `{\"value\": null}` makes the line marks use the original order in the data sources.\n- Otherwise, this `order` channel encodes layer order of the marks.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
+        },
+        "row": {
+          "$ref": "#/definitions/FacetFieldDef",
+          "description": "Vertical facets for trellis plots."
+        },
+        "shape": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ShapeFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/ShapeValueDefWithCondition"
+            }
+          ],
+          "description": "For `point` marks the supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string.\nFor `geoshape` marks it should be a field definition of the geojson data\n\n__Default value:__ If undefined, the default shape depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape` property."
+        },
+        "size": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NumericFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/NumericValueDefWithCondition"
+            }
+          ],
+          "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
+        },
+        "stroke": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ColorFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/ColorValueDefWithCondition"
+            }
+          ],
+          "description": "Stroke color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `stroke` channel, `color ` channel will be ignored. To customize both stroke and fill, please use `stroke` and `fill` channels (not `stroke` and `color`)."
+        },
+        "strokeOpacity": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NumericFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/NumericValueDefWithCondition"
+            }
+          ],
+          "description": "Stroke opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeOpacity` property."
+        },
+        "strokeWidth": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/NumericFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/NumericValueDefWithCondition"
+            }
+          ],
+          "description": "Stroke width of the marks.\n\n__Default value:__ If undefined, the default stroke width depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeWidth` property."
+        },
+        "text": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/TextValueDefWithCondition"
+            }
+          ],
+          "description": "Text of the `text` mark."
+        },
+        "tooltip": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextFieldDefWithCondition"
+            },
+            {
+              "$ref": "#/definitions/TextValueDefWithCondition"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/TextFieldDef"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The tooltip text to show upon mouse hover."
+        },
+        "x": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PositionFieldDef"
+            },
+            {
+              "$ref": "#/definitions/XValueDef"
+            }
+          ],
+          "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+        },
+        "x2": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SecondaryFieldDef"
+            },
+            {
+              "$ref": "#/definitions/XValueDef"
+            }
+          ],
+          "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+        },
+        "xError": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SecondaryFieldDef"
+            },
+            {
+              "$ref": "#/definitions/NumberValueDef"
+            }
+          ],
+          "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+        },
+        "xError2": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SecondaryFieldDef"
+            },
+            {
+              "$ref": "#/definitions/NumberValueDef"
+            }
+          ],
+          "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+        },
+        "y": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PositionFieldDef"
+            },
+            {
+              "$ref": "#/definitions/YValueDef"
+            }
+          ],
+          "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+        },
+        "y2": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SecondaryFieldDef"
+            },
+            {
+              "$ref": "#/definitions/YValueDef"
+            }
+          ],
+          "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+        },
+        "yError": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SecondaryFieldDef"
+            },
+            {
+              "$ref": "#/definitions/NumberValueDef"
+            }
+          ],
+          "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+        },
+        "yError2": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SecondaryFieldDef"
+            },
+            {
+              "$ref": "#/definitions/NumberValueDef"
+            }
+          ],
+          "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+        }
+      },
+      "type": "object"
+    },
+    "FacetedUnitSpec": {
+      "$ref": "#/definitions/GenericUnitSpec<FacetedEncoding,AnyMark>",
       "description": "Unit spec that can have a composite mark and row or column channels (shorthand for a facet spec)."
     },
     "Field": {
@@ -4859,7 +5177,7 @@
               "$ref": "#/definitions/LayerSpec"
             },
             {
-              "$ref": "#/definitions/FacetedExtendedUnitSpec"
+              "$ref": "#/definitions/FacetedUnitSpec"
             }
           ],
           "description": "A specification of the view that gets faceted."
@@ -5052,7 +5370,7 @@
     "Spec": {
       "anyOf": [
         {
-          "$ref": "#/definitions/FacetedExtendedUnitSpec"
+          "$ref": "#/definitions/FacetedUnitSpec"
         },
         {
           "$ref": "#/definitions/LayerSpec"
@@ -5072,7 +5390,7 @@
       ],
       "description": "Any specification in Vega-Lite."
     },
-    "GenericUnitSpec<(BoxPlotEncoding),(BoxPlot|BoxPlotDef)>": {
+    "GenericUnitSpec<Encoding,AnyMark>": {
       "additionalProperties": false,
       "description": "Base interface for a unit (single-view) specification.",
       "properties": {
@@ -5085,102 +5403,15 @@
           "type": "string"
         },
         "encoding": {
-          "additionalProperties": false,
-          "description": "A key-value mapping between encoding channels and definition of fields.",
-          "properties": {
-            "color": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ColorFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ColorValueDefWithCondition"
-                }
-              ],
-              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
-            },
-            "detail": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/FieldDef"
-                },
-                {
-                  "items": {
-                    "$ref": "#/definitions/FieldDef"
-                  },
-                  "type": "array"
-                }
-              ],
-              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
-            },
-            "opacity": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
-            },
-            "size": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
-            },
-            "x": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/XValueDef"
-                }
-              ],
-              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-            },
-            "y": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/YValueDef"
-                }
-              ],
-              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-            }
-          },
-          "required": [
-            "color",
-            "detail",
-            "opacity",
-            "size",
-            "x",
-            "y"
-          ],
-          "type": "object"
+          "$ref": "#/definitions/Encoding",
+          "description": "A key-value mapping between encoding channels and definition of fields."
         },
         "height": {
           "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
           "type": "number"
         },
         "mark": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/BoxPlot"
-            },
-            {
-              "$ref": "#/definitions/BoxPlotDef"
-            }
-          ],
+          "$ref": "#/definitions/AnyMark",
           "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
         },
         "name": {
@@ -5230,7 +5461,7 @@
       ],
       "type": "object"
     },
-    "GenericUnitSpec<(BoxPlotEncodingWithFacet),(BoxPlot|BoxPlotDef)>": {
+    "GenericUnitSpec<FacetedEncoding,AnyMark>": {
       "additionalProperties": false,
       "description": "Base interface for a unit (single-view) specification.",
       "properties": {
@@ -5243,1624 +5474,15 @@
           "type": "string"
         },
         "encoding": {
-          "additionalProperties": false,
-          "description": "A key-value mapping between encoding channels and definition of fields.",
-          "properties": {
-            "color": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ColorFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ColorValueDefWithCondition"
-                }
-              ],
-              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
-            },
-            "column": {
-              "$ref": "#/definitions/FacetFieldDef",
-              "description": "Horizontal facets for trellis plots."
-            },
-            "detail": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/FieldDef"
-                },
-                {
-                  "items": {
-                    "$ref": "#/definitions/FieldDef"
-                  },
-                  "type": "array"
-                }
-              ],
-              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
-            },
-            "opacity": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
-            },
-            "row": {
-              "$ref": "#/definitions/FacetFieldDef",
-              "description": "Vertical facets for trellis plots."
-            },
-            "size": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
-            },
-            "x": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/XValueDef"
-                }
-              ],
-              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-            },
-            "y": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/YValueDef"
-                }
-              ],
-              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-            }
-          },
-          "required": [
-            "color",
-            "detail",
-            "opacity",
-            "size",
-            "x",
-            "y"
-          ],
-          "type": "object"
+          "$ref": "#/definitions/FacetedEncoding",
+          "description": "A key-value mapping between encoding channels and definition of fields."
         },
         "height": {
           "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
           "type": "number"
         },
         "mark": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/BoxPlot"
-            },
-            {
-              "$ref": "#/definitions/BoxPlotDef"
-            }
-          ],
-          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
-        },
-        "name": {
-          "description": "Name of the visualization for later reference.",
-          "type": "string"
-        },
-        "projection": {
-          "$ref": "#/definitions/Projection",
-          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
-        },
-        "selection": {
-          "additionalProperties": {
-            "$ref": "#/definitions/SelectionDef"
-          },
-          "description": "A key-value mapping between selection names and definitions.",
-          "type": "object"
-        },
-        "title": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/TitleParams"
-            }
-          ],
-          "description": "Title for the plot."
-        },
-        "transform": {
-          "description": "An array of data transformations such as filter and new field calculation.",
-          "items": {
-            "$ref": "#/definitions/Transform"
-          },
-          "type": "array"
-        },
-        "view": {
-          "$ref": "#/definitions/ViewBackground",
-          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
-        },
-        "width": {
-          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-          "type": "number"
-        }
-      },
-      "required": [
-        "mark"
-      ],
-      "type": "object"
-    },
-    "GenericUnitSpec<(Encoding),(Mark|MarkDef)>": {
-      "additionalProperties": false,
-      "description": "Base interface for a unit (single-view) specification.",
-      "properties": {
-        "data": {
-          "$ref": "#/definitions/Data",
-          "description": "An object describing the data source"
-        },
-        "description": {
-          "description": "Description of this mark for commenting purpose.",
-          "type": "string"
-        },
-        "encoding": {
-          "additionalProperties": false,
-          "description": "A key-value mapping between encoding channels and definition of fields.",
-          "properties": {
-            "color": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ColorFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ColorValueDefWithCondition"
-                }
-              ],
-              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
-            },
-            "detail": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/FieldDef"
-                },
-                {
-                  "items": {
-                    "$ref": "#/definitions/FieldDef"
-                  },
-                  "type": "array"
-                }
-              ],
-              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
-            },
-            "fill": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ColorFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ColorValueDefWithCondition"
-                }
-              ],
-              "description": "Fill color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `fill` channel, `color ` channel will be ignored. To customize both fill and stroke, please use `fill` and `stroke` channels (not `fill` and `color`)."
-            },
-            "fillOpacity": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Fill opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `fillOpacity` property."
-            },
-            "href": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/StringFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/StringValueDefWithCondition"
-                }
-              ],
-              "description": "A URL to load upon mouse click."
-            },
-            "key": {
-              "$ref": "#/definitions/FieldDef",
-              "description": "A data field to use as a unique key for data binding. When a visualization’s data is updated, the key value will be used to match data elements to existing mark instances. Use a key channel to enable object constancy for transitions over dynamic data."
-            },
-            "latitude": {
-              "$ref": "#/definitions/LatLongFieldDef",
-              "description": "Latitude position of geographically projected marks."
-            },
-            "latitude2": {
-              "$ref": "#/definitions/SecondaryFieldDef",
-              "description": "Latitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
-            },
-            "longitude": {
-              "$ref": "#/definitions/LatLongFieldDef",
-              "description": "Longitude position of geographically projected marks."
-            },
-            "longitude2": {
-              "$ref": "#/definitions/SecondaryFieldDef",
-              "description": "Longitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
-            },
-            "opacity": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
-            },
-            "order": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/OrderFieldDef"
-                },
-                {
-                  "items": {
-                    "$ref": "#/definitions/OrderFieldDef"
-                  },
-                  "type": "array"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Order of the marks.\n- For stacked marks, this `order` channel encodes [stack order](https://vega.github.io/vega-lite/docs/stack.html#order).\n- For line and trail marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/connected_scatterplot.html).  Setting `order` to `{\"value\": null}` makes the line marks use the original order in the data sources.\n- Otherwise, this `order` channel encodes layer order of the marks.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
-            },
-            "shape": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ShapeFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ShapeValueDefWithCondition"
-                }
-              ],
-              "description": "For `point` marks the supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string.\nFor `geoshape` marks it should be a field definition of the geojson data\n\n__Default value:__ If undefined, the default shape depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape` property."
-            },
-            "size": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
-            },
-            "stroke": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ColorFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ColorValueDefWithCondition"
-                }
-              ],
-              "description": "Stroke color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `stroke` channel, `color ` channel will be ignored. To customize both stroke and fill, please use `stroke` and `fill` channels (not `stroke` and `color`)."
-            },
-            "strokeOpacity": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Stroke opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeOpacity` property."
-            },
-            "strokeWidth": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Stroke width of the marks.\n\n__Default value:__ If undefined, the default stroke width depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeWidth` property."
-            },
-            "text": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/TextFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/TextValueDefWithCondition"
-                }
-              ],
-              "description": "Text of the `text` mark."
-            },
-            "tooltip": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/TextFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/TextValueDefWithCondition"
-                },
-                {
-                  "items": {
-                    "$ref": "#/definitions/TextFieldDef"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The tooltip text to show upon mouse hover."
-            },
-            "x": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/XValueDef"
-                }
-              ],
-              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-            },
-            "x2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/XValueDef"
-                }
-              ],
-              "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-            },
-            "y": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/YValueDef"
-                }
-              ],
-              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-            },
-            "y2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/YValueDef"
-                }
-              ],
-              "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-            }
-          },
-          "type": "object"
-        },
-        "height": {
-          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-          "type": "number"
-        },
-        "mark": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Mark"
-            },
-            {
-              "$ref": "#/definitions/MarkDef"
-            }
-          ],
-          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
-        },
-        "name": {
-          "description": "Name of the visualization for later reference.",
-          "type": "string"
-        },
-        "projection": {
-          "$ref": "#/definitions/Projection",
-          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
-        },
-        "selection": {
-          "additionalProperties": {
-            "$ref": "#/definitions/SelectionDef"
-          },
-          "description": "A key-value mapping between selection names and definitions.",
-          "type": "object"
-        },
-        "title": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/TitleParams"
-            }
-          ],
-          "description": "Title for the plot."
-        },
-        "transform": {
-          "description": "An array of data transformations such as filter and new field calculation.",
-          "items": {
-            "$ref": "#/definitions/Transform"
-          },
-          "type": "array"
-        },
-        "view": {
-          "$ref": "#/definitions/ViewBackground",
-          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
-        },
-        "width": {
-          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-          "type": "number"
-        }
-      },
-      "required": [
-        "mark"
-      ],
-      "type": "object"
-    },
-    "GenericUnitSpec<(EncodingWithFacet),(Mark|MarkDef)>": {
-      "additionalProperties": false,
-      "description": "Base interface for a unit (single-view) specification.",
-      "properties": {
-        "data": {
-          "$ref": "#/definitions/Data",
-          "description": "An object describing the data source"
-        },
-        "description": {
-          "description": "Description of this mark for commenting purpose.",
-          "type": "string"
-        },
-        "encoding": {
-          "additionalProperties": false,
-          "description": "A key-value mapping between encoding channels and definition of fields.",
-          "properties": {
-            "color": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ColorFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ColorValueDefWithCondition"
-                }
-              ],
-              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
-            },
-            "column": {
-              "$ref": "#/definitions/FacetFieldDef",
-              "description": "Horizontal facets for trellis plots."
-            },
-            "detail": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/FieldDef"
-                },
-                {
-                  "items": {
-                    "$ref": "#/definitions/FieldDef"
-                  },
-                  "type": "array"
-                }
-              ],
-              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
-            },
-            "fill": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ColorFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ColorValueDefWithCondition"
-                }
-              ],
-              "description": "Fill color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `fill` channel, `color ` channel will be ignored. To customize both fill and stroke, please use `fill` and `stroke` channels (not `fill` and `color`)."
-            },
-            "fillOpacity": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Fill opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `fillOpacity` property."
-            },
-            "href": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/StringFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/StringValueDefWithCondition"
-                }
-              ],
-              "description": "A URL to load upon mouse click."
-            },
-            "key": {
-              "$ref": "#/definitions/FieldDef",
-              "description": "A data field to use as a unique key for data binding. When a visualization’s data is updated, the key value will be used to match data elements to existing mark instances. Use a key channel to enable object constancy for transitions over dynamic data."
-            },
-            "latitude": {
-              "$ref": "#/definitions/LatLongFieldDef",
-              "description": "Latitude position of geographically projected marks."
-            },
-            "latitude2": {
-              "$ref": "#/definitions/SecondaryFieldDef",
-              "description": "Latitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
-            },
-            "longitude": {
-              "$ref": "#/definitions/LatLongFieldDef",
-              "description": "Longitude position of geographically projected marks."
-            },
-            "longitude2": {
-              "$ref": "#/definitions/SecondaryFieldDef",
-              "description": "Longitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
-            },
-            "opacity": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
-            },
-            "order": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/OrderFieldDef"
-                },
-                {
-                  "items": {
-                    "$ref": "#/definitions/OrderFieldDef"
-                  },
-                  "type": "array"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Order of the marks.\n- For stacked marks, this `order` channel encodes [stack order](https://vega.github.io/vega-lite/docs/stack.html#order).\n- For line and trail marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/connected_scatterplot.html).  Setting `order` to `{\"value\": null}` makes the line marks use the original order in the data sources.\n- Otherwise, this `order` channel encodes layer order of the marks.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
-            },
-            "row": {
-              "$ref": "#/definitions/FacetFieldDef",
-              "description": "Vertical facets for trellis plots."
-            },
-            "shape": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ShapeFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ShapeValueDefWithCondition"
-                }
-              ],
-              "description": "For `point` marks the supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string.\nFor `geoshape` marks it should be a field definition of the geojson data\n\n__Default value:__ If undefined, the default shape depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape` property."
-            },
-            "size": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
-            },
-            "stroke": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ColorFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ColorValueDefWithCondition"
-                }
-              ],
-              "description": "Stroke color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `stroke` channel, `color ` channel will be ignored. To customize both stroke and fill, please use `stroke` and `fill` channels (not `stroke` and `color`)."
-            },
-            "strokeOpacity": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Stroke opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeOpacity` property."
-            },
-            "strokeWidth": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Stroke width of the marks.\n\n__Default value:__ If undefined, the default stroke width depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeWidth` property."
-            },
-            "text": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/TextFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/TextValueDefWithCondition"
-                }
-              ],
-              "description": "Text of the `text` mark."
-            },
-            "tooltip": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/TextFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/TextValueDefWithCondition"
-                },
-                {
-                  "items": {
-                    "$ref": "#/definitions/TextFieldDef"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The tooltip text to show upon mouse hover."
-            },
-            "x": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/XValueDef"
-                }
-              ],
-              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-            },
-            "x2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/XValueDef"
-                }
-              ],
-              "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-            },
-            "y": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/YValueDef"
-                }
-              ],
-              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-            },
-            "y2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/YValueDef"
-                }
-              ],
-              "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-            }
-          },
-          "type": "object"
-        },
-        "height": {
-          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-          "type": "number"
-        },
-        "mark": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Mark"
-            },
-            {
-              "$ref": "#/definitions/MarkDef"
-            }
-          ],
-          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
-        },
-        "name": {
-          "description": "Name of the visualization for later reference.",
-          "type": "string"
-        },
-        "projection": {
-          "$ref": "#/definitions/Projection",
-          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
-        },
-        "selection": {
-          "additionalProperties": {
-            "$ref": "#/definitions/SelectionDef"
-          },
-          "description": "A key-value mapping between selection names and definitions.",
-          "type": "object"
-        },
-        "title": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/TitleParams"
-            }
-          ],
-          "description": "Title for the plot."
-        },
-        "transform": {
-          "description": "An array of data transformations such as filter and new field calculation.",
-          "items": {
-            "$ref": "#/definitions/Transform"
-          },
-          "type": "array"
-        },
-        "view": {
-          "$ref": "#/definitions/ViewBackground",
-          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
-        },
-        "width": {
-          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-          "type": "number"
-        }
-      },
-      "required": [
-        "mark"
-      ],
-      "type": "object"
-    },
-    "GenericUnitSpec<(ErrorEncoding),(ErrorBand|ErrorBandDef)>": {
-      "additionalProperties": false,
-      "description": "Base interface for a unit (single-view) specification.",
-      "properties": {
-        "data": {
-          "$ref": "#/definitions/Data",
-          "description": "An object describing the data source"
-        },
-        "description": {
-          "description": "Description of this mark for commenting purpose.",
-          "type": "string"
-        },
-        "encoding": {
-          "additionalProperties": false,
-          "description": "A key-value mapping between encoding channels and definition of fields.",
-          "properties": {
-            "color": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ColorFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ColorValueDefWithCondition"
-                }
-              ],
-              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
-            },
-            "detail": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/FieldDef"
-                },
-                {
-                  "items": {
-                    "$ref": "#/definitions/FieldDef"
-                  },
-                  "type": "array"
-                }
-              ],
-              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
-            },
-            "opacity": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
-            },
-            "x": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/XValueDef"
-                }
-              ],
-              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-            },
-            "x2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/XValueDef"
-                }
-              ],
-              "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-            },
-            "xError": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-            },
-            "xError2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-            },
-            "y": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/YValueDef"
-                }
-              ],
-              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-            },
-            "y2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/YValueDef"
-                }
-              ],
-              "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-            },
-            "yError": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-            },
-            "yError2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-            }
-          },
-          "required": [
-            "color",
-            "detail",
-            "opacity",
-            "x",
-            "x2",
-            "y",
-            "y2"
-          ],
-          "type": "object"
-        },
-        "height": {
-          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-          "type": "number"
-        },
-        "mark": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ErrorBand"
-            },
-            {
-              "$ref": "#/definitions/ErrorBandDef"
-            }
-          ],
-          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
-        },
-        "name": {
-          "description": "Name of the visualization for later reference.",
-          "type": "string"
-        },
-        "projection": {
-          "$ref": "#/definitions/Projection",
-          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
-        },
-        "selection": {
-          "additionalProperties": {
-            "$ref": "#/definitions/SelectionDef"
-          },
-          "description": "A key-value mapping between selection names and definitions.",
-          "type": "object"
-        },
-        "title": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/TitleParams"
-            }
-          ],
-          "description": "Title for the plot."
-        },
-        "transform": {
-          "description": "An array of data transformations such as filter and new field calculation.",
-          "items": {
-            "$ref": "#/definitions/Transform"
-          },
-          "type": "array"
-        },
-        "view": {
-          "$ref": "#/definitions/ViewBackground",
-          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
-        },
-        "width": {
-          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-          "type": "number"
-        }
-      },
-      "required": [
-        "mark"
-      ],
-      "type": "object"
-    },
-    "GenericUnitSpec<(ErrorEncoding),(ErrorBar|ErrorBarDef)>": {
-      "additionalProperties": false,
-      "description": "Base interface for a unit (single-view) specification.",
-      "properties": {
-        "data": {
-          "$ref": "#/definitions/Data",
-          "description": "An object describing the data source"
-        },
-        "description": {
-          "description": "Description of this mark for commenting purpose.",
-          "type": "string"
-        },
-        "encoding": {
-          "additionalProperties": false,
-          "description": "A key-value mapping between encoding channels and definition of fields.",
-          "properties": {
-            "color": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ColorFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ColorValueDefWithCondition"
-                }
-              ],
-              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
-            },
-            "detail": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/FieldDef"
-                },
-                {
-                  "items": {
-                    "$ref": "#/definitions/FieldDef"
-                  },
-                  "type": "array"
-                }
-              ],
-              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
-            },
-            "opacity": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
-            },
-            "x": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/XValueDef"
-                }
-              ],
-              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-            },
-            "x2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/XValueDef"
-                }
-              ],
-              "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-            },
-            "xError": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-            },
-            "xError2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-            },
-            "y": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/YValueDef"
-                }
-              ],
-              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-            },
-            "y2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/YValueDef"
-                }
-              ],
-              "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-            },
-            "yError": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-            },
-            "yError2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-            }
-          },
-          "required": [
-            "color",
-            "detail",
-            "opacity",
-            "x",
-            "x2",
-            "y",
-            "y2"
-          ],
-          "type": "object"
-        },
-        "height": {
-          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-          "type": "number"
-        },
-        "mark": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ErrorBar"
-            },
-            {
-              "$ref": "#/definitions/ErrorBarDef"
-            }
-          ],
-          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
-        },
-        "name": {
-          "description": "Name of the visualization for later reference.",
-          "type": "string"
-        },
-        "projection": {
-          "$ref": "#/definitions/Projection",
-          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
-        },
-        "selection": {
-          "additionalProperties": {
-            "$ref": "#/definitions/SelectionDef"
-          },
-          "description": "A key-value mapping between selection names and definitions.",
-          "type": "object"
-        },
-        "title": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/TitleParams"
-            }
-          ],
-          "description": "Title for the plot."
-        },
-        "transform": {
-          "description": "An array of data transformations such as filter and new field calculation.",
-          "items": {
-            "$ref": "#/definitions/Transform"
-          },
-          "type": "array"
-        },
-        "view": {
-          "$ref": "#/definitions/ViewBackground",
-          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
-        },
-        "width": {
-          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-          "type": "number"
-        }
-      },
-      "required": [
-        "mark"
-      ],
-      "type": "object"
-    },
-    "GenericUnitSpec<(ErrorEncodingWithFacet),(ErrorBand|ErrorBandDef)>": {
-      "additionalProperties": false,
-      "description": "Base interface for a unit (single-view) specification.",
-      "properties": {
-        "data": {
-          "$ref": "#/definitions/Data",
-          "description": "An object describing the data source"
-        },
-        "description": {
-          "description": "Description of this mark for commenting purpose.",
-          "type": "string"
-        },
-        "encoding": {
-          "additionalProperties": false,
-          "description": "A key-value mapping between encoding channels and definition of fields.",
-          "properties": {
-            "color": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ColorFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ColorValueDefWithCondition"
-                }
-              ],
-              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
-            },
-            "column": {
-              "$ref": "#/definitions/FacetFieldDef",
-              "description": "Horizontal facets for trellis plots."
-            },
-            "detail": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/FieldDef"
-                },
-                {
-                  "items": {
-                    "$ref": "#/definitions/FieldDef"
-                  },
-                  "type": "array"
-                }
-              ],
-              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
-            },
-            "opacity": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
-            },
-            "row": {
-              "$ref": "#/definitions/FacetFieldDef",
-              "description": "Vertical facets for trellis plots."
-            },
-            "x": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/XValueDef"
-                }
-              ],
-              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-            },
-            "x2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/XValueDef"
-                }
-              ],
-              "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-            },
-            "xError": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-            },
-            "xError2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-            },
-            "y": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/YValueDef"
-                }
-              ],
-              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-            },
-            "y2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/YValueDef"
-                }
-              ],
-              "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-            },
-            "yError": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-            },
-            "yError2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-            }
-          },
-          "required": [
-            "color",
-            "detail",
-            "opacity",
-            "x",
-            "x2",
-            "y",
-            "y2"
-          ],
-          "type": "object"
-        },
-        "height": {
-          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-          "type": "number"
-        },
-        "mark": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ErrorBand"
-            },
-            {
-              "$ref": "#/definitions/ErrorBandDef"
-            }
-          ],
-          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
-        },
-        "name": {
-          "description": "Name of the visualization for later reference.",
-          "type": "string"
-        },
-        "projection": {
-          "$ref": "#/definitions/Projection",
-          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
-        },
-        "selection": {
-          "additionalProperties": {
-            "$ref": "#/definitions/SelectionDef"
-          },
-          "description": "A key-value mapping between selection names and definitions.",
-          "type": "object"
-        },
-        "title": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/TitleParams"
-            }
-          ],
-          "description": "Title for the plot."
-        },
-        "transform": {
-          "description": "An array of data transformations such as filter and new field calculation.",
-          "items": {
-            "$ref": "#/definitions/Transform"
-          },
-          "type": "array"
-        },
-        "view": {
-          "$ref": "#/definitions/ViewBackground",
-          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
-        },
-        "width": {
-          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-          "type": "number"
-        }
-      },
-      "required": [
-        "mark"
-      ],
-      "type": "object"
-    },
-    "GenericUnitSpec<(ErrorEncodingWithFacet),(ErrorBar|ErrorBarDef)>": {
-      "additionalProperties": false,
-      "description": "Base interface for a unit (single-view) specification.",
-      "properties": {
-        "data": {
-          "$ref": "#/definitions/Data",
-          "description": "An object describing the data source"
-        },
-        "description": {
-          "description": "Description of this mark for commenting purpose.",
-          "type": "string"
-        },
-        "encoding": {
-          "additionalProperties": false,
-          "description": "A key-value mapping between encoding channels and definition of fields.",
-          "properties": {
-            "color": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ColorFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ColorValueDefWithCondition"
-                }
-              ],
-              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
-            },
-            "column": {
-              "$ref": "#/definitions/FacetFieldDef",
-              "description": "Horizontal facets for trellis plots."
-            },
-            "detail": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/FieldDef"
-                },
-                {
-                  "items": {
-                    "$ref": "#/definitions/FieldDef"
-                  },
-                  "type": "array"
-                }
-              ],
-              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
-            },
-            "opacity": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
-            },
-            "row": {
-              "$ref": "#/definitions/FacetFieldDef",
-              "description": "Vertical facets for trellis plots."
-            },
-            "x": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/XValueDef"
-                }
-              ],
-              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-            },
-            "x2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/XValueDef"
-                }
-              ],
-              "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-            },
-            "xError": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-            },
-            "xError2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-            },
-            "y": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/YValueDef"
-                }
-              ],
-              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-            },
-            "y2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/YValueDef"
-                }
-              ],
-              "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-            },
-            "yError": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-            },
-            "yError2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-            }
-          },
-          "required": [
-            "color",
-            "detail",
-            "opacity",
-            "x",
-            "x2",
-            "y",
-            "y2"
-          ],
-          "type": "object"
-        },
-        "height": {
-          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-          "type": "number"
-        },
-        "mark": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ErrorBar"
-            },
-            {
-              "$ref": "#/definitions/ErrorBarDef"
-            }
-          ],
+          "$ref": "#/definitions/AnyMark",
           "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
         },
         "name": {
@@ -9099,14 +7721,6 @@
         "year"
       ],
       "type": "string"
-    },
-    "NormalizedUnitSpec": {
-      "$ref": "#/definitions/GenericUnitSpec<(Encoding),(Mark|MarkDef)>",
-      "description": "A unit specification without any shortcut/expansion syntax."
-    },
-    "NormalizedUnitSpecWithFacet": {
-      "$ref": "#/definitions/GenericUnitSpec<(EncodingWithFacet),(Mark|MarkDef)>",
-      "description": "A unit specification without any shortcut/expansion syntax."
     },
     "NumericFieldDefWithCondition": {
       "$ref": "#/definitions/FieldDefWithCondition<MarkPropFieldDef,number>"
@@ -11636,7 +10250,7 @@
                 "$ref": "#/definitions/LayerSpec"
               },
               {
-                "$ref": "#/definitions/ExtendedUnitSpec"
+                "$ref": "#/definitions/CompositeUnitSpec"
               }
             ]
           },
@@ -12026,728 +10640,6 @@
       ],
       "type": "object"
     },
-    "TopLevelCompositeMarkUnitSpec": {
-      "anyOf": [
-        {
-          "additionalProperties": false,
-          "properties": {
-            "$schema": {
-              "description": "URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless you have a reason to change this, use `https://vega.github.io/schema/vega-lite/v3.json`. Setting the `$schema` property allows automatic validation and autocomplete in editors that support JSON schema.",
-              "format": "uri",
-              "type": "string"
-            },
-            "autosize": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/AutosizeType"
-                },
-                {
-                  "$ref": "#/definitions/AutoSizeParams"
-                }
-              ],
-              "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
-            },
-            "background": {
-              "description": "CSS color property to use as the background of the entire view.\n\n__Default value:__ none (transparent)",
-              "type": "string"
-            },
-            "config": {
-              "$ref": "#/definitions/Config",
-              "description": "Vega-Lite configuration object.  This property can only be defined at the top-level of a specification."
-            },
-            "data": {
-              "$ref": "#/definitions/Data",
-              "description": "An object describing the data source"
-            },
-            "datasets": {
-              "$ref": "#/definitions/Datasets",
-              "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
-            },
-            "description": {
-              "description": "Description of this mark for commenting purpose.",
-              "type": "string"
-            },
-            "encoding": {
-              "additionalProperties": false,
-              "description": "A key-value mapping between encoding channels and definition of fields.",
-              "properties": {
-                "color": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/ColorFieldDefWithCondition"
-                    },
-                    {
-                      "$ref": "#/definitions/ColorValueDefWithCondition"
-                    }
-                  ],
-                  "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
-                },
-                "column": {
-                  "$ref": "#/definitions/FacetFieldDef",
-                  "description": "Horizontal facets for trellis plots."
-                },
-                "detail": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/FieldDef"
-                    },
-                    {
-                      "items": {
-                        "$ref": "#/definitions/FieldDef"
-                      },
-                      "type": "array"
-                    }
-                  ],
-                  "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
-                },
-                "opacity": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/NumericFieldDefWithCondition"
-                    },
-                    {
-                      "$ref": "#/definitions/NumericValueDefWithCondition"
-                    }
-                  ],
-                  "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
-                },
-                "row": {
-                  "$ref": "#/definitions/FacetFieldDef",
-                  "description": "Vertical facets for trellis plots."
-                },
-                "x": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/PositionFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/XValueDef"
-                    }
-                  ],
-                  "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-                },
-                "x2": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/SecondaryFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/XValueDef"
-                    }
-                  ],
-                  "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-                },
-                "xError": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/SecondaryFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/NumberValueDef"
-                    }
-                  ],
-                  "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-                },
-                "xError2": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/SecondaryFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/NumberValueDef"
-                    }
-                  ],
-                  "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-                },
-                "y": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/PositionFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/YValueDef"
-                    }
-                  ],
-                  "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-                },
-                "y2": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/SecondaryFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/YValueDef"
-                    }
-                  ],
-                  "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-                },
-                "yError": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/SecondaryFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/NumberValueDef"
-                    }
-                  ],
-                  "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-                },
-                "yError2": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/SecondaryFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/NumberValueDef"
-                    }
-                  ],
-                  "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-                }
-              },
-              "required": [
-                "color",
-                "detail",
-                "opacity",
-                "x",
-                "x2",
-                "y",
-                "y2"
-              ],
-              "type": "object"
-            },
-            "height": {
-              "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-              "type": "number"
-            },
-            "mark": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ErrorBar"
-                },
-                {
-                  "$ref": "#/definitions/ErrorBarDef"
-                }
-              ],
-              "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
-            },
-            "name": {
-              "description": "Name of the visualization for later reference.",
-              "type": "string"
-            },
-            "padding": {
-              "$ref": "#/definitions/Padding",
-              "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle.  If a number, specifies padding for all sides.\nIf an object, the value should have the format `{\"left\": 5, \"top\": 5, \"right\": 5, \"bottom\": 5}` to specify padding for each side of the visualization.\n\n__Default value__: `5`"
-            },
-            "projection": {
-              "$ref": "#/definitions/Projection",
-              "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
-            },
-            "selection": {
-              "additionalProperties": {
-                "$ref": "#/definitions/SelectionDef"
-              },
-              "description": "A key-value mapping between selection names and definitions.",
-              "type": "object"
-            },
-            "title": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/definitions/TitleParams"
-                }
-              ],
-              "description": "Title for the plot."
-            },
-            "transform": {
-              "description": "An array of data transformations such as filter and new field calculation.",
-              "items": {
-                "$ref": "#/definitions/Transform"
-              },
-              "type": "array"
-            },
-            "usermeta": {
-              "description": "Optional metadata that will be passed to Vega.\nThis object is completely ignored by Vega and Vega-Lite and can be used for custom metadata.",
-              "type": "object"
-            },
-            "view": {
-              "$ref": "#/definitions/ViewBackground",
-              "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
-            },
-            "width": {
-              "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-              "type": "number"
-            }
-          },
-          "required": [
-            "data",
-            "mark"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "$schema": {
-              "description": "URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless you have a reason to change this, use `https://vega.github.io/schema/vega-lite/v3.json`. Setting the `$schema` property allows automatic validation and autocomplete in editors that support JSON schema.",
-              "format": "uri",
-              "type": "string"
-            },
-            "autosize": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/AutosizeType"
-                },
-                {
-                  "$ref": "#/definitions/AutoSizeParams"
-                }
-              ],
-              "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
-            },
-            "background": {
-              "description": "CSS color property to use as the background of the entire view.\n\n__Default value:__ none (transparent)",
-              "type": "string"
-            },
-            "config": {
-              "$ref": "#/definitions/Config",
-              "description": "Vega-Lite configuration object.  This property can only be defined at the top-level of a specification."
-            },
-            "data": {
-              "$ref": "#/definitions/Data",
-              "description": "An object describing the data source"
-            },
-            "datasets": {
-              "$ref": "#/definitions/Datasets",
-              "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
-            },
-            "description": {
-              "description": "Description of this mark for commenting purpose.",
-              "type": "string"
-            },
-            "encoding": {
-              "additionalProperties": false,
-              "description": "A key-value mapping between encoding channels and definition of fields.",
-              "properties": {
-                "color": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/ColorFieldDefWithCondition"
-                    },
-                    {
-                      "$ref": "#/definitions/ColorValueDefWithCondition"
-                    }
-                  ],
-                  "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
-                },
-                "column": {
-                  "$ref": "#/definitions/FacetFieldDef",
-                  "description": "Horizontal facets for trellis plots."
-                },
-                "detail": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/FieldDef"
-                    },
-                    {
-                      "items": {
-                        "$ref": "#/definitions/FieldDef"
-                      },
-                      "type": "array"
-                    }
-                  ],
-                  "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
-                },
-                "opacity": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/NumericFieldDefWithCondition"
-                    },
-                    {
-                      "$ref": "#/definitions/NumericValueDefWithCondition"
-                    }
-                  ],
-                  "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
-                },
-                "row": {
-                  "$ref": "#/definitions/FacetFieldDef",
-                  "description": "Vertical facets for trellis plots."
-                },
-                "x": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/PositionFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/XValueDef"
-                    }
-                  ],
-                  "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-                },
-                "x2": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/SecondaryFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/XValueDef"
-                    }
-                  ],
-                  "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-                },
-                "xError": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/SecondaryFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/NumberValueDef"
-                    }
-                  ],
-                  "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-                },
-                "xError2": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/SecondaryFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/NumberValueDef"
-                    }
-                  ],
-                  "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-                },
-                "y": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/PositionFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/YValueDef"
-                    }
-                  ],
-                  "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-                },
-                "y2": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/SecondaryFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/YValueDef"
-                    }
-                  ],
-                  "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-                },
-                "yError": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/SecondaryFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/NumberValueDef"
-                    }
-                  ],
-                  "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-                },
-                "yError2": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/SecondaryFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/NumberValueDef"
-                    }
-                  ],
-                  "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-                }
-              },
-              "required": [
-                "color",
-                "detail",
-                "opacity",
-                "x",
-                "x2",
-                "y",
-                "y2"
-              ],
-              "type": "object"
-            },
-            "height": {
-              "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-              "type": "number"
-            },
-            "mark": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ErrorBand"
-                },
-                {
-                  "$ref": "#/definitions/ErrorBandDef"
-                }
-              ],
-              "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
-            },
-            "name": {
-              "description": "Name of the visualization for later reference.",
-              "type": "string"
-            },
-            "padding": {
-              "$ref": "#/definitions/Padding",
-              "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle.  If a number, specifies padding for all sides.\nIf an object, the value should have the format `{\"left\": 5, \"top\": 5, \"right\": 5, \"bottom\": 5}` to specify padding for each side of the visualization.\n\n__Default value__: `5`"
-            },
-            "projection": {
-              "$ref": "#/definitions/Projection",
-              "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
-            },
-            "selection": {
-              "additionalProperties": {
-                "$ref": "#/definitions/SelectionDef"
-              },
-              "description": "A key-value mapping between selection names and definitions.",
-              "type": "object"
-            },
-            "title": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/definitions/TitleParams"
-                }
-              ],
-              "description": "Title for the plot."
-            },
-            "transform": {
-              "description": "An array of data transformations such as filter and new field calculation.",
-              "items": {
-                "$ref": "#/definitions/Transform"
-              },
-              "type": "array"
-            },
-            "usermeta": {
-              "description": "Optional metadata that will be passed to Vega.\nThis object is completely ignored by Vega and Vega-Lite and can be used for custom metadata.",
-              "type": "object"
-            },
-            "view": {
-              "$ref": "#/definitions/ViewBackground",
-              "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
-            },
-            "width": {
-              "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-              "type": "number"
-            }
-          },
-          "required": [
-            "data",
-            "mark"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "$schema": {
-              "description": "URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless you have a reason to change this, use `https://vega.github.io/schema/vega-lite/v3.json`. Setting the `$schema` property allows automatic validation and autocomplete in editors that support JSON schema.",
-              "format": "uri",
-              "type": "string"
-            },
-            "autosize": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/AutosizeType"
-                },
-                {
-                  "$ref": "#/definitions/AutoSizeParams"
-                }
-              ],
-              "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
-            },
-            "background": {
-              "description": "CSS color property to use as the background of the entire view.\n\n__Default value:__ none (transparent)",
-              "type": "string"
-            },
-            "config": {
-              "$ref": "#/definitions/Config",
-              "description": "Vega-Lite configuration object.  This property can only be defined at the top-level of a specification."
-            },
-            "data": {
-              "$ref": "#/definitions/Data",
-              "description": "An object describing the data source"
-            },
-            "datasets": {
-              "$ref": "#/definitions/Datasets",
-              "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
-            },
-            "description": {
-              "description": "Description of this mark for commenting purpose.",
-              "type": "string"
-            },
-            "encoding": {
-              "additionalProperties": false,
-              "description": "A key-value mapping between encoding channels and definition of fields.",
-              "properties": {
-                "color": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/ColorFieldDefWithCondition"
-                    },
-                    {
-                      "$ref": "#/definitions/ColorValueDefWithCondition"
-                    }
-                  ],
-                  "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
-                },
-                "column": {
-                  "$ref": "#/definitions/FacetFieldDef",
-                  "description": "Horizontal facets for trellis plots."
-                },
-                "detail": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/FieldDef"
-                    },
-                    {
-                      "items": {
-                        "$ref": "#/definitions/FieldDef"
-                      },
-                      "type": "array"
-                    }
-                  ],
-                  "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
-                },
-                "opacity": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/NumericFieldDefWithCondition"
-                    },
-                    {
-                      "$ref": "#/definitions/NumericValueDefWithCondition"
-                    }
-                  ],
-                  "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
-                },
-                "row": {
-                  "$ref": "#/definitions/FacetFieldDef",
-                  "description": "Vertical facets for trellis plots."
-                },
-                "size": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/NumericFieldDefWithCondition"
-                    },
-                    {
-                      "$ref": "#/definitions/NumericValueDefWithCondition"
-                    }
-                  ],
-                  "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
-                },
-                "x": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/PositionFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/XValueDef"
-                    }
-                  ],
-                  "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-                },
-                "y": {
-                  "anyOf": [
-                    {
-                      "$ref": "#/definitions/PositionFieldDef"
-                    },
-                    {
-                      "$ref": "#/definitions/YValueDef"
-                    }
-                  ],
-                  "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-                }
-              },
-              "required": [
-                "color",
-                "detail",
-                "opacity",
-                "size",
-                "x",
-                "y"
-              ],
-              "type": "object"
-            },
-            "height": {
-              "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-              "type": "number"
-            },
-            "mark": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/BoxPlot"
-                },
-                {
-                  "$ref": "#/definitions/BoxPlotDef"
-                }
-              ],
-              "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
-            },
-            "name": {
-              "description": "Name of the visualization for later reference.",
-              "type": "string"
-            },
-            "padding": {
-              "$ref": "#/definitions/Padding",
-              "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle.  If a number, specifies padding for all sides.\nIf an object, the value should have the format `{\"left\": 5, \"top\": 5, \"right\": 5, \"bottom\": 5}` to specify padding for each side of the visualization.\n\n__Default value__: `5`"
-            },
-            "projection": {
-              "$ref": "#/definitions/Projection",
-              "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
-            },
-            "selection": {
-              "additionalProperties": {
-                "$ref": "#/definitions/SelectionDef"
-              },
-              "description": "A key-value mapping between selection names and definitions.",
-              "type": "object"
-            },
-            "title": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "$ref": "#/definitions/TitleParams"
-                }
-              ],
-              "description": "Title for the plot."
-            },
-            "transform": {
-              "description": "An array of data transformations such as filter and new field calculation.",
-              "items": {
-                "$ref": "#/definitions/Transform"
-              },
-              "type": "array"
-            },
-            "usermeta": {
-              "description": "Optional metadata that will be passed to Vega.\nThis object is completely ignored by Vega and Vega-Lite and can be used for custom metadata.",
-              "type": "object"
-            },
-            "view": {
-              "$ref": "#/definitions/ViewBackground",
-              "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
-            },
-            "width": {
-              "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
-              "type": "number"
-            }
-          },
-          "required": [
-            "data",
-            "mark"
-          ],
-          "type": "object"
-        }
-      ]
-    },
     "TopLevelFacetSpec": {
       "additionalProperties": false,
       "properties": {
@@ -12850,7 +10742,7 @@
               "$ref": "#/definitions/LayerSpec"
             },
             {
-              "$ref": "#/definitions/FacetedExtendedUnitSpec"
+              "$ref": "#/definitions/FacetedUnitSpec"
             }
           ],
           "description": "A specification of the view that gets faceted."
@@ -12885,17 +10777,30 @@
       ],
       "type": "object"
     },
-    "TopLevelFacetedUnitSpec": {
+    "TopLevelSpec": {
       "anyOf": [
         {
-          "$ref": "#/definitions/TopLevelNormalizedUnitSpec"
+          "$ref": "#/definitions/TopLevelUnitSpec"
         },
         {
-          "$ref": "#/definitions/TopLevelCompositeMarkUnitSpec"
+          "$ref": "#/definitions/TopLevelFacetSpec"
+        },
+        {
+          "$ref": "#/definitions/TopLevelLayerSpec"
+        },
+        {
+          "$ref": "#/definitions/TopLevelRepeatSpec"
+        },
+        {
+          "$ref": "#/definitions/TopLevelVConcatSpec"
+        },
+        {
+          "$ref": "#/definitions/TopLevelHConcatSpec"
         }
-      ]
+      ],
+      "description": "A Vega-Lite top-level specification.\nThis is the root class for all Vega-Lite specifications.\n(The json schema is generated from this type.)"
     },
-    "TopLevelNormalizedUnitSpec": {
+    "TopLevelUnitSpec": {
       "additionalProperties": false,
       "properties": {
         "$schema": {
@@ -12935,269 +10840,15 @@
           "type": "string"
         },
         "encoding": {
-          "additionalProperties": false,
-          "description": "A key-value mapping between encoding channels and definition of fields.",
-          "properties": {
-            "color": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ColorFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ColorValueDefWithCondition"
-                }
-              ],
-              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
-            },
-            "column": {
-              "$ref": "#/definitions/FacetFieldDef",
-              "description": "Horizontal facets for trellis plots."
-            },
-            "detail": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/FieldDef"
-                },
-                {
-                  "items": {
-                    "$ref": "#/definitions/FieldDef"
-                  },
-                  "type": "array"
-                }
-              ],
-              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
-            },
-            "fill": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ColorFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ColorValueDefWithCondition"
-                }
-              ],
-              "description": "Fill color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `fill` channel, `color ` channel will be ignored. To customize both fill and stroke, please use `fill` and `stroke` channels (not `fill` and `color`)."
-            },
-            "fillOpacity": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Fill opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `fillOpacity` property."
-            },
-            "href": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/StringFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/StringValueDefWithCondition"
-                }
-              ],
-              "description": "A URL to load upon mouse click."
-            },
-            "key": {
-              "$ref": "#/definitions/FieldDef",
-              "description": "A data field to use as a unique key for data binding. When a visualization’s data is updated, the key value will be used to match data elements to existing mark instances. Use a key channel to enable object constancy for transitions over dynamic data."
-            },
-            "latitude": {
-              "$ref": "#/definitions/LatLongFieldDef",
-              "description": "Latitude position of geographically projected marks."
-            },
-            "latitude2": {
-              "$ref": "#/definitions/SecondaryFieldDef",
-              "description": "Latitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
-            },
-            "longitude": {
-              "$ref": "#/definitions/LatLongFieldDef",
-              "description": "Longitude position of geographically projected marks."
-            },
-            "longitude2": {
-              "$ref": "#/definitions/SecondaryFieldDef",
-              "description": "Longitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
-            },
-            "opacity": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
-            },
-            "order": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/OrderFieldDef"
-                },
-                {
-                  "items": {
-                    "$ref": "#/definitions/OrderFieldDef"
-                  },
-                  "type": "array"
-                },
-                {
-                  "$ref": "#/definitions/NumberValueDef"
-                }
-              ],
-              "description": "Order of the marks.\n- For stacked marks, this `order` channel encodes [stack order](https://vega.github.io/vega-lite/docs/stack.html#order).\n- For line and trail marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/connected_scatterplot.html).  Setting `order` to `{\"value\": null}` makes the line marks use the original order in the data sources.\n- Otherwise, this `order` channel encodes layer order of the marks.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
-            },
-            "row": {
-              "$ref": "#/definitions/FacetFieldDef",
-              "description": "Vertical facets for trellis plots."
-            },
-            "shape": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ShapeFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ShapeValueDefWithCondition"
-                }
-              ],
-              "description": "For `point` marks the supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string.\nFor `geoshape` marks it should be a field definition of the geojson data\n\n__Default value:__ If undefined, the default shape depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape` property."
-            },
-            "size": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
-            },
-            "stroke": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/ColorFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/ColorValueDefWithCondition"
-                }
-              ],
-              "description": "Stroke color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `stroke` channel, `color ` channel will be ignored. To customize both stroke and fill, please use `stroke` and `fill` channels (not `stroke` and `color`)."
-            },
-            "strokeOpacity": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Stroke opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeOpacity` property."
-            },
-            "strokeWidth": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/NumericFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/NumericValueDefWithCondition"
-                }
-              ],
-              "description": "Stroke width of the marks.\n\n__Default value:__ If undefined, the default stroke width depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeWidth` property."
-            },
-            "text": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/TextFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/TextValueDefWithCondition"
-                }
-              ],
-              "description": "Text of the `text` mark."
-            },
-            "tooltip": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/TextFieldDefWithCondition"
-                },
-                {
-                  "$ref": "#/definitions/TextValueDefWithCondition"
-                },
-                {
-                  "items": {
-                    "$ref": "#/definitions/TextFieldDef"
-                  },
-                  "type": "array"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "description": "The tooltip text to show upon mouse hover."
-            },
-            "x": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/XValueDef"
-                }
-              ],
-              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-            },
-            "x2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/XValueDef"
-                }
-              ],
-              "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-            },
-            "y": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/PositionFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/YValueDef"
-                }
-              ],
-              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-            },
-            "y2": {
-              "anyOf": [
-                {
-                  "$ref": "#/definitions/SecondaryFieldDef"
-                },
-                {
-                  "$ref": "#/definitions/YValueDef"
-                }
-              ],
-              "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-            }
-          },
-          "type": "object"
+          "$ref": "#/definitions/FacetedEncoding",
+          "description": "A key-value mapping between encoding channels and definition of fields."
         },
         "height": {
           "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
           "type": "number"
         },
         "mark": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Mark"
-            },
-            {
-              "$ref": "#/definitions/MarkDef"
-            }
-          ],
+          "$ref": "#/definitions/AnyMark",
           "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
         },
         "name": {
@@ -13255,29 +10906,6 @@
         "mark"
       ],
       "type": "object"
-    },
-    "TopLevelSpec": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/TopLevelFacetedUnitSpec"
-        },
-        {
-          "$ref": "#/definitions/TopLevelFacetSpec"
-        },
-        {
-          "$ref": "#/definitions/TopLevelLayerSpec"
-        },
-        {
-          "$ref": "#/definitions/TopLevelRepeatSpec"
-        },
-        {
-          "$ref": "#/definitions/TopLevelVConcatSpec"
-        },
-        {
-          "$ref": "#/definitions/TopLevelHConcatSpec"
-        }
-      ],
-      "description": "A Vega-Lite top-level specification.\nThis is the root class for all Vega-Lite specifications.\n(The json schema is generated from this type.)"
     },
     "TopoDataFormat": {
       "additionalProperties": false,

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -85,22 +85,6 @@
       ],
       "type": "string"
     },
-    "AnyMark": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/CompositeMark"
-        },
-        {
-          "$ref": "#/definitions/CompositeMarkDef"
-        },
-        {
-          "$ref": "#/definitions/Mark"
-        },
-        {
-          "$ref": "#/definitions/MarkDef"
-        }
-      ]
-    },
     "AreaConfig": {
       "additionalProperties": false,
       "properties": {
@@ -1676,6 +1660,12 @@
       ],
       "type": "object"
     },
+    "BoxPlotUnitSpec": {
+      "$ref": "#/definitions/GenericUnitSpec<(BoxPlotEncoding),(BoxPlot|BoxPlotDef)>"
+    },
+    "BoxPlotUnitSpecWithFacet": {
+      "$ref": "#/definitions/GenericUnitSpec<(BoxPlotEncodingWithFacet),(BoxPlot|BoxPlotDef)>"
+    },
     "BrushConfig": {
       "additionalProperties": false,
       "properties": {
@@ -1740,35 +1730,31 @@
     "ColorValueDefWithCondition": {
       "$ref": "#/definitions/ValueDefWithCondition<MarkPropFieldDef,(string|null)>"
     },
-    "CompositeMark": {
+    "CompositeMarkUnitSpec": {
       "anyOf": [
         {
-          "$ref": "#/definitions/BoxPlot"
+          "$ref": "#/definitions/ErrorBarUnitSpec"
         },
         {
-          "$ref": "#/definitions/ErrorBar"
+          "$ref": "#/definitions/ErrorBandUnitSpec"
         },
         {
-          "$ref": "#/definitions/ErrorBand"
+          "$ref": "#/definitions/BoxPlotUnitSpec"
         }
       ]
     },
-    "CompositeMarkDef": {
+    "CompositeMarkUnitSpecWithFacet": {
       "anyOf": [
         {
-          "$ref": "#/definitions/BoxPlotDef"
+          "$ref": "#/definitions/ErrorBarUnitSpecWithFacet"
         },
         {
-          "$ref": "#/definitions/ErrorBarDef"
+          "$ref": "#/definitions/ErrorBandUnitSpecWithFacet"
         },
         {
-          "$ref": "#/definitions/ErrorBandDef"
+          "$ref": "#/definitions/BoxPlotUnitSpecWithFacet"
         }
       ]
-    },
-    "CompositeUnitSpec": {
-      "$ref": "#/definitions/CompositeUnitSpecAlias",
-      "description": "Unit spec that can have a composite mark."
     },
     "ConditionOnlyDef<MarkPropFieldDef<\"nominal\">>": {
       "additionalProperties": false,
@@ -3424,28 +3410,6 @@
           ],
           "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
         },
-        "xError": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SecondaryFieldDef"
-            },
-            {
-              "$ref": "#/definitions/NumberValueDef"
-            }
-          ],
-          "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-        },
-        "xError2": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SecondaryFieldDef"
-            },
-            {
-              "$ref": "#/definitions/NumberValueDef"
-            }
-          ],
-          "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-        },
         "y": {
           "anyOf": [
             {
@@ -3467,28 +3431,6 @@
             }
           ],
           "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-        },
-        "yError": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SecondaryFieldDef"
-            },
-            {
-              "$ref": "#/definitions/NumberValueDef"
-            }
-          ],
-          "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-        },
-        "yError2": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SecondaryFieldDef"
-            },
-            {
-              "$ref": "#/definitions/NumberValueDef"
-            }
-          ],
-          "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
         }
       },
       "type": "object"
@@ -3515,300 +3457,6 @@
             }
           ],
           "description": "The sort order. One of `\"ascending\"` (default), `\"descending\"`, or `null` (no not sort)."
-        }
-      },
-      "type": "object"
-    },
-    "EncodingWithFacet": {
-      "additionalProperties": false,
-      "properties": {
-        "color": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ColorFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/ColorValueDefWithCondition"
-            }
-          ],
-          "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
-        },
-        "column": {
-          "$ref": "#/definitions/FacetFieldDef",
-          "description": "Horizontal facets for trellis plots."
-        },
-        "detail": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/FieldDef"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/FieldDef"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
-        },
-        "fill": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ColorFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/ColorValueDefWithCondition"
-            }
-          ],
-          "description": "Fill color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `fill` channel, `color ` channel will be ignored. To customize both fill and stroke, please use `fill` and `stroke` channels (not `fill` and `color`)."
-        },
-        "fillOpacity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/NumericFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/NumericValueDefWithCondition"
-            }
-          ],
-          "description": "Fill opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `fillOpacity` property."
-        },
-        "href": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/StringFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/StringValueDefWithCondition"
-            }
-          ],
-          "description": "A URL to load upon mouse click."
-        },
-        "key": {
-          "$ref": "#/definitions/FieldDef",
-          "description": "A data field to use as a unique key for data binding. When a visualization’s data is updated, the key value will be used to match data elements to existing mark instances. Use a key channel to enable object constancy for transitions over dynamic data."
-        },
-        "latitude": {
-          "$ref": "#/definitions/LatLongFieldDef",
-          "description": "Latitude position of geographically projected marks."
-        },
-        "latitude2": {
-          "$ref": "#/definitions/SecondaryFieldDef",
-          "description": "Latitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
-        },
-        "longitude": {
-          "$ref": "#/definitions/LatLongFieldDef",
-          "description": "Longitude position of geographically projected marks."
-        },
-        "longitude2": {
-          "$ref": "#/definitions/SecondaryFieldDef",
-          "description": "Longitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
-        },
-        "opacity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/NumericFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/NumericValueDefWithCondition"
-            }
-          ],
-          "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
-        },
-        "order": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/OrderFieldDef"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/OrderFieldDef"
-              },
-              "type": "array"
-            },
-            {
-              "$ref": "#/definitions/NumberValueDef"
-            }
-          ],
-          "description": "Order of the marks.\n- For stacked marks, this `order` channel encodes [stack order](https://vega.github.io/vega-lite/docs/stack.html#order).\n- For line and trail marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/connected_scatterplot.html).  Setting `order` to `{\"value\": null}` makes the line marks use the original order in the data sources.\n- Otherwise, this `order` channel encodes layer order of the marks.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
-        },
-        "row": {
-          "$ref": "#/definitions/FacetFieldDef",
-          "description": "Vertical facets for trellis plots."
-        },
-        "shape": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ShapeFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/ShapeValueDefWithCondition"
-            }
-          ],
-          "description": "For `point` marks the supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string.\nFor `geoshape` marks it should be a field definition of the geojson data\n\n__Default value:__ If undefined, the default shape depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape` property."
-        },
-        "size": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/NumericFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/NumericValueDefWithCondition"
-            }
-          ],
-          "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
-        },
-        "stroke": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ColorFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/ColorValueDefWithCondition"
-            }
-          ],
-          "description": "Stroke color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `stroke` channel, `color ` channel will be ignored. To customize both stroke and fill, please use `stroke` and `fill` channels (not `stroke` and `color`)."
-        },
-        "strokeOpacity": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/NumericFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/NumericValueDefWithCondition"
-            }
-          ],
-          "description": "Stroke opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeOpacity` property."
-        },
-        "strokeWidth": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/NumericFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/NumericValueDefWithCondition"
-            }
-          ],
-          "description": "Stroke width of the marks.\n\n__Default value:__ If undefined, the default stroke width depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeWidth` property."
-        },
-        "text": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TextFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/TextValueDefWithCondition"
-            }
-          ],
-          "description": "Text of the `text` mark."
-        },
-        "tooltip": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TextFieldDefWithCondition"
-            },
-            {
-              "$ref": "#/definitions/TextValueDefWithCondition"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/TextFieldDef"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "The tooltip text to show upon mouse hover."
-        },
-        "x": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PositionFieldDef"
-            },
-            {
-              "$ref": "#/definitions/XValueDef"
-            }
-          ],
-          "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-        },
-        "x2": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SecondaryFieldDef"
-            },
-            {
-              "$ref": "#/definitions/XValueDef"
-            }
-          ],
-          "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
-        },
-        "xError": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SecondaryFieldDef"
-            },
-            {
-              "$ref": "#/definitions/NumberValueDef"
-            }
-          ],
-          "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-        },
-        "xError2": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SecondaryFieldDef"
-            },
-            {
-              "$ref": "#/definitions/NumberValueDef"
-            }
-          ],
-          "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-        },
-        "y": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/PositionFieldDef"
-            },
-            {
-              "$ref": "#/definitions/YValueDef"
-            }
-          ],
-          "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-        },
-        "y2": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SecondaryFieldDef"
-            },
-            {
-              "$ref": "#/definitions/YValueDef"
-            }
-          ],
-          "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
-        },
-        "yError": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SecondaryFieldDef"
-            },
-            {
-              "$ref": "#/definitions/NumberValueDef"
-            }
-          ],
-          "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
-        },
-        "yError2": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SecondaryFieldDef"
-            },
-            {
-              "$ref": "#/definitions/NumberValueDef"
-            }
-          ],
-          "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
         }
       },
       "type": "object"
@@ -3922,6 +3570,12 @@
       ],
       "type": "object"
     },
+    "ErrorBandUnitSpec": {
+      "$ref": "#/definitions/GenericUnitSpec<(ErrorEncoding),(ErrorBand|ErrorBandDef)>"
+    },
+    "ErrorBandUnitSpecWithFacet": {
+      "$ref": "#/definitions/GenericUnitSpec<(ErrorEncodingWithFacet),(ErrorBand|ErrorBandDef)>"
+    },
     "ErrorBar": {
       "enum": [
         "errorbar"
@@ -4020,6 +3674,12 @@
       ],
       "type": "string"
     },
+    "ErrorBarUnitSpec": {
+      "$ref": "#/definitions/GenericUnitSpec<(ErrorEncoding),(ErrorBar|ErrorBarDef)>"
+    },
+    "ErrorBarUnitSpecWithFacet": {
+      "$ref": "#/definitions/GenericUnitSpec<(ErrorEncodingWithFacet),(ErrorBar|ErrorBarDef)>"
+    },
     "EventStream": {
     },
     "LayerSpec": {
@@ -4050,7 +3710,7 @@
                 "$ref": "#/definitions/LayerSpec"
               },
               {
-                "$ref": "#/definitions/CompositeUnitSpec"
+                "$ref": "#/definitions/ExtendedUnitSpec"
               }
             ]
           },
@@ -4099,6 +3759,28 @@
         "layer"
       ],
       "type": "object"
+    },
+    "ExtendedUnitSpec": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/NormalizedUnitSpec"
+        },
+        {
+          "$ref": "#/definitions/CompositeMarkUnitSpec"
+        }
+      ],
+      "description": "Unit spec that can be normalized/expanded into a layer spec or another unit spec."
+    },
+    "ExtendedUnitSpecWithFacet": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/NormalizedUnitSpecWithFacet"
+        },
+        {
+          "$ref": "#/definitions/CompositeMarkUnitSpecWithFacet"
+        }
+      ],
+      "description": "Unit spec that can be normalized/expanded into a layer spec or another unit spec."
     },
     "FacetFieldDef": {
       "additionalProperties": false,
@@ -4187,9 +3869,9 @@
       },
       "type": "object"
     },
-    "FacetedUnitSpec": {
-      "$ref": "#/definitions/FacetedCompositeUnitSpecAlias",
-      "description": "Unit spec that can have a composite mark and row or column channels."
+    "FacetedExtendedUnitSpec": {
+      "$ref": "#/definitions/ExtendedUnitSpecWithFacet",
+      "description": "Unit spec that can have a composite mark and row or column channels (shorthand for a facet spec)."
     },
     "Field": {
       "anyOf": [
@@ -5177,7 +4859,7 @@
               "$ref": "#/definitions/LayerSpec"
             },
             {
-              "$ref": "#/definitions/FacetedUnitSpec"
+              "$ref": "#/definitions/FacetedExtendedUnitSpec"
             }
           ],
           "description": "A specification of the view that gets faceted."
@@ -5370,7 +5052,7 @@
     "Spec": {
       "anyOf": [
         {
-          "$ref": "#/definitions/FacetedUnitSpec"
+          "$ref": "#/definitions/FacetedExtendedUnitSpec"
         },
         {
           "$ref": "#/definitions/LayerSpec"
@@ -5390,7 +5072,7 @@
       ],
       "description": "Any specification in Vega-Lite."
     },
-    "CompositeUnitSpecAlias": {
+    "GenericUnitSpec<(BoxPlotEncoding),(BoxPlot|BoxPlotDef)>": {
       "additionalProperties": false,
       "description": "Base interface for a unit (single-view) specification.",
       "properties": {
@@ -5403,15 +5085,102 @@
           "type": "string"
         },
         "encoding": {
-          "$ref": "#/definitions/Encoding",
-          "description": "A key-value mapping between encoding channels and definition of fields."
+          "additionalProperties": false,
+          "description": "A key-value mapping between encoding channels and definition of fields.",
+          "properties": {
+            "color": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ColorFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ColorValueDefWithCondition"
+                }
+              ],
+              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
+            },
+            "detail": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FieldDef"
+                },
+                {
+                  "items": {
+                    "$ref": "#/definitions/FieldDef"
+                  },
+                  "type": "array"
+                }
+              ],
+              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
+            },
+            "opacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
+            },
+            "size": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
+            },
+            "x": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/XValueDef"
+                }
+              ],
+              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+            },
+            "y": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/YValueDef"
+                }
+              ],
+              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+            }
+          },
+          "required": [
+            "color",
+            "detail",
+            "opacity",
+            "size",
+            "x",
+            "y"
+          ],
+          "type": "object"
         },
         "height": {
           "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
           "type": "number"
         },
         "mark": {
-          "$ref": "#/definitions/AnyMark",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BoxPlot"
+            },
+            {
+              "$ref": "#/definitions/BoxPlotDef"
+            }
+          ],
           "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
         },
         "name": {
@@ -5461,7 +5230,7 @@
       ],
       "type": "object"
     },
-    "FacetedCompositeUnitSpecAlias": {
+    "GenericUnitSpec<(BoxPlotEncodingWithFacet),(BoxPlot|BoxPlotDef)>": {
       "additionalProperties": false,
       "description": "Base interface for a unit (single-view) specification.",
       "properties": {
@@ -5474,15 +5243,1624 @@
           "type": "string"
         },
         "encoding": {
-          "$ref": "#/definitions/EncodingWithFacet",
-          "description": "A key-value mapping between encoding channels and definition of fields."
+          "additionalProperties": false,
+          "description": "A key-value mapping between encoding channels and definition of fields.",
+          "properties": {
+            "color": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ColorFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ColorValueDefWithCondition"
+                }
+              ],
+              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
+            },
+            "column": {
+              "$ref": "#/definitions/FacetFieldDef",
+              "description": "Horizontal facets for trellis plots."
+            },
+            "detail": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FieldDef"
+                },
+                {
+                  "items": {
+                    "$ref": "#/definitions/FieldDef"
+                  },
+                  "type": "array"
+                }
+              ],
+              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
+            },
+            "opacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
+            },
+            "row": {
+              "$ref": "#/definitions/FacetFieldDef",
+              "description": "Vertical facets for trellis plots."
+            },
+            "size": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
+            },
+            "x": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/XValueDef"
+                }
+              ],
+              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+            },
+            "y": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/YValueDef"
+                }
+              ],
+              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+            }
+          },
+          "required": [
+            "color",
+            "detail",
+            "opacity",
+            "size",
+            "x",
+            "y"
+          ],
+          "type": "object"
         },
         "height": {
           "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
           "type": "number"
         },
         "mark": {
-          "$ref": "#/definitions/AnyMark",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/BoxPlot"
+            },
+            {
+              "$ref": "#/definitions/BoxPlotDef"
+            }
+          ],
+          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "projection": {
+          "$ref": "#/definitions/Projection",
+          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
+        },
+        "selection": {
+          "additionalProperties": {
+            "$ref": "#/definitions/SelectionDef"
+          },
+          "description": "A key-value mapping between selection names and definitions.",
+          "type": "object"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "view": {
+          "$ref": "#/definitions/ViewBackground",
+          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
+        },
+        "width": {
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "mark"
+      ],
+      "type": "object"
+    },
+    "GenericUnitSpec<(Encoding),(Mark|MarkDef)>": {
+      "additionalProperties": false,
+      "description": "Base interface for a unit (single-view) specification.",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "encoding": {
+          "additionalProperties": false,
+          "description": "A key-value mapping between encoding channels and definition of fields.",
+          "properties": {
+            "color": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ColorFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ColorValueDefWithCondition"
+                }
+              ],
+              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
+            },
+            "detail": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FieldDef"
+                },
+                {
+                  "items": {
+                    "$ref": "#/definitions/FieldDef"
+                  },
+                  "type": "array"
+                }
+              ],
+              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
+            },
+            "fill": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ColorFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ColorValueDefWithCondition"
+                }
+              ],
+              "description": "Fill color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `fill` channel, `color ` channel will be ignored. To customize both fill and stroke, please use `fill` and `stroke` channels (not `fill` and `color`)."
+            },
+            "fillOpacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Fill opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `fillOpacity` property."
+            },
+            "href": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/StringValueDefWithCondition"
+                }
+              ],
+              "description": "A URL to load upon mouse click."
+            },
+            "key": {
+              "$ref": "#/definitions/FieldDef",
+              "description": "A data field to use as a unique key for data binding. When a visualization’s data is updated, the key value will be used to match data elements to existing mark instances. Use a key channel to enable object constancy for transitions over dynamic data."
+            },
+            "latitude": {
+              "$ref": "#/definitions/LatLongFieldDef",
+              "description": "Latitude position of geographically projected marks."
+            },
+            "latitude2": {
+              "$ref": "#/definitions/SecondaryFieldDef",
+              "description": "Latitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+            },
+            "longitude": {
+              "$ref": "#/definitions/LatLongFieldDef",
+              "description": "Longitude position of geographically projected marks."
+            },
+            "longitude2": {
+              "$ref": "#/definitions/SecondaryFieldDef",
+              "description": "Longitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+            },
+            "opacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
+            },
+            "order": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/OrderFieldDef"
+                },
+                {
+                  "items": {
+                    "$ref": "#/definitions/OrderFieldDef"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Order of the marks.\n- For stacked marks, this `order` channel encodes [stack order](https://vega.github.io/vega-lite/docs/stack.html#order).\n- For line and trail marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/connected_scatterplot.html).  Setting `order` to `{\"value\": null}` makes the line marks use the original order in the data sources.\n- Otherwise, this `order` channel encodes layer order of the marks.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
+            },
+            "shape": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ShapeFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ShapeValueDefWithCondition"
+                }
+              ],
+              "description": "For `point` marks the supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string.\nFor `geoshape` marks it should be a field definition of the geojson data\n\n__Default value:__ If undefined, the default shape depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape` property."
+            },
+            "size": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
+            },
+            "stroke": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ColorFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ColorValueDefWithCondition"
+                }
+              ],
+              "description": "Stroke color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `stroke` channel, `color ` channel will be ignored. To customize both stroke and fill, please use `stroke` and `fill` channels (not `stroke` and `color`)."
+            },
+            "strokeOpacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Stroke opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeOpacity` property."
+            },
+            "strokeWidth": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Stroke width of the marks.\n\n__Default value:__ If undefined, the default stroke width depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeWidth` property."
+            },
+            "text": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/TextFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/TextValueDefWithCondition"
+                }
+              ],
+              "description": "Text of the `text` mark."
+            },
+            "tooltip": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/TextFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/TextValueDefWithCondition"
+                },
+                {
+                  "items": {
+                    "$ref": "#/definitions/TextFieldDef"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The tooltip text to show upon mouse hover."
+            },
+            "x": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/XValueDef"
+                }
+              ],
+              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+            },
+            "x2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/XValueDef"
+                }
+              ],
+              "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+            },
+            "y": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/YValueDef"
+                }
+              ],
+              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+            },
+            "y2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/YValueDef"
+                }
+              ],
+              "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+            }
+          },
+          "type": "object"
+        },
+        "height": {
+          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        },
+        "mark": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Mark"
+            },
+            {
+              "$ref": "#/definitions/MarkDef"
+            }
+          ],
+          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "projection": {
+          "$ref": "#/definitions/Projection",
+          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
+        },
+        "selection": {
+          "additionalProperties": {
+            "$ref": "#/definitions/SelectionDef"
+          },
+          "description": "A key-value mapping between selection names and definitions.",
+          "type": "object"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "view": {
+          "$ref": "#/definitions/ViewBackground",
+          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
+        },
+        "width": {
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "mark"
+      ],
+      "type": "object"
+    },
+    "GenericUnitSpec<(EncodingWithFacet),(Mark|MarkDef)>": {
+      "additionalProperties": false,
+      "description": "Base interface for a unit (single-view) specification.",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "encoding": {
+          "additionalProperties": false,
+          "description": "A key-value mapping between encoding channels and definition of fields.",
+          "properties": {
+            "color": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ColorFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ColorValueDefWithCondition"
+                }
+              ],
+              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
+            },
+            "column": {
+              "$ref": "#/definitions/FacetFieldDef",
+              "description": "Horizontal facets for trellis plots."
+            },
+            "detail": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FieldDef"
+                },
+                {
+                  "items": {
+                    "$ref": "#/definitions/FieldDef"
+                  },
+                  "type": "array"
+                }
+              ],
+              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
+            },
+            "fill": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ColorFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ColorValueDefWithCondition"
+                }
+              ],
+              "description": "Fill color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `fill` channel, `color ` channel will be ignored. To customize both fill and stroke, please use `fill` and `stroke` channels (not `fill` and `color`)."
+            },
+            "fillOpacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Fill opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `fillOpacity` property."
+            },
+            "href": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/StringValueDefWithCondition"
+                }
+              ],
+              "description": "A URL to load upon mouse click."
+            },
+            "key": {
+              "$ref": "#/definitions/FieldDef",
+              "description": "A data field to use as a unique key for data binding. When a visualization’s data is updated, the key value will be used to match data elements to existing mark instances. Use a key channel to enable object constancy for transitions over dynamic data."
+            },
+            "latitude": {
+              "$ref": "#/definitions/LatLongFieldDef",
+              "description": "Latitude position of geographically projected marks."
+            },
+            "latitude2": {
+              "$ref": "#/definitions/SecondaryFieldDef",
+              "description": "Latitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+            },
+            "longitude": {
+              "$ref": "#/definitions/LatLongFieldDef",
+              "description": "Longitude position of geographically projected marks."
+            },
+            "longitude2": {
+              "$ref": "#/definitions/SecondaryFieldDef",
+              "description": "Longitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+            },
+            "opacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
+            },
+            "order": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/OrderFieldDef"
+                },
+                {
+                  "items": {
+                    "$ref": "#/definitions/OrderFieldDef"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Order of the marks.\n- For stacked marks, this `order` channel encodes [stack order](https://vega.github.io/vega-lite/docs/stack.html#order).\n- For line and trail marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/connected_scatterplot.html).  Setting `order` to `{\"value\": null}` makes the line marks use the original order in the data sources.\n- Otherwise, this `order` channel encodes layer order of the marks.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
+            },
+            "row": {
+              "$ref": "#/definitions/FacetFieldDef",
+              "description": "Vertical facets for trellis plots."
+            },
+            "shape": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ShapeFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ShapeValueDefWithCondition"
+                }
+              ],
+              "description": "For `point` marks the supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string.\nFor `geoshape` marks it should be a field definition of the geojson data\n\n__Default value:__ If undefined, the default shape depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape` property."
+            },
+            "size": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
+            },
+            "stroke": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ColorFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ColorValueDefWithCondition"
+                }
+              ],
+              "description": "Stroke color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `stroke` channel, `color ` channel will be ignored. To customize both stroke and fill, please use `stroke` and `fill` channels (not `stroke` and `color`)."
+            },
+            "strokeOpacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Stroke opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeOpacity` property."
+            },
+            "strokeWidth": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Stroke width of the marks.\n\n__Default value:__ If undefined, the default stroke width depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeWidth` property."
+            },
+            "text": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/TextFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/TextValueDefWithCondition"
+                }
+              ],
+              "description": "Text of the `text` mark."
+            },
+            "tooltip": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/TextFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/TextValueDefWithCondition"
+                },
+                {
+                  "items": {
+                    "$ref": "#/definitions/TextFieldDef"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The tooltip text to show upon mouse hover."
+            },
+            "x": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/XValueDef"
+                }
+              ],
+              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+            },
+            "x2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/XValueDef"
+                }
+              ],
+              "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+            },
+            "y": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/YValueDef"
+                }
+              ],
+              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+            },
+            "y2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/YValueDef"
+                }
+              ],
+              "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+            }
+          },
+          "type": "object"
+        },
+        "height": {
+          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        },
+        "mark": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Mark"
+            },
+            {
+              "$ref": "#/definitions/MarkDef"
+            }
+          ],
+          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "projection": {
+          "$ref": "#/definitions/Projection",
+          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
+        },
+        "selection": {
+          "additionalProperties": {
+            "$ref": "#/definitions/SelectionDef"
+          },
+          "description": "A key-value mapping between selection names and definitions.",
+          "type": "object"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "view": {
+          "$ref": "#/definitions/ViewBackground",
+          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
+        },
+        "width": {
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "mark"
+      ],
+      "type": "object"
+    },
+    "GenericUnitSpec<(ErrorEncoding),(ErrorBand|ErrorBandDef)>": {
+      "additionalProperties": false,
+      "description": "Base interface for a unit (single-view) specification.",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "encoding": {
+          "additionalProperties": false,
+          "description": "A key-value mapping between encoding channels and definition of fields.",
+          "properties": {
+            "color": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ColorFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ColorValueDefWithCondition"
+                }
+              ],
+              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
+            },
+            "detail": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FieldDef"
+                },
+                {
+                  "items": {
+                    "$ref": "#/definitions/FieldDef"
+                  },
+                  "type": "array"
+                }
+              ],
+              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
+            },
+            "opacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
+            },
+            "x": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/XValueDef"
+                }
+              ],
+              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+            },
+            "x2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/XValueDef"
+                }
+              ],
+              "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+            },
+            "xError": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+            },
+            "xError2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+            },
+            "y": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/YValueDef"
+                }
+              ],
+              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+            },
+            "y2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/YValueDef"
+                }
+              ],
+              "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+            },
+            "yError": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+            },
+            "yError2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+            }
+          },
+          "required": [
+            "color",
+            "detail",
+            "opacity",
+            "x",
+            "x2",
+            "y",
+            "y2"
+          ],
+          "type": "object"
+        },
+        "height": {
+          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        },
+        "mark": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ErrorBand"
+            },
+            {
+              "$ref": "#/definitions/ErrorBandDef"
+            }
+          ],
+          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "projection": {
+          "$ref": "#/definitions/Projection",
+          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
+        },
+        "selection": {
+          "additionalProperties": {
+            "$ref": "#/definitions/SelectionDef"
+          },
+          "description": "A key-value mapping between selection names and definitions.",
+          "type": "object"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "view": {
+          "$ref": "#/definitions/ViewBackground",
+          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
+        },
+        "width": {
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "mark"
+      ],
+      "type": "object"
+    },
+    "GenericUnitSpec<(ErrorEncoding),(ErrorBar|ErrorBarDef)>": {
+      "additionalProperties": false,
+      "description": "Base interface for a unit (single-view) specification.",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "encoding": {
+          "additionalProperties": false,
+          "description": "A key-value mapping between encoding channels and definition of fields.",
+          "properties": {
+            "color": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ColorFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ColorValueDefWithCondition"
+                }
+              ],
+              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
+            },
+            "detail": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FieldDef"
+                },
+                {
+                  "items": {
+                    "$ref": "#/definitions/FieldDef"
+                  },
+                  "type": "array"
+                }
+              ],
+              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
+            },
+            "opacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
+            },
+            "x": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/XValueDef"
+                }
+              ],
+              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+            },
+            "x2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/XValueDef"
+                }
+              ],
+              "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+            },
+            "xError": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+            },
+            "xError2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+            },
+            "y": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/YValueDef"
+                }
+              ],
+              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+            },
+            "y2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/YValueDef"
+                }
+              ],
+              "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+            },
+            "yError": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+            },
+            "yError2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+            }
+          },
+          "required": [
+            "color",
+            "detail",
+            "opacity",
+            "x",
+            "x2",
+            "y",
+            "y2"
+          ],
+          "type": "object"
+        },
+        "height": {
+          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        },
+        "mark": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ErrorBar"
+            },
+            {
+              "$ref": "#/definitions/ErrorBarDef"
+            }
+          ],
+          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "projection": {
+          "$ref": "#/definitions/Projection",
+          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
+        },
+        "selection": {
+          "additionalProperties": {
+            "$ref": "#/definitions/SelectionDef"
+          },
+          "description": "A key-value mapping between selection names and definitions.",
+          "type": "object"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "view": {
+          "$ref": "#/definitions/ViewBackground",
+          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
+        },
+        "width": {
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "mark"
+      ],
+      "type": "object"
+    },
+    "GenericUnitSpec<(ErrorEncodingWithFacet),(ErrorBand|ErrorBandDef)>": {
+      "additionalProperties": false,
+      "description": "Base interface for a unit (single-view) specification.",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "encoding": {
+          "additionalProperties": false,
+          "description": "A key-value mapping between encoding channels and definition of fields.",
+          "properties": {
+            "color": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ColorFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ColorValueDefWithCondition"
+                }
+              ],
+              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
+            },
+            "column": {
+              "$ref": "#/definitions/FacetFieldDef",
+              "description": "Horizontal facets for trellis plots."
+            },
+            "detail": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FieldDef"
+                },
+                {
+                  "items": {
+                    "$ref": "#/definitions/FieldDef"
+                  },
+                  "type": "array"
+                }
+              ],
+              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
+            },
+            "opacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
+            },
+            "row": {
+              "$ref": "#/definitions/FacetFieldDef",
+              "description": "Vertical facets for trellis plots."
+            },
+            "x": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/XValueDef"
+                }
+              ],
+              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+            },
+            "x2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/XValueDef"
+                }
+              ],
+              "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+            },
+            "xError": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+            },
+            "xError2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+            },
+            "y": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/YValueDef"
+                }
+              ],
+              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+            },
+            "y2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/YValueDef"
+                }
+              ],
+              "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+            },
+            "yError": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+            },
+            "yError2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+            }
+          },
+          "required": [
+            "color",
+            "detail",
+            "opacity",
+            "x",
+            "x2",
+            "y",
+            "y2"
+          ],
+          "type": "object"
+        },
+        "height": {
+          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        },
+        "mark": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ErrorBand"
+            },
+            {
+              "$ref": "#/definitions/ErrorBandDef"
+            }
+          ],
+          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "projection": {
+          "$ref": "#/definitions/Projection",
+          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
+        },
+        "selection": {
+          "additionalProperties": {
+            "$ref": "#/definitions/SelectionDef"
+          },
+          "description": "A key-value mapping between selection names and definitions.",
+          "type": "object"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "view": {
+          "$ref": "#/definitions/ViewBackground",
+          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
+        },
+        "width": {
+          "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "mark"
+      ],
+      "type": "object"
+    },
+    "GenericUnitSpec<(ErrorEncodingWithFacet),(ErrorBar|ErrorBarDef)>": {
+      "additionalProperties": false,
+      "description": "Base interface for a unit (single-view) specification.",
+      "properties": {
+        "data": {
+          "$ref": "#/definitions/Data",
+          "description": "An object describing the data source"
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "encoding": {
+          "additionalProperties": false,
+          "description": "A key-value mapping between encoding channels and definition of fields.",
+          "properties": {
+            "color": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ColorFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ColorValueDefWithCondition"
+                }
+              ],
+              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
+            },
+            "column": {
+              "$ref": "#/definitions/FacetFieldDef",
+              "description": "Horizontal facets for trellis plots."
+            },
+            "detail": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FieldDef"
+                },
+                {
+                  "items": {
+                    "$ref": "#/definitions/FieldDef"
+                  },
+                  "type": "array"
+                }
+              ],
+              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
+            },
+            "opacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
+            },
+            "row": {
+              "$ref": "#/definitions/FacetFieldDef",
+              "description": "Vertical facets for trellis plots."
+            },
+            "x": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/XValueDef"
+                }
+              ],
+              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+            },
+            "x2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/XValueDef"
+                }
+              ],
+              "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+            },
+            "xError": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+            },
+            "xError2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+            },
+            "y": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/YValueDef"
+                }
+              ],
+              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+            },
+            "y2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/YValueDef"
+                }
+              ],
+              "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+            },
+            "yError": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+            },
+            "yError2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+            }
+          },
+          "required": [
+            "color",
+            "detail",
+            "opacity",
+            "x",
+            "x2",
+            "y",
+            "y2"
+          ],
+          "type": "object"
+        },
+        "height": {
+          "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+          "type": "number"
+        },
+        "mark": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ErrorBar"
+            },
+            {
+              "$ref": "#/definitions/ErrorBarDef"
+            }
+          ],
           "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
         },
         "name": {
@@ -7722,6 +9100,14 @@
       ],
       "type": "string"
     },
+    "NormalizedUnitSpec": {
+      "$ref": "#/definitions/GenericUnitSpec<(Encoding),(Mark|MarkDef)>",
+      "description": "A unit specification without any shortcut/expansion syntax."
+    },
+    "NormalizedUnitSpecWithFacet": {
+      "$ref": "#/definitions/GenericUnitSpec<(EncodingWithFacet),(Mark|MarkDef)>",
+      "description": "A unit specification without any shortcut/expansion syntax."
+    },
     "NumericFieldDefWithCondition": {
       "$ref": "#/definitions/FieldDefWithCondition<MarkPropFieldDef,number>"
     },
@@ -9236,10 +10622,6 @@
         "y",
         "x2",
         "y2",
-        "xError",
-        "yError",
-        "xError2",
-        "yError2",
         "longitude",
         "latitude",
         "longitude2",
@@ -10254,7 +11636,7 @@
                 "$ref": "#/definitions/LayerSpec"
               },
               {
-                "$ref": "#/definitions/CompositeUnitSpec"
+                "$ref": "#/definitions/ExtendedUnitSpec"
               }
             ]
           },
@@ -10644,6 +12026,728 @@
       ],
       "type": "object"
     },
+    "TopLevelCompositeMarkUnitSpec": {
+      "anyOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "$schema": {
+              "description": "URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless you have a reason to change this, use `https://vega.github.io/schema/vega-lite/v3.json`. Setting the `$schema` property allows automatic validation and autocomplete in editors that support JSON schema.",
+              "format": "uri",
+              "type": "string"
+            },
+            "autosize": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AutosizeType"
+                },
+                {
+                  "$ref": "#/definitions/AutoSizeParams"
+                }
+              ],
+              "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
+            },
+            "background": {
+              "description": "CSS color property to use as the background of the entire view.\n\n__Default value:__ none (transparent)",
+              "type": "string"
+            },
+            "config": {
+              "$ref": "#/definitions/Config",
+              "description": "Vega-Lite configuration object.  This property can only be defined at the top-level of a specification."
+            },
+            "data": {
+              "$ref": "#/definitions/Data",
+              "description": "An object describing the data source"
+            },
+            "datasets": {
+              "$ref": "#/definitions/Datasets",
+              "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
+            },
+            "description": {
+              "description": "Description of this mark for commenting purpose.",
+              "type": "string"
+            },
+            "encoding": {
+              "additionalProperties": false,
+              "description": "A key-value mapping between encoding channels and definition of fields.",
+              "properties": {
+                "color": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/ColorFieldDefWithCondition"
+                    },
+                    {
+                      "$ref": "#/definitions/ColorValueDefWithCondition"
+                    }
+                  ],
+                  "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
+                },
+                "column": {
+                  "$ref": "#/definitions/FacetFieldDef",
+                  "description": "Horizontal facets for trellis plots."
+                },
+                "detail": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/FieldDef"
+                    },
+                    {
+                      "items": {
+                        "$ref": "#/definitions/FieldDef"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
+                },
+                "opacity": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/NumericFieldDefWithCondition"
+                    },
+                    {
+                      "$ref": "#/definitions/NumericValueDefWithCondition"
+                    }
+                  ],
+                  "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
+                },
+                "row": {
+                  "$ref": "#/definitions/FacetFieldDef",
+                  "description": "Vertical facets for trellis plots."
+                },
+                "x": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/PositionFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/XValueDef"
+                    }
+                  ],
+                  "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+                },
+                "x2": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/SecondaryFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/XValueDef"
+                    }
+                  ],
+                  "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+                },
+                "xError": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/SecondaryFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/NumberValueDef"
+                    }
+                  ],
+                  "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+                },
+                "xError2": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/SecondaryFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/NumberValueDef"
+                    }
+                  ],
+                  "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+                },
+                "y": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/PositionFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/YValueDef"
+                    }
+                  ],
+                  "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+                },
+                "y2": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/SecondaryFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/YValueDef"
+                    }
+                  ],
+                  "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+                },
+                "yError": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/SecondaryFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/NumberValueDef"
+                    }
+                  ],
+                  "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+                },
+                "yError2": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/SecondaryFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/NumberValueDef"
+                    }
+                  ],
+                  "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+                }
+              },
+              "required": [
+                "color",
+                "detail",
+                "opacity",
+                "x",
+                "x2",
+                "y",
+                "y2"
+              ],
+              "type": "object"
+            },
+            "height": {
+              "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+              "type": "number"
+            },
+            "mark": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ErrorBar"
+                },
+                {
+                  "$ref": "#/definitions/ErrorBarDef"
+                }
+              ],
+              "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
+            },
+            "name": {
+              "description": "Name of the visualization for later reference.",
+              "type": "string"
+            },
+            "padding": {
+              "$ref": "#/definitions/Padding",
+              "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle.  If a number, specifies padding for all sides.\nIf an object, the value should have the format `{\"left\": 5, \"top\": 5, \"right\": 5, \"bottom\": 5}` to specify padding for each side of the visualization.\n\n__Default value__: `5`"
+            },
+            "projection": {
+              "$ref": "#/definitions/Projection",
+              "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
+            },
+            "selection": {
+              "additionalProperties": {
+                "$ref": "#/definitions/SelectionDef"
+              },
+              "description": "A key-value mapping between selection names and definitions.",
+              "type": "object"
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/TitleParams"
+                }
+              ],
+              "description": "Title for the plot."
+            },
+            "transform": {
+              "description": "An array of data transformations such as filter and new field calculation.",
+              "items": {
+                "$ref": "#/definitions/Transform"
+              },
+              "type": "array"
+            },
+            "usermeta": {
+              "description": "Optional metadata that will be passed to Vega.\nThis object is completely ignored by Vega and Vega-Lite and can be used for custom metadata.",
+              "type": "object"
+            },
+            "view": {
+              "$ref": "#/definitions/ViewBackground",
+              "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
+            },
+            "width": {
+              "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+              "type": "number"
+            }
+          },
+          "required": [
+            "data",
+            "mark"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "$schema": {
+              "description": "URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless you have a reason to change this, use `https://vega.github.io/schema/vega-lite/v3.json`. Setting the `$schema` property allows automatic validation and autocomplete in editors that support JSON schema.",
+              "format": "uri",
+              "type": "string"
+            },
+            "autosize": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AutosizeType"
+                },
+                {
+                  "$ref": "#/definitions/AutoSizeParams"
+                }
+              ],
+              "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
+            },
+            "background": {
+              "description": "CSS color property to use as the background of the entire view.\n\n__Default value:__ none (transparent)",
+              "type": "string"
+            },
+            "config": {
+              "$ref": "#/definitions/Config",
+              "description": "Vega-Lite configuration object.  This property can only be defined at the top-level of a specification."
+            },
+            "data": {
+              "$ref": "#/definitions/Data",
+              "description": "An object describing the data source"
+            },
+            "datasets": {
+              "$ref": "#/definitions/Datasets",
+              "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
+            },
+            "description": {
+              "description": "Description of this mark for commenting purpose.",
+              "type": "string"
+            },
+            "encoding": {
+              "additionalProperties": false,
+              "description": "A key-value mapping between encoding channels and definition of fields.",
+              "properties": {
+                "color": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/ColorFieldDefWithCondition"
+                    },
+                    {
+                      "$ref": "#/definitions/ColorValueDefWithCondition"
+                    }
+                  ],
+                  "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
+                },
+                "column": {
+                  "$ref": "#/definitions/FacetFieldDef",
+                  "description": "Horizontal facets for trellis plots."
+                },
+                "detail": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/FieldDef"
+                    },
+                    {
+                      "items": {
+                        "$ref": "#/definitions/FieldDef"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
+                },
+                "opacity": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/NumericFieldDefWithCondition"
+                    },
+                    {
+                      "$ref": "#/definitions/NumericValueDefWithCondition"
+                    }
+                  ],
+                  "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
+                },
+                "row": {
+                  "$ref": "#/definitions/FacetFieldDef",
+                  "description": "Vertical facets for trellis plots."
+                },
+                "x": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/PositionFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/XValueDef"
+                    }
+                  ],
+                  "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+                },
+                "x2": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/SecondaryFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/XValueDef"
+                    }
+                  ],
+                  "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+                },
+                "xError": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/SecondaryFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/NumberValueDef"
+                    }
+                  ],
+                  "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+                },
+                "xError2": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/SecondaryFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/NumberValueDef"
+                    }
+                  ],
+                  "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+                },
+                "y": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/PositionFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/YValueDef"
+                    }
+                  ],
+                  "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+                },
+                "y2": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/SecondaryFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/YValueDef"
+                    }
+                  ],
+                  "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+                },
+                "yError": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/SecondaryFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/NumberValueDef"
+                    }
+                  ],
+                  "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+                },
+                "yError2": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/SecondaryFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/NumberValueDef"
+                    }
+                  ],
+                  "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
+                }
+              },
+              "required": [
+                "color",
+                "detail",
+                "opacity",
+                "x",
+                "x2",
+                "y",
+                "y2"
+              ],
+              "type": "object"
+            },
+            "height": {
+              "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+              "type": "number"
+            },
+            "mark": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ErrorBand"
+                },
+                {
+                  "$ref": "#/definitions/ErrorBandDef"
+                }
+              ],
+              "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
+            },
+            "name": {
+              "description": "Name of the visualization for later reference.",
+              "type": "string"
+            },
+            "padding": {
+              "$ref": "#/definitions/Padding",
+              "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle.  If a number, specifies padding for all sides.\nIf an object, the value should have the format `{\"left\": 5, \"top\": 5, \"right\": 5, \"bottom\": 5}` to specify padding for each side of the visualization.\n\n__Default value__: `5`"
+            },
+            "projection": {
+              "$ref": "#/definitions/Projection",
+              "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
+            },
+            "selection": {
+              "additionalProperties": {
+                "$ref": "#/definitions/SelectionDef"
+              },
+              "description": "A key-value mapping between selection names and definitions.",
+              "type": "object"
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/TitleParams"
+                }
+              ],
+              "description": "Title for the plot."
+            },
+            "transform": {
+              "description": "An array of data transformations such as filter and new field calculation.",
+              "items": {
+                "$ref": "#/definitions/Transform"
+              },
+              "type": "array"
+            },
+            "usermeta": {
+              "description": "Optional metadata that will be passed to Vega.\nThis object is completely ignored by Vega and Vega-Lite and can be used for custom metadata.",
+              "type": "object"
+            },
+            "view": {
+              "$ref": "#/definitions/ViewBackground",
+              "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
+            },
+            "width": {
+              "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+              "type": "number"
+            }
+          },
+          "required": [
+            "data",
+            "mark"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "$schema": {
+              "description": "URL to [JSON schema](http://json-schema.org/) for a Vega-Lite specification. Unless you have a reason to change this, use `https://vega.github.io/schema/vega-lite/v3.json`. Setting the `$schema` property allows automatic validation and autocomplete in editors that support JSON schema.",
+              "format": "uri",
+              "type": "string"
+            },
+            "autosize": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/AutosizeType"
+                },
+                {
+                  "$ref": "#/definitions/AutoSizeParams"
+                }
+              ],
+              "description": "Sets how the visualization size should be determined. If a string, should be one of `\"pad\"`, `\"fit\"` or `\"none\"`.\nObject values can additionally specify parameters for content sizing and automatic resizing.\n`\"fit\"` is only supported for single and layered views that don't use `rangeStep`.\n\n__Default value__: `pad`"
+            },
+            "background": {
+              "description": "CSS color property to use as the background of the entire view.\n\n__Default value:__ none (transparent)",
+              "type": "string"
+            },
+            "config": {
+              "$ref": "#/definitions/Config",
+              "description": "Vega-Lite configuration object.  This property can only be defined at the top-level of a specification."
+            },
+            "data": {
+              "$ref": "#/definitions/Data",
+              "description": "An object describing the data source"
+            },
+            "datasets": {
+              "$ref": "#/definitions/Datasets",
+              "description": "A global data store for named datasets. This is a mapping from names to inline datasets.\nThis can be an array of objects or primitive values or a string. Arrays of primitive values are ingested as objects with a `data` property."
+            },
+            "description": {
+              "description": "Description of this mark for commenting purpose.",
+              "type": "string"
+            },
+            "encoding": {
+              "additionalProperties": false,
+              "description": "A key-value mapping between encoding channels and definition of fields.",
+              "properties": {
+                "color": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/ColorFieldDefWithCondition"
+                    },
+                    {
+                      "$ref": "#/definitions/ColorValueDefWithCondition"
+                    }
+                  ],
+                  "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
+                },
+                "column": {
+                  "$ref": "#/definitions/FacetFieldDef",
+                  "description": "Horizontal facets for trellis plots."
+                },
+                "detail": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/FieldDef"
+                    },
+                    {
+                      "items": {
+                        "$ref": "#/definitions/FieldDef"
+                      },
+                      "type": "array"
+                    }
+                  ],
+                  "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
+                },
+                "opacity": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/NumericFieldDefWithCondition"
+                    },
+                    {
+                      "$ref": "#/definitions/NumericValueDefWithCondition"
+                    }
+                  ],
+                  "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
+                },
+                "row": {
+                  "$ref": "#/definitions/FacetFieldDef",
+                  "description": "Vertical facets for trellis plots."
+                },
+                "size": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/NumericFieldDefWithCondition"
+                    },
+                    {
+                      "$ref": "#/definitions/NumericValueDefWithCondition"
+                    }
+                  ],
+                  "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
+                },
+                "x": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/PositionFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/XValueDef"
+                    }
+                  ],
+                  "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+                },
+                "y": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/PositionFieldDef"
+                    },
+                    {
+                      "$ref": "#/definitions/YValueDef"
+                    }
+                  ],
+                  "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+                }
+              },
+              "required": [
+                "color",
+                "detail",
+                "opacity",
+                "size",
+                "x",
+                "y"
+              ],
+              "type": "object"
+            },
+            "height": {
+              "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+              "type": "number"
+            },
+            "mark": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/BoxPlot"
+                },
+                {
+                  "$ref": "#/definitions/BoxPlotDef"
+                }
+              ],
+              "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
+            },
+            "name": {
+              "description": "Name of the visualization for later reference.",
+              "type": "string"
+            },
+            "padding": {
+              "$ref": "#/definitions/Padding",
+              "description": "The default visualization padding, in pixels, from the edge of the visualization canvas to the data rectangle.  If a number, specifies padding for all sides.\nIf an object, the value should have the format `{\"left\": 5, \"top\": 5, \"right\": 5, \"bottom\": 5}` to specify padding for each side of the visualization.\n\n__Default value__: `5`"
+            },
+            "projection": {
+              "$ref": "#/definitions/Projection",
+              "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
+            },
+            "selection": {
+              "additionalProperties": {
+                "$ref": "#/definitions/SelectionDef"
+              },
+              "description": "A key-value mapping between selection names and definitions.",
+              "type": "object"
+            },
+            "title": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/definitions/TitleParams"
+                }
+              ],
+              "description": "Title for the plot."
+            },
+            "transform": {
+              "description": "An array of data transformations such as filter and new field calculation.",
+              "items": {
+                "$ref": "#/definitions/Transform"
+              },
+              "type": "array"
+            },
+            "usermeta": {
+              "description": "Optional metadata that will be passed to Vega.\nThis object is completely ignored by Vega and Vega-Lite and can be used for custom metadata.",
+              "type": "object"
+            },
+            "view": {
+              "$ref": "#/definitions/ViewBackground",
+              "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
+            },
+            "width": {
+              "description": "The width of a visualization.\n\n__Default value:__ This will be determined by the following rules:\n\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its x-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For x-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the width is [determined by the range step, paddings, and the cardinality of the field mapped to x-channel](https://vega.github.io/vega-lite/docs/scale.html#band).   Otherwise, if the `rangeStep` is `null`, the width will be the value of [`config.view.width`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `x` channel, the `width` will be the value of [`config.scale.textXRangeStep`](https://vega.github.io/vega-lite/docs/size.html#default-width-and-height) for `text` mark and the value of `rangeStep` for other marks.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
+              "type": "number"
+            }
+          },
+          "required": [
+            "data",
+            "mark"
+          ],
+          "type": "object"
+        }
+      ]
+    },
     "TopLevelFacetSpec": {
       "additionalProperties": false,
       "properties": {
@@ -10746,7 +12850,7 @@
               "$ref": "#/definitions/LayerSpec"
             },
             {
-              "$ref": "#/definitions/FacetedUnitSpec"
+              "$ref": "#/definitions/FacetedExtendedUnitSpec"
             }
           ],
           "description": "A specification of the view that gets faceted."
@@ -10782,6 +12886,16 @@
       "type": "object"
     },
     "TopLevelFacetedUnitSpec": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TopLevelNormalizedUnitSpec"
+        },
+        {
+          "$ref": "#/definitions/TopLevelCompositeMarkUnitSpec"
+        }
+      ]
+    },
+    "TopLevelNormalizedUnitSpec": {
       "additionalProperties": false,
       "properties": {
         "$schema": {
@@ -10821,15 +12935,269 @@
           "type": "string"
         },
         "encoding": {
-          "$ref": "#/definitions/EncodingWithFacet",
-          "description": "A key-value mapping between encoding channels and definition of fields."
+          "additionalProperties": false,
+          "description": "A key-value mapping between encoding channels and definition of fields.",
+          "properties": {
+            "color": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ColorFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ColorValueDefWithCondition"
+                }
+              ],
+              "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels.  If either `fill` or `stroke` channel is specified, `color` channel will be ignored.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
+            },
+            "column": {
+              "$ref": "#/definitions/FacetFieldDef",
+              "description": "Horizontal facets for trellis plots."
+            },
+            "detail": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/FieldDef"
+                },
+                {
+                  "items": {
+                    "$ref": "#/definitions/FieldDef"
+                  },
+                  "type": "array"
+                }
+              ],
+              "description": "Additional levels of detail for grouping data in aggregate views and\nin line, trail, and area marks without mapping data to a specific visual channel."
+            },
+            "fill": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ColorFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ColorValueDefWithCondition"
+                }
+              ],
+              "description": "Fill color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `fill` channel, `color ` channel will be ignored. To customize both fill and stroke, please use `fill` and `stroke` channels (not `fill` and `color`)."
+            },
+            "fillOpacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Fill opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `fillOpacity` property."
+            },
+            "href": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/StringFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/StringValueDefWithCondition"
+                }
+              ],
+              "description": "A URL to load upon mouse click."
+            },
+            "key": {
+              "$ref": "#/definitions/FieldDef",
+              "description": "A data field to use as a unique key for data binding. When a visualization’s data is updated, the key value will be used to match data elements to existing mark instances. Use a key channel to enable object constancy for transitions over dynamic data."
+            },
+            "latitude": {
+              "$ref": "#/definitions/LatLongFieldDef",
+              "description": "Latitude position of geographically projected marks."
+            },
+            "latitude2": {
+              "$ref": "#/definitions/SecondaryFieldDef",
+              "description": "Latitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+            },
+            "longitude": {
+              "$ref": "#/definitions/LatLongFieldDef",
+              "description": "Longitude position of geographically projected marks."
+            },
+            "longitude2": {
+              "$ref": "#/definitions/SecondaryFieldDef",
+              "description": "Longitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
+            },
+            "opacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `opacity` property."
+            },
+            "order": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/OrderFieldDef"
+                },
+                {
+                  "items": {
+                    "$ref": "#/definitions/OrderFieldDef"
+                  },
+                  "type": "array"
+                },
+                {
+                  "$ref": "#/definitions/NumberValueDef"
+                }
+              ],
+              "description": "Order of the marks.\n- For stacked marks, this `order` channel encodes [stack order](https://vega.github.io/vega-lite/docs/stack.html#order).\n- For line and trail marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/connected_scatterplot.html).  Setting `order` to `{\"value\": null}` makes the line marks use the original order in the data sources.\n- Otherwise, this `order` channel encodes layer order of the marks.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
+            },
+            "row": {
+              "$ref": "#/definitions/FacetFieldDef",
+              "description": "Vertical facets for trellis plots."
+            },
+            "shape": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ShapeFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ShapeValueDefWithCondition"
+                }
+              ],
+              "description": "For `point` marks the supported values are\n`\"circle\"` (default), `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`,\nor `\"triangle-down\"`, or else a custom SVG path string.\nFor `geoshape` marks it should be a field definition of the geojson data\n\n__Default value:__ If undefined, the default shape depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape` property."
+            },
+            "size": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
+            },
+            "stroke": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/ColorFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/ColorValueDefWithCondition"
+                }
+              ],
+              "description": "Stroke color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `color` property.\n\n_Note:_ When using `stroke` channel, `color ` channel will be ignored. To customize both stroke and fill, please use `stroke` and `fill` channels (not `stroke` and `color`)."
+            },
+            "strokeOpacity": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Stroke opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeOpacity` property."
+            },
+            "strokeWidth": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/NumericFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/NumericValueDefWithCondition"
+                }
+              ],
+              "description": "Stroke width of the marks.\n\n__Default value:__ If undefined, the default stroke width depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark)'s `strokeWidth` property."
+            },
+            "text": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/TextFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/TextValueDefWithCondition"
+                }
+              ],
+              "description": "Text of the `text` mark."
+            },
+            "tooltip": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/TextFieldDefWithCondition"
+                },
+                {
+                  "$ref": "#/definitions/TextValueDefWithCondition"
+                },
+                {
+                  "items": {
+                    "$ref": "#/definitions/TextFieldDef"
+                  },
+                  "type": "array"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "The tooltip text to show upon mouse hover."
+            },
+            "x": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/XValueDef"
+                }
+              ],
+              "description": "X coordinates of the marks, or width of horizontal `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+            },
+            "x2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/XValueDef"
+                }
+              ],
+              "description": "X2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"width\"`."
+            },
+            "y": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/PositionFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/YValueDef"
+                }
+              ],
+              "description": "Y coordinates of the marks, or height of vertical `\"bar\"` and `\"area\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+            },
+            "y2": {
+              "anyOf": [
+                {
+                  "$ref": "#/definitions/SecondaryFieldDef"
+                },
+                {
+                  "$ref": "#/definitions/YValueDef"
+                }
+              ],
+              "description": "Y2 coordinates for ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`.\n\nThe `value` of this channel can be a number or a string `\"height\"`."
+            }
+          },
+          "type": "object"
         },
         "height": {
           "description": "The height of a visualization.\n\n__Default value:__\n- If a view's [`autosize`](https://vega.github.io/vega-lite/docs/size.html#autosize) type is `\"fit\"` or its y-channel has a [continuous scale](https://vega.github.io/vega-lite/docs/scale.html#continuous), the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- For y-axis with a band or point scale: if [`rangeStep`](https://vega.github.io/vega-lite/docs/scale.html#band) is a numeric value or unspecified, the height is [determined by the range step, paddings, and the cardinality of the field mapped to y-channel](https://vega.github.io/vega-lite/docs/scale.html#band). Otherwise, if the `rangeStep` is `null`, the height will be the value of [`config.view.height`](https://vega.github.io/vega-lite/docs/spec.html#config).\n- If no field is mapped to `y` channel, the `height` will be the value of `rangeStep`.\n\n__Note__: For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view.\n\n__See also:__ The documentation for [width and height](https://vega.github.io/vega-lite/docs/size.html) contains more examples.",
           "type": "number"
         },
         "mark": {
-          "$ref": "#/definitions/AnyMark",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Mark"
+            },
+            {
+              "$ref": "#/definitions/MarkDef"
+            }
+          ],
           "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
         },
         "name": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "deploy:gh": "scripts/deploy-gh.sh",
     "deploy:schema": "scripts/deploy-schema.sh",
     "preschema": "npm run prebuild",
-    "schema": "node --stack-size=2800 ./node_modules/.bin/ts-json-schema-generator --no-type-check --path tsconfig.json --type TopLevelSpec > build/vega-lite-schema.json && npm run renameschema && cp build/vega-lite-schema.json _data/",
+    "schema": "node --stack-size=4000 ./node_modules/.bin/ts-json-schema-generator --no-type-check --path tsconfig.json --type TopLevelSpec > build/vega-lite-schema.json && npm run renameschema && cp build/vega-lite-schema.json _data/",
     "renameschema": "scripts/rename-schema.sh",
     "presite": "npm run prebuild && npm run data && npm run build:site && npm run build:toc && npm run build:versions && scripts/create-example-pages",
     "site": "bundle exec jekyll serve --incremental",

--- a/scripts/check-schema.sh
+++ b/scripts/check-schema.sh
@@ -4,10 +4,6 @@ if grep 'Generic[^U].*Spec<' ./build/vega-lite-schema.json
 then
   echo "Non-Unit Generic Spec in the schema have not been replaced."
   exit 1
-elif grep 'UnitSpec<Encoding' ./build/vega-lite-schema.json
-then
-  echo "UnitSpec<...> in the schema have not been replaced."
-  exit 1
 elif grep '<Field>' ./build/vega-lite-schema.json
 then
   echo "...<Field> in the schema have not been replaced."

--- a/scripts/check-schema.sh
+++ b/scripts/check-schema.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-if grep 'Generic.*Spec<' ./build/vega-lite-schema.json
+if grep 'Generic[^U].*Spec<' ./build/vega-lite-schema.json
 then
-  echo "Generic*Spec in the schema have not been replaced."
+  echo "Non-Unit Generic Spec in the schema have not been replaced."
   exit 1
 elif grep 'UnitSpec<Encoding' ./build/vega-lite-schema.json
 then

--- a/scripts/rename-schema.sh
+++ b/scripts/rename-schema.sh
@@ -1,20 +1,13 @@
 #!/usr/bin/env bash
-perl -pi -e s,'\<EmptyObject\>','',g build/vega-lite-schema.json
-perl -pi -e s,'\&EmptyObject','',g build/vega-lite-schema.json
 perl -pi -e s,'<Field>','',g build/vega-lite-schema.json
 perl -pi -e s,'<Field\,','<',g build/vega-lite-schema.json
 perl -pi -e s,'<StandardType>','',g build/vega-lite-schema.json
 
-perl -pi -e s,'\&FacetMapping','WithFacet',g build/vega-lite-schema.json
-perl -pi -e s,'<FacetMapping>','WithFacet',g build/vega-lite-schema.json
-
+perl -pi -e s,'CompositeEncoding','Encoding',g build/vega-lite-schema.json
 perl -pi -e s,'FacetedCompositeUnitSpec','FacetedUnitSpec',g build/vega-lite-schema.json
 perl -pi -e s,'ExtendedLayerSpec','LayerSpec',g build/vega-lite-schema.json
-perl -pi -e s,'GenericLayerSpec<ExtendedUnitSpec>','LayerSpec',g build/vega-lite-schema.json
-perl -pi -e s,'Generic(.*)<FacetedExtendedUnitSpec\,LayerSpec>','\1',g build/vega-lite-schema.json
-
-perl -pi -e s,'GenericUnitSpec<EncodingWithFacet\,AnyMark>','FacetedCompositeUnitSpecAlias',g build/vega-lite-schema.json
-perl -pi -e s,'GenericUnitSpec<Encoding\,AnyMark>','CompositeUnitSpecAlias',g build/vega-lite-schema.json
+perl -pi -e s,'GenericLayerSpec<CompositeUnitSpec>','LayerSpec',g build/vega-lite-schema.json
+perl -pi -e s,'Generic(.*)<FacetedUnitSpec\,LayerSpec>','\1',g build/vega-lite-schema.json
 
 perl -pi -e s,'FieldDefWithoutScale','FieldDef',g build/vega-lite-schema.json
 

--- a/scripts/rename-schema.sh
+++ b/scripts/rename-schema.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
-
+perl -pi -e s,'\<EmptyObject\>','',g build/vega-lite-schema.json
+perl -pi -e s,'\&EmptyObject','',g build/vega-lite-schema.json
 perl -pi -e s,'<Field>','',g build/vega-lite-schema.json
 perl -pi -e s,'<Field\,','<',g build/vega-lite-schema.json
 perl -pi -e s,'<StandardType>','',g build/vega-lite-schema.json
 
+perl -pi -e s,'\&FacetMapping','WithFacet',g build/vega-lite-schema.json
+perl -pi -e s,'<FacetMapping>','WithFacet',g build/vega-lite-schema.json
+
 perl -pi -e s,'FacetedCompositeUnitSpec','FacetedUnitSpec',g build/vega-lite-schema.json
 perl -pi -e s,'ExtendedLayerSpec','LayerSpec',g build/vega-lite-schema.json
-perl -pi -e s,'GenericLayerSpec<CompositeUnitSpec>','LayerSpec',g build/vega-lite-schema.json
-perl -pi -e s,'Generic(.*)<FacetedUnitSpec\,LayerSpec>','\1',g build/vega-lite-schema.json
+perl -pi -e s,'GenericLayerSpec<ExtendedUnitSpec>','LayerSpec',g build/vega-lite-schema.json
+perl -pi -e s,'Generic(.*)<FacetedExtendedUnitSpec\,LayerSpec>','\1',g build/vega-lite-schema.json
 
 perl -pi -e s,'GenericUnitSpec<EncodingWithFacet\,AnyMark>','FacetedCompositeUnitSpecAlias',g build/vega-lite-schema.json
 perl -pi -e s,'GenericUnitSpec<Encoding\,AnyMark>','CompositeUnitSpecAlias',g build/vega-lite-schema.json

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -19,11 +19,6 @@ export namespace Channel {
   export const Y: 'y' = 'y';
   export const X2: 'x2' = 'x2';
   export const Y2: 'y2' = 'y2';
-  export const XERROR: 'xError' = 'xError';
-  export const YERROR: 'yError' = 'yError';
-  export const XERROR2: 'xError2' = 'xError2';
-  export const YERROR2: 'yError2' = 'yError2';
-
   // Geo Position
   export const LATITUDE: 'latitude' = 'latitude';
   export const LONGITUDE: 'longitude' = 'longitude';

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -62,10 +62,6 @@ export const X = Channel.X;
 export const Y = Channel.Y;
 export const X2 = Channel.X2;
 export const Y2 = Channel.Y2;
-export const XERROR = Channel.XERROR;
-export const YERROR = Channel.YERROR;
-export const XERROR2 = Channel.XERROR2;
-export const YERROR2 = Channel.YERROR2;
 
 export const LATITUDE = Channel.LATITUDE;
 export const LATITUDE2 = Channel.LATITUDE2;
@@ -111,10 +107,6 @@ const UNIT_CHANNEL_INDEX: Flag<keyof Encoding<any>> = {
   y: 1,
   x2: 1,
   y2: 1,
-  xError: 1,
-  yError: 1,
-  xError2: 1,
-  yError2: 1,
 
   ...GEOPOSITION_CHANNEL_INDEX,
 
@@ -180,10 +172,6 @@ export type SingleDefUnitChannel =
   | 'y'
   | 'x2'
   | 'y2'
-  | 'xError'
-  | 'yError'
-  | 'xError2'
-  | 'yError2'
   | 'longitude'
   | 'latitude'
   | 'longitude2'
@@ -237,10 +225,6 @@ const {
   // x2 and y2 share the same scale as x and y
   x2: _x2,
   y2: _y2,
-  xError: _xError,
-  yError: _yError,
-  xError2: _xError2,
-  yError2: _yError2,
   latitude: _latitude,
   longitude: _longitude,
   latitude2: _latitude2,
@@ -409,11 +393,6 @@ function getSupportedMark(channel: Channel): SupportedMark {
       return {point: 'always', geoshape: 'always'};
     case TEXT:
       return {text: 'always'};
-    case XERROR:
-    case YERROR:
-    case XERROR2:
-    case YERROR2:
-      return {};
   }
 }
 
@@ -429,10 +408,6 @@ export function rangeType(channel: Channel): RangeType {
     // X2 and Y2 use X and Y scales, so they similarly have continuous range.
     case X2:
     case Y2:
-    case XERROR:
-    case YERROR:
-    case XERROR2:
-    case YERROR2:
       return undefined;
 
     case ROW:

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -172,10 +172,6 @@ export function pathGroupingFields(mark: Mark, encoding: Encoding<string>): stri
       case 'href':
       case 'x2':
       case 'y2':
-      case 'xError':
-      case 'yError':
-      case 'xError2':
-      case 'yError2':
 
       case 'latitude':
       case 'longitude':

--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -1,8 +1,7 @@
 import {isNumber, isObject} from 'vega-util';
-import {Channel} from '../channel';
 import {Config} from '../config';
 import {Encoding, extractTransformsFromEncoding} from '../encoding';
-import {PositionFieldDef} from '../fielddef';
+import {Field, PositionFieldDef} from '../fielddef';
 import * as log from '../log';
 import {isMarkDef, MarkDef} from '../mark';
 import {GenericUnitSpec, NormalizedLayerSpec, NormalizedUnitSpec} from '../spec';
@@ -13,13 +12,16 @@ import {
   compositeMarkContinuousAxis,
   compositeMarkOrient,
   CompositeMarkTooltipSummary,
-  filterUnsupportedChannels,
   GenericCompositeMarkDef,
   getCompositeMarkTooltip,
   makeCompositeAggregatePartFactory,
   partLayerMixins,
   PartsMixins
 } from './common';
+
+export type BoxPlotUnitSpec<
+  EE = {} // extra encoding parameter (for faceted composite unit spec)
+> = GenericUnitSpec<BoxPlotEncoding<Field> & EE, BoxPlot | BoxPlotDef>;
 
 export const BOXPLOT: 'boxplot' = 'boxplot';
 export type BoxPlot = typeof BOXPLOT;
@@ -68,6 +70,8 @@ export type BoxPlotDef = GenericCompositeMarkDef<BoxPlot> &
     orient?: Orient;
   };
 
+export type BoxPlotEncoding<F extends Field> = Pick<Encoding<F>, 'x' | 'y' | 'color' | 'detail' | 'opacity' | 'size'>;
+
 export interface BoxPlotConfigMixins {
   /**
    * Box Config
@@ -75,14 +79,10 @@ export interface BoxPlotConfigMixins {
   boxplot?: BoxPlotConfig;
 }
 
-const boxPlotSupportedChannels: Channel[] = ['x', 'y', 'color', 'detail', 'opacity', 'size'];
-
 export function normalizeBoxPlot(
   spec: GenericUnitSpec<Encoding<string>, BoxPlot | BoxPlotDef>,
   config: Config
 ): NormalizedLayerSpec {
-  spec = filterUnsupportedChannels(spec, boxPlotSupportedChannels, BOXPLOT);
-
   // TODO: use selection
   const {mark, encoding: _encoding, selection, projection: _p, ...outerSpec} = spec;
   const markDef: BoxPlotDef = isMarkDef(mark) ? mark : {type: mark};

--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -1,7 +1,7 @@
 import {isNumber, isObject} from 'vega-util';
 import {Config} from '../config';
 import {Encoding, extractTransformsFromEncoding} from '../encoding';
-import {Field, PositionFieldDef} from '../fielddef';
+import {PositionFieldDef} from '../fielddef';
 import * as log from '../log';
 import {isMarkDef, MarkDef} from '../mark';
 import {GenericUnitSpec, NormalizedLayerSpec, NormalizedUnitSpec} from '../spec';
@@ -18,10 +18,6 @@ import {
   partLayerMixins,
   PartsMixins
 } from './common';
-
-export type BoxPlotUnitSpec<
-  EE = {} // extra encoding parameter (for faceted composite unit spec)
-> = GenericUnitSpec<BoxPlotEncoding<Field> & EE, BoxPlot | BoxPlotDef>;
 
 export const BOXPLOT: 'boxplot' = 'boxplot';
 export type BoxPlot = typeof BOXPLOT;
@@ -69,8 +65,6 @@ export type BoxPlotDef = GenericCompositeMarkDef<BoxPlot> &
      */
     orient?: Orient;
   };
-
-export type BoxPlotEncoding<F extends Field> = Pick<Encoding<F>, 'x' | 'y' | 'color' | 'detail' | 'opacity' | 'size'>;
 
 export interface BoxPlotConfigMixins {
   /**

--- a/src/compositemark/common.ts
+++ b/src/compositemark/common.ts
@@ -1,7 +1,6 @@
 import {isBoolean, isString} from 'vega-util';
 import {CompositeMark, CompositeMarkDef} from '.';
-import {Channel} from '../channel';
-import {Encoding, fieldDefs, reduce} from '../encoding';
+import {Encoding, fieldDefs} from '../encoding';
 import {
   Field,
   FieldDefBase,
@@ -15,6 +14,7 @@ import {
 import * as log from '../log';
 import {ColorMixins, GenericMarkDef, isMarkDef, Mark, MarkConfig, MarkDef} from '../mark';
 import {GenericUnitSpec, NormalizedUnitSpec} from '../spec';
+import {StandardType} from '../type';
 import {Orient} from '../vega.schema';
 
 export type PartsMixins<P extends string> = Partial<Record<P, boolean | MarkConfig>>;
@@ -154,7 +154,13 @@ export function compositeMarkContinuousAxis<M extends CompositeMark>(
   spec: GenericUnitSpec<Encoding<string>, CompositeMark | CompositeMarkDef>,
   orient: Orient,
   compositeMark: M
-) {
+): {
+  continuousAxisChannelDef: PositionFieldDef<string>;
+  continuousAxisChannelDef2: SecondaryFieldDef<string>;
+  continuousAxisChannelDefError: FieldDefWithoutScale<string, StandardType>;
+  continuousAxisChannelDefError2: FieldDefWithoutScale<string, StandardType>;
+  continuousAxis: 'x' | 'y';
+} {
   const {encoding} = spec;
   const continuousAxis: 'x' | 'y' = orient === 'vertical' ? 'y' : 'x';
 
@@ -222,26 +228,4 @@ export function compositeMarkOrient<M extends CompositeMark>(
     // Neither x nor y is continuous.
     throw new Error('Need a valid continuous axis for ' + compositeMark + 's');
   }
-}
-
-export function filterUnsupportedChannels<M extends CompositeMark, MD extends GenericCompositeMarkDef<M>>(
-  spec: GenericUnitSpec<Encoding<string>, M | MD>,
-  supportedChannels: Channel[],
-  compositeMark: M
-): GenericUnitSpec<Encoding<string>, M | MD> {
-  return {
-    ...spec,
-    encoding: reduce(
-      spec.encoding,
-      (newEncoding, fieldDef, channel) => {
-        if (supportedChannels.indexOf(channel) > -1) {
-          newEncoding[channel] = fieldDef;
-        } else {
-          log.warn(log.message.incompatibleChannel(channel, compositeMark));
-        }
-        return newEncoding;
-      },
-      {}
-    )
-  };
 }

--- a/src/compositemark/errorband.ts
+++ b/src/compositemark/errorband.ts
@@ -1,12 +1,17 @@
 import {Config} from '../config';
 import {Encoding} from '../encoding';
+import {Field} from '../fielddef';
 import * as log from '../log';
 import {MarkDef} from '../mark';
 import {GenericUnitSpec, NormalizedLayerSpec} from '../spec';
 import {Flag, keys} from '../util';
 import {Interpolate, Orient} from '../vega.schema';
 import {GenericCompositeMarkDef, makeCompositeAggregatePartFactory, PartsMixins} from './common';
-import {ErrorBarCenter, ErrorBarExtent, errorBarParams} from './errorbar';
+import {ErrorBarCenter, ErrorBarExtent, errorBarParams, ErrorEncoding} from './errorbar';
+
+export type ErrorBandUnitSpec<
+  EE = {} // extra encoding parameter (for faceted composite unit spec)
+> = GenericUnitSpec<ErrorEncoding<Field> & EE, ErrorBand | ErrorBandDef>;
 
 export const ERRORBAND: 'errorband' = 'errorband';
 export type ErrorBand = typeof ERRORBAND;

--- a/src/compositemark/errorbar.ts
+++ b/src/compositemark/errorbar.ts
@@ -30,10 +30,6 @@ import {
 } from './common';
 import {ErrorBand, ErrorBandDef} from './errorband';
 
-export type ErrorBarUnitSpec<
-  EE = {} // extra encoding parameter (for faceted composite unit spec)
-> = GenericUnitSpec<ErrorEncoding<Field> & EE, ErrorBar | ErrorBarDef>;
-
 export const ERRORBAR: 'errorbar' = 'errorbar';
 export type ErrorBar = typeof ERRORBAR;
 
@@ -49,8 +45,7 @@ const ERRORBAR_PART_INDEX: Flag<ErrorBarPart> = {
   rule: 1
 };
 
-export interface ErrorEncoding<F extends Field>
-  extends Pick<Encoding<F>, 'x' | 'y' | 'x2' | 'y2' | 'color' | 'detail' | 'opacity'> {
+export interface ErrorExtraEncoding<F extends Field> {
   /**
    * Error value of x coordinates for error specified `"errorbar"` and `"errorband"`.
    */
@@ -73,6 +68,12 @@ export interface ErrorEncoding<F extends Field>
   // `yError2` cannot have type as it should have the same type as `yError`
   yError2?: SecondaryFieldDef<F> | ValueDef<number>;
 }
+
+export type ErrorEncoding<F extends Field> = Pick<
+  Encoding<F>,
+  'x' | 'y' | 'x2' | 'y2' | 'color' | 'detail' | 'opacity'
+> &
+  ErrorExtraEncoding<F>;
 
 export const ERRORBAR_PARTS = keys(ERRORBAR_PART_INDEX);
 

--- a/src/compositemark/index.ts
+++ b/src/compositemark/index.ts
@@ -1,23 +1,17 @@
 import {Config} from '../config';
+import {Encoding} from '../encoding';
+import {Field} from '../fielddef';
 import {AnyMark, isMarkDef} from '../mark';
 import {GenericUnitSpec, NormalizedLayerSpec} from '../spec';
+import {FacetMapping} from '../spec/facet';
 import {keys} from '../util';
-import {
-  BOXPLOT,
-  BoxPlot,
-  BOXPLOT_PARTS,
-  BoxPlotConfigMixins,
-  BoxPlotDef,
-  BoxPlotUnitSpec,
-  normalizeBoxPlot
-} from './boxplot';
+import {BOXPLOT, BoxPlot, BOXPLOT_PARTS, BoxPlotConfigMixins, BoxPlotDef, normalizeBoxPlot} from './boxplot';
 import {
   ERRORBAND,
   ErrorBand,
   ERRORBAND_PARTS,
   ErrorBandConfigMixins,
   ErrorBandDef,
-  ErrorBandUnitSpec,
   normalizeErrorBand
 } from './errorband';
 import {
@@ -26,7 +20,7 @@ import {
   ERRORBAR_PARTS,
   ErrorBarConfigMixins,
   ErrorBarDef,
-  ErrorBarUnitSpec,
+  ErrorExtraEncoding,
   normalizeErrorBar
 } from './errorbar';
 
@@ -53,9 +47,9 @@ export function remove(mark: string) {
   delete compositeMarkRegistry[mark];
 }
 
-export type CompositeMarkUnitSpec<
-  EE = {} // extra encoding parameter (for faceted composite unit spec)
-> = ErrorBarUnitSpec<EE> | ErrorBandUnitSpec<EE> | BoxPlotUnitSpec<EE>;
+export type CompositeEncoding = Encoding<Field> & ErrorExtraEncoding<Field>;
+export type FacetedCompositeEncoding = Encoding<Field> & ErrorExtraEncoding<Field> & FacetMapping<Field>;
+
 export type CompositeMark = BoxPlot | ErrorBar | ErrorBand;
 
 export function getAllCompositeMarks() {

--- a/src/compositemark/index.ts
+++ b/src/compositemark/index.ts
@@ -2,16 +2,33 @@ import {Config} from '../config';
 import {AnyMark, isMarkDef} from '../mark';
 import {GenericUnitSpec, NormalizedLayerSpec} from '../spec';
 import {keys} from '../util';
-import {BOXPLOT, BoxPlot, BOXPLOT_PARTS, BoxPlotConfigMixins, BoxPlotDef, normalizeBoxPlot} from './boxplot';
+import {
+  BOXPLOT,
+  BoxPlot,
+  BOXPLOT_PARTS,
+  BoxPlotConfigMixins,
+  BoxPlotDef,
+  BoxPlotUnitSpec,
+  normalizeBoxPlot
+} from './boxplot';
 import {
   ERRORBAND,
   ErrorBand,
   ERRORBAND_PARTS,
   ErrorBandConfigMixins,
   ErrorBandDef,
+  ErrorBandUnitSpec,
   normalizeErrorBand
 } from './errorband';
-import {ERRORBAR, ErrorBar, ERRORBAR_PARTS, ErrorBarConfigMixins, ErrorBarDef, normalizeErrorBar} from './errorbar';
+import {
+  ERRORBAR,
+  ErrorBar,
+  ERRORBAR_PARTS,
+  ErrorBarConfigMixins,
+  ErrorBarDef,
+  ErrorBarUnitSpec,
+  normalizeErrorBar
+} from './errorbar';
 
 export {BoxPlotConfig} from './boxplot';
 export {ErrorBandConfigMixins} from './errorband';
@@ -36,6 +53,9 @@ export function remove(mark: string) {
   delete compositeMarkRegistry[mark];
 }
 
+export type CompositeMarkUnitSpec<
+  EE = {} // extra encoding parameter (for faceted composite unit spec)
+> = ErrorBarUnitSpec<EE> | ErrorBandUnitSpec<EE> | BoxPlotUnitSpec<EE>;
 export type CompositeMark = BoxPlot | ErrorBar | ErrorBand;
 
 export function getAllCompositeMarks() {

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -81,28 +81,6 @@ export interface Encoding<F extends Field> {
   y2?: SecondaryFieldDef<F> | ValueDef<number | 'height'>;
 
   /**
-   * Error value of x coordinates for error specified `"errorbar"` and `"errorband"`.
-   */
-  xError?: SecondaryFieldDef<F> | ValueDef<number>;
-
-  /**
-   * Secondary error value of x coordinates for error specified `"errorbar"` and `"errorband"`.
-   */
-  // `xError2` cannot have type as it should have the same type as `xError`
-  xError2?: SecondaryFieldDef<F> | ValueDef<number>;
-
-  /**
-   * Error value of y coordinates for error specified `"errorbar"` and `"errorband"`.
-   */
-  yError?: SecondaryFieldDef<F> | ValueDef<number>;
-
-  /**
-   * Secondary error value of y coordinates for error specified `"errorbar"` and `"errorband"`.
-   */
-  // `yError2` cannot have type as it should have the same type as `yError`
-  yError2?: SecondaryFieldDef<F> | ValueDef<number>;
-
-  /**
    * Longitude position of geographically projected marks.
    */
   longitude?: LatLongFieldDef<F>;

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -145,7 +145,7 @@ export function isMarkDef(mark: AnyMark): mark is MarkDef | CompositeMarkDef {
 
 const PRIMITIVE_MARK_INDEX = toSet(PRIMITIVE_MARKS);
 
-export function isPrimitiveMark(mark: CompositeMark | CompositeMarkDef | Mark | MarkDef): mark is Mark {
+export function isPrimitiveMark(mark: AnyMark): mark is Mark {
   const markType = isMarkDef(mark) ? mark.type : mark;
   return markType in PRIMITIVE_MARK_INDEX;
 }

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -18,9 +18,9 @@ import {
 } from './mark';
 import {Projection} from './projection';
 import {
-  CompositeUnitSpec,
   ExtendedLayerSpec,
-  FacetedCompositeUnitSpec,
+  ExtendedUnitSpec,
+  FacetedExtendedUnitSpec,
   GenericFacetSpec,
   GenericHConcatSpec,
   GenericRepeatSpec,
@@ -46,7 +46,7 @@ import {stack} from './stack';
 import {keys, omit, pick} from './util';
 
 export function normalizeTopLevelSpec(
-  spec: TopLevelSpec | GenericSpec<CompositeUnitSpec, ExtendedLayerSpec> | FacetedCompositeUnitSpec,
+  spec: TopLevelSpec | GenericSpec<ExtendedUnitSpec, ExtendedLayerSpec> | FacetedExtendedUnitSpec,
   config: Config
 ): TopLevel<NormalizedSpec> {
   return normalize(spec, config);
@@ -56,7 +56,7 @@ export function normalizeTopLevelSpec(
  * Decompose extended unit specs into composition of pure unit specs.
  */
 function normalize(
-  spec: GenericSpec<CompositeUnitSpec, ExtendedLayerSpec> | FacetedCompositeUnitSpec,
+  spec: GenericSpec<ExtendedUnitSpec, ExtendedLayerSpec> | FacetedExtendedUnitSpec,
   config: Config
 ): NormalizedSpec {
   if (isFacetSpec(spec)) {
@@ -87,7 +87,7 @@ function normalize(
 }
 
 function normalizeFacet(
-  spec: GenericFacetSpec<CompositeUnitSpec, ExtendedLayerSpec>,
+  spec: GenericFacetSpec<ExtendedUnitSpec, ExtendedLayerSpec>,
   config: Config
 ): NormalizedFacetSpec {
   const {spec: subspec, ...rest} = spec;
@@ -149,7 +149,7 @@ function normalizeLayer(
 }
 
 function normalizeRepeat(
-  spec: GenericRepeatSpec<CompositeUnitSpec, ExtendedLayerSpec>,
+  spec: GenericRepeatSpec<ExtendedUnitSpec, ExtendedLayerSpec>,
   config: Config
 ): NormalizedRepeatSpec {
   const {spec: subspec, ...rest} = spec;
@@ -160,7 +160,7 @@ function normalizeRepeat(
 }
 
 function normalizeVConcat(
-  spec: GenericVConcatSpec<CompositeUnitSpec, ExtendedLayerSpec>,
+  spec: GenericVConcatSpec<ExtendedUnitSpec, ExtendedLayerSpec>,
   config: Config
 ): NormalizedConcatSpec {
   const {vconcat: vconcat, ...rest} = spec;
@@ -171,7 +171,7 @@ function normalizeVConcat(
 }
 
 function normalizeHConcat(
-  spec: GenericHConcatSpec<CompositeUnitSpec, ExtendedLayerSpec>,
+  spec: GenericHConcatSpec<ExtendedUnitSpec, ExtendedLayerSpec>,
   config: Config
 ): NormalizedConcatSpec {
   const {hconcat: hconcat, ...rest} = spec;
@@ -181,7 +181,7 @@ function normalizeHConcat(
   };
 }
 
-function normalizeFacetedUnit(spec: FacetedCompositeUnitSpec, config: Config): NormalizedFacetSpec {
+function normalizeFacetedUnit(spec: FacetedExtendedUnitSpec, config: Config): NormalizedFacetSpec {
   // New encoding in the inside spec should not contain row / column
   // as row/column should be moved to facet
   const {row: row, column: column, ...encoding} = spec.encoding;

--- a/src/spec/index.ts
+++ b/src/spec/index.ts
@@ -17,7 +17,13 @@ import {GenericFacetSpec, isFacetSpec} from './facet';
 import {ExtendedLayerSpec, GenericLayerSpec, isLayerSpec, NormalizedLayerSpec} from './layer';
 import {GenericRepeatSpec, isRepeatSpec} from './repeat';
 import {TopLevel} from './toplevel';
-import {FacetedCompositeUnitSpec, GenericUnitSpec, isUnitSpec, NormalizedUnitSpec} from './unit';
+import {
+  FacetedExtendedUnitSpec,
+  GenericUnitSpec,
+  isUnitSpec,
+  NormalizedUnitSpec,
+  TopLevelFacetedUnitSpec
+} from './unit';
 
 export {normalizeTopLevelSpec as normalize} from '../normalize';
 export {BaseSpec, DataMixins, LayoutSizeMixins} from './base';
@@ -33,7 +39,7 @@ export {GenericFacetSpec, isFacetSpec, NormalizedFacetSpec} from './facet';
 export {ExtendedLayerSpec, GenericLayerSpec, isLayerSpec, NormalizedLayerSpec} from './layer';
 export {GenericRepeatSpec, isRepeatSpec, NormalizedRepeatSpec} from './repeat';
 export {TopLevel} from './toplevel';
-export {CompositeUnitSpec, FacetedCompositeUnitSpec, GenericUnitSpec, isUnitSpec, NormalizedUnitSpec} from './unit';
+export {ExtendedUnitSpec, FacetedExtendedUnitSpec, GenericUnitSpec, isUnitSpec, NormalizedUnitSpec} from './unit';
 
 /**
  * Any specification in Vega-Lite.
@@ -51,8 +57,7 @@ export type GenericSpec<U extends GenericUnitSpec<any, any>, L extends GenericLa
  */
 export type NormalizedSpec = GenericSpec<NormalizedUnitSpec, NormalizedLayerSpec>;
 
-export type TopLevelFacetedUnitSpec = TopLevel<FacetedCompositeUnitSpec> & DataMixins;
-export type TopLevelFacetSpec = TopLevel<GenericFacetSpec<FacetedCompositeUnitSpec, ExtendedLayerSpec>> & DataMixins;
+export type TopLevelFacetSpec = TopLevel<GenericFacetSpec<FacetedExtendedUnitSpec, ExtendedLayerSpec>> & DataMixins;
 
 /**
  * A Vega-Lite top-level specification.
@@ -63,9 +68,9 @@ export type TopLevelSpec =
   | TopLevelFacetedUnitSpec
   | TopLevelFacetSpec
   | TopLevel<ExtendedLayerSpec>
-  | TopLevel<GenericRepeatSpec<FacetedCompositeUnitSpec, ExtendedLayerSpec>>
-  | TopLevel<GenericVConcatSpec<FacetedCompositeUnitSpec, ExtendedLayerSpec>>
-  | TopLevel<GenericHConcatSpec<FacetedCompositeUnitSpec, ExtendedLayerSpec>>;
+  | TopLevel<GenericRepeatSpec<FacetedExtendedUnitSpec, ExtendedLayerSpec>>
+  | TopLevel<GenericVConcatSpec<FacetedExtendedUnitSpec, ExtendedLayerSpec>>
+  | TopLevel<GenericHConcatSpec<FacetedExtendedUnitSpec, ExtendedLayerSpec>>;
 
 /* Custom type guards */
 
@@ -121,7 +126,7 @@ export function fieldDefs(spec: GenericSpec<any, any>): TypedFieldDef<any>[] {
   return vals(fieldDefIndex(spec));
 }
 
-export function isStacked(spec: TopLevel<FacetedCompositeUnitSpec>, config?: Config): boolean {
+export function isStacked(spec: TopLevel<FacetedExtendedUnitSpec>, config?: Config): boolean {
   config = config || spec.config;
   if (isPrimitiveMark(spec.mark)) {
     return stack(spec.mark, spec.encoding, config ? config.stack : undefined) !== null;

--- a/src/spec/index.ts
+++ b/src/spec/index.ts
@@ -17,13 +17,7 @@ import {GenericFacetSpec, isFacetSpec} from './facet';
 import {ExtendedLayerSpec, GenericLayerSpec, isLayerSpec, NormalizedLayerSpec} from './layer';
 import {GenericRepeatSpec, isRepeatSpec} from './repeat';
 import {TopLevel} from './toplevel';
-import {
-  FacetedExtendedUnitSpec,
-  GenericUnitSpec,
-  isUnitSpec,
-  NormalizedUnitSpec,
-  TopLevelFacetedUnitSpec
-} from './unit';
+import {FacetedCompositeUnitSpec, GenericUnitSpec, isUnitSpec, NormalizedUnitSpec, TopLevelUnitSpec} from './unit';
 
 export {normalizeTopLevelSpec as normalize} from '../normalize';
 export {BaseSpec, DataMixins, LayoutSizeMixins} from './base';
@@ -39,7 +33,13 @@ export {GenericFacetSpec, isFacetSpec, NormalizedFacetSpec} from './facet';
 export {ExtendedLayerSpec, GenericLayerSpec, isLayerSpec, NormalizedLayerSpec} from './layer';
 export {GenericRepeatSpec, isRepeatSpec, NormalizedRepeatSpec} from './repeat';
 export {TopLevel} from './toplevel';
-export {ExtendedUnitSpec, FacetedExtendedUnitSpec, GenericUnitSpec, isUnitSpec, NormalizedUnitSpec} from './unit';
+export {
+  CompositeUnitSpec as ExtendedUnitSpec,
+  FacetedCompositeUnitSpec as FacetedExtendedUnitSpec,
+  GenericUnitSpec,
+  isUnitSpec,
+  NormalizedUnitSpec
+} from './unit';
 
 /**
  * Any specification in Vega-Lite.
@@ -57,7 +57,7 @@ export type GenericSpec<U extends GenericUnitSpec<any, any>, L extends GenericLa
  */
 export type NormalizedSpec = GenericSpec<NormalizedUnitSpec, NormalizedLayerSpec>;
 
-export type TopLevelFacetSpec = TopLevel<GenericFacetSpec<FacetedExtendedUnitSpec, ExtendedLayerSpec>> & DataMixins;
+export type TopLevelFacetSpec = TopLevel<GenericFacetSpec<FacetedCompositeUnitSpec, ExtendedLayerSpec>> & DataMixins;
 
 /**
  * A Vega-Lite top-level specification.
@@ -65,12 +65,12 @@ export type TopLevelFacetSpec = TopLevel<GenericFacetSpec<FacetedExtendedUnitSpe
  * (The json schema is generated from this type.)
  */
 export type TopLevelSpec =
-  | TopLevelFacetedUnitSpec
+  | TopLevelUnitSpec
   | TopLevelFacetSpec
   | TopLevel<ExtendedLayerSpec>
-  | TopLevel<GenericRepeatSpec<FacetedExtendedUnitSpec, ExtendedLayerSpec>>
-  | TopLevel<GenericVConcatSpec<FacetedExtendedUnitSpec, ExtendedLayerSpec>>
-  | TopLevel<GenericHConcatSpec<FacetedExtendedUnitSpec, ExtendedLayerSpec>>;
+  | TopLevel<GenericRepeatSpec<FacetedCompositeUnitSpec, ExtendedLayerSpec>>
+  | TopLevel<GenericVConcatSpec<FacetedCompositeUnitSpec, ExtendedLayerSpec>>
+  | TopLevel<GenericHConcatSpec<FacetedCompositeUnitSpec, ExtendedLayerSpec>>;
 
 /* Custom type guards */
 
@@ -126,7 +126,7 @@ export function fieldDefs(spec: GenericSpec<any, any>): TypedFieldDef<any>[] {
   return vals(fieldDefIndex(spec));
 }
 
-export function isStacked(spec: TopLevel<FacetedExtendedUnitSpec>, config?: Config): boolean {
+export function isStacked(spec: TopLevel<FacetedCompositeUnitSpec>, config?: Config): boolean {
   config = config || spec.config;
   if (isPrimitiveMark(spec.mark)) {
     return stack(spec.mark, spec.encoding, config ? config.stack : undefined) !== null;

--- a/src/spec/layer.ts
+++ b/src/spec/layer.ts
@@ -1,9 +1,8 @@
-import {Encoding} from '../encoding';
-import {Field} from '../fielddef';
+import {CompositeEncoding} from '../compositemark/index';
 import {Projection} from '../projection';
 import {Resolve} from '../resolve';
 import {BaseSpec, LayerUnitMixins} from './base';
-import {ExtendedUnitSpec, GenericUnitSpec, NormalizedUnitSpec} from './unit';
+import {CompositeUnitSpec, GenericUnitSpec, NormalizedUnitSpec} from './unit';
 
 /**
  * Base interface for a layer specification.
@@ -25,11 +24,11 @@ export interface GenericLayerSpec<U extends GenericUnitSpec<any, any>> extends B
 /**
  * Layer Spec with `encoding` and `projection` shorthands that will be applied to underlying unit (single-view) specifications.
  */
-export interface ExtendedLayerSpec extends GenericLayerSpec<ExtendedUnitSpec> {
+export interface ExtendedLayerSpec extends GenericLayerSpec<CompositeUnitSpec> {
   /**
    * A shared key-value mapping between encoding channels and definition of fields in the underlying layers.
    */
-  encoding?: Encoding<Field>;
+  encoding?: CompositeEncoding;
 
   /**
    * An object defining properties of the geographic projection shared by underlying layers.

--- a/src/spec/layer.ts
+++ b/src/spec/layer.ts
@@ -3,7 +3,7 @@ import {Field} from '../fielddef';
 import {Projection} from '../projection';
 import {Resolve} from '../resolve';
 import {BaseSpec, LayerUnitMixins} from './base';
-import {CompositeUnitSpec, GenericUnitSpec, NormalizedUnitSpec} from './unit';
+import {ExtendedUnitSpec, GenericUnitSpec, NormalizedUnitSpec} from './unit';
 
 /**
  * Base interface for a layer specification.
@@ -25,7 +25,7 @@ export interface GenericLayerSpec<U extends GenericUnitSpec<any, any>> extends B
 /**
  * Layer Spec with `encoding` and `projection` shorthands that will be applied to underlying unit (single-view) specifications.
  */
-export interface ExtendedLayerSpec extends GenericLayerSpec<CompositeUnitSpec> {
+export interface ExtendedLayerSpec extends GenericLayerSpec<ExtendedUnitSpec> {
   /**
    * A shared key-value mapping between encoding channels and definition of fields in the underlying layers.
    */

--- a/src/spec/unit.ts
+++ b/src/spec/unit.ts
@@ -1,14 +1,10 @@
-import {BoxPlotUnitSpec} from '../compositemark/boxplot';
-import {ErrorBandUnitSpec} from '../compositemark/errorband';
-import {ErrorBarUnitSpec} from '../compositemark/errorbar';
-import {CompositeMarkUnitSpec} from '../compositemark/index';
+import {CompositeEncoding, FacetedCompositeEncoding} from '../compositemark/index';
 import {Encoding} from '../encoding';
 import {Field} from '../fielddef';
-import {Mark, MarkDef} from '../mark';
+import {AnyMark, Mark, MarkDef} from '../mark';
 import {Projection} from '../projection';
 import {SelectionDef} from '../selection';
 import {BaseSpec, DataMixins, LayerUnitMixins} from './base';
-import {FacetMapping} from './facet';
 import {TopLevel} from './toplevel';
 
 /**
@@ -41,42 +37,20 @@ export interface GenericUnitSpec<E extends Encoding<any>, M> extends BaseSpec, L
 /**
  * A unit specification without any shortcut/expansion syntax.
  */
-export type NormalizedUnitSpec<
-  /** Extra Encoding */
-  EE = {}
-> = GenericUnitSpec<Encoding<Field> & EE, Mark | MarkDef>;
-
-/* tslint:disable */
-// Need to declare empty object so the generated schema has a reasonable name for ExtendedUnitSpec
-export interface EmptyObject {}
-/* tslint:enable */
+export type NormalizedUnitSpec = GenericUnitSpec<Encoding<Field>, Mark | MarkDef>;
 
 /**
  * Unit spec that can be normalized/expanded into a layer spec or another unit spec.
  */
-export type ExtendedUnitSpec<
-  /** Extra Encoding */
-  EE = EmptyObject
-> = NormalizedUnitSpec<EE> | CompositeMarkUnitSpec<EE>;
+export type CompositeUnitSpec = GenericUnitSpec<CompositeEncoding, AnyMark>;
 
 /**
  * Unit spec that can have a composite mark and row or column channels (shorthand for a facet spec).
  */
-export type FacetedExtendedUnitSpec = ExtendedUnitSpec<FacetMapping<Field>>;
+export type FacetedCompositeUnitSpec = GenericUnitSpec<FacetedCompositeEncoding, AnyMark>;
 
-// Note: The following three declarations are equivalent to:
-// ```
-// export type TopLevelFacetedUnitSpec = TopLevel<FacetedExtendedUnitSpec> & DataMixins;
-// ```
-// However, the JSON schema generator does not support the simpler syntax
+export type TopLevelUnitSpec = TopLevel<FacetedCompositeUnitSpec> & DataMixins;
 
-export type TopLevelNormalizedUnitSpec = TopLevel<NormalizedUnitSpec<FacetMapping<Field>>> & DataMixins;
-export type TopLevelCompositeMarkUnitSpec =
-  | (TopLevel<ErrorBarUnitSpec<FacetMapping<Field>>> & DataMixins)
-  | (TopLevel<ErrorBandUnitSpec<FacetMapping<Field>>> & DataMixins)
-  | (TopLevel<BoxPlotUnitSpec<FacetMapping<Field>>> & DataMixins);
-export type TopLevelFacetedUnitSpec = TopLevelNormalizedUnitSpec | TopLevelCompositeMarkUnitSpec;
-
-export function isUnitSpec(spec: BaseSpec): spec is FacetedExtendedUnitSpec | NormalizedUnitSpec {
+export function isUnitSpec(spec: BaseSpec): spec is FacetedCompositeUnitSpec | NormalizedUnitSpec {
   return !!spec['mark'];
 }

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,7 +1,6 @@
 import {toSet} from 'vega-util';
-import {isMarkDef} from './mark';
-import {BAR} from './mark';
-import {FacetedCompositeUnitSpec} from './spec';
+import {BAR, isMarkDef} from './mark';
+import {FacetedExtendedUnitSpec} from './spec';
 
 // TODO: move to vl.spec.validator?
 export interface RequiredChannelMap {
@@ -57,7 +56,7 @@ export const DEFAULT_SUPPORTED_CHANNEL_TYPE: SupportedChannelMap = {
  *                  or null if the encoding is valid.
  */
 export function getEncodingMappingError(
-  spec: FacetedCompositeUnitSpec,
+  spec: FacetedExtendedUnitSpec,
   requiredChannelMap: RequiredChannelMap = DEFAULT_REQUIRED_CHANNEL_MAP,
   supportedChannelMap: SupportedChannelMap = DEFAULT_SUPPORTED_CHANNEL_TYPE
 ) {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,6 +1,6 @@
 import {toSet} from 'vega-util';
 import {BAR, isMarkDef} from './mark';
-import {FacetedExtendedUnitSpec} from './spec';
+import {FacetedCompositeUnitSpec} from './spec/unit';
 
 // TODO: move to vl.spec.validator?
 export interface RequiredChannelMap {
@@ -56,7 +56,7 @@ export const DEFAULT_SUPPORTED_CHANNEL_TYPE: SupportedChannelMap = {
  *                  or null if the encoding is valid.
  */
 export function getEncodingMappingError(
-  spec: FacetedExtendedUnitSpec,
+  spec: FacetedCompositeUnitSpec,
   requiredChannelMap: RequiredChannelMap = DEFAULT_REQUIRED_CHANNEL_MAP,
   supportedChannelMap: SupportedChannelMap = DEFAULT_SUPPORTED_CHANNEL_TYPE
 ) {

--- a/test/compositemark/errorbar.test.ts
+++ b/test/compositemark/errorbar.test.ts
@@ -1,11 +1,12 @@
 /* tslint:disable:quotemark */
 import {AggregateOp} from 'vega';
 import {ErrorBarCenter, ErrorBarExtent} from '../../src/compositemark/errorbar';
+import {CompositeMarkUnitSpec} from '../../src/compositemark/index';
 import {defaultConfig} from '../../src/config';
 import {isFieldDef} from '../../src/fielddef';
 import * as log from '../../src/log';
 import {isMarkDef} from '../../src/mark';
-import {CompositeUnitSpec, ExtendedLayerSpec, GenericSpec, isLayerSpec, isUnitSpec, normalize} from '../../src/spec';
+import {ExtendedLayerSpec, GenericSpec, isLayerSpec, isUnitSpec, normalize} from '../../src/spec';
 import {isAggregate, isCalculate, Transform} from '../../src/transform';
 import {some} from '../../src/util';
 
@@ -614,7 +615,7 @@ describe('normalizeErrorBar for all possible extents and centers with raw data i
 
   for (const center of centers) {
     for (const extent of extents) {
-      const spec: GenericSpec<CompositeUnitSpec, ExtendedLayerSpec> = {
+      const spec: GenericSpec<CompositeMarkUnitSpec, ExtendedLayerSpec> = {
         data: {url: 'data/population.json'},
         mark: {type, ...(center ? {center} : {}), ...(extent ? {extent} : {})},
         encoding: {
@@ -897,29 +898,6 @@ describe('normalizeErrorBar with aggregated upper and lower bound input', () => 
       );
 
       expect(localLogger.warns[0]).toEqual(log.message.errorBarContinuousAxisHasCustomizedAggregate(aggregate, mark));
-    })
-  );
-
-  it(
-    'should produce a warning if there is an unsupported channel in encoding',
-    log.wrap(localLogger => {
-      const size = 'size';
-
-      normalize(
-        {
-          data,
-          mark,
-          encoding: {
-            x: {field: 'age', type: 'ordinal'},
-            y: {field: 'people', type: 'quantitative'},
-            y2: {field: 'people2', type: 'quantitative', aggregate: 'min'},
-            size: {value: 10}
-          }
-        },
-        defaultConfig
-      );
-
-      expect(localLogger.warns[0]).toEqual(log.message.incompatibleChannel(size, mark));
     })
   );
 

--- a/test/compositemark/errorbar.test.ts
+++ b/test/compositemark/errorbar.test.ts
@@ -1,12 +1,12 @@
 /* tslint:disable:quotemark */
 import {AggregateOp} from 'vega';
 import {ErrorBarCenter, ErrorBarExtent} from '../../src/compositemark/errorbar';
-import {CompositeMarkUnitSpec} from '../../src/compositemark/index';
 import {defaultConfig} from '../../src/config';
 import {isFieldDef} from '../../src/fielddef';
 import * as log from '../../src/log';
 import {isMarkDef} from '../../src/mark';
 import {ExtendedLayerSpec, GenericSpec, isLayerSpec, isUnitSpec, normalize} from '../../src/spec';
+import {CompositeUnitSpec} from '../../src/spec/unit';
 import {isAggregate, isCalculate, Transform} from '../../src/transform';
 import {some} from '../../src/util';
 
@@ -615,7 +615,7 @@ describe('normalizeErrorBar for all possible extents and centers with raw data i
 
   for (const center of centers) {
     for (const extent of extents) {
-      const spec: GenericSpec<CompositeMarkUnitSpec, ExtendedLayerSpec> = {
+      const spec: GenericSpec<CompositeUnitSpec, ExtendedLayerSpec> = {
         data: {url: 'data/population.json'},
         mark: {type, ...(center ? {center} : {}), ...(extent ? {extent} : {})},
         encoding: {


### PR DESCRIPTION
This PR simplifies #4440 and keep the number of `Encoding` declarations small. 

In the schema, there are still simply `FacetedEncoding` and `Encoding`.