### PR TITLE
fix: ts error clone import

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,4 @@
-import clone_ from 'clone';
+import {default as clone_} from 'clone';
 import deepEqual_ from 'fast-deep-equal';
 import stableStringify from 'fast-json-stable-stringify';
 import {isArray, isNumber, isString, splitAccessPath, stringValue} from 'vega-util';


### PR DESCRIPTION
This change addresses the error from when running `tsc`:

> error TS1192: Module '"/.../node_modules/@types/clone/index"' has no default export.
