### PR TITLE
Removed gradient length for #4508

### DIFF
--- a/examples/compiled/point_color_with_shape.vg.json
+++ b/examples/compiled/point_color_with_shape.vg.json
@@ -122,7 +122,6 @@
   "legends": [
     {
       "stroke": "color",
-      "gradientLength": {"signal": "clamp(height, 64, 200)"},
       "title": "Origin",
       "encode": {
         "symbols": {


### PR DESCRIPTION
The gradient length has been removed from the symbol type 
