### PR TITLE
Redirect `titleAnchor` to the underlying `layout.titleBand` + Automatically adjusting titleAlign

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -5768,8 +5768,8 @@
           ]
         },
         "titleAnchor": {
-          "description": "The anchor position for placing the title. One of `\"start\"`, `\"middle\"`, or `\"end\"`. For example, with an orientation of top these anchor positions map to a left-, center-, or right-aligned title.\n\n__Default value:__ `\"middle\"` for [single](https://vega.github.io/vega-lite/docs/spec.html) and [layered](https://vega.github.io/vega-lite/docs/layer.html) views.\n`\"start\"` for other composite views.\n\n__Note:__ [For now](https://github.com/vega/vega-lite/issues/2875), `anchor` is only customizable only for [single](https://vega.github.io/vega-lite/docs/spec.html) and [layered](https://vega.github.io/vega-lite/docs/layer.html) views.  For other composite views, `anchor` is always `\"start\"`.",
-          "type": "string"
+          "$ref": "#/definitions/TitleAnchor",
+          "description": "The anchor position for placing the title. One of `\"start\"`, `\"middle\"`, or `\"end\"`. For example, with an orientation of top these anchor positions map to a left-, center-, or right-aligned title."
         },
         "titleAngle": {
           "description": "The rotation angle of the header title.\n\n__Default value:__ `0`.",
@@ -5840,8 +5840,8 @@
           "type": "number"
         },
         "titleAnchor": {
-          "description": "The anchor position for placing the title. One of `\"start\"`, `\"middle\"`, or `\"end\"`. For example, with an orientation of top these anchor positions map to a left-, center-, or right-aligned title.\n\n__Default value:__ `\"middle\"` for [single](https://vega.github.io/vega-lite/docs/spec.html) and [layered](https://vega.github.io/vega-lite/docs/layer.html) views.\n`\"start\"` for other composite views.\n\n__Note:__ [For now](https://github.com/vega/vega-lite/issues/2875), `anchor` is only customizable only for [single](https://vega.github.io/vega-lite/docs/spec.html) and [layered](https://vega.github.io/vega-lite/docs/layer.html) views.  For other composite views, `anchor` is always `\"start\"`.",
-          "type": "string"
+          "$ref": "#/definitions/TitleAnchor",
+          "description": "The anchor position for placing the title. One of `\"start\"`, `\"middle\"`, or `\"end\"`. For example, with an orientation of top these anchor positions map to a left-, center-, or right-aligned title."
         },
         "titleAngle": {
           "description": "The rotation angle of the header title.\n\n__Default value:__ `0`.",

--- a/src/compile/header/index.ts
+++ b/src/compile/header/index.ts
@@ -101,7 +101,7 @@ export function assembleTitleGroup(model: Model, channel: FacetChannel) {
   };
 }
 
-function titleAlign(titleAnchor: TitleAnchor) {
+export function titleAlign(titleAnchor: TitleAnchor) {
   switch (titleAnchor) {
     case 'start':
       return {align: 'left'};
@@ -239,6 +239,15 @@ export function assembleHeaderGroup(
   return null;
 }
 
+export function getLayoutTitleBand(titleAnchor: TitleAnchor) {
+  if (titleAnchor === 'start') {
+    return 0;
+  } else if (titleAnchor === 'end') {
+    return 1;
+  }
+  return undefined;
+}
+
 export function assembleLayoutTitleBand(headerComponentIndex: LayoutHeaderComponentIndex): RowCol<number> {
   const titleBand = {};
 
@@ -246,10 +255,9 @@ export function assembleLayoutTitleBand(headerComponentIndex: LayoutHeaderCompon
     const headerComponent = headerComponentIndex[channel];
     if (headerComponent && headerComponent.facetFieldDef && headerComponent.facetFieldDef.header) {
       const {titleAnchor} = headerComponent.facetFieldDef.header;
-      if (titleAnchor === 'start') {
-        titleBand[channel === 'facet' ? 'column' : channel] = 0;
-      } else if (titleAnchor === 'end') {
-        titleBand[channel === 'facet' ? 'column' : channel] = 1;
+      const band = getLayoutTitleBand(titleAnchor);
+      if (band !== undefined) {
+        titleBand[channel === 'facet' ? 'column' : channel] = band;
       }
     }
   }

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -20,7 +20,13 @@ import {AxisComponentIndex} from './axis/component';
 import {ConcatModel} from './concat';
 import {DataComponent} from './data';
 import {FacetModel} from './facet';
-import {assembleHeaderGroups, assembleTitleGroup, HEADER_CHANNELS, LayoutHeaderComponent} from './header/index';
+import {
+  assembleHeaderGroups,
+  assembleLayoutTitleBand,
+  assembleTitleGroup,
+  HEADER_CHANNELS,
+  LayoutHeaderComponent
+} from './header/index';
 import {LayerModel} from './layer';
 import {sizeExpr} from './layoutsize/assemble';
 import {LayoutSizeComponent, LayoutSizeIndex} from './layoutsize/component';
@@ -335,6 +341,8 @@ export abstract class Model {
 
     const {spacing = {}, ...layout} = this.layout;
 
+    const titleBand = assembleLayoutTitleBand(this.component.layoutHeaders);
+
     return {
       padding: isNumber(spacing)
         ? spacing
@@ -343,7 +351,8 @@ export abstract class Model {
             column: spacing.column || DEFAULT_SPACING
           },
       ...this.assembleDefaultLayout(),
-      ...layout
+      ...layout,
+      ...(titleBand ? {titleBand} : {})
     };
   }
 

--- a/src/header.ts
+++ b/src/header.ts
@@ -1,9 +1,9 @@
-import {FontWeight, TextBaseline, TitleConfig} from 'vega';
+import {FontWeight, TextBaseline, TitleAnchor, TitleConfig} from 'vega';
 import {Guide} from './guide';
 import {keys} from './util';
 
 export const HEADER_TITLE_PROPERTIES_MAP: {[k in keyof HeaderConfig]: keyof TitleConfig} = {
-  titleAnchor: 'anchor',
+  titleAnchor: undefined,
   titleAngle: 'angle',
   titleBaseline: 'baseline',
   titleColor: 'color',
@@ -31,13 +31,8 @@ export interface HeaderConfig {
   // ---------- Title ----------
   /**
    * The anchor position for placing the title. One of `"start"`, `"middle"`, or `"end"`. For example, with an orientation of top these anchor positions map to a left-, center-, or right-aligned title.
-   *
-   * __Default value:__ `"middle"` for [single](https://vega.github.io/vega-lite/docs/spec.html) and [layered](https://vega.github.io/vega-lite/docs/layer.html) views.
-   * `"start"` for other composite views.
-   *
-   * __Note:__ [For now](https://github.com/vega/vega-lite/issues/2875), `anchor` is only customizable only for [single](https://vega.github.io/vega-lite/docs/spec.html) and [layered](https://vega.github.io/vega-lite/docs/layer.html) views.  For other composite views, `anchor` is always `"start"`.
    */
-  titleAnchor?: string;
+  titleAnchor?: TitleAnchor;
 
   /**
    * The rotation angle of the header title.

--- a/test/compile/header/index.test.ts
+++ b/test/compile/header/index.test.ts
@@ -1,4 +1,11 @@
-import {assembleHeaderGroups, assembleTitleGroup, labelAlign, labelBaseline} from '../../../src/compile/header';
+import {
+  assembleHeaderGroups,
+  assembleTitleGroup,
+  getLayoutTitleBand,
+  labelAlign,
+  labelBaseline,
+  titleAlign
+} from '../../../src/compile/header';
 import {getHeaderProperties} from '../../../src/compile/header/index';
 import {
   HEADER_LABEL_PROPERTIES,
@@ -9,10 +16,22 @@ import {
 import {parseFacetModel} from '../../util';
 
 describe('compile/header/index', () => {
-  describe('label aligns correctly according to angle', () => {
-    expect(labelAlign(23)).toEqual({align: {value: 'right'}});
-    expect(labelAlign(135)).toEqual({align: {value: 'left'}});
-    expect(labelAlign(50)).toEqual({align: {value: 'right'}});
+  describe('titleAlign', () => {
+    it('should return left for anchor=start', () => {
+      expect(titleAlign('start')).toEqual({align: 'left'});
+    });
+
+    it('should return right for anchor=start', () => {
+      expect(titleAlign('end')).toEqual({align: 'right'});
+    });
+  });
+
+  describe('labelAlign', () => {
+    it('label aligns correctly according to angle', () => {
+      expect(labelAlign(23)).toEqual({align: {value: 'right'}});
+      expect(labelAlign(135)).toEqual({align: {value: 'left'}});
+      expect(labelAlign(50)).toEqual({align: {value: 'right'}});
+    });
   });
 
   describe('label baseline adjusted according to angle', () => {
@@ -64,6 +83,16 @@ describe('compile/header/index', () => {
 
       const rowHeaderGroups = assembleHeaderGroups(model, 'row');
       expect(rowHeaderGroups[0].sort.field).toEqual('datum["min_d"]');
+    });
+  });
+
+  describe('getLayoutTitleBand', () => {
+    it('should return 0 for start', () => {
+      expect(getLayoutTitleBand('start')).toEqual(0);
+    });
+
+    it('should return 1 for end', () => {
+      expect(getLayoutTitleBand('end')).toEqual(1);
     });
   });
 


### PR DESCRIPTION


Fix #4624 

