### PR TITLE
Remove exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,56 +1,9 @@
 import pkg from '../package.json';
-import * as aggregate from './aggregate';
-import * as axis from './axis';
-import * as bin from './bin';
-import * as channel from './channel';
-import * as compositeMark from './compositemark';
-import * as config from './config';
-import * as data from './data';
-import * as datetime from './datetime';
-import * as encoding from './encoding';
-import * as fieldDef from './fielddef';
-import * as header from './header';
-import * as legend from './legend';
-import * as mark from './mark';
 import {normalize} from './normalize';
-import * as scale from './scale';
-import * as sort from './sort';
-import * as spec from './spec';
-import * as stack from './stack';
-import * as timeUnit from './timeunit';
-import * as transform from './transform';
-import * as type from './type';
-import * as util from './util';
-import * as validate from './validate';
 export {compile} from './compile/compile';
 export {Config} from './config';
 export {TopLevelSpec} from './spec';
 export {extractTransforms} from './transformextract';
-export {
-  aggregate,
-  axis,
-  bin,
-  channel,
-  compositeMark,
-  config,
-  data,
-  datetime,
-  encoding,
-  fieldDef,
-  header,
-  legend,
-  mark,
-  normalize,
-  scale,
-  sort,
-  spec,
-  stack,
-  timeUnit,
-  transform,
-  type,
-  util,
-  validate,
-  version
-};
 
 const version = pkg.version;
+export {normalize, version};


### PR DESCRIPTION
3% smaller build and we are not exposing the internals of Vega-Lite which we break from time to time. 

Fixes #4635