### PR TITLE
Infer selection projection from initial value if none given.

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -6395,7 +6395,7 @@
         "encodings": {
           "description": "An array of encoding channels. The corresponding data field values\nmust match for a data tuple to fall within the selection.",
           "items": {
-            "$ref": "#/definitions/SingleDefChannel"
+            "$ref": "#/definitions/SingleDefUnitChannel"
           },
           "type": "array"
         },
@@ -6469,7 +6469,7 @@
         "encodings": {
           "description": "An array of encoding channels. The corresponding data field values\nmust match for a data tuple to fall within the selection.",
           "items": {
-            "$ref": "#/definitions/SingleDefChannel"
+            "$ref": "#/definitions/SingleDefUnitChannel"
           },
           "type": "array"
         },
@@ -8377,7 +8377,7 @@
         "encodings": {
           "description": "An array of encoding channels. The corresponding data field values\nmust match for a data tuple to fall within the selection.",
           "items": {
-            "$ref": "#/definitions/SingleDefChannel"
+            "$ref": "#/definitions/SingleDefUnitChannel"
           },
           "type": "array"
         },
@@ -8447,7 +8447,7 @@
         "encodings": {
           "description": "An array of encoding channels. The corresponding data field values\nmust match for a data tuple to fall within the selection.",
           "items": {
-            "$ref": "#/definitions/SingleDefChannel"
+            "$ref": "#/definitions/SingleDefUnitChannel"
           },
           "type": "array"
         },
@@ -10175,31 +10175,6 @@
       ],
       "type": "object"
     },
-    "SingleDefChannel": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SingleDefUnitChannel"
-        },
-        {
-          "enum": [
-            "row"
-          ],
-          "type": "string"
-        },
-        {
-          "enum": [
-            "column"
-          ],
-          "type": "string"
-        },
-        {
-          "enum": [
-            "facet"
-          ],
-          "type": "string"
-        }
-      ]
-    },
     "SingleDefUnitChannel": {
       "enum": [
         "x",
@@ -10254,7 +10229,7 @@
         "encodings": {
           "description": "An array of encoding channels. The corresponding data field values\nmust match for a data tuple to fall within the selection.",
           "items": {
-            "$ref": "#/definitions/SingleDefChannel"
+            "$ref": "#/definitions/SingleDefUnitChannel"
           },
           "type": "array"
         },
@@ -10321,7 +10296,7 @@
         "encodings": {
           "description": "An array of encoding channels. The corresponding data field values\nmust match for a data tuple to fall within the selection.",
           "items": {
-            "$ref": "#/definitions/SingleDefChannel"
+            "$ref": "#/definitions/SingleDefUnitChannel"
           },
           "type": "array"
         },

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -158,6 +158,7 @@ const CHANNEL_INDEX = {
 export const CHANNELS = flagKeys(CHANNEL_INDEX);
 
 const {order: _o, detail: _d, ...SINGLE_DEF_CHANNEL_INDEX} = CHANNEL_INDEX;
+const {order: _o1, detail: _d1, row: _r, column: _c, facet: _f, ...SINGLE_DEF_UNIT_CHANNEL_INDEX} = CHANNEL_INDEX;
 /**
  * Channels that cannot have an array of channelDef.
  * model.fieldDef, getFieldDef only work for these channels.
@@ -168,6 +169,8 @@ const {order: _o, detail: _d, ...SINGLE_DEF_CHANNEL_INDEX} = CHANNEL_INDEX;
  */
 
 export const SINGLE_DEF_CHANNELS: SingleDefChannel[] = flagKeys(SINGLE_DEF_CHANNEL_INDEX);
+
+export const SINGLE_DEF_UNIT_CHANNELS: SingleDefUnitChannel[] = flagKeys(SINGLE_DEF_UNIT_CHANNEL_INDEX);
 
 // Using the following line leads to TypeError: Cannot read property 'elementTypes' of undefined
 // when running the schema generator
@@ -197,6 +200,10 @@ export type SingleDefUnitChannel =
   | 'key';
 
 export type SingleDefChannel = SingleDefUnitChannel | 'row' | 'column' | 'facet';
+
+export function isSingleDefUnitChannel(str: string): str is SingleDefUnitChannel {
+  return !!SINGLE_DEF_UNIT_CHANNEL_INDEX[str];
+}
 
 export function isChannel(str: string): str is Channel {
   return !!CHANNEL_INDEX[str];

--- a/src/compile/selection/parse.ts
+++ b/src/compile/selection/parse.ts
@@ -20,7 +20,7 @@ export function parseUnitSelection(model: UnitModel, selDefs: Dict<SelectionDef>
     }
 
     const selDef = selDefs[name];
-    const cfg = selectionConfig[selDef.type];
+    const {fields, encodings, ...cfg} = selectionConfig[selDef.type]; // Project transform applies its defaults.
 
     // Set default values from config if a property hasn't been specified,
     // or if it is true. E.g., "translate": true should use the default

--- a/src/compile/selection/transforms/project.ts
+++ b/src/compile/selection/transforms/project.ts
@@ -1,6 +1,6 @@
 import {isArray} from 'vega-util';
 import {SelectionComponent} from '..';
-import {ScaleChannel, SingleDefChannel} from '../../../channel';
+import {isSingleDefUnitChannel, ScaleChannel, SingleDefUnitChannel} from '../../../channel';
 import * as log from '../../../log';
 import {hasContinuousDomain} from '../../../scale';
 import {isIntervalSelection, SelectionDef, SelectionInitArrayMapping, SelectionInitMapping} from '../../../selection';
@@ -20,12 +20,12 @@ export type TupleStoreType = 'E' | 'R' | 'R-RE';
 export interface SelectionProjection {
   type: TupleStoreType;
   field: string;
-  channel?: SingleDefChannel;
+  channel?: SingleDefUnitChannel;
   signals?: {data?: string; visual?: string};
 }
 
 export class SelectionProjectionComponent extends Array<SelectionProjection> {
-  public has: {[key in SingleDefChannel]?: SelectionProjection};
+  public has: {[key in SingleDefUnitChannel]?: SelectionProjection};
   public timeUnit?: TimeUnitNode;
   constructor(...items: SelectionProjection[]) {
     super(...items);
@@ -36,8 +36,7 @@ export class SelectionProjectionComponent extends Array<SelectionProjection> {
 
 const project: TransformCompiler = {
   has: (selDef: SelectionComponent | SelectionDef) => {
-    const def = selDef as SelectionDef;
-    return def.fields !== undefined || def.encodings !== undefined;
+    return true; // This transform handles its own defaults, so always run parse.
   },
 
   parse: (model, selDef, selCmpt) => {
@@ -55,6 +54,31 @@ const project: TransformCompiler = {
       }
       return {[range]: signals[sg] = sg};
     };
+
+    // If no explicit encodings are specified, set some defaults.
+    // If an initial value is set, try to infer projections for more concise specification.
+    // Otherwise, use the default configuration.
+    if (!selDef.fields && !selDef.encodings) {
+      const cfg = model.config.selection[selDef.type];
+
+      if (selDef.init) {
+        for (const key of keys(selDef.init)) {
+          if (isSingleDefUnitChannel(key)) {
+            (selDef.encodings || (selDef.encodings = [])).push(key as SingleDefUnitChannel);
+          } else {
+            if (isIntervalSelection(selDef)) {
+              log.warn('Interval selections should be initialized using "x" and/or "y" keys.');
+              selDef.encodings = cfg.encodings;
+            } else {
+              (selDef.fields || (selDef.fields = [])).push(key);
+            }
+          }
+        }
+      } else {
+        selDef.encodings = cfg.encodings;
+        selDef.fields = cfg.fields;
+      }
+    }
 
     // TODO: find a possible channel mapping for these fields.
     for (const field of selDef.fields || []) {

--- a/src/compile/selection/transforms/project.ts
+++ b/src/compile/selection/transforms/project.ts
@@ -55,8 +55,8 @@ const project: TransformCompiler = {
       return {[range]: signals[sg] = sg};
     };
 
-    // If no explicit encodings are specified, set some defaults.
-    // If an initial value is set, try to infer projections for more concise specification.
+    // If no explicit projection (either fields or encodings) is specified, set some defaults.
+    // If an initial value is set, try to infer projections.
     // Otherwise, use the default configuration.
     if (!selDef.fields && !selDef.encodings) {
       const cfg = model.config.selection[selDef.type];

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,5 +1,5 @@
 import {Binding} from 'vega';
-import {SingleDefChannel} from './channel';
+import {SingleDefUnitChannel} from './channel';
 import {DateTime} from './datetime';
 import {EventStream} from './vega.schema';
 
@@ -41,7 +41,7 @@ export interface BaseSelectionDef {
    * An array of encoding channels. The corresponding data field values
    * must match for a data tuple to fall within the selection.
    */
-  encodings?: SingleDefChannel[];
+  encodings?: SingleDefUnitChannel[];
 
   /**
    * An array of field names whose values must match for a data tuple to

--- a/test/compile/selection/parse.test.ts
+++ b/test/compile/selection/parse.test.ts
@@ -261,5 +261,29 @@ describe('Selection', () => {
         ])
       );
     });
+
+    it('infers from initial values', () => {
+      const component = parseUnitSelection(model, {
+        one: {type: 'single', init: {Origin: 5}},
+        two: {type: 'multi', init: {color: 10}},
+        three: {type: 'interval', init: {x: [10, 100]}}
+      });
+
+      expect<SelectionProjectionComponent>(component['one'].project).toEqual(
+        expect.arrayContaining([{field: 'Origin', type: 'E', signals: {data: 'one_Origin'}}])
+      );
+
+      expect<SelectionProjectionComponent>(component['two'].project).toEqual(
+        expect.arrayContaining([
+          {channel: 'color', field: 'Origin', type: 'E', signals: {data: 'two_Origin', visual: 'two_color'}}
+        ])
+      );
+
+      expect<SelectionProjectionComponent>(component['three'].project).toEqual(
+        expect.arrayContaining([
+          {field: 'Horsepower', channel: 'x', type: 'R', signals: {data: 'three_Horsepower', visual: 'three_x'}}
+        ])
+      );
+    });
   });
 });


### PR DESCRIPTION
Addresses #4575. If no explicit projection is provided for a selection, it first looks to the initial value and _then_ uses the default configuration values. As before, the initial value first attempts to interpret initial value keys as encoding channels, and then as field names.