### PR TITLE
 Throw an error when we import node util or vega

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,17 @@ import json from 'rollup-plugin-json';
 import nodeResolve from 'rollup-plugin-node-resolve';
 import sourcemaps from 'rollup-plugin-sourcemaps';
 
+export function disallowedImports() {
+  return {
+    resolveId: module => {
+      if (module === 'vega' || module === 'util') {
+        throw new Error('Cannot import from Vega or Node Util in Vega-Lite.');
+      }
+      return null;
+    }
+  };
+}
+
 export default {
   input: 'build/src/index.js',
   output: {
@@ -11,5 +22,5 @@ export default {
     sourcemap: true,
     name: 'vl'
   },
-  plugins: [nodeResolve({browser: true}), commonjs(), json(), sourcemaps()]
+  plugins: [disallowedImports(), nodeResolve({browser: true}), commonjs(), json(), sourcemaps()]
 };


### PR DESCRIPTION
This makes sure #4679 and #4683 never happen again. 