### PR TITLE
Add `order` to mark definition and mark config

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -219,6 +219,13 @@
           "minimum": 0,
           "type": "number"
         },
+        "order": {
+          "description": "For line and trail marks, this `order` property can be set to `null` or `false` to make the lines use the original order in the data sources.",
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
         "orient": {
           "$ref": "#/definitions/Orientation",
           "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line and trail marks, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
@@ -1089,6 +1096,13 @@
           "maximum": 1,
           "minimum": 0,
           "type": "number"
+        },
+        "order": {
+          "description": "For line and trail marks, this `order` property can be set to `null` or `false` to make the lines use the original order in the data sources.",
+          "type": [
+            "null",
+            "boolean"
+          ]
         },
         "orient": {
           "$ref": "#/definitions/Orientation",
@@ -7561,6 +7575,13 @@
           "minimum": 0,
           "type": "number"
         },
+        "order": {
+          "description": "For line and trail marks, this `order` property can be set to `null` or `false` to make the lines use the original order in the data sources.",
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
         "orient": {
           "$ref": "#/definitions/Orientation",
           "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line and trail marks, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
@@ -8003,6 +8024,13 @@
           "minimum": 0,
           "type": "number"
         },
+        "order": {
+          "description": "For line and trail marks, this `order` property can be set to `null` or `false` to make the lines use the original order in the data sources.",
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
         "orient": {
           "$ref": "#/definitions/Orientation",
           "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line and trail marks, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
@@ -8219,6 +8247,13 @@
           "maximum": 1,
           "minimum": 0,
           "type": "number"
+        },
+        "order": {
+          "description": "For line and trail marks, this `order` property can be set to `null` or `false` to make the lines use the original order in the data sources.",
+          "type": [
+            "null",
+            "boolean"
+          ]
         },
         "orient": {
           "$ref": "#/definitions/Orientation",
@@ -8732,6 +8767,13 @@
           "maximum": 1,
           "minimum": 0,
           "type": "number"
+        },
+        "order": {
+          "description": "For line and trail marks, this `order` property can be set to `null` or `false` to make the lines use the original order in the data sources.",
+          "type": [
+            "null",
+            "boolean"
+          ]
         },
         "orient": {
           "$ref": "#/definitions/Orientation",
@@ -10701,6 +10743,13 @@
           "minimum": 0,
           "type": "number"
         },
+        "order": {
+          "description": "For line and trail marks, this `order` property can be set to `null` or `false` to make the lines use the original order in the data sources.",
+          "type": [
+            "null",
+            "boolean"
+          ]
+        },
         "orient": {
           "$ref": "#/definitions/Orientation",
           "description": "The orientation of a non-stacked bar, tick, area, and line charts.\nThe value is either horizontal (default) or vertical.\n- For bar, rule and tick, this determines whether the size of the bar and tick\nshould be applied to x or y dimension.\n- For area, this property determines the orient property of the Vega output.\n- For line and trail marks, this property determines the sort order of the points in the line\nif `config.sortLineBy` is not specified.\nFor stacked charts, this is always determined by the orientation of the stack;\ntherefore explicitly specified value will be ignored."
@@ -10968,6 +11017,13 @@
           "maximum": 1,
           "minimum": 0,
           "type": "number"
+        },
+        "order": {
+          "description": "For line and trail marks, this `order` property can be set to `null` or `false` to make the lines use the original order in the data sources.",
+          "type": [
+            "null",
+            "boolean"
+          ]
         },
         "orient": {
           "$ref": "#/definitions/Orientation",

--- a/site/docs/mark/mark.md
+++ b/site/docs/mark/mark.md
@@ -63,7 +63,7 @@ Note: If [mark property encoding channels](encoding.html#mark-prop) are specifie
 
 ### General Mark Properties
 
-{% include table.html props="type,style,clip" source="MarkDef" %}
+{% include table.html props="type,style,clip,order" source="MarkDef" %}
 
 {:#offset}
 

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -4,9 +4,9 @@ import {Encoding, isAggregate} from '../../encoding';
 import {getTypedFieldDef, isFieldDef, isValueDef, vgField} from '../../fielddef';
 import {AREA, isPathMark, LINE, Mark, TRAIL} from '../../mark';
 import {isSortField} from '../../sort';
-import {contains, getFirstDefined, keys} from '../../util';
+import {contains, getFirstDefined, isNullOrFalse, keys} from '../../util';
 import {VgCompare} from '../../vega.schema';
-import {getStyles, sortParams} from '../common';
+import {getMarkConfig, getStyles, sortParams} from '../common';
 import {UnitModel} from '../unit';
 import {area} from './area';
 import {bar} from './bar';
@@ -82,9 +82,12 @@ function parsePathMark(model: UnitModel) {
 }
 
 export function getSort(model: UnitModel): VgCompare {
-  const {encoding, stack, mark, markDef} = model;
+  const {encoding, stack, mark, markDef, config} = model;
   const order = encoding.order;
-  if (!isArray(order) && isValueDef(order)) {
+  if (
+    (!isArray(order) && isValueDef(order) && isNullOrFalse(order.value)) ||
+    ((!order && isNullOrFalse(markDef.order)) || isNullOrFalse(getMarkConfig('order', markDef, config)))
+  ) {
     return undefined;
   } else if ((isArray(order) || isFieldDef(order)) && !stack) {
     // Sort by the order field if it is specified and the field is not stacked. (For stacked field, order specify stack order.)

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -125,6 +125,11 @@ export interface MarkConfig extends ColorMixins, BaseMarkConfig {
    * @minimum 0
    */
   size?: number;
+
+  /**
+   * For line and trail marks, this `order` property can be set to `null` or `false` to make the lines use the original order in the data sources.
+   */
+  order?: null | boolean;
 }
 
 export interface BarBinSpacingMixins {

--- a/src/util.ts
+++ b/src/util.ts
@@ -74,6 +74,10 @@ export function hash(a: any): string | number {
   return h;
 }
 
+export function isNullOrFalse(x: any): x is false | null {
+  return x === false || x === null;
+}
+
 export function contains<T>(array: T[], item: T) {
   return array.indexOf(item) > -1;
 }


### PR DESCRIPTION
cc: @manzt 

Now 

```
mark: {type: 'line', order: null}
```

should work in addition to 

```
{
  encoding: {
    ...,
    order: {value: null}
  }
}
```