### PR TITLE
Add config.axisX/Y.orient

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -530,7 +530,7 @@
         },
         "orient": {
           "$ref": "#/definitions/AxisOrient",
-          "description": "The orientation of the axis. One of `\"top\"`, `\"bottom\"`, `\"left\"` or `\"right\"`. The orientation can be used to further specialize the axis type (e.g., a y axis oriented for the right edge of the chart).\n\n__Default value:__ `\"bottom\"` for x-axes and `\"left\"` for y-axes."
+          "description": "The orientation of the axis. One of `\"top\"`, `\"bottom\"`, `\"left\"` or `\"right\"`. The orientation can be used to further specialize the axis type (e.g., a y-axis oriented for the right edge of the chart).\n\n__Default value:__ `\"bottom\"` for x-axes and `\"left\"` for y-axes."
         },
         "position": {
           "description": "The anchor position of the axis in pixels. For x-axes with top or bottom orientation, this sets the axis group x coordinate. For y-axes with left or right orientation, this sets the axis group y coordinate.\n\n__Default value__: `0`",
@@ -839,6 +839,10 @@
         "minExtent": {
           "description": "The minimum extent in pixels that axis ticks and labels should use. This determines a minimum offset value for axis titles.\n\n__Default value:__ `30` for y-axis; `undefined` for x-axis.",
           "type": "number"
+        },
+        "orient": {
+          "$ref": "#/definitions/AxisOrient",
+          "description": "The orientation of the axis. One of `\"top\"`, `\"bottom\"`, `\"left\"` or `\"right\"`. The orientation can be used to further specialize the axis type (e.g., a y-axis oriented for the right edge of the chart).\n\n__Default value:__ `\"bottom\"` for x-axes and `\"left\"` for y-axes."
         },
         "shortTimeLabels": {
           "description": "Whether month names and weekday names should be abbreviated.\n\n__Default value:__  `false`",

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -530,7 +530,7 @@
         },
         "orient": {
           "$ref": "#/definitions/AxisOrient",
-          "description": "The orientation of the axis. One of `\"top\"`, `\"bottom\"`, `\"left\"` or `\"right\"`. The orientation can be used to further specialize the axis type (e.g., a y-axis oriented for the right edge of the chart).\n\n__Default value:__ `\"bottom\"` for x-axes and `\"left\"` for y-axes."
+          "description": "The orientation of the axis. One of `\"top\"`, `\"bottom\"`, `\"left\"` or `\"right\"`. The orientation can be used to further specialize the axis type (e.g., a y-axis oriented towards the right edge of the chart).\n\n__Default value:__ `\"bottom\"` for x-axes and `\"left\"` for y-axes."
         },
         "position": {
           "description": "The anchor position of the axis in pixels. For x-axes with top or bottom orientation, this sets the axis group x coordinate. For y-axes with left or right orientation, this sets the axis group y coordinate.\n\n__Default value__: `0`",
@@ -842,7 +842,7 @@
         },
         "orient": {
           "$ref": "#/definitions/AxisOrient",
-          "description": "The orientation of the axis. One of `\"top\"`, `\"bottom\"`, `\"left\"` or `\"right\"`. The orientation can be used to further specialize the axis type (e.g., a y-axis oriented for the right edge of the chart).\n\n__Default value:__ `\"bottom\"` for x-axes and `\"left\"` for y-axes."
+          "description": "The orientation of the axis. One of `\"top\"`, `\"bottom\"`, `\"left\"` or `\"right\"`. The orientation can be used to further specialize the axis type (e.g., a y-axis oriented towards the right edge of the chart).\n\n__Default value:__ `\"bottom\"` for x-axes and `\"left\"` for y-axes."
         },
         "shortTimeLabels": {
           "description": "Whether month names and weekday names should be abbreviated.\n\n__Default value:__  `false`",

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -59,16 +59,18 @@ interface AxisMixins {
   labelOverlap?: LabelOverlap;
 }
 
-export type AxisConfig = VgAxisConfigNoSignals & VlOnlyGuideConfig;
-
-export interface Axis extends BaseAxisNoSignals, Guide {
+export interface AxisOrientMixins {
   /**
-   * The orientation of the axis. One of `"top"`, `"bottom"`, `"left"` or `"right"`. The orientation can be used to further specialize the axis type (e.g., a y axis oriented for the right edge of the chart).
+   * The orientation of the axis. One of `"top"`, `"bottom"`, `"left"` or `"right"`. The orientation can be used to further specialize the axis type (e.g., a y-axis oriented for the right edge of the chart).
    *
    * __Default value:__ `"bottom"` for x-axes and `"left"` for y-axes.
    */
   orient?: AxisOrient;
+}
 
+export type AxisConfig = VgAxisConfigNoSignals & VlOnlyGuideConfig & AxisOrientMixins;
+
+export interface Axis extends AxisOrientMixins, BaseAxisNoSignals, Guide {
   /**
    * The offset, in pixels, by which to displace the axis from the edge of the enclosing group or data rectangle.
    *

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -61,7 +61,7 @@ interface AxisMixins {
 
 export interface AxisOrientMixins {
   /**
-   * The orientation of the axis. One of `"top"`, `"bottom"`, `"left"` or `"right"`. The orientation can be used to further specialize the axis type (e.g., a y-axis oriented for the right edge of the chart).
+   * The orientation of the axis. One of `"top"`, `"bottom"`, `"left"` or `"right"`. The orientation can be used to further specialize the axis type (e.g., a y-axis oriented towards the right edge of the chart).
    *
    * __Default value:__ `"bottom"` for x-axes and `"left"` for y-axes.
    */

--- a/src/compile/axis/config.ts
+++ b/src/compile/axis/config.ts
@@ -6,15 +6,18 @@ export function getAxisConfig(
   property: string,
   config: Config,
   channel: PositionScaleChannel,
-  orient: string = '',
+  orient: string,
   scaleType: ScaleType
 ) {
   // configTypes to loop, starting from higher precedence
-  const configTypes = (scaleType === 'band' ? ['axisBand'] : []).concat([
+  const configTypes = [
+    ...(scaleType === 'band' ? ['axisBand'] : []),
     channel === 'x' ? 'axisX' : 'axisY',
-    'axis' + orient.substr(0, 1).toUpperCase() + orient.substr(1), // axisTop, axisBottom, ...
+
+    // axisTop, axisBottom, ...
+    ...(orient ? ['axis' + orient.substr(0, 1).toUpperCase() + orient.substr(1)] : []),
     'axis'
-  ]);
+  ];
   for (const configType of configTypes) {
     if (config[configType] && config[configType][property] !== undefined) {
       return config[configType][property];

--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -3,7 +3,7 @@ import {Axis, AXIS_PARTS, isAxisProperty, VG_AXIS_PROPERTIES} from '../../axis';
 import {isBinned} from '../../bin';
 import {POSITION_SCALE_CHANNELS, PositionScaleChannel, X, Y} from '../../channel';
 import {FieldDefBase, toFieldDefBase} from '../../fielddef';
-import {getFirstDefined, keys, normalizeAngle} from '../../util';
+import {contains, getFirstDefined, keys, normalizeAngle} from '../../util';
 import {mergeTitle, mergeTitleComponent, mergeTitleFieldDefs, numberFormat} from '../common';
 import {guideEncodeEntry} from '../guide';
 import {LayerModel} from '../layer';
@@ -241,8 +241,9 @@ function parseAxis(channel: PositionScaleChannel, model: UnitModel): AxisCompone
       if (explicit || configValue === undefined) {
         // Do not apply implicit rule if there is a config value
         axisComponent.set(property, value, explicit);
-      } else if (property === 'grid' && configValue) {
-        // Grid is an exception because we need to set grid = true to generate another grid axis
+      } else if (contains(['grid', 'orient'], property) && configValue) {
+        // - Grid is an exception because we need to set grid = true to generate another grid axis
+        // - Orient is not an axis config in Vega, so we need to set too.
         axisComponent.set(property, configValue, false);
       }
     }


### PR DESCRIPTION
Note that I don't distinguish types for config.axis from config.axisX/Y even though orient doesn't make sense for the general axis because I don't want to make the schema too complicated, which in turn will make Altair APIs too complicated.

Also refactor getAxisConfig to use `...`. 

Fix #4648

cc: @evschen -- I was fixing similar things in header and found that this is quite easy for me to fix so I went ahead and fix it to save your time.

![image](https://user-images.githubusercontent.com/111269/54076522-7b55eb00-4261-11e9-9d63-b987c4d3a849.png)


