### PR TITLE
Fix typo in docstring

### DIFF
--- a/site/docs/composition/facet.md
+++ b/site/docs/composition/facet.md
@@ -115,7 +115,7 @@ Under the hood, Vega-Lite translates this spec with `"facet"` channel to the mor
 
 The default [resolutions](resolve.html) for row/column facet are shared scales, axes, and legends.
 
-To override this behavior, tou can set `resolve` to `"independent"`:
+To override this behavior, you can set `resolve` to `"independent"`:
 
 <span class="vl-example" data-name="trellis_barley_independent"></span>
 

--- a/site/docs/composition/facet.md
+++ b/site/docs/composition/facet.md
@@ -115,7 +115,7 @@ Under the hood, Vega-Lite translates this spec with `"facet"` channel to the mor
 
 The default [resolutions](resolve.html) for row/column facet are shared scales, axes, and legends.
 
-To overrride this behavior, tou can set `resolve` to `"independent"`:
+To override this behavior, tou can set `resolve` to `"independent"`:
 
 <span class="vl-example" data-name="trellis_barley_independent"></span>
 


### PR DESCRIPTION
`s/overrride/override/g`
`s/tou/you/g`