### PR TITLE
Fix interval scale_triggers to only register dependencies on scales.

### DIFF
--- a/examples/compiled/brush_table.vg.json
+++ b/examples/compiled/brush_table.vg.json
@@ -195,7 +195,13 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Horsepower) || (+invert(\"concat_0_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"concat_0_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"concat_0_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"concat_0_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "concat_0_x"}, {"scale": "concat_0_y"}],
+              "update": "(!isArray(brush_Horsepower) || (+invert(\"concat_0_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"concat_0_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"concat_0_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"concat_0_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",

--- a/examples/compiled/interactive_area_brush.vg.json
+++ b/examples/compiled/interactive_area_brush.vg.json
@@ -119,7 +119,13 @@
     },
     {
       "name": "brush_scale_trigger",
-      "update": "(!isArray(brush_yearmonth_date) || (+invert(\"x\", brush_x)[0] === +brush_yearmonth_date[0] && +invert(\"x\", brush_x)[1] === +brush_yearmonth_date[1])) ? brush_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}],
+          "update": "(!isArray(brush_yearmonth_date) || (+invert(\"x\", brush_x)[0] === +brush_yearmonth_date[0] && +invert(\"x\", brush_x)[1] === +brush_yearmonth_date[1])) ? brush_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "brush_tuple",

--- a/examples/compiled/interactive_brush.vg.json
+++ b/examples/compiled/interactive_brush.vg.json
@@ -133,7 +133,13 @@
     },
     {
       "name": "brush_scale_trigger",
-      "update": "(!isArray(brush_Horsepower) || (+invert(\"x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(brush_Horsepower) || (+invert(\"x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "brush_tuple",

--- a/examples/compiled/interactive_dashboard_europe_pop.vg.json
+++ b/examples/compiled/interactive_dashboard_europe_pop.vg.json
@@ -393,7 +393,13 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Country) || (invert(\"concat_0_y\", brush_y)[0] === brush_Country[0] && invert(\"concat_0_y\", brush_y)[1] === brush_Country[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "concat_0_y"}],
+              "update": "(!isArray(brush_Country) || (invert(\"concat_0_y\", brush_y)[0] === brush_Country[0] && invert(\"concat_0_y\", brush_y)[1] === brush_Country[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -701,7 +707,13 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Country) || (invert(\"concat_1_y\", brush_y)[0] === brush_Country[0] && invert(\"concat_1_y\", brush_y)[1] === brush_Country[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "concat_1_y"}],
+              "update": "(!isArray(brush_Country) || (invert(\"concat_1_y\", brush_y)[0] === brush_Country[0] && invert(\"concat_1_y\", brush_y)[1] === brush_Country[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -1067,7 +1079,13 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Population_ages_65_and_above_of_total) || (+invert(\"concat_2_x\", brush_x)[0] === +brush_Population_ages_65_and_above_of_total[0] && +invert(\"concat_2_x\", brush_x)[1] === +brush_Population_ages_65_and_above_of_total[1])) && (!isArray(brush_Population_ages_15_64_of_total) || (+invert(\"concat_2_y\", brush_y)[0] === +brush_Population_ages_15_64_of_total[0] && +invert(\"concat_2_y\", brush_y)[1] === +brush_Population_ages_15_64_of_total[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "concat_2_x"}, {"scale": "concat_2_y"}],
+              "update": "(!isArray(brush_Population_ages_65_and_above_of_total) || (+invert(\"concat_2_x\", brush_x)[0] === +brush_Population_ages_65_and_above_of_total[0] && +invert(\"concat_2_x\", brush_x)[1] === +brush_Population_ages_65_and_above_of_total[1])) && (!isArray(brush_Population_ages_15_64_of_total) || (+invert(\"concat_2_y\", brush_y)[0] === +brush_Population_ages_15_64_of_total[0] && +invert(\"concat_2_y\", brush_y)[1] === +brush_Population_ages_15_64_of_total[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",

--- a/examples/compiled/interactive_layered_crossfilter.vg.json
+++ b/examples/compiled/interactive_layered_crossfilter.vg.json
@@ -235,7 +235,13 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_distance) || (+invert(\"child__repeat_column_distance_x\", brush_x)[0] === +brush_distance[0] && +invert(\"child__repeat_column_distance_x\", brush_x)[1] === +brush_distance[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "child__repeat_column_distance_x"}],
+              "update": "(!isArray(brush_distance) || (+invert(\"child__repeat_column_distance_x\", brush_x)[0] === +brush_distance[0] && +invert(\"child__repeat_column_distance_x\", brush_x)[1] === +brush_distance[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -605,7 +611,13 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_delay) || (+invert(\"child__repeat_column_delay_x\", brush_x)[0] === +brush_delay[0] && +invert(\"child__repeat_column_delay_x\", brush_x)[1] === +brush_delay[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "child__repeat_column_delay_x"}],
+              "update": "(!isArray(brush_delay) || (+invert(\"child__repeat_column_delay_x\", brush_x)[0] === +brush_delay[0] && +invert(\"child__repeat_column_delay_x\", brush_x)[1] === +brush_delay[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -975,7 +987,13 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_time) || (+invert(\"child__repeat_column_time_x\", brush_x)[0] === +brush_time[0] && +invert(\"child__repeat_column_time_x\", brush_x)[1] === +brush_time[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "child__repeat_column_time_x"}],
+              "update": "(!isArray(brush_time) || (+invert(\"child__repeat_column_time_x\", brush_x)[0] === +brush_time[0] && +invert(\"child__repeat_column_time_x\", brush_x)[1] === +brush_time[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",

--- a/examples/compiled/interactive_overview_detail.vg.json
+++ b/examples/compiled/interactive_overview_detail.vg.json
@@ -175,7 +175,13 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_date) || (+invert(\"concat_1_x\", brush_x)[0] === +brush_date[0] && +invert(\"concat_1_x\", brush_x)[1] === +brush_date[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "concat_1_x"}],
+              "update": "(!isArray(brush_date) || (+invert(\"concat_1_x\", brush_x)[0] === +brush_date[0] && +invert(\"concat_1_x\", brush_x)[1] === +brush_date[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",

--- a/examples/compiled/interactive_paintbrush_interval.vg.json
+++ b/examples/compiled/interactive_paintbrush_interval.vg.json
@@ -134,7 +134,13 @@
     },
     {
       "name": "paintbrush_scale_trigger",
-      "update": "(!isArray(paintbrush_Horsepower) || (+invert(\"x\", paintbrush_x)[0] === +paintbrush_Horsepower[0] && +invert(\"x\", paintbrush_x)[1] === +paintbrush_Horsepower[1])) && (!isArray(paintbrush_Miles_per_Gallon) || (+invert(\"y\", paintbrush_y)[0] === +paintbrush_Miles_per_Gallon[0] && +invert(\"y\", paintbrush_y)[1] === +paintbrush_Miles_per_Gallon[1])) ? paintbrush_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(paintbrush_Horsepower) || (+invert(\"x\", paintbrush_x)[0] === +paintbrush_Horsepower[0] && +invert(\"x\", paintbrush_x)[1] === +paintbrush_Horsepower[1])) && (!isArray(paintbrush_Miles_per_Gallon) || (+invert(\"y\", paintbrush_y)[0] === +paintbrush_Miles_per_Gallon[0] && +invert(\"y\", paintbrush_y)[1] === +paintbrush_Miles_per_Gallon[1])) ? paintbrush_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "paintbrush_tuple",

--- a/examples/compiled/interactive_seattle_weather.vg.json
+++ b/examples/compiled/interactive_seattle_weather.vg.json
@@ -138,7 +138,13 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_monthdate_date) || (+invert(\"concat_0_x\", brush_x)[0] === +brush_monthdate_date[0] && +invert(\"concat_0_x\", brush_x)[1] === +brush_monthdate_date[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "concat_0_x"}],
+              "update": "(!isArray(brush_monthdate_date) || (+invert(\"concat_0_x\", brush_x)[0] === +brush_monthdate_date[0] && +invert(\"concat_0_x\", brush_x)[1] === +brush_monthdate_date[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",

--- a/examples/compiled/interactive_splom.vg.json
+++ b/examples/compiled/interactive_splom.vg.json
@@ -155,7 +155,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x"
+                },
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y"
+                }
+              ],
+              "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -635,7 +648,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) && (!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Acceleration_x"
+                },
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Acceleration_y"
+                }
+              ],
+              "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) && (!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -1054,7 +1080,17 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Horsepower_x"
+                }
+              ],
+              "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -1507,7 +1543,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y\", brush_y)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y\", brush_y)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x"
+                },
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y"
+                }
+              ],
+              "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y\", brush_y)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y\", brush_y)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -1930,7 +1979,17 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Acceleration_x"
+                }
+              ],
+              "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -2383,7 +2442,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_y\", brush_y)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_y\", brush_y)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Horsepower_x"
+                },
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Horsepower_y"
+                }
+              ],
+              "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_y\", brush_y)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_y\", brush_y)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -2802,7 +2874,17 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x"
+                }
+              ],
+              "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -3255,7 +3337,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x"
+                },
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y"
+                }
+              ],
+              "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -3735,7 +3830,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x"
+                },
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y"
+                }
+              ],
+              "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",

--- a/examples/compiled/isotype_grid.vg.json
+++ b/examples/compiled/isotype_grid.vg.json
@@ -236,7 +236,13 @@
     },
     {
       "name": "highlight_scale_trigger",
-      "update": "(!isArray(highlight_col) || (invert(\"x\", highlight_x)[0] === highlight_col[0] && invert(\"x\", highlight_x)[1] === highlight_col[1])) && (!isArray(highlight_row) || (invert(\"y\", highlight_y)[0] === highlight_row[0] && invert(\"y\", highlight_y)[1] === highlight_row[1])) ? highlight_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(highlight_col) || (invert(\"x\", highlight_x)[0] === highlight_col[0] && invert(\"x\", highlight_x)[1] === highlight_col[1])) && (!isArray(highlight_row) || (invert(\"y\", highlight_y)[0] === highlight_row[0] && invert(\"y\", highlight_y)[1] === highlight_row[1])) ? highlight_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "highlight_tuple",

--- a/examples/compiled/selection_brush_timeunit.vg.json
+++ b/examples/compiled/selection_brush_timeunit.vg.json
@@ -125,7 +125,13 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_seconds_date) || (+invert(\"concat_0_x\", brush_x)[0] === +brush_seconds_date[0] && +invert(\"concat_0_x\", brush_x)[1] === +brush_seconds_date[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "concat_0_x"}],
+              "update": "(!isArray(brush_seconds_date) || (+invert(\"concat_0_x\", brush_x)[0] === +brush_seconds_date[0] && +invert(\"concat_0_x\", brush_x)[1] === +brush_seconds_date[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",

--- a/examples/compiled/selection_composition_and.vg.json
+++ b/examples/compiled/selection_composition_and.vg.json
@@ -146,7 +146,13 @@
     },
     {
       "name": "alex_scale_trigger",
-      "update": "(!isArray(alex_Cylinders) || (invert(\"x\", alex_x)[0] === alex_Cylinders[0] && invert(\"x\", alex_x)[1] === alex_Cylinders[1])) && (!isArray(alex_Origin) || (invert(\"y\", alex_y)[0] === alex_Origin[0] && invert(\"y\", alex_y)[1] === alex_Origin[1])) ? alex_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(alex_Cylinders) || (invert(\"x\", alex_x)[0] === alex_Cylinders[0] && invert(\"x\", alex_x)[1] === alex_Cylinders[1])) && (!isArray(alex_Origin) || (invert(\"y\", alex_y)[0] === alex_Origin[0] && invert(\"y\", alex_y)[1] === alex_Origin[1])) ? alex_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "alex_tuple",
@@ -350,7 +356,13 @@
     },
     {
       "name": "morgan_scale_trigger",
-      "update": "(!isArray(morgan_Cylinders) || (invert(\"x\", morgan_x)[0] === morgan_Cylinders[0] && invert(\"x\", morgan_x)[1] === morgan_Cylinders[1])) && (!isArray(morgan_Origin) || (invert(\"y\", morgan_y)[0] === morgan_Origin[0] && invert(\"y\", morgan_y)[1] === morgan_Origin[1])) ? morgan_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(morgan_Cylinders) || (invert(\"x\", morgan_x)[0] === morgan_Cylinders[0] && invert(\"x\", morgan_x)[1] === morgan_Cylinders[1])) && (!isArray(morgan_Origin) || (invert(\"y\", morgan_y)[0] === morgan_Origin[0] && invert(\"y\", morgan_y)[1] === morgan_Origin[1])) ? morgan_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "morgan_tuple",

--- a/examples/compiled/selection_composition_or.vg.json
+++ b/examples/compiled/selection_composition_or.vg.json
@@ -146,7 +146,13 @@
     },
     {
       "name": "alex_scale_trigger",
-      "update": "(!isArray(alex_Cylinders) || (invert(\"x\", alex_x)[0] === alex_Cylinders[0] && invert(\"x\", alex_x)[1] === alex_Cylinders[1])) && (!isArray(alex_Origin) || (invert(\"y\", alex_y)[0] === alex_Origin[0] && invert(\"y\", alex_y)[1] === alex_Origin[1])) ? alex_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(alex_Cylinders) || (invert(\"x\", alex_x)[0] === alex_Cylinders[0] && invert(\"x\", alex_x)[1] === alex_Cylinders[1])) && (!isArray(alex_Origin) || (invert(\"y\", alex_y)[0] === alex_Origin[0] && invert(\"y\", alex_y)[1] === alex_Origin[1])) ? alex_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "alex_tuple",
@@ -350,7 +356,13 @@
     },
     {
       "name": "morgan_scale_trigger",
-      "update": "(!isArray(morgan_Cylinders) || (invert(\"x\", morgan_x)[0] === morgan_Cylinders[0] && invert(\"x\", morgan_x)[1] === morgan_Cylinders[1])) && (!isArray(morgan_Origin) || (invert(\"y\", morgan_y)[0] === morgan_Origin[0] && invert(\"y\", morgan_y)[1] === morgan_Origin[1])) ? morgan_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(morgan_Cylinders) || (invert(\"x\", morgan_x)[0] === morgan_Cylinders[0] && invert(\"x\", morgan_x)[1] === morgan_Cylinders[1])) && (!isArray(morgan_Origin) || (invert(\"y\", morgan_y)[0] === morgan_Origin[0] && invert(\"y\", morgan_y)[1] === morgan_Origin[1])) ? morgan_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "morgan_tuple",

--- a/examples/compiled/selection_concat.vg.json
+++ b/examples/compiled/selection_concat.vg.json
@@ -151,7 +151,13 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"concat_0_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"concat_0_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Horsepower) || (+invert(\"concat_0_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"concat_0_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "concat_0_x"}, {"scale": "concat_0_y"}],
+              "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"concat_0_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"concat_0_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Horsepower) || (+invert(\"concat_0_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"concat_0_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",

--- a/examples/compiled/selection_filter.vg.json
+++ b/examples/compiled/selection_filter.vg.json
@@ -154,7 +154,13 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Horsepower) || (+invert(\"concat_0_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"concat_0_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"concat_0_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"concat_0_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "concat_0_x"}, {"scale": "concat_0_y"}],
+              "update": "(!isArray(brush_Horsepower) || (+invert(\"concat_0_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"concat_0_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"concat_0_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"concat_0_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",

--- a/examples/compiled/selection_filter_composition.vg.json
+++ b/examples/compiled/selection_filter_composition.vg.json
@@ -154,7 +154,13 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Horsepower) || (+invert(\"concat_0_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"concat_0_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"concat_0_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"concat_0_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "concat_0_x"}, {"scale": "concat_0_y"}],
+              "update": "(!isArray(brush_Horsepower) || (+invert(\"concat_0_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"concat_0_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"concat_0_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"concat_0_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",

--- a/examples/compiled/selection_interval_mark_style.vg.json
+++ b/examples/compiled/selection_interval_mark_style.vg.json
@@ -146,7 +146,13 @@
     },
     {
       "name": "alex_scale_trigger",
-      "update": "(!isArray(alex_Cylinders) || (invert(\"x\", alex_x)[0] === alex_Cylinders[0] && invert(\"x\", alex_x)[1] === alex_Cylinders[1])) && (!isArray(alex_Origin) || (invert(\"y\", alex_y)[0] === alex_Origin[0] && invert(\"y\", alex_y)[1] === alex_Origin[1])) ? alex_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(alex_Cylinders) || (invert(\"x\", alex_x)[0] === alex_Cylinders[0] && invert(\"x\", alex_x)[1] === alex_Cylinders[1])) && (!isArray(alex_Origin) || (invert(\"y\", alex_y)[0] === alex_Origin[0] && invert(\"y\", alex_y)[1] === alex_Origin[1])) ? alex_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "alex_tuple",
@@ -350,7 +356,13 @@
     },
     {
       "name": "morgan_scale_trigger",
-      "update": "(!isArray(morgan_Cylinders) || (invert(\"x\", morgan_x)[0] === morgan_Cylinders[0] && invert(\"x\", morgan_x)[1] === morgan_Cylinders[1])) && (!isArray(morgan_Origin) || (invert(\"y\", morgan_y)[0] === morgan_Origin[0] && invert(\"y\", morgan_y)[1] === morgan_Origin[1])) ? morgan_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(morgan_Cylinders) || (invert(\"x\", morgan_x)[0] === morgan_Cylinders[0] && invert(\"x\", morgan_x)[1] === morgan_Cylinders[1])) && (!isArray(morgan_Origin) || (invert(\"y\", morgan_y)[0] === morgan_Origin[0] && invert(\"y\", morgan_y)[1] === morgan_Origin[1])) ? morgan_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "morgan_tuple",

--- a/examples/compiled/selection_layer_bar_month.vg.json
+++ b/examples/compiled/selection_layer_bar_month.vg.json
@@ -121,7 +121,13 @@
     },
     {
       "name": "brush_scale_trigger",
-      "update": "(!isArray(brush_month_date) || (invert(\"x\", brush_x)[0] === brush_month_date[0] && invert(\"x\", brush_x)[1] === brush_month_date[1])) ? brush_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}],
+          "update": "(!isArray(brush_month_date) || (invert(\"x\", brush_x)[0] === brush_month_date[0] && invert(\"x\", brush_x)[1] === brush_month_date[1])) ? brush_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "brush_tuple",

--- a/examples/compiled/selection_multi_condition.vg.json
+++ b/examples/compiled/selection_multi_condition.vg.json
@@ -141,7 +141,13 @@
     },
     {
       "name": "brush_scale_trigger",
-      "update": "(!isArray(brush_Horsepower) || (+invert(\"x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(brush_Horsepower) || (+invert(\"x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "brush_tuple",

--- a/examples/compiled/selection_project_binned_interval.vg.json
+++ b/examples/compiled/selection_project_binned_interval.vg.json
@@ -133,7 +133,13 @@
     },
     {
       "name": "brush_scale_trigger",
-      "update": "(!isArray(brush_Acceleration) || (+invert(\"x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"x\", brush_x)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}],
+          "update": "(!isArray(brush_Acceleration) || (+invert(\"x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"x\", brush_x)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "brush_tuple",

--- a/examples/compiled/selection_project_interval.vg.json
+++ b/examples/compiled/selection_project_interval.vg.json
@@ -138,7 +138,13 @@
     },
     {
       "name": "pts_scale_trigger",
-      "update": "(!isArray(pts_Cylinders) || (invert(\"x\", pts_x)[0] === pts_Cylinders[0] && invert(\"x\", pts_x)[1] === pts_Cylinders[1])) && (!isArray(pts_Origin) || (invert(\"y\", pts_y)[0] === pts_Origin[0] && invert(\"y\", pts_y)[1] === pts_Origin[1])) ? pts_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(pts_Cylinders) || (invert(\"x\", pts_x)[0] === pts_Cylinders[0] && invert(\"x\", pts_x)[1] === pts_Cylinders[1])) && (!isArray(pts_Origin) || (invert(\"y\", pts_y)[0] === pts_Origin[0] && invert(\"y\", pts_y)[1] === pts_Origin[1])) ? pts_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "pts_tuple",

--- a/examples/compiled/selection_project_interval_x.vg.json
+++ b/examples/compiled/selection_project_interval_x.vg.json
@@ -88,7 +88,13 @@
     },
     {
       "name": "pts_scale_trigger",
-      "update": "(!isArray(pts_Cylinders) || (invert(\"x\", pts_x)[0] === pts_Cylinders[0] && invert(\"x\", pts_x)[1] === pts_Cylinders[1])) ? pts_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}],
+          "update": "(!isArray(pts_Cylinders) || (invert(\"x\", pts_x)[0] === pts_Cylinders[0] && invert(\"x\", pts_x)[1] === pts_Cylinders[1])) ? pts_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "pts_tuple",

--- a/examples/compiled/selection_project_interval_x_y.vg.json
+++ b/examples/compiled/selection_project_interval_x_y.vg.json
@@ -138,7 +138,13 @@
     },
     {
       "name": "pts_scale_trigger",
-      "update": "(!isArray(pts_Cylinders) || (invert(\"x\", pts_x)[0] === pts_Cylinders[0] && invert(\"x\", pts_x)[1] === pts_Cylinders[1])) && (!isArray(pts_Origin) || (invert(\"y\", pts_y)[0] === pts_Origin[0] && invert(\"y\", pts_y)[1] === pts_Origin[1])) ? pts_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(pts_Cylinders) || (invert(\"x\", pts_x)[0] === pts_Cylinders[0] && invert(\"x\", pts_x)[1] === pts_Cylinders[1])) && (!isArray(pts_Origin) || (invert(\"y\", pts_y)[0] === pts_Origin[0] && invert(\"y\", pts_y)[1] === pts_Origin[1])) ? pts_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "pts_tuple",

--- a/examples/compiled/selection_project_interval_y.vg.json
+++ b/examples/compiled/selection_project_interval_y.vg.json
@@ -88,7 +88,13 @@
     },
     {
       "name": "pts_scale_trigger",
-      "update": "(!isArray(pts_Origin) || (invert(\"y\", pts_y)[0] === pts_Origin[0] && invert(\"y\", pts_y)[1] === pts_Origin[1])) ? pts_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "y"}],
+          "update": "(!isArray(pts_Origin) || (invert(\"y\", pts_y)[0] === pts_Origin[0] && invert(\"y\", pts_y)[1] === pts_Origin[1])) ? pts_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "pts_tuple",

--- a/examples/compiled/selection_resolution_global.vg.json
+++ b/examples/compiled/selection_resolution_global.vg.json
@@ -140,7 +140,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x"
+                },
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y"
+                }
+              ],
+              "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -535,7 +548,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) && (!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Acceleration_x"
+                },
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Acceleration_y"
+                }
+              ],
+              "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) && (!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -873,7 +899,17 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Horsepower_x"
+                }
+              ],
+              "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -1260,7 +1296,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y\", brush_y)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y\", brush_y)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x"
+                },
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y"
+                }
+              ],
+              "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y\", brush_y)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y\", brush_y)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -1600,7 +1649,17 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Acceleration_x"
+                }
+              ],
+              "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -1987,7 +2046,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_y\", brush_y)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_y\", brush_y)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Horsepower_x"
+                },
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Horsepower_y"
+                }
+              ],
+              "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_y\", brush_y)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_y\", brush_y)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -2325,7 +2397,17 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x"
+                }
+              ],
+              "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -2712,7 +2794,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x"
+                },
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y"
+                }
+              ],
+              "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -3107,7 +3202,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x"
+                },
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y"
+                }
+              ],
+              "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",

--- a/examples/compiled/selection_resolution_intersect.vg.json
+++ b/examples/compiled/selection_resolution_intersect.vg.json
@@ -143,7 +143,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x"
+                },
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y"
+                }
+              ],
+              "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -490,7 +503,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) && (!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Acceleration_x"
+                },
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Acceleration_y"
+                }
+              ],
+              "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) && (!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -780,7 +806,17 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Horsepower_x"
+                }
+              ],
+              "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -1119,7 +1155,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y\", brush_y)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y\", brush_y)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x"
+                },
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y"
+                }
+              ],
+              "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y\", brush_y)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y\", brush_y)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -1411,7 +1460,17 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Acceleration_x"
+                }
+              ],
+              "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -1750,7 +1809,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_y\", brush_y)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_y\", brush_y)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Horsepower_x"
+                },
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Horsepower_y"
+                }
+              ],
+              "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_y\", brush_y)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_y\", brush_y)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -2040,7 +2112,17 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x"
+                }
+              ],
+              "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -2379,7 +2461,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x"
+                },
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y"
+                }
+              ],
+              "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -2726,7 +2821,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x"
+                },
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y"
+                }
+              ],
+              "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",

--- a/examples/compiled/selection_resolution_union.vg.json
+++ b/examples/compiled/selection_resolution_union.vg.json
@@ -143,7 +143,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x"
+                },
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y"
+                }
+              ],
+              "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -490,7 +503,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) && (!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Acceleration_x"
+                },
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Acceleration_y"
+                }
+              ],
+              "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) && (!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_y\", brush_y)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Acceleration_y\", brush_y)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -780,7 +806,17 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Horsepower__repeat_column_Horsepower_x"
+                }
+              ],
+              "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Horsepower__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Horsepower__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -1119,7 +1155,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y\", brush_y)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y\", brush_y)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x"
+                },
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y"
+                }
+              ],
+              "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) && (!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y\", brush_y)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon_y\", brush_y)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -1411,7 +1460,17 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Acceleration_x"
+                }
+              ],
+              "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -1750,7 +1809,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_y\", brush_y)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_y\", brush_y)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Horsepower_x"
+                },
+                {
+                  "scale": "child__repeat_row_Acceleration__repeat_column_Horsepower_y"
+                }
+              ],
+              "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_y\", brush_y)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Acceleration__repeat_column_Horsepower_y\", brush_y)[1] === +brush_Acceleration[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -2040,7 +2112,17 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x"
+                }
+              ],
+              "update": "(!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x\", brush_x)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon_x\", brush_x)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -2379,7 +2461,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x"
+                },
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y"
+                }
+              ],
+              "update": "(!isArray(brush_Acceleration) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x\", brush_x)[0] === +brush_Acceleration[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_x\", brush_x)[1] === +brush_Acceleration[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",
@@ -2726,7 +2821,20 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x"
+                },
+                {
+                  "scale": "child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y"
+                }
+              ],
+              "update": "(!isArray(brush_Horsepower) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower_y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",

--- a/examples/compiled/selection_translate_brush_drag.vg.json
+++ b/examples/compiled/selection_translate_brush_drag.vg.json
@@ -130,7 +130,13 @@
     },
     {
       "name": "brush_scale_trigger",
-      "update": "(!isArray(brush_Horsepower) || (+invert(\"x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(brush_Horsepower) || (+invert(\"x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "brush_tuple",

--- a/examples/compiled/selection_translate_brush_shift-drag.vg.json
+++ b/examples/compiled/selection_translate_brush_shift-drag.vg.json
@@ -130,7 +130,13 @@
     },
     {
       "name": "brush_scale_trigger",
-      "update": "(!isArray(brush_Horsepower) || (+invert(\"x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(brush_Horsepower) || (+invert(\"x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "brush_tuple",

--- a/examples/compiled/selection_type_interval.vg.json
+++ b/examples/compiled/selection_type_interval.vg.json
@@ -138,7 +138,13 @@
     },
     {
       "name": "pts_scale_trigger",
-      "update": "(!isArray(pts_Cylinders) || (invert(\"x\", pts_x)[0] === pts_Cylinders[0] && invert(\"x\", pts_x)[1] === pts_Cylinders[1])) && (!isArray(pts_Origin) || (invert(\"y\", pts_y)[0] === pts_Origin[0] && invert(\"y\", pts_y)[1] === pts_Origin[1])) ? pts_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(pts_Cylinders) || (invert(\"x\", pts_x)[0] === pts_Cylinders[0] && invert(\"x\", pts_x)[1] === pts_Cylinders[1])) && (!isArray(pts_Origin) || (invert(\"y\", pts_y)[0] === pts_Origin[0] && invert(\"y\", pts_y)[1] === pts_Origin[1])) ? pts_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "pts_tuple",

--- a/examples/compiled/selection_type_interval_invert.vg.json
+++ b/examples/compiled/selection_type_interval_invert.vg.json
@@ -138,7 +138,13 @@
     },
     {
       "name": "pts_scale_trigger",
-      "update": "(!isArray(pts_Cylinders) || (invert(\"x\", pts_x)[0] === pts_Cylinders[0] && invert(\"x\", pts_x)[1] === pts_Cylinders[1])) && (!isArray(pts_Origin) || (invert(\"y\", pts_y)[0] === pts_Origin[0] && invert(\"y\", pts_y)[1] === pts_Origin[1])) ? pts_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(pts_Cylinders) || (invert(\"x\", pts_x)[0] === pts_Cylinders[0] && invert(\"x\", pts_x)[1] === pts_Cylinders[1])) && (!isArray(pts_Origin) || (invert(\"y\", pts_y)[0] === pts_Origin[0] && invert(\"y\", pts_y)[1] === pts_Origin[1])) ? pts_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "pts_tuple",

--- a/examples/compiled/selection_zoom_brush_shift-wheel.vg.json
+++ b/examples/compiled/selection_zoom_brush_shift-wheel.vg.json
@@ -130,7 +130,13 @@
     },
     {
       "name": "brush_scale_trigger",
-      "update": "(!isArray(brush_Horsepower) || (+invert(\"x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(brush_Horsepower) || (+invert(\"x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "brush_tuple",

--- a/examples/compiled/selection_zoom_brush_wheel.vg.json
+++ b/examples/compiled/selection_zoom_brush_wheel.vg.json
@@ -130,7 +130,13 @@
     },
     {
       "name": "brush_scale_trigger",
-      "update": "(!isArray(brush_Horsepower) || (+invert(\"x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+      "value": {},
+      "on": [
+        {
+          "events": [{"scale": "x"}, {"scale": "y"}],
+          "update": "(!isArray(brush_Horsepower) || (+invert(\"x\", brush_x)[0] === +brush_Horsepower[0] && +invert(\"x\", brush_x)[1] === +brush_Horsepower[1])) && (!isArray(brush_Miles_per_Gallon) || (+invert(\"y\", brush_y)[0] === +brush_Miles_per_Gallon[0] && +invert(\"y\", brush_y)[1] === +brush_Miles_per_Gallon[1])) ? brush_scale_trigger : {}"
+        }
+      ]
     },
     {
       "name": "brush_tuple",

--- a/examples/compiled/trellis_selections.vg.json
+++ b/examples/compiled/trellis_selections.vg.json
@@ -196,7 +196,13 @@
         },
         {
           "name": "brush_scale_trigger",
-          "update": "(!isArray(brush_X) || (+invert(\"x\", brush_x)[0] === +brush_X[0] && +invert(\"x\", brush_x)[1] === +brush_X[1])) ? brush_scale_trigger : {}"
+          "value": {},
+          "on": [
+            {
+              "events": [{"scale": "x"}],
+              "update": "(!isArray(brush_X) || (+invert(\"x\", brush_x)[0] === +brush_X[0] && +invert(\"x\", brush_x)[1] === +brush_X[1])) ? brush_scale_trigger : {}"
+            }
+          ]
         },
         {
           "name": "brush_tuple",

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -65,7 +65,13 @@ const interval: SelectionCompiler<'interval'> = {
     if (!hasScales) {
       signals.push({
         name: name + SCALE_TRIGGER,
-        update: scaleTriggers.map(t => t.expr).join(' && ') + ` ? ${name + SCALE_TRIGGER} : {}`
+        value: {},
+        on: [
+          {
+            events: scaleTriggers.map(t => ({scale: t.scaleName})),
+            update: scaleTriggers.map(t => t.expr).join(' && ') + ` ? ${name + SCALE_TRIGGER} : {}`
+          }
+        ]
       });
     }
 

--- a/test/compile/selection/interval.test.ts
+++ b/test/compile/selection/interval.test.ts
@@ -100,8 +100,14 @@ describe('Interval Selections', () => {
           },
           {
             name: 'one_scale_trigger',
-            update:
-              '(!isArray(one_Horsepower) || (+invert("x", one_x)[0] === +one_Horsepower[0] && +invert("x", one_x)[1] === +one_Horsepower[1])) ? one_scale_trigger : {}'
+            value: {},
+            on: [
+              {
+                events: [{scale: 'x'}],
+                update:
+                  '(!isArray(one_Horsepower) || (+invert("x", one_x)[0] === +one_Horsepower[0] && +invert("x", one_x)[1] === +one_Horsepower[1])) ? one_scale_trigger : {}'
+              }
+            ]
           }
         ])
       );
@@ -187,8 +193,14 @@ describe('Interval Selections', () => {
           },
           {
             name: 'thr_ee_scale_trigger',
-            update:
-              '(!isArray(thr_ee_Horsepower) || (+invert("x", thr_ee_x)[0] === +thr_ee_Horsepower[0] && +invert("x", thr_ee_x)[1] === +thr_ee_Horsepower[1])) && (!isArray(thr_ee_Miles_per_Gallon) || (+invert("y", thr_ee_y)[0] === +thr_ee_Miles_per_Gallon[0] && +invert("y", thr_ee_y)[1] === +thr_ee_Miles_per_Gallon[1])) ? thr_ee_scale_trigger : {}'
+            value: {},
+            on: [
+              {
+                events: [{scale: 'x'}, {scale: 'y'}],
+                update:
+                  '(!isArray(thr_ee_Horsepower) || (+invert("x", thr_ee_x)[0] === +thr_ee_Horsepower[0] && +invert("x", thr_ee_x)[1] === +thr_ee_Horsepower[1])) && (!isArray(thr_ee_Miles_per_Gallon) || (+invert("y", thr_ee_y)[0] === +thr_ee_Miles_per_Gallon[0] && +invert("y", thr_ee_y)[1] === +thr_ee_Miles_per_Gallon[1])) ? thr_ee_scale_trigger : {}'
+              }
+            ]
           }
         ])
       );
@@ -226,8 +238,14 @@ describe('Interval Selections', () => {
           },
           {
             name: 'four_scale_trigger',
-            update:
-              '(!isArray(four_Horsepower) || (+invert("x", four_x)[0] === +four_Horsepower[0] && +invert("x", four_x)[1] === +four_Horsepower[1])) ? four_scale_trigger : {}'
+            value: {},
+            on: [
+              {
+                events: [{scale: 'x'}],
+                update:
+                  '(!isArray(four_Horsepower) || (+invert("x", four_x)[0] === +four_Horsepower[0] && +invert("x", four_x)[1] === +four_Horsepower[1])) ? four_scale_trigger : {}'
+              }
+            ]
           }
         ])
       );
@@ -293,8 +311,14 @@ describe('Interval Selections', () => {
           },
           {
             name: 'five_scale_trigger',
-            update:
-              '(!isArray(five_Horsepower) || (+invert("x", five_x)[0] === +five_Horsepower[0] && +invert("x", five_x)[1] === +five_Horsepower[1])) && (!isArray(five_Miles_per_Gallon) || (+invert("y", five_y)[0] === +five_Miles_per_Gallon[0] && +invert("y", five_y)[1] === +five_Miles_per_Gallon[1])) ? five_scale_trigger : {}'
+            value: {},
+            on: [
+              {
+                events: [{scale: 'x'}, {scale: 'y'}],
+                update:
+                  '(!isArray(five_Horsepower) || (+invert("x", five_x)[0] === +five_Horsepower[0] && +invert("x", five_x)[1] === +five_Horsepower[1])) && (!isArray(five_Miles_per_Gallon) || (+invert("y", five_y)[0] === +five_Miles_per_Gallon[0] && +invert("y", five_y)[1] === +five_Miles_per_Gallon[1])) ? five_scale_trigger : {}'
+              }
+            ]
           }
         ])
       );
@@ -332,8 +356,14 @@ describe('Interval Selections', () => {
           },
           {
             name: 'six_scale_trigger',
-            update:
-              '(!isArray(six_Horsepower) || (+invert("x", six_x)[0] === +six_Horsepower[0] && +invert("x", six_x)[1] === +six_Horsepower[1])) ? six_scale_trigger : {}'
+            value: {},
+            on: [
+              {
+                events: [{scale: 'x'}],
+                update:
+                  '(!isArray(six_Horsepower) || (+invert("x", six_x)[0] === +six_Horsepower[0] && +invert("x", six_x)[1] === +six_Horsepower[1])) ? six_scale_trigger : {}'
+              }
+            ]
           }
         ])
       );


### PR DESCRIPTION
This should unblock bumping to Vega v5.2 (#4709) which was blocked because selection runtime tests would crash due to an infinite loop in the dataflow graph.

Scale trigger signals were introduced to break infinite loops in the dataflow graph by proxing scale reactions. Unfortunately, by using a straight `update` function, the same dependency links were being
registered (i.e., the infinite loop in the dataflow graph persisted) but went undetected due to dataflow bugs in Vega pre-5.1 (see vega/vega#1678). Once these bugs were fixed, the infinite loop resurfaced (see vega/vega#1689). By using on-event-triggers, this commit should actually break the loop
by making scale_triggers dependent on only the scales, rather than the interval signals as well.

/cc @jheer