### PR TITLE
Interactive Legend for Unit Specs

### DIFF
--- a/src/compile/legend/component.ts
+++ b/src/compile/legend/component.ts
@@ -8,3 +8,9 @@ export class LegendComponent extends Split<VgLegend> {}
 export type LegendComponentIndex = {[P in NonPositionScaleChannel]?: LegendComponent};
 
 export type LegendIndex = {[P in NonPositionScaleChannel]?: Legend};
+
+export interface InteractiveSelections {
+  name: string;
+  store: string;
+  fields: string[];
+}

--- a/src/compile/legend/parse.ts
+++ b/src/compile/legend/parse.ts
@@ -1,4 +1,5 @@
 import {Legend as VgLegend, LegendEncode, SignalRef} from 'vega';
+import {stringValue} from 'vega-util';
 import {
   COLOR,
   FILL,
@@ -19,9 +20,10 @@ import {mergeTitleComponent, numberFormat} from '../common';
 import {guideEncodeEntry} from '../guide';
 import {isUnitModel, Model} from '../model';
 import {parseGuideResolve} from '../resolve';
+import {forEachSelection, LEGEND, STORE, VL_SELECTION_TEST} from '../selection';
 import {defaultTieBreaker, Explicit, makeImplicit, mergeValuesWithExplicit} from '../split';
 import {UnitModel} from '../unit';
-import {LegendComponent, LegendComponentIndex} from './component';
+import {InteractiveSelections, LegendComponent, LegendComponentIndex} from './component';
 import * as encode from './encode';
 import * as properties from './properties';
 import {direction, type} from './properties';
@@ -97,7 +99,7 @@ export function parseLegendForChannel(model: UnitModel, channel: NonPositionScal
   }
 
   const legendEncoding = legend.encoding || {};
-  const legendEncode = ['labels', 'legend', 'title', 'symbols', 'gradient'].reduce(
+  let legendEncode = ['labels', 'legend', 'title', 'symbols', 'gradient'].reduce(
     (e: LegendEncode, part) => {
       const legendEncodingPart = guideEncodeEntry(legendEncoding[part] || {}, model);
       const value = encode[part]
@@ -111,11 +113,124 @@ export function parseLegendForChannel(model: UnitModel, channel: NonPositionScal
     {} as LegendEncode
   );
 
+  const interactiveSelections = interactiveLegendExists(model);
+  if (interactiveSelections.length) {
+    legendEncode = updateInteractiveLegendComponent(model, legendEncode, channel, interactiveSelections);
+  }
   if (keys(legendEncode).length > 0) {
     legendCmpt.set('encode', legendEncode, !!legend.encoding);
   }
 
   return legendCmpt;
+}
+
+export function interactiveLegendExists(model: UnitModel) {
+  const selections: InteractiveSelections[] = [];
+  // Look over all selections
+  forEachSelection(model, selCmpt => {
+    if (selCmpt['fields']) {
+      selections.push({name: selCmpt.name, store: stringValue(selCmpt.name + STORE), fields: selCmpt['fields']});
+    }
+  });
+
+  // Quit if no selections have projections
+  if (!selections.length) {
+    return [];
+  }
+
+  // Encoding channels should fully populate selections
+  let selectionFields: string[] = [].concat.apply([], selections.map(s => s.fields)); // Flatten array
+  selectionFields = selectionFields.filter((v, i, a) => a.indexOf(v) === i); // Get unique elements
+
+  let encodingFields: string[] = [];
+  [COLOR, OPACITY, SIZE, SHAPE].forEach(channel => {
+    const fieldDef = model.fieldDef(channel);
+    if (fieldDef) {
+      encodingFields.push(fieldDef.field);
+    }
+  });
+
+  encodingFields = encodingFields.filter((v, i, a) => a.indexOf(v) === i); // Get unique elements
+  const differenceFields = selectionFields.filter(x => encodingFields.indexOf(x) === -1);
+  if (differenceFields.length) {
+    return [];
+  }
+  return selections;
+}
+
+function updateInteractiveLegendComponent(
+  model: UnitModel,
+  legendEncode: LegendEncode,
+  channel: NonPositionScaleChannel,
+  interactiveSelections: InteractiveSelections[]
+): LegendEncode {
+  switch (channel) {
+    case COLOR:
+    case OPACITY:
+    case SIZE:
+    case SHAPE:
+      break;
+    default:
+      return legendEncode;
+  }
+  const field = model.fieldDef(channel).field;
+
+  // Choose the selection with highest specifictiy of projection containing the field
+  let selectionIndex: number;
+  let maxFields = 0;
+  interactiveSelections.forEach((s, i) => {
+    if (s.fields.length > maxFields && s.fields.indexOf(field) > -1) {
+      maxFields = s.fields.length;
+      selectionIndex = i;
+    }
+  });
+  if (!maxFields) {
+    return legendEncode;
+  }
+  const maxProjSelection = interactiveSelections[selectionIndex];
+
+  const updatedLegendEncode = legendEncode;
+  let updateValue;
+  ['labels', 'symbols'].forEach(part => {
+    if (updatedLegendEncode.hasOwnProperty(part)) {
+      updateValue = updatedLegendEncode[part].update;
+    } else {
+      updateValue = {opacity: {value: 0.7}};
+    }
+    // Replace VlSeclectionTest datapoint to accomodate multiple fields selection
+    updateValue.opacity = [
+      {
+        test: `!(length(data(${maxProjSelection.store}))) || ${VL_SELECTION_TEST}(${
+          maxProjSelection.store
+        }, {${field}: datum.value})`,
+        value: updateValue.opacity.value
+      },
+      {value: 0.2}
+    ];
+    updatedLegendEncode[part] = {name: `${part}_${field}${LEGEND}`, interactive: true, update: updateValue};
+  });
+  // For Opacity-symbols
+  // let updatedValue;
+  // if (part === 'symbols' && channel === OPACITY) {
+  //   updatedValue = value;
+  //   if (updatedValue.stroke.value === 'transparent') {
+  //     updatedValue.stroke = [
+  //       {test: `vlSelectionTest(${maxProjSelection.store}, {${field}: datum.value})`, value: '#000000'},
+  //       {value: 'transparent'}
+  //     ];
+  //   } else {
+  //     updatedValue.stroke = [
+  //       {
+  //         test: `length(data(${maxProjSelection.store}))) && vlSelectionTest(${
+  //           maxProjSelection.store
+  //           }, {${field}: datum.value})`,
+  //         value: '#000000'
+  //       },
+  //       updatedValue.stroke
+  //     ];
+  //   }
+  // }
+  return updatedLegendEncode;
 }
 
 function getProperty<K extends keyof VgLegend>(

--- a/src/compile/selection/assemble.ts
+++ b/src/compile/selection/assemble.ts
@@ -59,7 +59,7 @@ export function assembleUnitSelectionSignals(model: UnitModel, signals: any[]) {
   return signals;
 }
 
-function assembleInteractiveLegendSignals(
+export function assembleInteractiveLegendSignals(
   model: UnitModel,
   signals: any[],
   selections: InteractiveSelections[]

--- a/src/compile/selection/assemble.ts
+++ b/src/compile/selection/assemble.ts
@@ -89,7 +89,6 @@ function assembleInteractiveLegendSignals(
           on: [
             {
               events: [{source: 'scope', type: 'click'}],
-              // update: `${ignoreLegendExpression} item().mark.marktype !== 'group' ? (item().mark.marktype === 'group' ? ${name}_${field}_legend : ${datum}['${field}']) : null`
               update: `${ignoreLegendExpression} item().mark.marktype !== 'group' ? ${datum}['${field}'] : (!(${ignoreLegendExpression.slice(
                 0,
                 -4
@@ -110,8 +109,10 @@ function assembleInteractiveLegendSignals(
         )}, fields: ${name}_tuple_fields, values: [ ${fieldSignals.join(',')} ]} : ${signal.name}`
       });
 
-      const toggleSignal = signals.filter(s => s.name === name + '_toggle')[0];
-      toggleSignal.on[0].update = `${ignoreLegendExpression.slice(0, -4)} ? event.shiftKey : false`;
+      const toggleSignal = signals.filter(s => s.name === name + '_toggle');
+      if (toggleSignal.length) {
+        toggleSignal[0].on[0].update = `${ignoreLegendExpression.slice(0, -4)} ? event.shiftKey : false`;
+      }
     } else {
       signal.on.push({
         events: eventExpression,

--- a/src/compile/selection/index.ts
+++ b/src/compile/selection/index.ts
@@ -24,6 +24,8 @@ export const TUPLE = '_tuple';
 export const MODIFY = '_modify';
 export const SELECTION_DOMAIN = '_selection_domain_';
 export const VL_SELECTION_RESOLVE = 'vlSelectionResolve';
+export const VL_SELECTION_TEST = 'vlSelectionTest';
+export const LEGEND = '_legend';
 
 export interface SelectionComponent<T extends SelectionType = SelectionType> {
   name: string;

--- a/test/compile/legend/parse.test.ts
+++ b/test/compile/legend/parse.test.ts
@@ -3,6 +3,7 @@
 import {COLOR, FILLOPACITY, OPACITY, SHAPE, SIZE, STROKEOPACITY, STROKEWIDTH} from '../../../src/channel';
 import * as legendParse from '../../../src/compile/legend/parse';
 import {parseLegend} from '../../../src/compile/legend/parse';
+import {parseUnitSelection} from '../../../src/compile/selection/parse';
 import {isFieldDef} from '../../../src/fielddef';
 import {NormalizedUnitSpec} from '../../../src/spec';
 import {GEOJSON} from '../../../src/type';
@@ -139,6 +140,50 @@ describe('compile/legend', () => {
 
         expect(model.legend(channel)).toBeUndefined();
       });
+    });
+  });
+
+  describe('interactiveLegendExists()', () => {
+    const spec: NormalizedUnitSpec = {
+      description: 'Drag the sliders to highlight points.',
+      data: {url: 'data/cars.json'},
+      mark: 'point',
+      encoding: {
+        x: {field: 'Horsepower', type: 'quantitative'},
+        y: {field: 'Miles_per_Gallon', type: 'quantitative'},
+        color: {field: 'Origin', type: 'nominal'},
+        size: {field: 'Cylinders', type: 'nominal'}
+      }
+    };
+    const model = parseUnitModelWithScale(spec);
+    it('should correctly determine if interactive legend is present', () => {
+      model.component.selection = parseUnitSelection(model, {
+        sel1: {type: 'multi', fields: ['Origin']},
+        sel2: {type: 'multi', fields: ['Cylinders']}
+      });
+      const def = legendParse.interactiveLegendExists(model);
+      assert.isTrue(Boolean(def.length));
+    });
+    it('should correctly determine if interactive legend is present', () => {
+      model.component.selection = parseUnitSelection(model, {
+        sel1: {type: 'multi', fields: ['Origin', 'Cylinders']}
+      });
+      const def = legendParse.interactiveLegendExists(model);
+      assert.isTrue(Boolean(def.length));
+    });
+    it('should correctly determine if interactive legend is present', () => {
+      model.component.selection = parseUnitSelection(model, {
+        sel1: {type: 'multi', fields: ['Origin']}
+      });
+      const def = legendParse.interactiveLegendExists(model);
+      assert.isTrue(Boolean(def.length));
+    });
+    it('should correctly determine if interactive legend is present', () => {
+      model.component.selection = parseUnitSelection(model, {
+        sel1: {type: 'multi', fields: ['Origin', 'Cylinders', 'Year']}
+      });
+      const def = legendParse.interactiveLegendExists(model);
+      assert.isFalse(Boolean(def.length));
     });
   });
 

--- a/test/compile/legend/parse.test.ts
+++ b/test/compile/legend/parse.test.ts
@@ -162,28 +162,28 @@ describe('compile/legend', () => {
         sel2: {type: 'multi', fields: ['Cylinders']}
       });
       const def = legendParse.interactiveLegendExists(model);
-      assert.isTrue(Boolean(def.length));
+      expect(Boolean(def.length)).toBeTruthy();
     });
     it('should correctly determine if interactive legend is present', () => {
       model.component.selection = parseUnitSelection(model, {
         sel1: {type: 'multi', fields: ['Origin', 'Cylinders']}
       });
       const def = legendParse.interactiveLegendExists(model);
-      assert.isTrue(Boolean(def.length));
+      expect(def.length).toBeTruthy();
     });
     it('should correctly determine if interactive legend is present', () => {
       model.component.selection = parseUnitSelection(model, {
         sel1: {type: 'multi', fields: ['Origin']}
       });
       const def = legendParse.interactiveLegendExists(model);
-      assert.isTrue(Boolean(def.length));
+      expect(def.length).toBeTruthy();
     });
     it('should correctly determine if interactive legend is present', () => {
       model.component.selection = parseUnitSelection(model, {
         sel1: {type: 'multi', fields: ['Origin', 'Cylinders', 'Year']}
       });
       const def = legendParse.interactiveLegendExists(model);
-      assert.isFalse(Boolean(def.length));
+      expect(def.length).toBeFalsy();
     });
   });
 

--- a/test/compile/legend/parse.test.ts
+++ b/test/compile/legend/parse.test.ts
@@ -97,6 +97,50 @@ describe('compile/legend', () => {
       expect(def.title).toEqual('foo');
     });
 
+    it('should add correct attributes to parts when Interactive Legend Exists', () => {
+      const spec: NormalizedUnitSpec = {
+        data: {url: 'data/cars.json'},
+        mark: 'point',
+        encoding: {
+          x: {field: 'Horsepower', type: 'quantitative'},
+          y: {field: 'Miles_per_Gallon', type: 'quantitative'},
+          color: {field: 'Origin', type: 'nominal'}
+        }
+      };
+      const model = parseUnitModelWithScale(spec);
+      model.component.selection = parseUnitSelection(model, {
+        sel: {type: 'multi', fields: ['Origin']}
+      });
+      const def = legendParse.parseLegendForChannel(model, COLOR).combine();
+      expect(typeof def).toBe('object');
+      expect(def.encode.labels.update).toBeDefined();
+      expect(def.encode.symbols.update).toBeDefined();
+      expect(def.encode.labels.interactive).toBeTruthy();
+      expect(def.encode.symbols.interactive).toBeTruthy();
+      expect(def.encode.labels.name).toBe('labels_Origin_legend');
+      expect(def.encode.symbols.name).toBe('symbols_Origin_legend');
+    });
+
+    it('should not add attributes to parts when interactive legend is not present for channel', () => {
+      const spec: NormalizedUnitSpec = {
+        data: {url: 'data/cars.json'},
+        mark: 'point',
+        encoding: {
+          x: {field: 'Horsepower', type: 'quantitative'},
+          y: {field: 'Miles_per_Gallon', type: 'quantitative'},
+          color: {field: 'Cylinders', type: 'nominal'},
+          size: {field: 'Origin', type: 'nominal'}
+        }
+      };
+      const model = parseUnitModelWithScale(spec);
+      model.component.selection = parseUnitSelection(model, {
+        sel: {type: 'multi', fields: ['Origin']}
+      });
+      const def = legendParse.parseLegendForChannel(model, COLOR).combine();
+      expect(def.encode.labels).not.toBeDefined();
+      expect(def.encode.symbols.interactive).not.toBeDefined();
+    });
+
     [SIZE, SHAPE, OPACITY].forEach(channel => {
       it(`should produce a Vega legend object with correct type and scale for ${channel}`, () => {
         const spec: NormalizedUnitSpec = {
@@ -181,6 +225,13 @@ describe('compile/legend', () => {
     it('should correctly determine if interactive legend is present', () => {
       model.component.selection = parseUnitSelection(model, {
         sel1: {type: 'multi', fields: ['Origin', 'Cylinders', 'Year']}
+      });
+      const def = legendParse.interactiveLegendExists(model);
+      expect(def.length).toBeFalsy();
+    });
+    it('should correctly determine if interactive legend is present', () => {
+      model.component.selection = parseUnitSelection(model, {
+        sel1: {type: 'single'}
       });
       const def = legendParse.interactiveLegendExists(model);
       expect(def.length).toBeFalsy();

--- a/test/compile/selection/legend.test.ts
+++ b/test/compile/selection/legend.test.ts
@@ -1,0 +1,99 @@
+import {assembleUnitSelectionSignals} from '../../../src/compile/selection/assemble';
+import {parseUnitSelection} from '../../../src/compile/selection/parse';
+import {parseUnitModel} from '../../util';
+
+describe('Inputs Selection Transform', () => {
+  const model = parseUnitModel({
+    mark: 'circle',
+    encoding: {
+      x: {field: 'Horsepower', type: 'quantitative'},
+      y: {field: 'Miles_per_Gallon', type: 'quantitative'},
+      color: {field: 'Origin', type: 'nominal'},
+      size: {field: 'Cylinders', type: 'nominal'}
+    }
+  });
+  model.parseScale();
+  const selCmpts = parseUnitSelection(model, {
+    one: {
+      type: 'multi',
+      fields: ['Origin']
+    },
+    two: {
+      type: 'multi',
+      fields: ['Cylinders']
+    },
+    three: {
+      type: 'multi',
+      fields: ['Origin', 'Cylinders']
+    }
+  });
+
+  it('modify the tuple singals when interactive legend is present', () => {
+    model.component.selection = {one: selCmpts['one'], two: selCmpts['two']};
+    const signals = assembleUnitSelectionSignals(model, []);
+    expect(signals.filter(s => s.name === 'one_tuple')[0].on).toEqual(
+      expect.arrayContaining([
+        {
+          events: [{source: 'scope', type: 'click'}],
+          update:
+            "item().mark.name !== 'symbols_Cylinders_legend' && item().mark.name !== 'labels_Cylinders_legend' && item().mark.name !== 'symbols_Origin_legend' && item().mark.name !== 'labels_Origin_legend' && datum && item().mark.marktype !== 'group' ? {unit: \"\", fields: one_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"Origin\"]]} : null",
+          force: true
+        },
+        {
+          events: '@symbols_Origin_legend:click, @labels_Origin_legend:click, ',
+          update: '{unit: "", fields: one_tuple_fields, values: [datum.value]}'
+        }
+      ])
+    );
+    expect(signals.filter(s => s.name === 'two_tuple')[0].on).toEqual(
+      expect.arrayContaining([
+        {
+          events: [{source: 'scope', type: 'click'}],
+          update:
+            "item().mark.name !== 'symbols_Cylinders_legend' && item().mark.name !== 'labels_Cylinders_legend' && item().mark.name !== 'symbols_Origin_legend' && item().mark.name !== 'labels_Origin_legend' && datum && item().mark.marktype !== 'group' ? {unit: \"\", fields: two_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"Cylinders\"]]} : null",
+          force: true
+        },
+        {
+          events: '@symbols_Cylinders_legend:click, @labels_Cylinders_legend:click, ',
+          update: '{unit: "", fields: two_tuple_fields, values: [datum.value]}'
+        }
+      ])
+    );
+  });
+
+  it('adds the signals for legends when one signal populate all encoding fields', () => {
+    model.component.selection = {three: selCmpts['three']};
+    expect(assembleUnitSelectionSignals(model, [])).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'three_Cylinders_legend',
+          on: [
+            {
+              events: [{source: 'scope', type: 'click'}],
+              update:
+                "item().mark.name !== 'symbols_Cylinders_legend' && item().mark.name !== 'labels_Cylinders_legend' && item().mark.name !== 'symbols_Origin_legend' && item().mark.name !== 'labels_Origin_legend' &&  item().mark.marktype !== 'group' ? (item().isVoronoi ? datum.datum : datum)['Cylinders'] : (!(item().mark.name !== 'symbols_Cylinders_legend' && item().mark.name !== 'labels_Cylinders_legend' && item().mark.name !== 'symbols_Origin_legend' && item().mark.name !== 'labels_Origin_legend') ? three_Cylinders_legend : null)"
+            },
+            {
+              events: '@symbols_Cylinders_legend:click, @labels_Cylinders_legend:click',
+              update: 'datum.value'
+            }
+          ]
+        },
+        {
+          name: 'three_Origin_legend',
+          on: [
+            {
+              events: [{source: 'scope', type: 'click'}],
+              update:
+                "item().mark.name !== 'symbols_Cylinders_legend' && item().mark.name !== 'labels_Cylinders_legend' && item().mark.name !== 'symbols_Origin_legend' && item().mark.name !== 'labels_Origin_legend' &&  item().mark.marktype !== 'group' ? (item().isVoronoi ? datum.datum : datum)['Origin'] : (!(item().mark.name !== 'symbols_Cylinders_legend' && item().mark.name !== 'labels_Cylinders_legend' && item().mark.name !== 'symbols_Origin_legend' && item().mark.name !== 'labels_Origin_legend') ? three_Origin_legend : null)"
+            },
+            {
+              events: '@symbols_Origin_legend:click, @labels_Origin_legend:click',
+              update: 'datum.value'
+            }
+          ]
+        }
+      ])
+    );
+  });
+});


### PR DESCRIPTION
A step towards Issue #1657. Continuation of PR #4317 

Legends can be interacted with when the mark encoding channels completely populate the selection fields.  

![vega-lite](https://user-images.githubusercontent.com/4402679/54434426-3e539200-4754-11e9-9e24-951be9d92d4e.gif)

