### PR TITLE
Avoid redundant identifier transforms 

### DIFF
--- a/examples/compiled/concat_hover_filter.vg.json
+++ b/examples/compiled/concat_hover_filter.vg.json
@@ -15,11 +15,6 @@
     {
       "name": "data_0",
       "source": "source_0",
-      "transform": [{"type": "identifier", "as": "_vgsid_"}]
-    },
-    {
-      "name": "data_1",
-      "source": "source_0",
       "transform": [
         {"type": "filter", "expr": "(vlSelectionTest(\"hover_store\", datum))"}
       ]
@@ -74,7 +69,7 @@
           "name": "concat_0_layer_0_marks",
           "type": "symbol",
           "style": ["point"],
-          "from": {"data": "data_0"},
+          "from": {"data": "source_0"},
           "encode": {
             "update": {
               "opacity": {"value": 0.7},
@@ -104,7 +99,7 @@
           "name": "concat_0_layer_1_marks",
           "type": "symbol",
           "style": ["point"],
-          "from": {"data": "data_1"},
+          "from": {"data": "data_0"},
           "encode": {
             "update": {
               "opacity": {"value": 0.7},
@@ -214,7 +209,7 @@
           "name": "concat_1_layer_0_marks",
           "type": "symbol",
           "style": ["point"],
-          "from": {"data": "data_0"},
+          "from": {"data": "source_0"},
           "encode": {
             "update": {
               "opacity": {"value": 0.7},
@@ -244,7 +239,7 @@
           "name": "concat_1_layer_1_marks",
           "type": "symbol",
           "style": ["point"],
-          "from": {"data": "data_1"},
+          "from": {"data": "data_0"},
           "encode": {
             "update": {
               "opacity": {"value": 0.7},
@@ -326,8 +321,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_0", "field": "Horsepower"},
-          {"data": "data_1", "field": "Horsepower"}
+          {"data": "source_0", "field": "Horsepower"},
+          {"data": "data_0", "field": "Horsepower"}
         ]
       },
       "range": [0, {"signal": "concat_0_width"}],
@@ -339,8 +334,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_0", "field": "Miles_per_Gallon"},
-          {"data": "data_1", "field": "Miles_per_Gallon"}
+          {"data": "source_0", "field": "Miles_per_Gallon"},
+          {"data": "data_0", "field": "Miles_per_Gallon"}
         ]
       },
       "range": [{"signal": "height"}, 0],
@@ -352,8 +347,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_0", "field": "Horsepower"},
-          {"data": "data_1", "field": "Horsepower"}
+          {"data": "source_0", "field": "Horsepower"},
+          {"data": "data_0", "field": "Horsepower"}
         ]
       },
       "range": [0, {"signal": "concat_1_width"}],
@@ -365,8 +360,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_0", "field": "Acceleration"},
-          {"data": "data_1", "field": "Acceleration"}
+          {"data": "source_0", "field": "Acceleration"},
+          {"data": "data_0", "field": "Acceleration"}
         ]
       },
       "range": [{"signal": "height"}, 0],

--- a/examples/compiled/interactive_multi_line_tooltip.vg.json
+++ b/examples/compiled/interactive_multi_line_tooltip.vg.json
@@ -11,22 +11,6 @@
       "name": "source_0",
       "url": "data/seattle-weather.csv",
       "format": {"type": "csv", "parse": {"date": "date"}},
-      "transform": [{"type": "identifier", "as": "_vgsid_"}]
-    },
-    {
-      "name": "data_0",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "formula",
-          "as": "yearmonthdate_date",
-          "expr": "datetime(year(datum[\"date\"]), month(datum[\"date\"]), date(datum[\"date\"]), 0, 0, 0, 0)"
-        }
-      ]
-    },
-    {
-      "name": "data_1",
-      "source": "source_0",
       "transform": [
         {"type": "identifier", "as": "_vgsid_"},
         {
@@ -71,7 +55,7 @@
       "type": "line",
       "style": ["line"],
       "sort": {"field": "datum[\"yearmonthdate_date\"]", "order": "descending"},
-      "from": {"data": "data_0"},
+      "from": {"data": "source_0"},
       "encode": {
         "update": {
           "stroke": {"value": "orange"},
@@ -91,7 +75,7 @@
       "type": "line",
       "style": ["line"],
       "sort": {"field": "datum[\"yearmonthdate_date\"]", "order": "descending"},
-      "from": {"data": "data_0"},
+      "from": {"data": "source_0"},
       "encode": {
         "update": {
           "stroke": {"value": "red"},
@@ -110,7 +94,7 @@
       "name": "layer_2_marks",
       "type": "rule",
       "style": ["rule"],
-      "from": {"data": "data_1"},
+      "from": {"data": "source_0"},
       "encode": {
         "update": {
           "stroke": [
@@ -138,18 +122,13 @@
     {
       "name": "x",
       "type": "time",
-      "domain": {
-        "fields": [
-          {"data": "data_0", "field": "yearmonthdate_date"},
-          {"data": "data_1", "field": "yearmonthdate_date"}
-        ]
-      },
+      "domain": {"data": "source_0", "field": "yearmonthdate_date"},
       "range": [0, {"signal": "width"}]
     },
     {
       "name": "y",
       "type": "linear",
-      "domain": {"data": "data_0", "fields": ["temp_max", "temp_min"]},
+      "domain": {"data": "source_0", "fields": ["temp_max", "temp_min"]},
       "range": [{"signal": "height"}, 0],
       "nice": true,
       "zero": true

--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -234,7 +234,11 @@ export function parseData(model: Model): DataComponent {
   // field is available for all subsequent datasets. Additional identifier
   // transforms will be necessary when new tuples are constructed
   // (e.g., post-aggregation).
-  if (requiresSelectionId(model) && (isUnitModel(model) || isLayerModel(model))) {
+  if (
+    requiresSelectionId(model) &&
+    // only add identifier to unit/layer models that do not have layer parents to avoid redundant identifier transforms
+    ((isUnitModel(model) || isLayerModel(model)) && (!model.parent || !isLayerModel(model.parent)))
+  ) {
     head = new IdentifierNode(head);
   }
 


### PR DESCRIPTION
Add identifier only to unit/layer models that do not have layer parents

Fix #4788

Merge #4787 first 

