### PR TITLE
Move VL logo to upper right corner of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Vega-Lite <a href="https://vega.github.io/vega-lite/"><img align="right" src="https://github.com/vega/logos/blob/master/assets/VL_Color@512.png?raw=true" height="38"></img></a>
+# Vega-Lite <a href="https://vega.github.io/vega-lite/"><img align="right" src="https://github.com/vega/logos/blob/master/assets/VL_Color@64.png?raw=true" height="38"></img></a>
 
 [![npm version](https://img.shields.io/npm/v/vega-lite.svg)](https://www.npmjs.com/package/vega-lite) [![Build Status](https://travis-ci.org/vega/vega-lite.svg?branch=master)](https://travis-ci.org/vega/vega-lite) [![codecov](https://codecov.io/gh/vega/vega-lite/branch/master/graph/badge.svg)](https://codecov.io/gh/vega/vega-lite) [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=rounded)](https://github.com/prettier/prettier) [![Greenkeeper badge](https://badges.greenkeeper.io/vega/vega-lite.svg)](https://greenkeeper.io/)
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,4 @@
-<p align="center">
-   <a href="https://vega.github.io/vega-lite/">
-      <img src="https://github.com/vega/logos/blob/master/assets/VL_Color@512.png?raw=true" width=220></img>
-   </a>
-</p>
-
-# Vega-Lite
+# Vega-Lite <a href="https://vega.github.io/vega-lite/"><img align="right" src="https://github.com/vega/logos/blob/master/assets/VL_Color@512.png?raw=true" height="38"></img></a>
 
 [![npm version](https://img.shields.io/npm/v/vega-lite.svg)](https://www.npmjs.com/package/vega-lite) [![Build Status](https://travis-ci.org/vega/vega-lite.svg?branch=master)](https://travis-ci.org/vega/vega-lite) [![codecov](https://codecov.io/gh/vega/vega-lite/branch/master/graph/badge.svg)](https://codecov.io/gh/vega/vega-lite) [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=rounded)](https://github.com/prettier/prettier) [![Greenkeeper badge](https://badges.greenkeeper.io/vega/vega-lite.svg)](https://greenkeeper.io/)
 


### PR DESCRIPTION
The current logo sizing feels over large and aggressive to me. This PR updates vega/vega-lite to mirror the setup I have on vega/vega and vega/vega-lite-api, with a smaller logo placed in the upper-right corner.

Feel free to merge if you agree with the change, or delete if you don't!
