### PR TITLE
Stop using `incremental` in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,8 +22,7 @@
     "resolveJsonModule": true,
     "suppressImplicitAnyIndexErrors": true,
     "typeRoots": ["./node_modules/@types", "./typings"],
-    "composite": true,
-    "incremental": true
+    "composite": true
   },
   "files": [],
   "include": [],


### PR DESCRIPTION
Even with VSCode using 3.4.1, it's still behaving weird. I think some of the plugins we use may not play nice with this mode yet

cc: @domoritz 

