### PR TITLE
[Docs] Use default value format consistent with the rest of the language

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -10164,7 +10164,7 @@
       "additionalProperties": false,
       "properties": {
         "as": {
-          "description": "The name of the generated sequence field.\n\n__Default value:__ `1`",
+          "description": "The name of the generated sequence field.\n\n__Default value:__ `\"data\"`",
           "type": "string"
         },
         "start": {

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -3437,7 +3437,7 @@
           "description": "If set to `null`, disable type inference based on the spec and only use type inference based on the data.\nAlternatively, a parsing directive object can be provided for explicit data types. Each property of the object corresponds to a field name, and the value to the desired data type (one of `\"number\"`, `\"boolean\"`, `\"date\"`, or null (do not parse the field)).\nFor example, `\"parse\": {\"modified_on\": \"date\"}` parses the `modified_on` field in each input record a Date value.\n\nFor `\"date\"`, we parse data based using Javascript's [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).\nFor Specific date formats can be provided (e.g., `{foo: \"date:'%m%d%Y'\"}`), using the [d3-time-format syntax](https://github.com/d3/d3-time-format#locale_format). UTC date format parsing is supported similarly (e.g., `{foo: \"utc:'%m%d%Y'\"}`). See more about [UTC time](https://vega.github.io/vega-lite/docs/timeunit.html#utc)"
         },
         "type": {
-          "description": "Type of input data: `\"json\"`, `\"csv\"`, `\"tsv\"`, `\"dsv\"`.\nThe default format type is determined by the extension of the file URL.\nIf no extension is detected, `\"json\"` will be used by default.",
+          "description": "Type of input data: `\"json\"`, `\"csv\"`, `\"tsv\"`, `\"dsv\"`.\n\n__Default value:__  The default format type is determined by the extension of the file URL.\nIf no extension is detected, `\"json\"` will be used by default.",
           "enum": [
             "csv",
             "tsv"
@@ -3642,7 +3642,7 @@
           "description": "If set to `null`, disable type inference based on the spec and only use type inference based on the data.\nAlternatively, a parsing directive object can be provided for explicit data types. Each property of the object corresponds to a field name, and the value to the desired data type (one of `\"number\"`, `\"boolean\"`, `\"date\"`, or null (do not parse the field)).\nFor example, `\"parse\": {\"modified_on\": \"date\"}` parses the `modified_on` field in each input record a Date value.\n\nFor `\"date\"`, we parse data based using Javascript's [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).\nFor Specific date formats can be provided (e.g., `{foo: \"date:'%m%d%Y'\"}`), using the [d3-time-format syntax](https://github.com/d3/d3-time-format#locale_format). UTC date format parsing is supported similarly (e.g., `{foo: \"utc:'%m%d%Y'\"}`). See more about [UTC time](https://vega.github.io/vega-lite/docs/timeunit.html#utc)"
         },
         "type": {
-          "description": "Type of input data: `\"json\"`, `\"csv\"`, `\"tsv\"`, `\"dsv\"`.\nThe default format type is determined by the extension of the file URL.\nIf no extension is detected, `\"json\"` will be used by default.",
+          "description": "Type of input data: `\"json\"`, `\"csv\"`, `\"tsv\"`, `\"dsv\"`.\n\n__Default value:__  The default format type is determined by the extension of the file URL.\nIf no extension is detected, `\"json\"` will be used by default.",
           "enum": [
             "dsv"
           ],
@@ -5869,7 +5869,7 @@
           "type": "array"
         },
         "precision": {
-          "description": "The precision of the graticule in degrees (default 2.5).",
+          "description": "The precision of the graticule in degrees.\n\n__Default value:__ `2.5`",
           "type": "number"
         },
         "step": {
@@ -5880,14 +5880,14 @@
           "type": "array"
         },
         "stepMajor": {
-          "description": "The major step angles of the graticule (default [90, 360]).",
+          "description": "The major step angles of the graticule.\n\n\n__Default value:__ `[90, 360]`",
           "items": {
             "type": "number"
           },
           "type": "array"
         },
         "stepMinor": {
-          "description": "The minor step angles of the graticule (default [10, 10]).",
+          "description": "The minor step angles of the graticule.\n\n__Default value:__ `[10, 10]`",
           "items": {
             "type": "number"
           },
@@ -6540,7 +6540,7 @@
           "type": "string"
         },
         "type": {
-          "description": "Type of input data: `\"json\"`, `\"csv\"`, `\"tsv\"`, `\"dsv\"`.\nThe default format type is determined by the extension of the file URL.\nIf no extension is detected, `\"json\"` will be used by default.",
+          "description": "Type of input data: `\"json\"`, `\"csv\"`, `\"tsv\"`, `\"dsv\"`.\n\n__Default value:__  The default format type is determined by the extension of the file URL.\nIf no extension is detected, `\"json\"` will be used by default.",
           "enum": [
             "json"
           ],
@@ -10164,7 +10164,7 @@
       "additionalProperties": false,
       "properties": {
         "as": {
-          "description": "The name of the generated sequence field (default \"data\").",
+          "description": "The name of the generated sequence field.\n\n__Default value:__ `1`",
           "type": "string"
         },
         "start": {
@@ -10172,7 +10172,7 @@
           "type": "number"
         },
         "step": {
-          "description": "The step value between sequence entries (default 1).",
+          "description": "The step value between sequence entries.\n\n__Default value:__ `1`",
           "type": "number"
         },
         "stop": {
@@ -12241,7 +12241,7 @@
           "description": "If set to `null`, disable type inference based on the spec and only use type inference based on the data.\nAlternatively, a parsing directive object can be provided for explicit data types. Each property of the object corresponds to a field name, and the value to the desired data type (one of `\"number\"`, `\"boolean\"`, `\"date\"`, or null (do not parse the field)).\nFor example, `\"parse\": {\"modified_on\": \"date\"}` parses the `modified_on` field in each input record a Date value.\n\nFor `\"date\"`, we parse data based using Javascript's [`Date.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse).\nFor Specific date formats can be provided (e.g., `{foo: \"date:'%m%d%Y'\"}`), using the [d3-time-format syntax](https://github.com/d3/d3-time-format#locale_format). UTC date format parsing is supported similarly (e.g., `{foo: \"utc:'%m%d%Y'\"}`). See more about [UTC time](https://vega.github.io/vega-lite/docs/timeunit.html#utc)"
         },
         "type": {
-          "description": "Type of input data: `\"json\"`, `\"csv\"`, `\"tsv\"`, `\"dsv\"`.\nThe default format type is determined by the extension of the file URL.\nIf no extension is detected, `\"json\"` will be used by default.",
+          "description": "Type of input data: `\"json\"`, `\"csv\"`, `\"tsv\"`, `\"dsv\"`.\n\n__Default value:__  The default format type is determined by the extension of the file URL.\nIf no extension is detected, `\"json\"` will be used by default.",
           "enum": [
             "topojson"
           ],

--- a/src/data.ts
+++ b/src/data.ts
@@ -19,23 +19,21 @@ export interface DataFormatBase {
    * For Specific date formats can be provided (e.g., `{foo: "date:'%m%d%Y'"}`), using the [d3-time-format syntax](https://github.com/d3/d3-time-format#locale_format). UTC date format parsing is supported similarly (e.g., `{foo: "utc:'%m%d%Y'"}`). See more about [UTC time](https://vega.github.io/vega-lite/docs/timeunit.html#utc)
    */
   parse?: Parse | null;
+
+  /**
+   * Type of input data: `"json"`, `"csv"`, `"tsv"`, `"dsv"`.
+   *
+   * __Default value:__  The default format type is determined by the extension of the file URL.
+   * If no extension is detected, `"json"` will be used by default.
+   */
+  type?: 'csv' | 'tsv' | 'dsv' | 'json' | 'topojson';
 }
 
 export interface CsvDataFormat extends DataFormatBase {
-  /**
-   * Type of input data: `"json"`, `"csv"`, `"tsv"`, `"dsv"`.
-   * The default format type is determined by the extension of the file URL.
-   * If no extension is detected, `"json"` will be used by default.
-   */
   type?: 'csv' | 'tsv';
 }
 
 export interface DsvDataFormat extends DataFormatBase {
-  /**
-   * Type of input data: `"json"`, `"csv"`, `"tsv"`, `"dsv"`.
-   * The default format type is determined by the extension of the file URL.
-   * If no extension is detected, `"json"` will be used by default.
-   */
   type?: 'dsv';
 
   /**
@@ -48,11 +46,6 @@ export interface DsvDataFormat extends DataFormatBase {
 }
 
 export interface JsonDataFormat extends DataFormatBase {
-  /**
-   * Type of input data: `"json"`, `"csv"`, `"tsv"`, `"dsv"`.
-   * The default format type is determined by the extension of the file URL.
-   * If no extension is detected, `"json"` will be used by default.
-   */
   type?: 'json';
   /**
    * The JSON property containing the desired data.
@@ -64,11 +57,6 @@ export interface JsonDataFormat extends DataFormatBase {
 }
 
 export interface TopoDataFormat extends DataFormatBase {
-  /**
-   * Type of input data: `"json"`, `"csv"`, `"tsv"`, `"dsv"`.
-   * The default format type is determined by the extension of the file URL.
-   * If no extension is detected, `"json"` will be used by default.
-   */
   type?: 'topojson';
   /**
    * The name of the TopoJSON object set to convert to a GeoJSON feature collection.
@@ -188,12 +176,16 @@ export interface SequenceParams {
    */
   stop: number;
   /**
-   * The step value between sequence entries (default 1).
+   * The step value between sequence entries.
+   *
+   * __Default value:__ `1`
    */
   step?: number;
 
   /**
-   * The name of the generated sequence field (default "data").
+   * The name of the generated sequence field.
+   *
+   * __Default value:__ `"data"`
    */
   as?: string;
 }
@@ -229,12 +221,17 @@ export interface GraticuleParams {
   extent?: number[][];
 
   /**
-   * The major step angles of the graticule (default [90, 360]).
+   * The major step angles of the graticule.
+   *
+   *
+   * __Default value:__ `[90, 360]`
    */
   stepMajor?: number[];
 
   /**
-   * The minor step angles of the graticule (default [10, 10]).
+   * The minor step angles of the graticule.
+   *
+   * __Default value:__ `[10, 10]`
    */
   stepMinor?: number[];
 
@@ -244,7 +241,9 @@ export interface GraticuleParams {
   step?: number[];
 
   /**
-   * The precision of the graticule in degrees (default 2.5).
+   * The precision of the graticule in degrees.
+   *
+   * __Default value:__ `2.5`
    */
   precision?: number;
 }


### PR DESCRIPTION
Also consolidate the docs for `type` of `FormatType`

cc: @jheer
