### PR TITLE
Fix documentation comment for sequence parameters.

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -10152,7 +10152,7 @@
         },
         "sequence": {
           "$ref": "#/definitions/SequenceParams",
-          "description": "Generate sphere GeoJSON data for the full globe."
+          "description": "Generate a sequence of numbers."
         }
       },
       "required": [

--- a/src/data.ts
+++ b/src/data.ts
@@ -161,7 +161,7 @@ export interface GeneratorBase {
 
 export interface SequenceGenerator extends GeneratorBase {
   /**
-   * Generate sphere GeoJSON data for the full globe.
+   * Generate a sequence of numbers.
    */
   sequence: SequenceParams;
 }


### PR DESCRIPTION
Previously the `SequenceParams` type mistakenly had the documentation comment for `GraticuleParams`, which propagates out to the JSON schema. This PR adds a proper description for the sequence generator.