### PR TITLE
Add default translate for scaled projection.

### DIFF
--- a/examples/compiled/geo_custom_projection.vg.json
+++ b/examples/compiled/geo_custom_projection.vg.json
@@ -28,9 +28,9 @@
   "projections": [
     {
       "name": "projection",
+      "translate": [1200, 700],
       "type": "albersUsa",
-      "scale": 3000,
-      "translate": [1200, 700]
+      "scale": 3000
     }
   ],
   "marks": [

--- a/examples/compiled/geo_sphere.vg.json
+++ b/examples/compiled/geo_sphere.vg.json
@@ -12,9 +12,9 @@
   "projections": [
     {
       "name": "projection",
+      "translate": [100, 100],
       "type": "orthographic",
-      "scale": 100,
-      "translate": [100, 100]
+      "scale": 100
     }
   ],
   "marks": [

--- a/src/compile/projection/assemble.ts
+++ b/src/compile/projection/assemble.ts
@@ -31,6 +31,9 @@ export function assembleProjectionForModel(model: Model): VgProjection[] {
     return [
       {
         name,
+        // translate to center by default
+        ...{translate: {signal: '[width / 2, height / 2]'}},
+        // parameters, overwrite default translate if specified
         ...rest
       }
     ];

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -137,7 +137,7 @@ export interface VgProjection {
   /*
    * The translation of the projection.
    */
-  translate?: number[];
+  translate?: SignalRef | number[];
   /*
    * The center of the projection.
    */

--- a/test/compile/projection/assemble.test.ts
+++ b/test/compile/projection/assemble.test.ts
@@ -35,7 +35,7 @@ describe('compile/projection/assemble', () => {
     });
   });
 
-  describe('assembleCustomProjectionForModel', () => {
+  describe('assembleScaledProjectionForModel', () => {
     const model = parseUnitModelWithScaleAndLayoutSize({
       mark: 'geoshape',
       projection: {
@@ -63,6 +63,43 @@ describe('compile/projection/assemble', () => {
       expect(typeof projection.name).toBe('string');
       expect(projection.scale).toBeDefined();
       expect(typeof projection.scale).toBe('number');
+      expect(projection.scale).toBe(1000);
+      expect(projection.translate).toBeDefined();
+      expect(projection.translate).toEqual({signal: '[width / 2, height / 2]'});
+      expect(projection.size).toBeUndefined();
+      expect(projection.fit).toBeUndefined();
+    });
+  });
+
+  describe('assembleTranslatedProjectionForModel', () => {
+    const model = parseUnitModelWithScaleAndLayoutSize({
+      mark: 'geoshape',
+      projection: {
+        type: 'albersUsa',
+        translate: [100, 200]
+      },
+      data: {
+        url: 'data/us-10m.json',
+        format: {
+          type: 'topojson',
+          feature: 'states'
+        }
+      },
+      encoding: {}
+    });
+    model.parse();
+
+    it('should not be empty', () => {
+      expect(assembleProjectionForModel(model).length).toBeGreaterThan(0);
+    });
+
+    it('should have properties of right type', () => {
+      const projection = assembleProjectionForModel(model)[0];
+      expect(projection.name).toBeDefined();
+      expect(typeof projection.name).toBe('string');
+      expect(projection.scale).toBeUndefined();
+      expect(projection.translate).toBeDefined();
+      expect(projection.translate).toEqual([100, 200]);
       expect(projection.size).toBeUndefined();
       expect(projection.fit).toBeUndefined();
     });


### PR DESCRIPTION
Changes:
- If a custom projection is specified with `scale` but not `translate`, emit a default `translate` property in the output Vega spec, set to one-half the `width` and `height` signals.
- Update unit tests.