### PR TITLE
Revert selection clear default to "dblclick".

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -6334,7 +6334,7 @@
               "type": "boolean"
             }
           ],
-          "description": "Clears the selection, emptying it of all values. Can be an\n[EventStream](https://vega.github.io/vega/docs/event-streams/) or `false` to disable.\n\n__Default value:__ `mouseout` if `on: mouseover` else `dblclick`.\n\nSee the [clear](https://vega.github.io/vega-lite/docs/clear.html) documentation for more information."
+          "description": "Clears the selection, emptying it of all values. Can be an\n[EventStream](https://vega.github.io/vega/docs/event-streams/) or `false` to disable.\n\n__Default value:__ `dblclick`.\n\nSee the [clear](https://vega.github.io/vega-lite/docs/clear.html) documentation for more information."
         },
         "empty": {
           "description": "By default, `all` data values are considered to lie within an empty selection.\nWhen set to `none`, empty selections contain no data values.",
@@ -6419,7 +6419,7 @@
               "type": "boolean"
             }
           ],
-          "description": "Clears the selection, emptying it of all values. Can be an\n[EventStream](https://vega.github.io/vega/docs/event-streams/) or `false` to disable.\n\n__Default value:__ `mouseout` if `on: mouseover` else `dblclick`.\n\nSee the [clear](https://vega.github.io/vega-lite/docs/clear.html) documentation for more information."
+          "description": "Clears the selection, emptying it of all values. Can be an\n[EventStream](https://vega.github.io/vega/docs/event-streams/) or `false` to disable.\n\n__Default value:__ `dblclick`.\n\nSee the [clear](https://vega.github.io/vega-lite/docs/clear.html) documentation for more information."
         },
         "empty": {
           "description": "By default, `all` data values are considered to lie within an empty selection.\nWhen set to `none`, empty selections contain no data values.",
@@ -8367,7 +8367,7 @@
               "type": "boolean"
             }
           ],
-          "description": "Clears the selection, emptying it of all values. Can be an\n[EventStream](https://vega.github.io/vega/docs/event-streams/) or `false` to disable.\n\n__Default value:__ `mouseout` if `on: mouseover` else `dblclick`.\n\nSee the [clear](https://vega.github.io/vega-lite/docs/clear.html) documentation for more information."
+          "description": "Clears the selection, emptying it of all values. Can be an\n[EventStream](https://vega.github.io/vega/docs/event-streams/) or `false` to disable.\n\n__Default value:__ `dblclick`.\n\nSee the [clear](https://vega.github.io/vega-lite/docs/clear.html) documentation for more information."
         },
         "empty": {
           "description": "By default, `all` data values are considered to lie within an empty selection.\nWhen set to `none`, empty selections contain no data values.",
@@ -8448,7 +8448,7 @@
               "type": "boolean"
             }
           ],
-          "description": "Clears the selection, emptying it of all values. Can be an\n[EventStream](https://vega.github.io/vega/docs/event-streams/) or `false` to disable.\n\n__Default value:__ `mouseout` if `on: mouseover` else `dblclick`.\n\nSee the [clear](https://vega.github.io/vega-lite/docs/clear.html) documentation for more information."
+          "description": "Clears the selection, emptying it of all values. Can be an\n[EventStream](https://vega.github.io/vega/docs/event-streams/) or `false` to disable.\n\n__Default value:__ `dblclick`.\n\nSee the [clear](https://vega.github.io/vega-lite/docs/clear.html) documentation for more information."
         },
         "empty": {
           "description": "By default, `all` data values are considered to lie within an empty selection.\nWhen set to `none`, empty selections contain no data values.",
@@ -10256,7 +10256,7 @@
               "type": "boolean"
             }
           ],
-          "description": "Clears the selection, emptying it of all values. Can be an\n[EventStream](https://vega.github.io/vega/docs/event-streams/) or `false` to disable.\n\n__Default value:__ `mouseout` if `on: mouseover` else `dblclick`.\n\nSee the [clear](https://vega.github.io/vega-lite/docs/clear.html) documentation for more information."
+          "description": "Clears the selection, emptying it of all values. Can be an\n[EventStream](https://vega.github.io/vega/docs/event-streams/) or `false` to disable.\n\n__Default value:__ `dblclick`.\n\nSee the [clear](https://vega.github.io/vega-lite/docs/clear.html) documentation for more information."
         },
         "empty": {
           "description": "By default, `all` data values are considered to lie within an empty selection.\nWhen set to `none`, empty selections contain no data values.",
@@ -10334,7 +10334,7 @@
               "type": "boolean"
             }
           ],
-          "description": "Clears the selection, emptying it of all values. Can be an\n[EventStream](https://vega.github.io/vega/docs/event-streams/) or `false` to disable.\n\n__Default value:__ `mouseout` if `on: mouseover` else `dblclick`.\n\nSee the [clear](https://vega.github.io/vega-lite/docs/clear.html) documentation for more information."
+          "description": "Clears the selection, emptying it of all values. Can be an\n[EventStream](https://vega.github.io/vega/docs/event-streams/) or `false` to disable.\n\n__Default value:__ `dblclick`.\n\nSee the [clear](https://vega.github.io/vega-lite/docs/clear.html) documentation for more information."
         },
         "empty": {
           "description": "By default, `all` data values are considered to lie within an empty selection.\nWhen set to `none`, empty selections contain no data values.",

--- a/examples/compiled/concat_hover.vg.json
+++ b/examples/compiled/concat_hover.vg.json
@@ -67,7 +67,7 @@
               "force": true
             },
             {
-              "events": [{"source": "scope", "type": "mouseout"}],
+              "events": [{"source": "scope", "type": "dblclick"}],
               "update": "null"
             }
           ]
@@ -176,7 +176,7 @@
               "force": true
             },
             {
-              "events": [{"source": "scope", "type": "mouseout"}],
+              "events": [{"source": "scope", "type": "dblclick"}],
               "update": "null"
             }
           ]

--- a/examples/compiled/concat_hover_filter.vg.json
+++ b/examples/compiled/concat_hover_filter.vg.json
@@ -94,7 +94,7 @@
               "force": true
             },
             {
-              "events": [{"source": "scope", "type": "mouseout"}],
+              "events": [{"source": "scope", "type": "dblclick"}],
               "update": "null"
             }
           ]
@@ -214,7 +214,7 @@
               "force": true
             },
             {
-              "events": [{"source": "scope", "type": "mouseout"}],
+              "events": [{"source": "scope", "type": "dblclick"}],
               "update": "null"
             }
           ]

--- a/examples/compiled/interactive_bar_select_highlight.vg.json
+++ b/examples/compiled/interactive_bar_select_highlight.vg.json
@@ -57,7 +57,7 @@
           "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", fields: highlight_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null",
           "force": true
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "null"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
       ]
     },
     {

--- a/examples/compiled/interactive_multi_line_label.vg.json
+++ b/examples/compiled/interactive_multi_line_label.vg.json
@@ -77,7 +77,7 @@
           "update": "datum && item().mark.marktype !== 'group' ? {unit: \"layer_0_layer_1\", fields: label_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"date\"]]} : null",
           "force": true
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "null"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
       ]
     },
     {

--- a/examples/compiled/interactive_multi_line_tooltip.vg.json
+++ b/examples/compiled/interactive_multi_line_tooltip.vg.json
@@ -48,7 +48,7 @@
           "update": "datum && item().mark.marktype !== 'group' ? {unit: \"layer_2\", fields: hover_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null",
           "force": true
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "null"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
       ]
     },
     {

--- a/examples/compiled/interactive_paintbrush.vg.json
+++ b/examples/compiled/interactive_paintbrush.vg.json
@@ -41,7 +41,7 @@
           "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", fields: paintbrush_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null",
           "force": true
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "null"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
       ]
     },
     {
@@ -56,7 +56,7 @@
           "events": [{"source": "scope", "type": "mouseover"}],
           "update": "event.shiftKey"
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "false"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "false"}
       ]
     },
     {

--- a/examples/compiled/interactive_paintbrush_color.vg.json
+++ b/examples/compiled/interactive_paintbrush_color.vg.json
@@ -41,7 +41,7 @@
           "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", fields: paintbrush_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null",
           "force": true
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "null"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
       ]
     },
     {
@@ -56,7 +56,7 @@
           "events": [{"source": "scope", "type": "mouseover"}],
           "update": "event.shiftKey"
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "false"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "false"}
       ]
     },
     {

--- a/examples/compiled/interactive_paintbrush_color_nearest.vg.json
+++ b/examples/compiled/interactive_paintbrush_color_nearest.vg.json
@@ -41,7 +41,7 @@
           "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", fields: paintbrush_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null",
           "force": true
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "null"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
       ]
     },
     {
@@ -56,7 +56,7 @@
           "events": [{"source": "scope", "type": "mouseover"}],
           "update": "event.shiftKey"
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "false"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "false"}
       ]
     },
     {

--- a/examples/compiled/interactive_paintbrush_simple_all.vg.json
+++ b/examples/compiled/interactive_paintbrush_simple_all.vg.json
@@ -40,7 +40,7 @@
           "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", fields: paintbrush_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null",
           "force": true
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "null"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
       ]
     },
     {
@@ -55,7 +55,7 @@
           "events": [{"source": "scope", "type": "mouseover"}],
           "update": "event.shiftKey"
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "false"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "false"}
       ]
     },
     {

--- a/examples/compiled/interactive_paintbrush_simple_none.vg.json
+++ b/examples/compiled/interactive_paintbrush_simple_none.vg.json
@@ -40,7 +40,7 @@
           "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", fields: paintbrush_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null",
           "force": true
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "null"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
       ]
     },
     {
@@ -55,7 +55,7 @@
           "events": [{"source": "scope", "type": "mouseover"}],
           "update": "event.shiftKey"
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "false"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "false"}
       ]
     },
     {

--- a/examples/compiled/selection_multi_condition.vg.json
+++ b/examples/compiled/selection_multi_condition.vg.json
@@ -260,7 +260,7 @@
           "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", fields: hoverbrush_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null",
           "force": true
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "null"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
       ]
     },
     {
@@ -275,7 +275,7 @@
           "events": [{"source": "scope", "type": "mouseover"}],
           "update": "event.shiftKey"
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "false"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "false"}
       ]
     },
     {

--- a/examples/compiled/selection_type_single_mouseover.vg.json
+++ b/examples/compiled/selection_type_single_mouseover.vg.json
@@ -46,7 +46,7 @@
           "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", fields: pts_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null",
           "force": true
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "null"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
       ]
     },
     {"name": "pts_tuple_fields", "value": [{"type": "E", "field": "_vgsid_"}]},

--- a/examples/compiled/trellis_selections.vg.json
+++ b/examples/compiled/trellis_selections.vg.json
@@ -42,7 +42,7 @@
           "events": [{"source": "scope", "type": "mouseover"}],
           "update": "datum && item().mark.marktype !== 'group' ? (item().isVoronoi ? datum.datum : datum)[\"X\"] : null"
         },
-        {"events": [{"source": "scope", "type": "mouseout"}], "update": "null"}
+        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
       ],
       "bind": {"input": "number"}
     },

--- a/site/docs/selection/clear.md
+++ b/site/docs/selection/clear.md
@@ -12,7 +12,7 @@ It can take one of the following values:
 - `false` -- disables clear behavior; there will be no event trigger that empties a selection.
 - A [Vega event stream definition](https://vega.github.io/vega/docs/event-streams/) to indicate which events should trigger clearing the selection.
 
-Vega-Lite automatically adds the clear property to all selections by default. If the selection is triggered by mouse hovers (i.e., `"on": "mouseover"`), then `"clear": "mouseout"`is used. For all other selection triggers,`"clear": "dblclick"` is used.
+Vega-Lite automatically adds the clear property to all selections by default, with the following definition: `"clear": "dblclick"`. Thus, to empty a select the user clicks the mouse button twice.
 
 ## Examples
 

--- a/site/docs/selection/clear.md
+++ b/site/docs/selection/clear.md
@@ -12,7 +12,7 @@ It can take one of the following values:
 - `false` -- disables clear behavior; there will be no event trigger that empties a selection.
 - A [Vega event stream definition](https://vega.github.io/vega/docs/event-streams/) to indicate which events should trigger clearing the selection.
 
-Vega-Lite automatically adds the clear property to all selections by default, with the following definition: `"clear": "dblclick"`. Thus, to empty a select the user clicks the mouse button twice.
+Vega-Lite automatically adds the clear property to all selections by default, with the following definition: `"clear": "dblclick"`. Thus, to empty a selection a user can double-click the mouse button.
 
 ## Examples
 

--- a/src/compile/selection/parse.ts
+++ b/src/compile/selection/parse.ts
@@ -42,12 +42,6 @@ export function parseUnitSelection(model: UnitModel, selDefs: Dict<SelectionDef>
       }
     }
 
-    // Define "clear" defaults here as it depends on "on".
-    if (selDef.clear !== false) {
-      const trigger = selDef.on === 'mouseover' ? 'mouseout' : 'dblclick';
-      selDef.clear = parseSelector(selDef.clear || trigger, 'scope');
-    }
-
     name = varName(name);
     const selCmpt = (selCmpts[name] = {
       ...selDef,

--- a/src/compile/selection/transforms/clear.ts
+++ b/src/compile/selection/transforms/clear.ts
@@ -1,4 +1,5 @@
 import {Update} from 'vega';
+import {selector as parseSelector} from 'vega-event-selector';
 import {TUPLE} from '..';
 import {varName} from '../../../util';
 import inputBindings from './inputs';
@@ -8,6 +9,12 @@ import {TransformCompiler} from './transforms';
 const clear: TransformCompiler = {
   has: selCmpt => {
     return selCmpt.clear !== false;
+  },
+
+  parse: (model, selDef, selCmpt) => {
+    if (selDef.clear) {
+      selCmpt.clear = parseSelector(selDef.clear, 'scope');
+    }
   },
 
   topLevelSignals: (model, selCmpt, signals) => {

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -61,7 +61,7 @@ export interface SingleSelectionConfig extends BaseSelectionDef {
    * Clears the selection, emptying it of all values. Can be an
    * [EventStream](https://vega.github.io/vega/docs/event-streams/) or `false` to disable.
    *
-   * __Default value:__ `mouseout` if `on: mouseover` else `dblclick`.
+   * __Default value:__ `dblclick`.
    *
    * See the [clear](https://vega.github.io/vega-lite/docs/clear.html) documentation for more information.
    */
@@ -95,7 +95,7 @@ export interface MultiSelectionConfig extends BaseSelectionDef {
    * Clears the selection, emptying it of all values. Can be an
    * [EventStream](https://vega.github.io/vega/docs/event-streams/) or `false` to disable.
    *
-   * __Default value:__ `mouseout` if `on: mouseover` else `dblclick`.
+   * __Default value:__ `dblclick`.
    *
    * See the [clear](https://vega.github.io/vega-lite/docs/clear.html) documentation for more information.
    */
@@ -172,7 +172,7 @@ export interface IntervalSelectionConfig extends BaseSelectionDef {
    * Clears the selection, emptying it of all values. Can be an
    * [EventStream](https://vega.github.io/vega/docs/event-streams/) or `false` to disable.
    *
-   * __Default value:__ `mouseout` if `on: mouseover` else `dblclick`.
+   * __Default value:__ `dblclick`.
    *
    * See the [clear](https://vega.github.io/vega-lite/docs/clear.html) documentation for more information.
    */
@@ -270,14 +270,16 @@ export const defaultConfig: SelectionConfig = {
     on: 'click',
     fields: [SELECTION_ID],
     resolve: 'global',
-    empty: 'all'
+    empty: 'all',
+    clear: 'dblclick'
   },
   multi: {
     on: 'click',
     fields: [SELECTION_ID],
     toggle: 'event.shiftKey',
     resolve: 'global',
-    empty: 'all'
+    empty: 'all',
+    clear: 'dblclick'
   },
   interval: {
     on: '[mousedown, window:mouseup] > window:mousemove!',
@@ -285,6 +287,7 @@ export const defaultConfig: SelectionConfig = {
     translate: '[mousedown, window:mouseup] > window:mousemove!',
     zoom: 'wheel!',
     mark: {fill: '#333', fillOpacity: 0.125, stroke: 'white'},
-    resolve: 'global'
+    resolve: 'global',
+    clear: 'dblclick'
   }
 };


### PR DESCRIPTION
This PR reverts to the original design of clearing selections: a `dblclick` event trigger. Switching to `clear: mouseout` when `on: mouseover` proved problematic for several reasons including making it difficult to support toggling multi selections on hover (#4879) and introducing a flickering behavior when using layered marks (#4306). 

Users can always opt _in_ to this behavior by specifying `clear: "mouseout"` manually as part of their specification. The `dblclick` default introduces the fewest conflicts. 