### PR TITLE
Include continuousPadding in scale config

### DIFF
--- a/site/docs/encoding/scale.md
+++ b/site/docs/encoding/scale.md
@@ -390,7 +390,7 @@ To provide themes for all scales, the scale config (`config: {scale: {...}}`) ca
 
 #### Padding
 
-{% include table.html props="continuousPadding,bandPaddingInner,bandPaddingOuter,barBandPaddingInner,barBandPaddingOuter,pointPadding,rectBandPaddingInner,rectBandPaddingOuter," source="ScaleConfig" %}
+{% include table.html props="bandPaddingInner,bandPaddingOuter,barBandPaddingInner,barBandPaddingOuter,continuousPadding,pointPadding,rectBandPaddingInner,rectBandPaddingOuter," source="ScaleConfig" %}
 
 #### Range
 

--- a/site/docs/encoding/scale.md
+++ b/site/docs/encoding/scale.md
@@ -390,7 +390,7 @@ To provide themes for all scales, the scale config (`config: {scale: {...}}`) ca
 
 #### Padding
 
-{% include table.html props="bandPaddingInner,bandPaddingOuter,barBandPaddingInner,barBandPaddingOuter,pointPadding,rectBandPaddingInner,rectBandPaddingOuter," source="ScaleConfig" %}
+{% include table.html props="continuousPadding,bandPaddingInner,bandPaddingOuter,barBandPaddingInner,barBandPaddingOuter,pointPadding,rectBandPaddingInner,rectBandPaddingOuter," source="ScaleConfig" %}
 
 #### Range
 


### PR DESCRIPTION
The `continuousPadding` scale config option referenced in the [definition of the `padding` option for continuous scales](https://vega.github.io/vega-lite/docs/scale.html#continuous) is not listed in the table of scale config padding options. I'm not sure this change will resolve the issue as I'm not familiar enough with this repo to trace down the `ScaleConfig` referenced in the include template directive. 