### PR TITLE
Fix tooltip propagation for voronoi marks.

### DIFF
--- a/src/compile/mark/mixins.ts
+++ b/src/compile/mark/mixins.ts
@@ -1,6 +1,6 @@
 import {array, isArray, isObject, isString} from 'vega-util';
 import {isBinned, isBinning} from '../../bin';
-import {Channel, NonPositionScaleChannel, ScaleChannel, SCALE_CHANNELS, X, X2, Y2} from '../../channel';
+import {Channel, NonPositionScaleChannel, SCALE_CHANNELS, ScaleChannel, X, X2, Y2} from '../../channel';
 import {
   ChannelDef,
   getTypedFieldDef,
@@ -15,7 +15,7 @@ import * as log from '../../log';
 import {isPathMark, Mark, MarkDef} from '../../mark';
 import {hasContinuousDomain} from '../../scale';
 import {contains, Dict, getFirstDefined, keys} from '../../util';
-import {VgEncodeChannel, VgEncodeEntry, VgValueRef, VG_MARK_CONFIGS} from '../../vega.schema';
+import {VG_MARK_CONFIGS, VgEncodeChannel, VgEncodeEntry, VgValueRef} from '../../vega.schema';
 import {getMarkConfig} from '../common';
 import {expression} from '../predicate';
 import {assembleSelectionPredicate} from '../selection/assemble';
@@ -282,7 +282,7 @@ export function tooltip(model: UnitModel, opt: {reactiveGeom?: boolean} = {}) {
   } else {
     return wrapCondition(model, channelDef, 'tooltip', cDef => {
       // use valueRef based on channelDef first
-      const tooltipRefFromChannelDef = ref.text(cDef, model.config);
+      const tooltipRefFromChannelDef = ref.text(cDef, model.config, opt.reactiveGeom ? 'datum.datum' : 'datum');
       if (tooltipRefFromChannelDef) {
         return tooltipRefFromChannelDef;
       }


### PR DESCRIPTION
#4726 introduced a `reactiveGeom` flag to lookup tooltip values on `datum.datum` rather than `datum` for voronoi marks which use reactive geometry. This PR fixes one location that was missed in the original PR that caused the bug to recur in #4859.