### PR TITLE
Add missing properties of impute transform

### DIFF
--- a/site/docs/transform/impute.md
+++ b/site/docs/transform/impute.md
@@ -94,7 +94,9 @@ An impute transform can also be specified as a part of the `transform` array.
       "impute": ...,
       "key": ...,
       "keyvals": ...,
-      "groupby": [...]
+      "groupby": [...],
+      "frame": [...],
+      "method": ...
     }
     ...
   ],
@@ -102,7 +104,7 @@ An impute transform can also be specified as a part of the `transform` array.
 }
 ```
 
-{% include table.html props="impute,key,keyvals,groupby" source="ImputeTransform" %}
+{% include table.html props="impute,key,keyvals,groupby,frame,method,value" source="ImputeTransform" %}
 
 For example, the same chart with `impute` in encoding [above]("#encoding-impute-value") can be created using the `impute` transform. Here, we have to manually specify the `key` and `groupby` fields, which were inferred automatically for `impute` in `encoding`.
 

--- a/site/docs/transform/impute.md
+++ b/site/docs/transform/impute.md
@@ -96,7 +96,8 @@ An impute transform can also be specified as a part of the `transform` array.
       "keyvals": ...,
       "groupby": [...],
       "frame": [...],
-      "method": ...
+      "method": ...,
+      "value": ...
     }
     ...
   ],


### PR DESCRIPTION
Missed some properties of `impute` in the impute transform docs. 