### PR TITLE
Qualify testPathIgnorePatterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,10 +136,10 @@
       "node"
     ],
     "testPathIgnorePatterns": [
-      "node_modules",
+      "/node_modules",
       "<rootDir>/build",
-      "_site",
-      "src"
+      "/_site",
+      "/src"
     ],
     "coverageDirectory": "./coverage/",
     "collectCoverage": false

--- a/package.json
+++ b/package.json
@@ -136,10 +136,10 @@
       "node"
     ],
     "testPathIgnorePatterns": [
-      "/node_modules",
+      "<rootDir>/node_modules",
       "<rootDir>/build",
-      "/_site",
-      "/src"
+      "<rootDir>/_site",
+      "<rootDir>/src"
     ],
     "coverageDirectory": "./coverage/",
     "collectCoverage": false


### PR DESCRIPTION
If the vega-lite source is in a directory that has a parent named "src" (in my case, `/opt/src/github/vega/vega-lite`), then the tests fail to run with the very inscrutable error:

```console
yarn run v1.15.2
$ jest test/ && npm run lint && npm run schema && jest examples/ && npm run test:runtime
No tests found, exiting with code 1
Run with `--passWithNoTests` to exit with code 0
In /opt/src/github/vega/vega-lite
  1527 files checked.
  testMatch:  - 0 matches
  testPathIgnorePatterns: node_modules, /opt/src/github/vega/vega-lite/build, _site, src - 0 matches
  testRegex: (/__tests__/.*|(\.|/)(test|spec))\.(jsx?|tsx?)$ - 117 matches
Pattern: test/ - 0 matches
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

shell returned 1
```

The solution of qualifying the `testPathIgnorePatterns` array with "/src" solves this issue.