### PR TITLE
Stop merging conflicting data sources

### DIFF
--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -86,18 +86,18 @@ export function findSource(data: Data, sources: SourceNode[]) {
  * @param source Source node whose data format is to be checked against that of data
  */
 function formatsConflict(data: Data, source: SourceNode): boolean {
-  let conflict = false;
   if (source && data && !isGenerator(data) && data.format) {
     // 'mesh' and 'feature' property should be exclusive of each other, ensure we don't combine them into one node
     const haveConflictingKeys = ['mesh', 'feature'].every((k: 'mesh' | 'feature') =>
       [...keys(data.format), ...keys(source.data.format)].includes(k)
     );
-    conflict =
+    return (
       haveConflictingKeys ||
       // ensure that common format properties agree
-      keys(data.format).some(k => k in source.data.format && data.format[k] !== source.data.format[k]);
+      keys(data.format).some(k => k in source.data.format && data.format[k] !== source.data.format[k])
+    );
   }
-  return conflict;
+  return false;
 }
 
 function parseRoot(model: Model, sources: SourceNode[]): DataFlowNode {

--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -86,18 +86,20 @@ export function findSource(data: Data, sources: SourceNode[]) {
  * @param source Source node whose data format is to be checked against that of data
  */
 function formatsConflict(data: Data, source: SourceNode): boolean {
-  if (source && data && !isGenerator(data) && data.format) {
-    // 'mesh' and 'feature' property should be exclusive of each other, ensure we don't combine them into one node
-    const haveConflictingKeys = ['mesh', 'feature'].every((k: 'mesh' | 'feature') =>
-      [...keys(data.format), ...keys(source.data.format)].includes(k)
-    );
-    return (
-      haveConflictingKeys ||
-      // ensure that common format properties agree
-      keys(data.format).some(k => k in source.data.format && data.format[k] !== source.data.format[k])
-    );
+  if (!source || !data || isGenerator(data) || !data.format) {
+    // formats can't conflict if they don't exist
+    return false;
   }
-  return false;
+
+  // 'mesh' and 'feature' property should be mutually exclusive of each other
+  const haveConflictingKeys = ['mesh', 'feature'].every((k: 'mesh' | 'feature') =>
+    [...keys(data.format), ...keys(source.data.format)].includes(k)
+  );
+  return (
+    haveConflictingKeys ||
+    // ensure that common format properties agree
+    keys(data.format).some(k => k in source.data.format && data.format[k] !== source.data.format[k])
+  );
 }
 
 function parseRoot(model: Model, sources: SourceNode[]): DataFlowNode {


### PR DESCRIPTION
Addresses #4910. Check to see if data sources conflict with each other and don't merge them if they do. A conflict can occur if the sources have properties with different values in their format or if they have mutually exclusive properties e.g. 'mesh' and 'feature'.
