### PR TITLE
Merge `ValueDefWithOptionalCondition` as a variant of `ConditionOnlyDef<F>`, but use minProperties = 1 instead

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -2349,87 +2349,6 @@
       },
       "type": "object"
     },
-    "ConditionOnlyDef<MarkPropFieldDef>": {
-      "additionalProperties": false,
-      "description": "A Condition<ValueDef | FieldDef> only definition.\n{\n   condition: {field: ...} | {value: ...}\n}",
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalMarkPropFieldDef"
-            },
-            {
-              "$ref": "#/definitions/ConditionalValueDef"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalValueDef"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "A field definition or one or more value definition(s) with a selection predicate."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionOnlyDef<MarkPropFieldDef<TypeForShape>>": {
-      "additionalProperties": false,
-      "description": "A Condition<ValueDef | FieldDef> only definition.\n{\n   condition: {field: ...} | {value: ...}\n}",
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalMarkPropFieldDef<TypeForShape>"
-            },
-            {
-              "$ref": "#/definitions/ConditionalValueDef"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalValueDef"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "A field definition or one or more value definition(s) with a selection predicate."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionOnlyDef<TextFieldDef>": {
-      "additionalProperties": false,
-      "description": "A Condition<ValueDef | FieldDef> only definition.\n{\n   condition: {field: ...} | {value: ...}\n}",
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalTextFieldDef"
-            },
-            {
-              "$ref": "#/definitions/ConditionalValueDef"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalValueDef"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "A field definition or one or more value definition(s) with a selection predicate."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
     "ConditionalMarkPropFieldDef": {
       "anyOf": [
         {
@@ -9173,7 +9092,7 @@
     },
     "RepeatRef": {
       "additionalProperties": false,
-      "description": "Reference to a repeated value.",
+      "description": "A ValueDef with optional Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n} \n Reference to a repeated value.",
       "properties": {
         "repeat": {
           "enum": [
@@ -12235,52 +12154,9 @@
       "type": "object"
     },
     "ValueDefWithCondition<MarkPropFieldDef,(string|null)>": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ValueDefWithOptionalCondition<MarkPropFieldDef,(string|null)>"
-        },
-        {
-          "$ref": "#/definitions/ConditionOnlyDef<MarkPropFieldDef>"
-        }
-      ],
-      "description": "A ValueDef with Condition<ValueDef | FieldDef> where either the conition or the value are optional.\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}"
-    },
-    "ValueDefWithCondition<MarkPropFieldDef,number>": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ValueDefWithOptionalCondition<MarkPropFieldDef,number>"
-        },
-        {
-          "$ref": "#/definitions/ConditionOnlyDef<MarkPropFieldDef>"
-        }
-      ],
-      "description": "A ValueDef with Condition<ValueDef | FieldDef> where either the conition or the value are optional.\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}"
-    },
-    "ValueDefWithCondition<MarkPropFieldDef<TypeForShape>,(string|null)>": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ValueDefWithOptionalCondition<MarkPropFieldDef<TypeForShape>,(string|null)>"
-        },
-        {
-          "$ref": "#/definitions/ConditionOnlyDef<MarkPropFieldDef<TypeForShape>>"
-        }
-      ],
-      "description": "A ValueDef with Condition<ValueDef | FieldDef> where either the conition or the value are optional.\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}"
-    },
-    "ValueDefWithCondition<TextFieldDef,Value>": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ValueDefWithOptionalCondition<TextFieldDef,Value>"
-        },
-        {
-          "$ref": "#/definitions/ConditionOnlyDef<TextFieldDef>"
-        }
-      ],
-      "description": "A ValueDef with Condition<ValueDef | FieldDef> where either the conition or the value are optional.\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}"
-    },
-    "ValueDefWithOptionalCondition<MarkPropFieldDef,(string|null)>": {
       "additionalProperties": false,
-      "description": "A ValueDef with optional Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
+      "description": "A ValueDef with Condition<ValueDef | FieldDef> where either the conition or the value are optional.\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
+      "minProperties": 1,
       "properties": {
         "condition": {
           "anyOf": [
@@ -12307,14 +12183,12 @@
           ]
         }
       },
-      "required": [
-        "value"
-      ],
       "type": "object"
     },
-    "ValueDefWithOptionalCondition<MarkPropFieldDef,number>": {
+    "ValueDefWithCondition<MarkPropFieldDef,number>": {
       "additionalProperties": false,
-      "description": "A ValueDef with optional Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
+      "description": "A ValueDef with Condition<ValueDef | FieldDef> where either the conition or the value are optional.\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
+      "minProperties": 1,
       "properties": {
         "condition": {
           "anyOf": [
@@ -12338,14 +12212,12 @@
           "type": "number"
         }
       },
-      "required": [
-        "value"
-      ],
       "type": "object"
     },
-    "ValueDefWithOptionalCondition<MarkPropFieldDef<TypeForShape>,(string|null)>": {
+    "ValueDefWithCondition<MarkPropFieldDef<TypeForShape>,(string|null)>": {
       "additionalProperties": false,
-      "description": "A ValueDef with optional Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
+      "description": "A ValueDef with Condition<ValueDef | FieldDef> where either the conition or the value are optional.\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
+      "minProperties": 1,
       "properties": {
         "condition": {
           "anyOf": [
@@ -12372,14 +12244,12 @@
           ]
         }
       },
-      "required": [
-        "value"
-      ],
       "type": "object"
     },
-    "ValueDefWithOptionalCondition<TextFieldDef,Value>": {
+    "ValueDefWithCondition<TextFieldDef,Value>": {
       "additionalProperties": false,
-      "description": "A ValueDef with optional Condition<ValueDef | FieldDef>\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
+      "description": "A ValueDef with Condition<ValueDef | FieldDef> where either the conition or the value are optional.\n{\n   condition: {field: ...} | {value: ...},\n   value: ...,\n}",
+      "minProperties": 1,
       "properties": {
         "condition": {
           "anyOf": [
@@ -12403,9 +12273,6 @@
           "description": "A constant value in visual domain (e.g., `\"red\"` / \"#0099ff\" for color, values between `0` to `1` for opacity)."
         }
       },
-      "required": [
-        "value"
-      ],
       "type": "object"
     },
     "ViewBackground": {

--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -58,9 +58,15 @@ export type ChannelDefWithCondition<F extends FieldDef<any>, V extends Value> =
  * }
  */
 
-export type ValueDefWithCondition<F extends FieldDef<any>, V extends Value = Value> =
-  | ValueDefWithOptionalCondition<F, V>
-  | ConditionOnlyDef<F>;
+/**
+ * @minProperties 1
+ */
+export type ValueDefWithCondition<F extends FieldDef<any>, V extends Value = Value> = Partial<ValueDef<V>> & {
+  /**
+   * A field definition or one or more value definition(s) with a selection predicate.
+   */
+  condition?: Conditional<F> | Conditional<ValueDef<V>> | Conditional<ValueDef<V>>[];
+};
 
 export type StringValueDefWithCondition<F extends Field, T extends Type = StandardType> = ValueDefWithCondition<
   MarkPropFieldDef<F, T>,
@@ -140,26 +146,6 @@ export type TextFieldDefWithCondition<F extends Field> = FieldDefWithCondition<T
  *   value: ...,
  * }
  */
-
-export interface ValueDefWithOptionalCondition<FD extends FieldDef<any>, V extends Value> extends ValueDef<V> {
-  /**
-   * A field definition or one or more value definition(s) with a selection predicate.
-   */
-  condition?: Conditional<FD> | Conditional<ValueDef<V>> | Conditional<ValueDef<V>>[];
-}
-
-/**
- * A Condition<ValueDef | FieldDef> only definition.
- * {
- *   condition: {field: ...} | {value: ...}
- * }
- */
-export interface ConditionOnlyDef<F extends FieldDef<any>, V extends Value = Value> {
-  /**
-   * A field definition or one or more value definition(s) with a selection predicate.
-   */
-  condition: Conditional<F> | Conditional<ValueDef<V>> | Conditional<ValueDef<V>>[];
-}
 
 /**
  * Reference to a repeated value.
@@ -403,7 +389,7 @@ export function isConditionalDef<F extends Field, V extends Value>(
 
 export function hasConditionalFieldDef<F extends Field, V extends Value>(
   channelDef: ChannelDef<FieldDef<F>, V>
-): channelDef is ValueDef<V> & {condition: Conditional<TypedFieldDef<F>>} {
+): channelDef is Partial<ValueDef<V>> & {condition: Conditional<TypedFieldDef<F>>} {
   return !!channelDef && !!channelDef.condition && !isArray(channelDef.condition) && isFieldDef(channelDef.condition);
 }
 

--- a/src/compile/scale/parse.ts
+++ b/src/compile/scale/parse.ts
@@ -1,4 +1,4 @@
-import {SCALE_CHANNELS, ScaleChannel, SHAPE} from '../../channel';
+import {ScaleChannel, SCALE_CHANNELS, SHAPE} from '../../channel';
 import {hasConditionalFieldDef, isFieldDef, TypedFieldDef} from '../../channeldef';
 import {GEOSHAPE} from '../../mark';
 import {
@@ -58,7 +58,8 @@ function parseUnitScaleCore(model: UnitModel): ScaleComponentIndex {
     if (isFieldDef(channelDef)) {
       fieldDef = channelDef;
       specifiedScale = channelDef.scale;
-    } else if (hasConditionalFieldDef(channelDef)) {
+    } else if (hasConditionalFieldDef<string, any>(channelDef)) {
+      // Need to specify generic for hasConditionalFieldDef as the value type can vary across channels
       fieldDef = channelDef.condition;
       specifiedScale = channelDef.condition['scale']; // We use ['scale'] since we know that channel here has scale for sure
     }

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -136,7 +136,7 @@ export class UnitModel extends ModelWithField {
         if (isFieldDef(channelDef)) {
           fieldDef = channelDef;
           specifiedScale = channelDef.scale;
-        } else if (hasConditionalFieldDef<string, any>(channelDef)) {
+        } else if (hasConditionalFieldDef<string, any>(channelDef)) { // Need to specify generic for hasConditionalFieldDef as the value type can vary across channels
           fieldDef = channelDef.condition;
           specifiedScale = channelDef.condition['scale'];
         }

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -136,7 +136,8 @@ export class UnitModel extends ModelWithField {
         if (isFieldDef(channelDef)) {
           fieldDef = channelDef;
           specifiedScale = channelDef.scale;
-        } else if (hasConditionalFieldDef<string, any>(channelDef)) { // Need to specify generic for hasConditionalFieldDef as the value type can vary across channels
+        } else if (hasConditionalFieldDef<string, any>(channelDef)) {
+          // Need to specify generic for hasConditionalFieldDef as the value type can vary across channels
           fieldDef = channelDef.condition;
           specifiedScale = channelDef.condition['scale'];
         }

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -4,8 +4,8 @@ import {
   Channel,
   GEOPOSITION_CHANNELS,
   NONPOSITION_SCALE_CHANNELS,
-  SCALE_CHANNELS,
   ScaleChannel,
+  SCALE_CHANNELS,
   SingleDefChannel,
   supportLegend,
   X,
@@ -136,7 +136,7 @@ export class UnitModel extends ModelWithField {
         if (isFieldDef(channelDef)) {
           fieldDef = channelDef;
           specifiedScale = channelDef.scale;
-        } else if (hasConditionalFieldDef(channelDef)) {
+        } else if (hasConditionalFieldDef<string, any>(channelDef)) {
           fieldDef = channelDef.condition;
           specifiedScale = channelDef.condition['scale'];
         }
@@ -179,7 +179,7 @@ export class UnitModel extends ModelWithField {
       if (channelDef) {
         const legend = isFieldDef(channelDef)
           ? channelDef.legend
-          : hasConditionalFieldDef(channelDef)
+          : hasConditionalFieldDef<string, any>(channelDef) // Need to specify generic for hasConditionalFieldDef as the value type can vary across channels
           ? channelDef.condition['legend']
           : null;
 


### PR DESCRIPTION
This simplifies our JSON schema, but we need to add `minProperties` support to the schema generator for this to remain correct. 

cc: @domoritz 