### PR TITLE
Add FieldName alias to string

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -55,7 +55,7 @@
         "groupby": {
           "description": "The data fields to group by. If not specified, a single group containing all data objects will be used.",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/FieldName"
           },
           "type": "array"
         }
@@ -69,12 +69,12 @@
       "additionalProperties": false,
       "properties": {
         "as": {
-          "description": "The output field names to use for each aggregated field.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "The output field names to use for each aggregated field."
         },
         "field": {
-          "description": "The data field for which to compute aggregate function. This is required for all aggregation operations except `\"count\"`.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "The data field for which to compute aggregate function. This is required for all aggregation operations except `\"count\"`."
         },
         "op": {
           "$ref": "#/definitions/AggregateOp",
@@ -1610,11 +1610,11 @@
         "as": {
           "anyOf": [
             {
-              "type": "string"
+              "$ref": "#/definitions/FieldName"
             },
             {
               "items": {
-                "type": "string"
+                "$ref": "#/definitions/FieldName"
               },
               "type": "array"
             }
@@ -1636,8 +1636,8 @@
           "description": "An object indicating bin properties, or simply `true` for using default bin parameters."
         },
         "field": {
-          "description": "The data field to bin.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "The data field to bin."
         }
       },
       "required": [
@@ -1978,8 +1978,8 @@
       "additionalProperties": false,
       "properties": {
         "as": {
-          "description": "The field for storing the computed formula value.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "The field for storing the computed formula value."
         },
         "calculate": {
           "description": "A [expression](https://vega.github.io/vega-lite/docs/types.html#expression) string. Use the variable `datum` to refer to the current data object.",
@@ -4267,7 +4267,7 @@
     "Field": {
       "anyOf": [
         {
-          "type": "string"
+          "$ref": "#/definitions/FieldName"
         },
         {
           "$ref": "#/definitions/RepeatRef"
@@ -4639,8 +4639,8 @@
           "description": "The value that the field should be equal to."
         },
         "field": {
-          "description": "Field to be filtered.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "Field to be filtered."
         },
         "timeUnit": {
           "$ref": "#/definitions/TimeUnit",
@@ -4657,8 +4657,8 @@
       "additionalProperties": false,
       "properties": {
         "field": {
-          "description": "Field to be filtered.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "Field to be filtered."
         },
         "gte": {
           "anyOf": [
@@ -4689,8 +4689,8 @@
       "additionalProperties": false,
       "properties": {
         "field": {
-          "description": "Field to be filtered.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "Field to be filtered."
         },
         "gt": {
           "anyOf": [
@@ -4721,8 +4721,8 @@
       "additionalProperties": false,
       "properties": {
         "field": {
-          "description": "Field to be filtered.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "Field to be filtered."
         },
         "lte": {
           "anyOf": [
@@ -4753,8 +4753,8 @@
       "additionalProperties": false,
       "properties": {
         "field": {
-          "description": "Field to be filtered.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "Field to be filtered."
         },
         "lt": {
           "anyOf": [
@@ -4781,12 +4781,15 @@
       ],
       "type": "object"
     },
+    "FieldName": {
+      "type": "string"
+    },
     "FieldOneOfPredicate": {
       "additionalProperties": false,
       "properties": {
         "field": {
-          "description": "Field to be filtered.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "Field to be filtered."
         },
         "oneOf": {
           "anyOf": [
@@ -4832,8 +4835,8 @@
       "additionalProperties": false,
       "properties": {
         "field": {
-          "description": "Field to be filtered.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "Field to be filtered."
         },
         "range": {
           "description": "An array of inclusive minimum and maximum values\nfor a field value of a data item to be included in the filtered data.",
@@ -4869,8 +4872,8 @@
       "additionalProperties": false,
       "properties": {
         "field": {
-          "description": "Field to be filtered.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "Field to be filtered."
         },
         "timeUnit": {
           "$ref": "#/definitions/TimeUnit",
@@ -4906,14 +4909,14 @@
         "as": {
           "description": "The output field names for extracted array values.\n\n__Default value:__ The field name of the corresponding array field",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/FieldName"
           },
           "type": "array"
         },
         "flatten": {
           "description": "An array of one or more data fields containing arrays to flatten.\nIf multiple fields are specified, their array values should have a parallel structure, ideally with the same length.\nIf the lengths of parallel arrays do not match,\nthe longest array will be used with `null` values added for missing entries.",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/FieldName"
           },
           "type": "array"
         }
@@ -4930,10 +4933,10 @@
           "description": "The output field names for the key and value properties produced by the fold transform.\n__Default value:__ `[\"key\", \"value\"]`",
           "items": [
             {
-              "type": "string"
+              "$ref": "#/definitions/FieldName"
             },
             {
-              "type": "string"
+              "$ref": "#/definitions/FieldName"
             }
           ],
           "maxItems": 2,
@@ -4943,7 +4946,7 @@
         "fold": {
           "description": "An array of data fields indicating the properties to fold.",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/FieldName"
           },
           "type": "array"
         }
@@ -5932,17 +5935,17 @@
         "groupby": {
           "description": "An optional array of fields by which to group the values.\nImputation will then be performed on a per-group basis.",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/FieldName"
           },
           "type": "array"
         },
         "impute": {
-          "description": "The data field for which the missing values should be imputed.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "The data field for which the missing values should be imputed."
         },
         "key": {
-          "description": "A key field that uniquely identifies data objects within a group.\nMissing key values (those occurring in the data but not in the current group) will be imputed.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "A key field that uniquely identifies data objects within a group.\nMissing key values (those occurring in the data but not in the current group) will be imputed."
         },
         "keyvals": {
           "anyOf": [
@@ -6110,7 +6113,7 @@
         "fields": {
           "description": "An array of field names whose values must match for a data tuple to\nfall within the selection.",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/FieldName"
           },
           "type": "array"
         },
@@ -6195,7 +6198,7 @@
         "fields": {
           "description": "An array of field names whose values must match for a data tuple to\nfall within the selection.",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/FieldName"
           },
           "type": "array"
         },
@@ -6236,12 +6239,12 @@
       "additionalProperties": false,
       "properties": {
         "as": {
-          "description": "The output name for the join aggregate operation.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "The output name for the join aggregate operation."
         },
         "field": {
-          "description": "The data field for which to compute the aggregate function. This can be omitted for functions that do not operate over a field such as `count`.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "The data field for which to compute the aggregate function. This can be omitted for functions that do not operate over a field such as `count`."
         },
         "op": {
           "$ref": "#/definitions/AggregateOp",
@@ -6260,7 +6263,7 @@
         "groupby": {
           "description": "The data fields for partitioning the data objects into separate groups. If unspecified, all data points will be in a single group.",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/FieldName"
           },
           "type": "array"
         },
@@ -7550,13 +7553,13 @@
         "fields": {
           "description": "Fields in foreign data to lookup.\nIf not specified, the entire object is queried.",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/FieldName"
           },
           "type": "array"
         },
         "key": {
-          "description": "Key in data to lookup.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "Key in data to lookup."
         }
       },
       "required": [
@@ -7571,11 +7574,11 @@
         "as": {
           "anyOf": [
             {
-              "type": "string"
+              "$ref": "#/definitions/FieldName"
             },
             {
               "items": {
-                "type": "string"
+                "$ref": "#/definitions/FieldName"
               },
               "type": "array"
             }
@@ -7591,8 +7594,8 @@
           "description": "Secondary data reference."
         },
         "lookup": {
-          "description": "Key in primary data source.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "Key in primary data source."
         }
       },
       "required": [
@@ -8143,7 +8146,7 @@
         "fields": {
           "description": "An array of field names whose values must match for a data tuple to\nfall within the selection.",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/FieldName"
           },
           "type": "array"
         },
@@ -8224,7 +8227,7 @@
         "fields": {
           "description": "An array of field names whose values must match for a data tuple to\nfall within the selection.",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/FieldName"
           },
           "type": "array"
         },
@@ -9774,8 +9777,8 @@
           "additionalProperties": false,
           "properties": {
             "field": {
-              "description": "The field name to extract selected values for, when a selection is [projected](https://vega.github.io/vega-lite/docs/project.html)\nover multiple fields or encodings.",
-              "type": "string"
+              "$ref": "#/definitions/FieldName",
+              "description": "The field name to extract selected values for, when a selection is [projected](https://vega.github.io/vega-lite/docs/project.html)\nover multiple fields or encodings."
             },
             "selection": {
               "description": "The name of a selection.",
@@ -9904,8 +9907,8 @@
       "additionalProperties": false,
       "properties": {
         "as": {
-          "description": "The name of the generated sequence field.\n\n__Default value:__ `\"data\"`",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "The name of the generated sequence field.\n\n__Default value:__ `\"data\"`"
         },
         "start": {
           "description": "The starting value of the sequence (inclusive).",
@@ -10016,7 +10019,7 @@
         "fields": {
           "description": "An array of field names whose values must match for a data tuple to\nfall within the selection.",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/FieldName"
           },
           "type": "array"
         },
@@ -10094,7 +10097,7 @@
         "fields": {
           "description": "An array of field names whose values must match for a data tuple to\nfall within the selection.",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/FieldName"
           },
           "type": "array"
         },
@@ -10203,8 +10206,8 @@
       "description": "A sort definition for transform",
       "properties": {
         "field": {
-          "description": "The name of the field to sort.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "The name of the field to sort."
         },
         "order": {
           "anyOf": [
@@ -10272,11 +10275,11 @@
         "as": {
           "anyOf": [
             {
-              "type": "string"
+              "$ref": "#/definitions/FieldName"
             },
             {
               "items": {
-                "type": "string"
+                "$ref": "#/definitions/FieldName"
               },
               "type": "array"
             }
@@ -10286,7 +10289,7 @@
         "groupby": {
           "description": "The data fields to group by.",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/FieldName"
           },
           "type": "array"
         },
@@ -10307,8 +10310,8 @@
           "type": "array"
         },
         "stack": {
-          "description": "The field which is stacked.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "The field which is stacked."
         }
       },
       "required": [
@@ -10883,12 +10886,12 @@
       "additionalProperties": false,
       "properties": {
         "as": {
-          "description": "The output field to write the timeUnit value.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "The output field to write the timeUnit value."
         },
         "field": {
-          "description": "The data field to apply time unit.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "The data field to apply time unit."
         },
         "timeUnit": {
           "$ref": "#/definitions/TimeUnit",
@@ -12562,12 +12565,12 @@
       "additionalProperties": false,
       "properties": {
         "as": {
-          "description": "The output name for the window operation.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "The output name for the window operation."
         },
         "field": {
-          "description": "The data field for which to compute the aggregate or window function. This can be omitted for window functions that do not operate over a field such as `count`, `rank`, `dense_rank`.",
-          "type": "string"
+          "$ref": "#/definitions/FieldName",
+          "description": "The data field for which to compute the aggregate or window function. This can be omitted for window functions that do not operate over a field such as `count`, `rank`, `dense_rank`."
         },
         "op": {
           "anyOf": [
@@ -12623,7 +12626,7 @@
         "groupby": {
           "description": "The data fields for partitioning the data objects into separate windows. If unspecified, all data points will be in a single window.",
           "items": {
-            "type": "string"
+            "$ref": "#/definitions/FieldName"
           },
           "type": "array"
         },

--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -168,7 +168,8 @@ export interface RepeatRef {
   repeat: 'row' | 'column' | 'repeat';
 }
 
-export type Field = string | RepeatRef;
+export type FieldName = string;
+export type Field = FieldName | RepeatRef;
 
 export function isRepeatRef(field: Field): field is RepeatRef {
   return field && !isString(field) && 'repeat' in field;

--- a/src/compile/data/bin.ts
+++ b/src/compile/data/bin.ts
@@ -1,7 +1,7 @@
 import {isString} from 'vega-util';
 import {BinParams, binToString, isBinning} from '../../bin';
 import {Channel} from '../../channel';
-import {binRequiresRange, isTypedFieldDef, normalizeBin, TypedFieldDef, vgField} from '../../channeldef';
+import {FieldName, binRequiresRange, isTypedFieldDef, normalizeBin, TypedFieldDef, vgField} from '../../channeldef';
 import {Config} from '../../config';
 import {BinTransform} from '../../transform';
 import {Dict, duplicate, flatten, hash, keys, unique, vals} from '../../util';
@@ -68,7 +68,7 @@ function createBinComponent(t: TypedFieldDef<string> | BinTransform, bin: boolea
 
 export interface BinComponent {
   bin: BinParams;
-  field: string;
+  field: FieldName;
   extentSignal?: string;
   signal?: string;
 

--- a/src/compile/data/stack.ts
+++ b/src/compile/data/stack.ts
@@ -1,5 +1,5 @@
 import {isArray, isString} from 'vega-util';
-import {getTypedFieldDef, isFieldDef, TypedFieldDef, vgField} from '../../channeldef';
+import {FieldName, getTypedFieldDef, isFieldDef, TypedFieldDef, vgField} from '../../channeldef';
 import {StackOffset} from '../../stack';
 import {StackTransform} from '../../transform';
 import {duplicate, getFirstDefined, hash} from '../../util';
@@ -60,11 +60,11 @@ export interface StackComponent {
   /**
    * The data fields to group by.
    */
-  groupby?: string[];
+  groupby?: FieldName[];
   /**
    * Output field names of each stack field.
    */
-  as: string[];
+  as: FieldName[];
 }
 
 function isValidAsArray(as: string[] | string): as is string[] {

--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -3,6 +3,7 @@
  */
 import {SignalRef} from 'vega';
 import {isFunction, isString, stringValue} from 'vega-util';
+import {FieldName} from '../../channeldef';
 import {isCountingAggregateOp} from '../../aggregate';
 import {isBinned, isBinning} from '../../bin';
 import {Channel, getMainRangeChannel, PositionChannel, X, X2, Y, Y2} from '../../channel';
@@ -91,7 +92,7 @@ export function fieldInvalidTestValueRef(fieldDef: FieldDef<string>, channel: Po
   return {test, ...zeroValueRef};
 }
 
-export function fieldInvalidPredicate(field: string | FieldDef<string>, invalid = true) {
+export function fieldInvalidPredicate(field: FieldName | FieldDef<string>, invalid = true) {
   field = isString(field) ? field : vgField(field, {expr: 'datum'});
   const op = invalid ? '||' : '&&';
   const eq = invalid ? '===' : '!==';

--- a/src/data.ts
+++ b/src/data.ts
@@ -2,6 +2,7 @@
  * Constants and utilities for data.
  */
 import {VgData} from './vega.schema';
+import {FieldName} from './channeldef';
 
 export type ParseValue = null | string | 'string' | 'boolean' | 'date' | 'number';
 
@@ -187,7 +188,7 @@ export interface SequenceParams {
    *
    * __Default value:__ `"data"`
    */
-  as?: string;
+  as?: FieldName;
 }
 
 export interface SphereGenerator extends GeneratorBase {

--- a/src/predicate.ts
+++ b/src/predicate.ts
@@ -1,6 +1,6 @@
 import {isArray} from 'vega-util';
-import {valueExpr, vgField} from './channeldef';
 import {DateTime} from './datetime';
+import {FieldName, valueExpr, vgField} from './channeldef';
 import {LogicalOperand} from './logical';
 import {fieldExpr as timeUnitFieldExpr, normalizeTimeUnit, TimeUnit} from './timeunit';
 
@@ -52,7 +52,7 @@ export interface FieldPredicateBase {
   /**
    * Field to be filtered.
    */
-  field: string;
+  field: FieldName;
 }
 
 export interface FieldEqualPredicate extends FieldPredicateBase {

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -1,6 +1,7 @@
 import {toSet} from 'vega-util';
 import * as CHANNEL from './channel';
 import {Channel, CHANNELS, isColorChannel} from './channel';
+import {FieldName} from './channeldef';
 import {DateTime} from './datetime';
 import * as log from './log';
 import * as TYPE from './type';
@@ -444,7 +445,7 @@ export type SelectionDomain =
        * The field name to extract selected values for, when a selection is [projected](https://vega.github.io/vega-lite/docs/project.html)
        * over multiple fields or encodings.
        */
-      field?: string;
+      field?: FieldName;
     }
   | {
       /**

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,5 +1,6 @@
 import {Binding} from 'vega';
 import {SingleDefUnitChannel} from './channel';
+import {FieldName} from './channeldef';
 import {DateTime} from './datetime';
 import {EventStream} from './vega.schema';
 
@@ -47,7 +48,7 @@ export interface BaseSelectionDef {
    * An array of field names whose values must match for a data tuple to
    * fall within the selection.
    */
-  fields?: string[];
+  fields?: FieldName[];
 
   /**
    * By default, `all` data values are considered to lie within an empty selection.

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -1,6 +1,7 @@
 import {AggregateOp} from 'vega';
 import {isArray} from 'vega-util';
 import {SingleDefUnitChannel} from './channel';
+import {FieldName} from './channeldef';
 import {DateTime} from './datetime';
 
 export type SortOrder = 'ascending' | 'descending';
@@ -12,7 +13,7 @@ export interface SortField {
   /**
    * The name of the field to sort.
    */
-  field: string;
+  field: FieldName;
 
   /**
    * Whether to sort the field in ascending or descending order. One of `"ascending"` (default), `"descending"`, or `null` (no not sort).
@@ -21,7 +22,7 @@ export interface SortField {
 }
 
 export interface SortFields {
-  field: string[];
+  field: FieldName[];
   order?: (SortOrder)[];
 }
 

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -1,6 +1,7 @@
 import {AggregateOp} from 'vega';
 import {BinParams} from './bin';
 import {Data} from './data';
+import {FieldName} from './channeldef';
 import {ImputeParams} from './impute';
 import {LogicalOperand, normalizeLogicalOperand} from './logical';
 import {normalizePredicate, Predicate} from './predicate';
@@ -45,7 +46,7 @@ export interface CalculateTransform {
   /**
    * The field for storing the computed formula value.
    */
-  as: string;
+  as: FieldName;
 }
 
 export interface BinTransform {
@@ -57,12 +58,12 @@ export interface BinTransform {
   /**
    * The data field to bin.
    */
-  field: string;
+  field: FieldName;
 
   /**
    * The output fields at which to write the start and end bin values.
    */
-  as: string | string[];
+  as: FieldName | FieldName[];
 }
 
 export interface TimeUnitTransform {
@@ -74,12 +75,12 @@ export interface TimeUnitTransform {
   /**
    * The data field to apply time unit.
    */
-  field: string;
+  field: FieldName;
 
   /**
    * The output field to write the timeUnit value.
    */
-  as: string;
+  as: FieldName;
 }
 
 export interface AggregateTransform {
@@ -91,7 +92,7 @@ export interface AggregateTransform {
   /**
    * The data fields to group by. If not specified, a single group containing all data objects will be used.
    */
-  groupby?: string[];
+  groupby?: FieldName[];
 }
 
 export interface AggregatedFieldDef {
@@ -105,23 +106,23 @@ export interface AggregatedFieldDef {
   /**
    * The data field for which to compute aggregate function. This is required for all aggregation operations except `"count"`.
    */
-  field?: string;
+  field?: FieldName;
 
   /**
    * The output field names to use for each aggregated field.
    */
-  as: string;
+  as: FieldName;
 }
 
 export interface StackTransform {
   /**
    * The field which is stacked.
    */
-  stack: string;
+  stack: FieldName;
   /**
    * The data fields to group by.
    */
-  groupby: string[];
+  groupby: FieldName[];
   /**
    * Mode for stacking marks.
    * __Default value:__ `"zero"`
@@ -137,7 +138,7 @@ export interface StackTransform {
    * respectively.
    * If a single string(eg."val") is provided, the end field will be "val_end".
    */
-  as: string | string[];
+  as: FieldName | FieldName[];
 }
 
 export type WindowOnlyOp =
@@ -169,12 +170,12 @@ export interface WindowFieldDef {
   /**
    * The data field for which to compute the aggregate or window function. This can be omitted for window functions that do not operate over a field such as `count`, `rank`, `dense_rank`.
    */
-  field?: string;
+  field?: FieldName;
 
   /**
    * The output name for the window operation.
    */
-  as: string;
+  as: FieldName;
 }
 
 export interface WindowTransform {
@@ -200,7 +201,7 @@ export interface WindowTransform {
   /**
    * The data fields for partitioning the data objects into separate windows. If unspecified, all data points will be in a single window.
    */
-  groupby?: string[];
+  groupby?: FieldName[];
 
   /**
    * A sort field definition for sorting data objects within a window. If two data objects are considered equal by the comparator, they are considered “peer” values of equal rank. If sort is not specified, the order is undefined: data objects are processed in the order they are observed and none are considered peers (the ignorePeers parameter is ignored and treated as if set to `true`).
@@ -217,12 +218,12 @@ export interface JoinAggregateFieldDef {
   /**
    * The data field for which to compute the aggregate function. This can be omitted for functions that do not operate over a field such as `count`.
    */
-  field?: string;
+  field?: FieldName;
 
   /**
    * The output name for the join aggregate operation.
    */
-  as: string;
+  as: FieldName;
 }
 
 export interface JoinAggregateTransform {
@@ -234,7 +235,7 @@ export interface JoinAggregateTransform {
   /**
    * The data fields for partitioning the data objects into separate groups. If unspecified, all data points will be in a single group.
    */
-  groupby?: string[];
+  groupby?: FieldName[];
 }
 
 export interface ImputeSequence {
@@ -262,19 +263,19 @@ export interface ImputeTransform extends ImputeParams {
   /**
    * The data field for which the missing values should be imputed.
    */
-  impute: string;
+  impute: FieldName;
 
   /**
    * A key field that uniquely identifies data objects within a group.
    * Missing key values (those occurring in the data but not in the current group) will be imputed.
    */
-  key: string;
+  key: FieldName;
 
   /**
    * An optional array of fields by which to group the values.
    * Imputation will then be performed on a per-group basis.
    */
-  groupby?: string[];
+  groupby?: FieldName[];
 }
 
 export interface FlattenTransform {
@@ -284,14 +285,14 @@ export interface FlattenTransform {
    * If the lengths of parallel arrays do not match,
    * the longest array will be used with `null` values added for missing entries.
    */
-  flatten: string[];
+  flatten: FieldName[];
 
   /**
    * The output field names for extracted array values.
    *
    * __Default value:__ The field name of the corresponding array field
    */
-  as?: string[];
+  as?: FieldName[];
 }
 
 export interface SampleTransform {
@@ -311,19 +312,19 @@ export interface LookupData {
   /**
    * Key in data to lookup.
    */
-  key: string;
+  key: FieldName;
   /**
    * Fields in foreign data to lookup.
    * If not specified, the entire object is queried.
    */
-  fields?: string[];
+  fields?: FieldName[];
 }
 
 export interface LookupTransform {
   /**
    * Key in primary data source.
    */
-  lookup: string;
+  lookup: FieldName;
 
   /**
    * Secondary data reference.
@@ -335,7 +336,7 @@ export interface LookupTransform {
    * If `from.fields` is specified, the transform will use the same names for `as`.
    * If `from.fields` is not specified, `as` has to be a string and we put the whole object into the data under the specified name.
    */
-  as?: string | string[];
+  as?: FieldName | FieldName[];
 
   /**
    * The default value to use if lookup fails.
@@ -349,13 +350,13 @@ export interface FoldTransform {
   /**
    * An array of data fields indicating the properties to fold.
    */
-  fold: string[];
+  fold: FieldName[];
 
   /**
    * The output field names for the key and value properties produced by the fold transform.
    * __Default value:__ `["key", "value"]`
    */
-  as?: [string, string];
+  as?: [FieldName, FieldName];
 }
 
 export function isLookup(t: Transform): t is LookupTransform {


### PR DESCRIPTION
This PR externalizes strings that semantically refer to field names as a new "`FieldName`" type. In the typescript, this is just an alias to `string`, but since it is a separate `definitions` type in the JSON schema, this can help third-party tools to identify when a field reference is being sought. For example, the editor (https://github.com/vega/editor) could use this field to try to auto-complete field names from the data set associated with the spec.

This is similar to how color names are externalized to a "Color" type (https://github.com/vega/vega-lite/pull/4228).