### PR TITLE
Added sample typing for WordcloudTransform from Vega

### DIFF
--- a/src/compile/data/assemble.ts
+++ b/src/compile/data/assemble.ts
@@ -25,6 +25,7 @@ import {SourceNode} from './source';
 import {StackNode} from './stack';
 import {TimeUnitNode} from './timeunit';
 import {WindowTransformNode} from './window';
+import {WordcloudNode} from './wordcloud';
 
 function makeWalkTree(data: VgData[]) {
   // to name datasources
@@ -81,7 +82,6 @@ function makeWalkTree(data: VgData[]) {
       // break here because the rest of the tree has to be taken care of by the facet.
       return;
     }
-
     if (
       node instanceof GraticuleNode ||
       node instanceof SequenceNode ||
@@ -97,7 +97,8 @@ function makeWalkTree(data: VgData[]) {
       node instanceof FoldTransformNode ||
       node instanceof FlattenTransformNode ||
       node instanceof IdentifierNode ||
-      node instanceof SampleTransformNode
+      node instanceof SampleTransformNode ||
+      node instanceof WordcloudNode
     ) {
       dataSource.transform.push(node.assemble());
     }

--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -24,7 +24,8 @@ import {
   isSample,
   isStack,
   isTimeUnit,
-  isWindow
+  isWindow,
+  isWordcloud
 } from '../../transform';
 import {deepEqual, mergeDeep} from '../../util';
 import {isFacetModel, isLayerModel, isUnitModel, Model} from '../model';
@@ -54,6 +55,7 @@ import {SourceNode} from './source';
 import {StackNode} from './stack';
 import {TimeUnitNode} from './timeunit';
 import {WindowTransformNode} from './window';
+import {WordcloudNode} from './wordcloud';
 
 export function findSource(data: Data, sources: SourceNode[]) {
   for (const other of sources) {
@@ -111,7 +113,6 @@ export function parseTransformArray(head: DataFlowNode, model: Model, ancestorPa
   for (const t of model.transforms) {
     let derivedType: ParseValue = undefined;
     let transformNode: DataFlowNode;
-
     if (isCalculate(t)) {
       transformNode = head = new CalculateNode(head, t);
       derivedType = 'derived';
@@ -160,6 +161,9 @@ export function parseTransformArray(head: DataFlowNode, model: Model, ancestorPa
       head = new SampleTransformNode(head, t);
     } else if (isImpute(t)) {
       transformNode = head = ImputeNode.makeFromTransform(head, t);
+      derivedType = 'derived';
+    } else if (isWordcloud(t)) {
+      transformNode = head = new WordcloudNode(head, t);
       derivedType = 'derived';
     } else {
       log.warn(log.message.invalidTransformIgnored(t));

--- a/src/compile/data/wordcloud.ts
+++ b/src/compile/data/wordcloud.ts
@@ -1,0 +1,19 @@
+import {VgWordCloudTransform} from '../../vega.schema';
+import {DataFlowNode} from './dataflow';
+
+export class WordcloudNode extends DataFlowNode {
+  public clone() {
+    return new WordcloudNode(null, this.params);
+  }
+
+  constructor(parent: DataFlowNode, private params: true) {
+    super(parent);
+  }
+
+  public assemble(): VgWordCloudTransform {
+    return {
+      type: 'wordcloud',
+      ...(this.params === true ? {} : this.params)
+    };
+  }
+}

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -470,7 +470,8 @@ export type Transform =
   | TimeUnitTransform
   | SampleTransform
   | StackTransform
-  | WindowTransform;
+  | WindowTransform
+  | WordcloudTransform;
 
 export function normalizeTransform(transform: Transform[]) {
   return transform.map(t => {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -358,6 +358,58 @@ export interface FoldTransform {
   as?: [string, string];
 }
 
+export interface WordcloudTransform {
+  wordcloud: string[];
+  /*
+   *
+   */
+  size: number[];
+  /*
+   *
+   */
+  font: string;
+  /*
+   *
+   */
+  fontStyle: string;
+  /*
+   *
+   */
+  fontWeight: string;
+  /*
+   *
+   */
+  fontSize: number;
+  /*
+   *
+   */
+  fontSizeRange: number[];
+  /*
+   *
+   */
+  rotate?: number;
+  /*
+   *
+   */
+  text?: string;
+  /*
+   *
+   */
+  spiral?: string;
+  /*
+   *
+   */
+  padding?: number;
+  /*
+   *
+   */
+  as?: string[];
+}
+
+export function isWordcloud(t: Transform): t is WordcloudTransform {
+  return t['wordcloud'] !== undefined;
+}
+
 export function isLookup(t: Transform): t is LookupTransform {
   return t['lookup'] !== undefined;
 }

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -406,7 +406,8 @@ export type VgTransform =
   | VgJoinAggregateTransform
   | VgFoldTransform
   | VgSampleTransform
-  | VgSequenceTransform;
+  | VgSequenceTransform
+  | VgWordcloudTransform;
 
 export interface VgGraticuleTransform {
   type: 'graticule';
@@ -417,6 +418,22 @@ export interface VgGraticuleTransform {
   stepMinor?: number[];
   step?: number[];
   precision?: number;
+}
+
+export interface VgWordcloudTransform {
+  type: 'wordcloud';
+  signal?: string;
+  size?: Vector2<number | SignalRef> | SignalRef;
+  font?: string | TransformField;
+  fontStyle?: FontStyle | TransformField;
+  fontWeight?: FontWeight | TransformField;
+  fontSize?: number | TransformField;
+  fontSizeRange?: Vector2<number | SignalRef> | SignalRef;
+  rotate?: number | TransformField;
+  text?: string | TransformField;
+  spiral?: 'archimedian' | 'rectangular';
+  padding?: number | TransformField;
+  as?: Vector7<string | SignalRef> | SignalRef;
 }
 
 export interface VgSequenceTransform {


### PR DESCRIPTION
There are a few questions I am not sure while implementing WordcloudTransform:
1. Vega.schema is used to create node but when is transform typing used?
2. How would I be able to test new vega typing?

I will definitely redo this typing and add comments for it, I just want to make sure that I get the idea right. Thanks