### PR TITLE
Add clamps for zooming and panning

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1689,6 +1689,35 @@
       ],
       "type": "object"
     },
+    "BindClamp": {
+      "additionalProperties": false,
+      "properties": {
+        "clamp": {
+          "additionalProperties": {
+            "items": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "maxItems": 2,
+            "minItems": 2,
+            "type": "array"
+          },
+          "type": "object"
+        },
+        "scales": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "scales",
+        "clamp"
+      ],
+      "type": "object"
+    },
     "BindRadioSelect": {
       "additionalProperties": false,
       "properties": {
@@ -6319,11 +6348,18 @@
       "additionalProperties": false,
       "properties": {
         "bind": {
-          "description": "Establishes a two-way binding between the interval selection and the scales\nused within the same view. This allows a user to interactively pan and\nzoom the view.",
-          "enum": [
-            "scales"
+          "anyOf": [
+            {
+              "enum": [
+                "scales"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/BindClamp"
+            }
           ],
-          "type": "string"
+          "description": "Establishes a two-way binding between the interval selection and the scales\nused within the same view. This allows a user to interactively pan and\nzoom the view."
         },
         "clear": {
           "anyOf": [
@@ -6404,11 +6440,18 @@
       "additionalProperties": false,
       "properties": {
         "bind": {
-          "description": "Establishes a two-way binding between the interval selection and the scales\nused within the same view. This allows a user to interactively pan and\nzoom the view.",
-          "enum": [
-            "scales"
+          "anyOf": [
+            {
+              "enum": [
+                "scales"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/BindClamp"
+            }
           ],
-          "type": "string"
+          "description": "Establishes a two-way binding between the interval selection and the scales\nused within the same view. This allows a user to interactively pan and\nzoom the view."
         },
         "clear": {
           "anyOf": [

--- a/src/compile/selection/index.ts
+++ b/src/compile/selection/index.ts
@@ -2,6 +2,7 @@ import {Binding, NewSignal, SignalRef} from 'vega';
 import {stringValue} from 'vega-util';
 import {FACET_CHANNELS} from '../../channel';
 import {
+  BindClamp,
   BrushConfig,
   SELECTION_ID,
   SelectionInit,
@@ -38,7 +39,7 @@ export interface SelectionComponent<T extends SelectionType = SelectionType> {
     : SelectionInit | SelectionInit[])[]; // multi
   events: EventStream;
   // predicate?: string;
-  bind?: 'scales' | Binding | Dict<Binding>;
+  bind?: 'scales' | BindClamp | Binding | Dict<Binding>;
   resolve: SelectionResolution;
   empty: 'all' | 'none';
   mark?: BrushConfig;

--- a/src/compile/selection/transforms/inputs.ts
+++ b/src/compile/selection/transforms/inputs.ts
@@ -7,7 +7,13 @@ import {TransformCompiler} from './transforms';
 
 const inputBindings: TransformCompiler = {
   has: selCmpt => {
-    return selCmpt.type === 'single' && selCmpt.resolve === 'global' && selCmpt.bind && selCmpt.bind !== 'scales';
+    return (
+      selCmpt.type === 'single' &&
+      selCmpt.resolve === 'global' &&
+      selCmpt.bind &&
+      selCmpt.bind !== 'scales' &&
+      !selCmpt.bind['scales']
+    );
   },
 
   topLevelSignals: (model, selCmpt, signals) => {

--- a/src/compile/selection/transforms/scales.ts
+++ b/src/compile/selection/transforms/scales.ts
@@ -10,7 +10,12 @@ import {TransformCompiler} from './transforms';
 
 const scaleBindings: TransformCompiler = {
   has: selCmpt => {
-    return selCmpt.type === 'interval' && selCmpt.resolve === 'global' && selCmpt.bind && selCmpt.bind === 'scales';
+    return (
+      selCmpt.type === 'interval' &&
+      selCmpt.resolve === 'global' &&
+      selCmpt.bind &&
+      (selCmpt.bind === 'scales' || selCmpt.bind['scales'])
+    );
   },
 
   parse: (model, selDef, selCmpt) => {

--- a/src/compile/selection/transforms/translate.ts
+++ b/src/compile/selection/transforms/translate.ts
@@ -87,6 +87,7 @@ function onDelta(
   const sign = hasScales && channel === X ? '-' : ''; // Invert delta when panning x-scales.
   const extent = `${anchor}.extent_${channel}`;
   const offset = `${sign}${delta}.${channel} / ` + (hasScales ? `${sizeSg}` : `span(${extent})`);
+  const zoomClamp = selCmpt.bind && selCmpt.bind['clamp'] && selCmpt.bind['clamp'][channel];
   const panFn = !hasScales
     ? 'panLinear'
     : scaleType === 'log'
@@ -101,6 +102,10 @@ function onDelta(
 
   signal.on.push({
     events: {signal: delta},
-    update: hasScales ? update : `clampRange(${update}, 0, ${sizeSg})`
+    update: hasScales
+      ? zoomClamp
+        ? `clampRange(${update}, ${Math.min(...zoomClamp)}, ${Math.max(...zoomClamp)})`
+        : update
+      : `clampRange(${update}, 0, ${sizeSg})`
   });
 }

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -17,6 +17,11 @@ export interface SelectionInitArrayMapping {
   [key: string]: SelectionInitArray;
 }
 
+export interface BindClamp {
+  scales: boolean;
+  clamp: {[key: string]: [number, number]};
+}
+
 export interface BaseSelectionDef {
   /**
    * A [Vega event stream](https://vega.github.io/vega/docs/event-streams/) (object or selector) that triggers the selection.
@@ -205,7 +210,7 @@ export interface IntervalSelectionConfig extends BaseSelectionDef {
    * used within the same view. This allows a user to interactively pan and
    * zoom the view.
    */
-  bind?: 'scales';
+  bind?: 'scales' | BindClamp;
 
   /**
    * An interval selection also adds a rectangle mark to depict the

--- a/test/compile/selection/translate.test.ts
+++ b/test/compile/selection/translate.test.ts
@@ -43,6 +43,14 @@ function getModel(xscale?: ScaleType, yscale?: ScaleType) {
     seven: {
       type: 'interval',
       translate: null
+    },
+    eight: {
+      type: 'interval',
+      bind: {scales: true, clamp: {x: [0, 250], y: [0, 50]}}
+    },
+    nine: {
+      type: 'interval',
+      bind: {scales: true, clamp: {y: [0, 50]}}
     }
   });
 
@@ -59,6 +67,8 @@ describe('Translate Selection Transform', () => {
     expect(translate.has(selCmpts['five'])).not.toBe(false);
     expect(translate.has(selCmpts['six'])).not.toBe(false);
     expect(translate.has(selCmpts['seven'])).not.toBe(true);
+    expect(translate.has(selCmpts['eight'])).not.toBe(false);
+    expect(translate.has(selCmpts['nine'])).not.toBe(false);
   });
 
   describe('Anchor/Delta signals', () => {
@@ -201,6 +211,38 @@ describe('Translate Selection Transform', () => {
       expect(signals.filter(s => s.name === 'six_Miles_per_Gallon')[0].on).toContainEqual({
         events: {signal: 'six_translate_delta'},
         update: 'panLinear(six_translate_anchor.extent_y, six_translate_delta.y / height)'
+      });
+    });
+
+    it('builds clamped pan exprs for scale and clamp bound zoom', () => {
+      const {model, selCmpts} = getModel();
+      model.component.selection = {six: selCmpts['eight']};
+      const signals = assembleUnitSelectionSignals(model, []);
+
+      expect(signals.filter(s => s.name === 'eight_Horsepower')[0].on).toContainEqual({
+        events: {signal: 'eight_translate_delta'},
+        update: 'clampRange(panLinear(eight_translate_anchor.extent_x, -eight_translate_delta.x / width), 0, 250)'
+      });
+
+      expect(signals.filter(s => s.name === 'eight_Miles_per_Gallon')[0].on).toContainEqual({
+        events: {signal: 'eight_translate_delta'},
+        update: 'clampRange(panLinear(eight_translate_anchor.extent_y, eight_translate_delta.y / height), 0, 50)'
+      });
+    });
+
+    it('builds clamped pan exprs for scale bound and singly clamped zoom', () => {
+      const {model, selCmpts} = getModel();
+      model.component.selection = {six: selCmpts['nine']};
+      const signals = assembleUnitSelectionSignals(model, []);
+
+      expect(signals.filter(s => s.name === 'nine_Horsepower')[0].on).toContainEqual({
+        events: {signal: 'nine_translate_delta'},
+        update: 'panLinear(nine_translate_anchor.extent_x, -nine_translate_delta.x / width)'
+      });
+
+      expect(signals.filter(s => s.name === 'nine_Miles_per_Gallon')[0].on).toContainEqual({
+        events: {signal: 'nine_translate_delta'},
+        update: 'clampRange(panLinear(nine_translate_anchor.extent_y, nine_translate_delta.y / height), 0, 50)'
       });
     });
 


### PR DESCRIPTION
Fix towards #4886 

Schema is of the form 
```json
"selection": {
    "zoom-signal": {
      "type": "interval", "bind": {"scales":true, "clamp": {"x": [0,250], "y": [0,50]}}
    }
```

WIP. Some parts do not work as expected yet. (There is a bug with panning and then zooming when both extents are mentioned and there is slight distortion in shape for singly clamped zoom.)

Currently, we are scaling down the clamp extent margins (when both clamps are mentioned) such that the initial ratio of the visualization is maintained throughout the zoom-in/zoom-out process.

1. The current system is designed such that if you keep zooming out, after a certain point there is some translation into effect to centre out the visualization relative to the given clamp extents. This way we have the same result at the end of the zoom out irrespective of the anchor point. Is this the way we want it to be or are we look at something else here?

2. Since we are clamping the zoom out feature, zoom is weird when the clamp range is "inside" the initialized domain range. I am not sure if there is a use case for this.  

3. We should probably add a warning when clamps are mentioned but the encoding domain is not. This leads to a more consistent workflow in my opinion (or should we default the domains to the clamp extents in absence of an explicit encoding domain)

4. The X axis right side of the visualization is slighlty padded for a given domain (250 extends to something around 255). I am not sure whether it was originally intended to have it this way or it's a bug. This causes a slight glitch when the clamp range is the same as the encoding domain range.