### PR TITLE
Interval brush marks should read signal names from projection.

### DIFF
--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -104,6 +104,8 @@ const interval: SelectionCompiler<'interval'> = {
   marks: (model, selCmpt, marks) => {
     const name = selCmpt.name;
     const {x, y} = selCmpt.project.has;
+    const xvname = x && x.signals.visual;
+    const yvname = y && y.signals.visual;
     const store = `data(${stringValue(selCmpt.name + STORE)})`;
 
     // Do not add a brush if we're binding to scales.
@@ -112,10 +114,10 @@ const interval: SelectionCompiler<'interval'> = {
     }
 
     const update: any = {
-      x: x !== undefined ? {signal: `${name}_x[0]`} : {value: 0},
-      y: y !== undefined ? {signal: `${name}_y[0]`} : {value: 0},
-      x2: x !== undefined ? {signal: `${name}_x[1]`} : {field: {group: 'width'}},
-      y2: y !== undefined ? {signal: `${name}_y[1]`} : {field: {group: 'height'}}
+      x: x !== undefined ? {signal: `${xvname}[0]`} : {value: 0},
+      y: y !== undefined ? {signal: `${yvname}[0]`} : {value: 0},
+      x2: x !== undefined ? {signal: `${xvname}[1]`} : {field: {group: 'width'}},
+      y2: y !== undefined ? {signal: `${yvname}[1]`} : {field: {group: 'height'}}
     };
 
     // If the selection is resolved to global, only a single interval is in
@@ -141,7 +143,7 @@ const interval: SelectionCompiler<'interval'> = {
     const vgStroke = keys(stroke).reduce((def, k) => {
       def[k] = [
         {
-          test: [x !== undefined && `${name}_x[0] !== ${name}_x[1]`, y !== undefined && `${name}_y[0] !== ${name}_y[1]`]
+          test: [x !== undefined && `${xvname}[0] !== ${xvname}[1]`, y !== undefined && `${yvname}[0] !== ${yvname}[1]`]
             .filter(t => t)
             .join(' && '),
           value: stroke[k]

--- a/test/compile/selection/interval.test.ts
+++ b/test/compile/selection/interval.test.ts
@@ -697,4 +697,111 @@ describe('Interval Selections', () => {
       }
     ]);
   });
+
+  it('should be robust to same channel/field names', () => {
+    const nameModel = parseUnitModel({
+      mark: 'circle',
+      encoding: {
+        x: {field: 'x', type: 'quantitative'},
+        y: {field: 'y', type: 'quantitative'}
+      }
+    });
+    nameModel.parseScale();
+
+    const nameSelCmpts = (nameModel.component.selection = parseUnitSelection(nameModel, {
+      brush: {type: 'interval'}
+    }));
+
+    const signals = interval.signals(nameModel, nameSelCmpts['brush']);
+    const names = signals.map(s => s.name);
+    expect(names).toEqual(expect.arrayContaining(['brush_x_1', 'brush_x', 'brush_y_1', 'brush_y']));
+
+    const marks: any[] = [{hello: 'world'}];
+    expect(interval.marks(nameModel, nameSelCmpts['brush'], marks)).toEqual([
+      {
+        name: 'brush_brush_bg',
+        type: 'rect',
+        clip: true,
+        encode: {
+          enter: {fill: {value: '#333'}, fillOpacity: {value: 0.125}},
+          update: {
+            x: [
+              {
+                test: 'data("brush_store").length && data("brush_store")[0].unit === ""',
+                signal: 'brush_x_1[0]'
+              },
+              {value: 0}
+            ],
+            y: [
+              {
+                test: 'data("brush_store").length && data("brush_store")[0].unit === ""',
+                signal: 'brush_y_1[0]'
+              },
+              {value: 0}
+            ],
+            x2: [
+              {
+                test: 'data("brush_store").length && data("brush_store")[0].unit === ""',
+                signal: 'brush_x_1[1]'
+              },
+              {value: 0}
+            ],
+            y2: [
+              {
+                test: 'data("brush_store").length && data("brush_store")[0].unit === ""',
+                signal: 'brush_y_1[1]'
+              },
+              {value: 0}
+            ]
+          }
+        }
+      },
+      {hello: 'world'},
+      {
+        name: 'brush_brush',
+        type: 'rect',
+        clip: true,
+        encode: {
+          enter: {fill: {value: 'transparent'}},
+          update: {
+            x: [
+              {
+                test: 'data("brush_store").length && data("brush_store")[0].unit === ""',
+                signal: 'brush_x_1[0]'
+              },
+              {value: 0}
+            ],
+            y: [
+              {
+                test: 'data("brush_store").length && data("brush_store")[0].unit === ""',
+                signal: 'brush_y_1[0]'
+              },
+              {value: 0}
+            ],
+            x2: [
+              {
+                test: 'data("brush_store").length && data("brush_store")[0].unit === ""',
+                signal: 'brush_x_1[1]'
+              },
+              {value: 0}
+            ],
+            y2: [
+              {
+                test: 'data("brush_store").length && data("brush_store")[0].unit === ""',
+                signal: 'brush_y_1[1]'
+              },
+              {value: 0}
+            ],
+            stroke: [
+              {
+                test: 'brush_x_1[0] !== brush_x_1[1] && brush_y_1[0] !== brush_y_1[1]',
+                value: 'white'
+              },
+              {value: null}
+            ]
+          }
+        }
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
Fixes #4951 -- our selection-signal generation code was robust to channel and field names colliding, but the brush marks for interval selections still referred to hardcoded signal names. This PR fixes the issue by referencing signal names stored on the `SelectionProjection`.