### PR TITLE
Expand type of TitleMixins title field to support array of FieldDefBase

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -624,11 +624,21 @@
           "type": "boolean"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "titleAlign": {
           "$ref": "#/definitions/Align",
@@ -2597,11 +2607,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "type": {
           "$ref": "#/definitions/StandardType",
@@ -2680,11 +2700,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "type": {
           "$ref": "#/definitions/TypeForShape",
@@ -2749,11 +2779,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "type": {
           "$ref": "#/definitions/StandardType",
@@ -2934,11 +2974,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "type": {
           "$ref": "#/definitions/StandardType",
@@ -3017,11 +3067,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "type": {
           "$ref": "#/definitions/TypeForShape",
@@ -3086,11 +3146,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "type": {
           "$ref": "#/definitions/StandardType",
@@ -3949,11 +4019,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "type": {
           "$ref": "#/definitions/Type",
@@ -4435,6 +4515,44 @@
         }
       ]
     },
+    "FieldDefBase<string>": {
+      "additionalProperties": false,
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/Aggregate",
+          "description": "Aggregation function for the field\n(e.g., `mean`, `sum`, `median`, `min`, `max`, `count`).\n\n__Default value:__ `undefined` (None)"
+        },
+        "bin": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/BinParams"
+            },
+            {
+              "enum": [
+                "binned"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`"
+        },
+        "field": {
+          "description": "__Required.__ A string defining the name of the field from which to pull a data value\nor an object defining iterated values from the [`repeat`](https://vega.github.io/vega-lite/docs/repeat.html) operator.\n\n__Note:__ Dots (`.`) and brackets (`[` and `]`) can be used to access nested objects (e.g., `\"field\": \"foo.bar\"` and `\"field\": \"foo['bar']\"`).\nIf field names contain dots or brackets but are not nested, you can use `\\\\` to escape dots and brackets (e.g., `\"a\\\\.b\"` and `\"a\\\\[0\\\\]\"`).\nSee more details about escaping in the [field documentation](https://vega.github.io/vega-lite/docs/field.html).\n\n__Note:__ `field` is not required if `aggregate` is `count`.",
+          "type": "string"
+        },
+        "timeUnit": {
+          "$ref": "#/definitions/TimeUnit",
+          "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
+        }
+      },
+      "type": "object"
+    },
     "FieldDefWithCondition<MarkPropFieldDef,(string|null)>": {
       "additionalProperties": false,
       "description": "A FieldDef with Condition<ValueDef>\n{\n   condition: {value: ...},\n   field: ...,\n   ...\n}",
@@ -4512,11 +4630,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "type": {
           "$ref": "#/definitions/StandardType",
@@ -4605,11 +4733,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "type": {
           "$ref": "#/definitions/StandardType",
@@ -4698,11 +4836,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "type": {
           "$ref": "#/definitions/TypeForShape",
@@ -4777,11 +4925,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "type": {
           "$ref": "#/definitions/StandardType",
@@ -4830,11 +4988,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "type": {
           "$ref": "#/definitions/StandardType",
@@ -5952,11 +6120,21 @@
           "type": "number"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "titleAlign": {
           "$ref": "#/definitions/Align",
@@ -6604,11 +6782,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "type": {
           "description": "The encoded field's type of measurement (`\"quantitative\"`, `\"temporal\"`, `\"ordinal\"`, or `\"nominal\"`).\nIt can also be a `\"geojson\"` type for encoding ['geoshape'](https://vega.github.io/vega-lite/docs/geoshape.html).\n\n\n__Note:__\n\n- Data values for a temporal field can be either a date-time string (e.g., `\"2015-03-07 12:32:17\"`, `\"17:01\"`, `\"2015-03-16\"`. `\"2015\"`) or a timestamp number (e.g., `1552199579097`).\n- Data `type` describes the semantics of the data rather than the primitive data types (`number`, `string`, etc.). The same primitive data type can have different types of measurement. For example, numeric data can represent quantitative, ordinal, or nominal data.\n- When using with [`bin`](https://vega.github.io/vega-lite/docs/bin.html), the `type` property can be either `\"quantitative\"` (for using a linear bin scale) or [`\"ordinal\"` (for using an ordinal bin scale)](https://vega.github.io/vega-lite/docs/type.html#cast-bin).\n- When using with [`timeUnit`](https://vega.github.io/vega-lite/docs/timeunit.html), the `type` property can be either `\"temporal\"` (for using a temporal scale) or [`\"ordinal\"` (for using an ordinal scale)](https://vega.github.io/vega-lite/docs/type.html#cast-bin).\n- When using with [`aggregate`](https://vega.github.io/vega-lite/docs/aggregate.html), the `type` property refers to the post-aggregation data type. For example, we can calculate count `distinct` of a categorical field `\"cat\"` using `{\"aggregate\": \"distinct\", \"field\": \"cat\", \"type\": \"quantitative\"}`. The `\"type\"` of the aggregate output is `\"quantitative\"`.\n- Secondary channels (e.g., `x2`, `y2`, `xError`, `yError`) do not have `type` as they have exactly the same type as their primary channels (e.g., `x`, `y`).",
@@ -6915,11 +7103,21 @@
           "type": "number"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "titleAlign": {
           "$ref": "#/definitions/Align",
@@ -8593,11 +8791,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "type": {
           "$ref": "#/definitions/StandardType",
@@ -9117,11 +9325,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "type": {
           "$ref": "#/definitions/StandardType",
@@ -9988,11 +10206,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         }
       },
       "type": "object"
@@ -10887,11 +11115,21 @@
           "description": "Time unit (e.g., `year`, `yearmonth`, `month`, `hours`) for a temporal field.\nor [a temporal field that gets casted as ordinal](https://vega.github.io/vega-lite/docs/type.html#cast).\n\n__Default value:__ `undefined` (None)"
         },
         "title": {
-          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.",
-          "type": [
-            "string",
-            "null"
-          ]
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldDefBase<string>"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A title for the field. If `null`, the title will be removed.\n\n__Default value:__  derived from the field's name and transformation function (`aggregate`, `bin` and `timeUnit`).  If the field has an aggregate function, the function is displayed as part of the title (e.g., `\"Sum of Profit\"`). If the field is binned or has a time unit applied, the applied function is shown in parentheses (e.g., `\"Profit (binned)\"`, `\"Transaction Date (year-month)\"`).  Otherwise, the title is simply the field name.\n\n__Notes__:\n\n1) You can customize the default field title format by providing the [`fieldTitle`](https://vega.github.io/vega-lite/docs/config.html#top-level-config) property in the [config](https://vega.github.io/vega-lite/docs/config.html) or [`fieldTitle` function via the `compile` function's options](https://vega.github.io/vega-lite/docs/compile.html#field-title).\n\n2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used."
         },
         "type": {
           "$ref": "#/definitions/StandardType",

--- a/examples/specs/normalized/boxplot_tooltip_aggregate_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_tooltip_aggregate_normalized.vl.json
@@ -73,7 +73,7 @@
                   },
                   {"field": "age", "type": "ordinal"},
                   {
-                    "title": "Mean of people",
+                    "title": [{"aggregate": "mean", "field": "people"}],
                     "type": "quantitative",
                     "field": "mean_people"
                   }
@@ -103,7 +103,7 @@
                   },
                   {"field": "age", "type": "ordinal"},
                   {
-                    "title": "Mean of people",
+                    "title": [{"aggregate": "mean", "field": "people"}],
                     "type": "quantitative",
                     "field": "mean_people"
                   }
@@ -167,7 +167,7 @@
               },
               {"field": "age", "type": "ordinal"},
               {
-                "title": "Mean of people",
+                "title": [{"aggregate": "mean", "field": "people"}],
                 "type": "quantitative",
                 "field": "mean_people"
               }
@@ -217,7 +217,7 @@
               },
               {"field": "age", "type": "ordinal"},
               {
-                "title": "Mean of people",
+                "title": [{"aggregate": "mean", "field": "people"}],
                 "type": "quantitative",
                 "field": "mean_people"
               }

--- a/examples/specs/normalized/errorband_2d_horizontal_color_encoding_normalized.vl.json
+++ b/examples/specs/normalized/errorband_2d_horizontal_color_encoding_normalized.vl.json
@@ -38,7 +38,7 @@
             },
             "y2": {"field": "upper_Miles_per_Gallon", "type": "quantitative"},
             "x": {
-              "title": "Year (year)",
+              "title": [{"timeUnit": "year", "field": "Year"}],
               "type": "temporal",
               "field": "year_Year",
               "axis": {"format": "%Y"}
@@ -61,7 +61,7 @@
                 "title": "Mean of Miles_per_Gallon"
               },
               {
-                "title": "Year (year)",
+                "title": [{"timeUnit": "year", "field": "Year"}],
                 "type": "temporal",
                 "field": "year_Year",
                 "axis": {"format": "%Y"}
@@ -79,7 +79,7 @@
               "scale": {"zero": false}
             },
             "x": {
-              "title": "Year (year)",
+              "title": [{"timeUnit": "year", "field": "Year"}],
               "type": "temporal",
               "field": "year_Year",
               "axis": {"format": "%Y"}
@@ -102,7 +102,7 @@
                 "title": "Mean of Miles_per_Gallon"
               },
               {
-                "title": "Year (year)",
+                "title": [{"timeUnit": "year", "field": "Year"}],
                 "type": "temporal",
                 "field": "year_Year",
                 "axis": {"format": "%Y"}
@@ -120,7 +120,7 @@
               "scale": {"zero": false}
             },
             "x": {
-              "title": "Year (year)",
+              "title": [{"timeUnit": "year", "field": "Year"}],
               "type": "temporal",
               "field": "year_Year",
               "axis": {"format": "%Y"}
@@ -143,7 +143,7 @@
                 "title": "Mean of Miles_per_Gallon"
               },
               {
-                "title": "Year (year)",
+                "title": [{"timeUnit": "year", "field": "Year"}],
                 "type": "temporal",
                 "field": "year_Year",
                 "axis": {"format": "%Y"}

--- a/examples/specs/normalized/errorband_2d_vertical_borders_normalized.vl.json
+++ b/examples/specs/normalized/errorband_2d_vertical_borders_normalized.vl.json
@@ -36,7 +36,7 @@
         },
         "y2": {"field": "upper_Miles_per_Gallon", "type": "quantitative"},
         "x": {
-          "title": "Year (year)",
+          "title": [{"timeUnit": "year", "field": "Year"}],
           "type": "temporal",
           "field": "year_Year",
           "axis": {"format": "%Y"}
@@ -58,7 +58,7 @@
             "title": "Mean of Miles_per_Gallon"
           },
           {
-            "title": "Year (year)",
+            "title": [{"timeUnit": "year", "field": "Year"}],
             "type": "temporal",
             "field": "year_Year",
             "axis": {"format": "%Y"}
@@ -76,7 +76,7 @@
           "scale": {"zero": false}
         },
         "x": {
-          "title": "Year (year)",
+          "title": [{"timeUnit": "year", "field": "Year"}],
           "type": "temporal",
           "field": "year_Year",
           "axis": {"format": "%Y"}
@@ -98,7 +98,7 @@
             "title": "Mean of Miles_per_Gallon"
           },
           {
-            "title": "Year (year)",
+            "title": [{"timeUnit": "year", "field": "Year"}],
             "type": "temporal",
             "field": "year_Year",
             "axis": {"format": "%Y"}
@@ -116,7 +116,7 @@
           "scale": {"zero": false}
         },
         "x": {
-          "title": "Year (year)",
+          "title": [{"timeUnit": "year", "field": "Year"}],
           "type": "temporal",
           "field": "year_Year",
           "axis": {"format": "%Y"}
@@ -138,7 +138,7 @@
             "title": "Mean of Miles_per_Gallon"
           },
           {
-            "title": "Year (year)",
+            "title": [{"timeUnit": "year", "field": "Year"}],
             "type": "temporal",
             "field": "year_Year",
             "axis": {"format": "%Y"}

--- a/examples/specs/normalized/errorbar_2d_vertical_ticks_normalized.vl.json
+++ b/examples/specs/normalized/errorbar_2d_vertical_ticks_normalized.vl.json
@@ -39,7 +39,7 @@
           "scale": {"zero": false}
         },
         "x": {
-          "title": "Year (year)",
+          "title": [{"timeUnit": "year", "field": "Year"}],
           "type": "temporal",
           "field": "year_Year",
           "axis": {"format": "%Y"}
@@ -61,7 +61,7 @@
             "title": "Mean of Miles_per_Gallon"
           },
           {
-            "title": "Year (year)",
+            "title": [{"timeUnit": "year", "field": "Year"}],
             "type": "temporal",
             "field": "year_Year",
             "axis": {"format": "%Y"}
@@ -83,7 +83,7 @@
           "scale": {"zero": false}
         },
         "x": {
-          "title": "Year (year)",
+          "title": [{"timeUnit": "year", "field": "Year"}],
           "type": "temporal",
           "field": "year_Year",
           "axis": {"format": "%Y"}
@@ -105,7 +105,7 @@
             "title": "Mean of Miles_per_Gallon"
           },
           {
-            "title": "Year (year)",
+            "title": [{"timeUnit": "year", "field": "Year"}],
             "type": "temporal",
             "field": "year_Year",
             "axis": {"format": "%Y"}
@@ -124,7 +124,7 @@
         },
         "y2": {"field": "upper_Miles_per_Gallon", "type": "quantitative"},
         "x": {
-          "title": "Year (year)",
+          "title": [{"timeUnit": "year", "field": "Year"}],
           "type": "temporal",
           "field": "year_Year",
           "axis": {"format": "%Y"}
@@ -146,7 +146,7 @@
             "title": "Mean of Miles_per_Gallon"
           },
           {
-            "title": "Year (year)",
+            "title": [{"timeUnit": "year", "field": "Year"}],
             "type": "temporal",
             "field": "year_Year",
             "axis": {"format": "%Y"}

--- a/examples/specs/normalized/layer_line_errorband_2d_horizontal_borders_strokedash_normalized.vl.json
+++ b/examples/specs/normalized/layer_line_errorband_2d_horizontal_borders_strokedash_normalized.vl.json
@@ -38,7 +38,7 @@
             },
             "y2": {"field": "upper_Miles_per_Gallon", "type": "quantitative"},
             "x": {
-              "title": "Year (year)",
+              "title": [{"timeUnit": "year", "field": "Year"}],
               "type": "temporal",
               "field": "year_Year",
               "axis": {"format": "%Y"}
@@ -60,7 +60,7 @@
                 "title": "Mean of Miles_per_Gallon"
               },
               {
-                "title": "Year (year)",
+                "title": [{"timeUnit": "year", "field": "Year"}],
                 "type": "temporal",
                 "field": "year_Year",
                 "axis": {"format": "%Y"}
@@ -83,7 +83,7 @@
               "scale": {"zero": false}
             },
             "x": {
-              "title": "Year (year)",
+              "title": [{"timeUnit": "year", "field": "Year"}],
               "type": "temporal",
               "field": "year_Year",
               "axis": {"format": "%Y"}
@@ -105,7 +105,7 @@
                 "title": "Mean of Miles_per_Gallon"
               },
               {
-                "title": "Year (year)",
+                "title": [{"timeUnit": "year", "field": "Year"}],
                 "type": "temporal",
                 "field": "year_Year",
                 "axis": {"format": "%Y"}
@@ -128,7 +128,7 @@
               "scale": {"zero": false}
             },
             "x": {
-              "title": "Year (year)",
+              "title": [{"timeUnit": "year", "field": "Year"}],
               "type": "temporal",
               "field": "year_Year",
               "axis": {"format": "%Y"}
@@ -150,7 +150,7 @@
                 "title": "Mean of Miles_per_Gallon"
               },
               {
-                "title": "Year (year)",
+                "title": [{"timeUnit": "year", "field": "Year"}],
                 "type": "temporal",
                 "field": "year_Year",
                 "axis": {"format": "%Y"}

--- a/examples/specs/normalized/layer_line_errorband_ci_normalized.vl.json
+++ b/examples/specs/normalized/layer_line_errorband_ci_normalized.vl.json
@@ -37,7 +37,7 @@
             },
             "y2": {"field": "upper_Miles_per_Gallon", "type": "quantitative"},
             "x": {
-              "title": "Year (year)",
+              "title": [{"timeUnit": "year", "field": "Year"}],
               "type": "temporal",
               "field": "year_Year",
               "axis": {"format": "%Y"}
@@ -59,7 +59,7 @@
                 "title": "Mean of Miles_per_Gallon"
               },
               {
-                "title": "Year (year)",
+                "title": [{"timeUnit": "year", "field": "Year"}],
                 "type": "temporal",
                 "field": "year_Year",
                 "axis": {"format": "%Y"}

--- a/examples/specs/normalized/layer_line_errorband_pre_aggregated_normalized.vl.json
+++ b/examples/specs/normalized/layer_line_errorband_pre_aggregated_normalized.vl.json
@@ -27,7 +27,7 @@
             },
             "y2": {"field": "upper_ci1", "type": "quantitative"},
             "x": {
-              "title": "Year (year)",
+              "title": [{"timeUnit": "year", "field": "Year"}],
               "type": "temporal",
               "field": "year_Year",
               "axis": {"format": "%Y"}
@@ -36,7 +36,7 @@
               {"field": "upper_ci1", "type": "quantitative", "title": "ci0"},
               {"field": "lower_ci1", "type": "quantitative", "title": "ci1"},
               {
-                "title": "Year (year)",
+                "title": [{"timeUnit": "year", "field": "Year"}],
                 "type": "temporal",
                 "field": "year_Year",
                 "axis": {"format": "%Y"}

--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -244,7 +244,7 @@ export interface FieldDefBase<F> extends BaseBinMixins {
   aggregate?: Aggregate | HiddenCompositeAggregate;
 }
 
-export function toFieldDefBase(fieldDef: TypedFieldDef<string>): FieldDefBase<string> {
+export function toFieldDefBase(fieldDef: FieldDef<string>): FieldDefBase<string> {
   const {field, timeUnit, bin, aggregate} = fieldDef;
   return {
     ...(timeUnit ? {timeUnit} : {}),

--- a/src/compile/axis/assemble.ts
+++ b/src/compile/axis/assemble.ts
@@ -8,7 +8,7 @@ import {getFirstDefined, keys} from '../../util';
 import {Model} from '../model';
 import {AxisComponent, AxisComponentIndex} from './component';
 
-function assembleTitle(title: string | FieldDefBase<string>[], config: Config) {
+export function assembleTitle(title: string | FieldDefBase<string>[], config: Config) {
   if (isArray(title)) {
     return title.map(fieldDef => defaultTitle(fieldDef, config)).join(', ');
   }

--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -10,6 +10,7 @@ import {LayerModel} from '../layer';
 import {parseGuideResolve} from '../resolve';
 import {defaultTieBreaker, Explicit, mergeValuesWithExplicit} from '../split';
 import {UnitModel} from '../unit';
+import {assembleTitle} from './assemble';
 import {AxisComponent, AxisComponentIndex, AxisComponentProps} from './component';
 import {getAxisConfig} from './config';
 import * as encode from './encode';
@@ -351,7 +352,7 @@ function getProperty<K extends keyof AxisComponentProps>(
       // For other falsy value, keep them so we will hide the title.
       return getFirstDefined<string | FieldDefBase<string>[]>(
         specifiedAxis.title,
-        getFieldDefTitle(model, channel), // If title not specified, store base parts of fieldDef (and fieldDef2 if exists)
+        assembleTitle(getFieldDefTitle(model, channel), model.config), // If title not specified, store base parts of fieldDef (and fieldDef2 if exists)
         mergeTitleFieldDefs([toFieldDefBase(fieldDef)], fieldDef2 ? [toFieldDefBase(fieldDef2)] : [])
       );
 

--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -204,7 +204,7 @@ export function mergeTitleFieldDefs(f1: FieldDefBase<string>[], f2: FieldDefBase
   return merged;
 }
 
-export function mergeTitle(title1: string, title2: string) {
+export function mergeStringTitles(title1: string, title2: string) {
   if (title1 === title2 || !title2) {
     // if titles are the same or title2 is falsy
     return title1;
@@ -217,18 +217,23 @@ export function mergeTitle(title1: string, title2: string) {
   }
 }
 
-export function mergeTitleComponent(v1: Explicit<AxisTitleComponent>, v2: Explicit<AxisTitleComponent>) {
-  if (isArray(v1.value) && isArray(v2.value)) {
-    return {
-      explicit: v1.explicit,
-      value: mergeTitleFieldDefs(v1.value, v2.value)
-    };
-  } else if (!isArray(v1.value) && !isArray(v2.value)) {
-    return {
-      explicit: v1.explicit, // keep the old explicit
-      value: mergeTitle(v1.value, v2.value)
-    };
+export function mergeTitle(title1: AxisTitleComponent, title2: AxisTitleComponent) {
+  if (isArray(title1) && isArray(title2)) {
+    return mergeTitleFieldDefs(title1, title2);
+  } else if (!isArray(title1) && !isArray(title2)) {
+    return mergeStringTitles(title1, title2);
+  } else if (!isArray(title1)) {
+    return title1;
+  } else if (!isArray(title2)) {
+    return title2;
   }
   /* istanbul ignore next: Condition should not happen -- only for warning in development. */
   throw new Error('It should never reach here');
+}
+
+export function mergeTitleComponent(v1: Explicit<AxisTitleComponent>, v2: Explicit<AxisTitleComponent>) {
+  return {
+    explicit: v1.explicit,
+    value: mergeTitle(v1.value, v2.value)
+  };
 }

--- a/src/compile/header/parse.ts
+++ b/src/compile/header/parse.ts
@@ -2,7 +2,7 @@ import {AxisOrient} from 'vega';
 import {FACET_CHANNELS, FacetChannel} from '../../channel';
 import {title as fieldDefTitle} from '../../channeldef';
 import {contains} from '../../util';
-import {assembleAxis} from '../axis/assemble';
+import {assembleAxis, assembleTitle} from '../axis/assemble';
 import {FacetModel} from '../facet';
 import {parseGuideResolve} from '../resolve';
 import {getHeaderProperty} from './common';
@@ -32,6 +32,8 @@ function parseFacetHeader(model: FacetModel, channel: FacetChannel) {
       allowDisabling: true,
       includeDefault: titleConfig === undefined || !!titleConfig
     });
+
+    title = assembleTitle(title, model.config);
 
     if (model.child.component.layoutHeaders[channel].title) {
       // merge title with child to produce "Title / Subtitle / Sub-subtitle"

--- a/src/compile/legend/parse.ts
+++ b/src/compile/legend/parse.ts
@@ -21,6 +21,7 @@ import {
 import {Legend, LEGEND_PROPERTIES, VG_LEGEND_PROPERTIES} from '../../legend';
 import {GEOJSON} from '../../type';
 import {deleteNestedProperty, getFirstDefined, keys} from '../../util';
+import {assembleTitle} from '../axis/assemble';
 import {mergeTitleComponent, numberFormat} from '../common';
 import {guideEncodeEntry} from '../guide';
 import {isUnitModel, Model} from '../model';
@@ -181,7 +182,7 @@ function getProperty<K extends keyof VgLegend>(
       return getFirstDefined(legend.symbolType, properties.defaultSymbolType(mark));
 
     case 'title':
-      return fieldDefTitle(fieldDef, model.config, {allowDisabling: true}) || undefined;
+      return assembleTitle(fieldDefTitle(fieldDef, model.config, {allowDisabling: true}), model.config) || undefined;
 
     case 'type':
       return type({legend, channel, timeUnit, scaleType, alwaysReturn: false});

--- a/src/compile/mark/valueref.ts
+++ b/src/compile/mark/valueref.ts
@@ -32,6 +32,7 @@ import {StackProperties} from '../../stack';
 import {QUANTITATIVE} from '../../type';
 import {contains, getFirstDefined} from '../../util';
 import {VgValueRef} from '../../vega.schema';
+import {assembleTitle} from '../axis/assemble';
 import {formatSignalRef, getMarkConfig} from '../common';
 import {ScaleComponent} from '../scale/component';
 
@@ -344,7 +345,7 @@ export function tooltipForEncoding(
   {reactiveGeom}: {reactiveGeom?: boolean}
 ) {
   const keyValues: string[] = [];
-  const usedKey = {};
+  const usedKeys: Set<string> = new Set();
 
   function add(fieldDef: TypedFieldDef<string> | SecondaryFieldDef<string>, channel: Channel) {
     const mainChannel = getMainRangeChannel(channel);
@@ -355,13 +356,13 @@ export function tooltipForEncoding(
       };
     }
 
-    const key = title(fieldDef, config, {allowDisabling: false});
+    const key = assembleTitle(title(fieldDef, config, {allowDisabling: false}), config);
     const value = text(fieldDef, config, reactiveGeom ? 'datum.datum' : 'datum').signal;
 
-    if (!usedKey[key]) {
+    if (!usedKeys.has(key)) {
       keyValues.push(`${stringValue(key)}: ${value}`);
     }
-    usedKey[key] = true;
+    usedKeys.add(key);
   }
 
   forEach(encoding, (channelDef, channel) => {

--- a/src/compositemark/errorbar.ts
+++ b/src/compositemark/errorbar.ts
@@ -10,6 +10,7 @@ import {
   title,
   ValueDef
 } from '../channeldef';
+import {assembleTitle} from '../compile/axis/assemble';
 import {Config} from '../config';
 import {Data} from '../data';
 import {Encoding, extractTransformsFromEncoding} from '../encoding';
@@ -482,25 +483,33 @@ function errorBarAggregationAndCalculation<
         {op: upperExtentOp, field: continuousFieldName, as: 'upper_' + continuousFieldName},
         {op: centerOp, field: continuousFieldName, as: 'center_' + continuousFieldName}
       ];
-
       tooltipSummary = [
         {
           fieldPrefix: 'upper_',
-          titlePrefix: title({field: continuousFieldName, aggregate: upperExtentOp, type: 'quantitative'}, config, {
-            allowDisabling: false
-          })
+          titlePrefix: assembleTitle(
+            title({field: continuousFieldName, aggregate: upperExtentOp, type: 'quantitative'}, config, {
+              allowDisabling: false
+            }),
+            config
+          )
         },
         {
           fieldPrefix: 'lower_',
-          titlePrefix: title({field: continuousFieldName, aggregate: lowerExtentOp, type: 'quantitative'}, config, {
-            allowDisabling: false
-          })
+          titlePrefix: assembleTitle(
+            title({field: continuousFieldName, aggregate: lowerExtentOp, type: 'quantitative'}, config, {
+              allowDisabling: false
+            }),
+            config
+          )
         },
         {
           fieldPrefix: 'center_',
-          titlePrefix: title({field: continuousFieldName, aggregate: centerOp, type: 'quantitative'}, config, {
-            allowDisabling: false
-          })
+          titlePrefix: assembleTitle(
+            title({field: continuousFieldName, aggregate: centerOp, type: 'quantitative'}, config, {
+              allowDisabling: false
+            }),
+            config
+          )
         }
       ];
     }

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -32,7 +32,7 @@ import {
   TextFieldDef,
   TextFieldDefWithCondition,
   TextValueDefWithCondition,
-  title,
+  toFieldDefBase,
   TypedFieldDef,
   ValueDef,
   vgField
@@ -264,7 +264,7 @@ export function extractTransformsFromEncoding(oldEncoding: Encoding<Field>, conf
         let newField = vgField(channelDef, {forAs: true});
         const newFieldDef: FieldDef<string> = {
           // Only add title if it doesn't exist
-          ...(isTitleDefined ? [] : {title: title(channelDef, config, {allowDisabling: true})}),
+          ...(isTitleDefined ? [] : {title: [toFieldDefBase(channelDef)]}),
           ...remaining,
           // Always overwrite field
           field: newField

--- a/src/guide.ts
+++ b/src/guide.ts
@@ -1,4 +1,4 @@
-import {ConditionValueDefMixins, ValueDef} from './channeldef';
+import {ConditionValueDefMixins, FieldDefBase, ValueDef} from './channeldef';
 import {LegendConfig} from './legend';
 import {VgEncodeChannel} from './vega.schema';
 
@@ -14,7 +14,7 @@ export interface TitleMixins {
    *
    * 2) If both field definition's `title` and axis, header, or legend `title` are defined, axis/header/legend title will be used.
    */
-  title?: string | null;
+  title?: string | FieldDefBase<string>[] | null;
 }
 
 export interface FormatMixins {

--- a/test/compile/common.test.ts
+++ b/test/compile/common.test.ts
@@ -130,5 +130,10 @@ describe('Common', () => {
     it('should join 2 titles with comma when both titles are not falsy and difference', () => {
       expect(mergeTitle('title1', 'title2')).toBe('title1, title2');
     });
+
+    it('should drop FieldDefBase[] title when also presented with a string title', () => {
+      expect(mergeTitle([{field: 'foo', aggregate: 'max'}], 'title')).toBe('title');
+      expect(mergeTitle('title', [{field: 'foo', aggregate: 'max'}])).toBe('title');
+    });
   });
 });

--- a/test/compositemark/boxplot.test.ts
+++ b/test/compositemark/boxplot.test.ts
@@ -873,7 +873,7 @@ describe('normalizeBoxIQR', () => {
         },
         color: {
           field: 'mean_people',
-          title: 'Mean of people',
+          title: [{aggregate: 'mean', field: 'people'}],
           type: 'quantitative'
         },
         tooltip: [
@@ -908,7 +908,7 @@ describe('normalizeBoxIQR', () => {
           },
           {
             field: 'mean_people',
-            title: 'Mean of people',
+            title: [{aggregate: 'mean', field: 'people'}],
             type: 'quantitative'
           }
         ]
@@ -969,7 +969,7 @@ describe('normalizeBoxIQR', () => {
     for (const whisker of whiskerLayer['layer']) {
       const {tooltip} = whisker['encoding'];
       expect(tooltip[tooltip.length - 1]).toEqual({
-        title: 'Mean of people',
+        title: [{aggregate: 'mean', field: 'people'}],
         type: 'quantitative',
         field: 'mean_people'
       });
@@ -989,7 +989,7 @@ describe('normalizeBoxIQR', () => {
     for (const box of boxLayer['layer']) {
       const {tooltip} = box['encoding'];
       expect(tooltip[tooltip.length - 1]).toEqual({
-        title: 'Mean of people',
+        title: [{aggregate: 'mean', field: 'people'}],
         type: 'quantitative',
         field: 'mean_people'
       });
@@ -1024,7 +1024,7 @@ describe('normalizeBoxIQR', () => {
     for (const whisker of whiskerLayer['layer']) {
       const {tooltip} = whisker['encoding'];
       expect(tooltip[tooltip.length - 1]).toEqual({
-        title: 'Mean of people',
+        title: [{aggregate: 'mean', field: 'people'}],
         type: 'quantitative',
         field: 'mean_people'
       });
@@ -1044,7 +1044,7 @@ describe('normalizeBoxIQR', () => {
     for (const box of boxLayer['layer']) {
       const {tooltip} = box['encoding'];
       expect(tooltip[tooltip.length - 1]).toEqual({
-        title: 'Mean of people',
+        title: [{aggregate: 'mean', field: 'people'}],
         type: 'quantitative',
         field: 'mean_people'
       });

--- a/test/compositemark/common.test.ts
+++ b/test/compositemark/common.test.ts
@@ -45,7 +45,7 @@ describe('common feature of composite marks', () => {
       const encoding: Encoding<string | RepeatRef> = isUnitSpec(unitSpec) && unitSpec.encoding;
       expect(encoding).toBeTruthy();
       expect(encoding.x).toEqual({
-        title: 'Year (year)',
+        title: [{timeUnit: 'year', field: 'Year'}],
         type: 'ordinal',
         field: 'year_Year',
         axis: {

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -84,7 +84,7 @@ describe('encoding', () => {
           x: {
             field: 'yearmonthdatehoursminutes_a',
             type: 'temporal',
-            title: 'a (year-month-date-hours-minutes)',
+            title: [{timeUnit: 'yearmonthdatehoursminutes', field: 'a'}],
             axis: {
               format: '%b %d, %Y %H:%M'
             }
@@ -111,7 +111,7 @@ describe('encoding', () => {
           formatType: 'time'
         },
         field: 'year_b',
-        title: 'b (year)',
+        title: [{timeUnit: 'year', field: 'b'}],
         type: 'ordinal'
       });
     });
@@ -132,7 +132,7 @@ describe('encoding', () => {
           format: '%Y'
         },
         field: 'year_b',
-        title: 'b (year)',
+        title: [{timeUnit: 'year', field: 'b'}],
         type: 'temporal'
       });
     });
@@ -155,7 +155,7 @@ describe('encoding', () => {
           formatType: 'time'
         },
         field: 'month_c',
-        title: 'c (month)',
+        title: [{timeUnit: 'month', field: 'c'}],
         type: 'nominal'
       });
     });
@@ -177,7 +177,7 @@ describe('encoding', () => {
           format: '%b'
         },
         field: 'month_c',
-        title: 'c (month)',
+        title: [{timeUnit: 'month', field: 'c'}],
         type: 'temporal'
       });
     });
@@ -198,14 +198,14 @@ describe('encoding', () => {
         format: '%b',
         formatType: 'time',
         field: 'month_c',
-        title: 'c (month)',
+        title: [{timeUnit: 'month', field: 'c'}],
         type: 'nominal'
       });
       expect(output.encoding.text).toEqual({
         format: '%b',
         formatType: 'time',
         field: 'month_c',
-        title: 'c (month)',
+        title: [{timeUnit: 'month', field: 'c'}],
         type: 'nominal'
       });
     });
@@ -234,7 +234,7 @@ describe('encoding', () => {
           y: {
             field: 'max_b',
             type: 'quantitative',
-            title: 'Max of b'
+            title: [{aggregate: 'max', field: 'b'}]
           }
         }
       });
@@ -256,9 +256,14 @@ describe('encoding', () => {
         aggregate: [{op: 'count', as: internalField('count')}],
         groupby: ['bin_maxbins_10_a_end', 'bin_maxbins_10_a_range', 'bin_maxbins_10_a'],
         encoding: {
-          x: {field: 'bin_maxbins_10_a', type: 'quantitative', title: 'a (binned)', bin: 'binned'},
+          x: {
+            field: 'bin_maxbins_10_a',
+            type: 'quantitative',
+            title: [{field: 'a', bin: {maxbins: 10}}],
+            bin: 'binned'
+          },
           x2: {field: 'bin_maxbins_10_a_end'},
-          y: {field: internalField('count'), type: 'quantitative', title: 'Count of Records'}
+          y: {field: internalField('count'), type: 'quantitative', title: [{aggregate: 'count'}]}
         }
       });
     });

--- a/test/transformextract.test.ts
+++ b/test/transformextract.test.ts
@@ -14,7 +14,6 @@ describe('extractTransforms()', () => {
   const failsList = new Set([
     'area_temperature_range.vl.json',
     'bar_argmax.vl.json',
-    'bar_argmax_transform.vl.json',
     'bar_aggregate_count.vl.json',
     'bar_aggregate_sort_by_encoding.vl.json',
     'bar_aggregate_sort_mean.vl.json',
@@ -45,7 +44,6 @@ describe('extractTransforms()', () => {
     'interactive_layered_crossfilter_discrete.vl.json',
     'interactive_layered_crossfilter.vl.json',
     'interactive_seattle_weather.vl.json',
-    'joinaggregate_mean_difference.vl.json',
     'layer_bar_dual_axis_minmax.vl.json',
     'layer_bar_month.vl.json', // data transform switches the order
     'layer_dual_axis.vl.json', // tooltip does not use the correct field name
@@ -72,7 +70,6 @@ describe('extractTransforms()', () => {
     'layer_point_errorbar_stdev.vl.json',
     'layer_precipitation_mean.vl.json',
     'layer_rect_extent.vl.json',
-    'layer_scatter_errorband_1D_stdev_global_mean.vl.json',
     'line_calculate.vl.json',
     'line_color_binned.vl.json',
     'line_max_year.vl.json',
@@ -106,16 +103,16 @@ describe('extractTransforms()', () => {
     'trellis_barley.vl.json',
     'trellis_barley_independent.vl.json',
     'trellis_column_year.vl.json',
-    'trellis_cross_sort_array.vl.json',
-    'trellis_cross_sort.vl.json',
     'trellis_line_quarter.vl.json',
     'vconcat_weather.vl.json',
     'window_top_k_others.vl.json'
   ]);
   for (const file of fs.readdirSync(specsDir)) {
+    // If true make sure that specs in the failsList do indeed fail
+    const TEST_EXPECTED_FAILS = false;
     const filepath = specsDir + file;
-    if (filepath.slice(-5) === '.json' && !failsList.has(file)) {
-      it(`should compile ${filepath} to the same spec`, () => {
+    if (filepath.slice(-5) === '.json' && (!failsList.has(file) || TEST_EXPECTED_FAILS)) {
+      it(`should${failsList.has(file) ? ' NOT ' : ' '}compile ${filepath} to the same spec`, () => {
         const specString = fs.readFileSync(filepath, 'utf8');
 
         const spec = JSON.parse(specString);
@@ -129,7 +126,11 @@ describe('extractTransforms()', () => {
         const originalCompiled = compile(spec, {config});
         const transformCompiled = compile(extractSpec, {config});
 
-        expect(transformCompiled).toEqual(originalCompiled);
+        if (failsList.has(file)) {
+          expect(transformCompiled).not.toEqual(originalCompiled);
+        } else {
+          expect(transformCompiled).toEqual(originalCompiled);
+        }
       });
     }
   }
@@ -174,7 +175,7 @@ describe('extractTransforms()', () => {
           height: 234,
           encoding: {
             x: {field: 'Worldwide_Gross', type: 'quantitative'},
-            y: {field: internalField('count'), type: 'quantitative', title: 'Count of Records'}
+            y: {field: internalField('count'), type: 'quantitative', title: [{aggregate: 'count'}]}
           }
         }
       });
@@ -246,7 +247,12 @@ describe('extractTransforms()', () => {
                   x: {
                     field: 'month_date',
                     type: 'ordinal',
-                    title: 'date (month)',
+                    title: [
+                      {
+                        field: 'date',
+                        timeUnit: 'month'
+                      }
+                    ],
                     axis: {
                       format: '%b',
                       formatType: 'time'
@@ -255,7 +261,7 @@ describe('extractTransforms()', () => {
                   y: {
                     field: 'mean_precipitation',
                     type: 'quantitative',
-                    title: 'Mean of precipitation',
+                    title: [{field: 'precipitation', aggregate: 'mean'}],
                     axis: {
                       grid: false
                     }
@@ -275,7 +281,12 @@ describe('extractTransforms()', () => {
                   x: {
                     field: 'month_date',
                     type: 'ordinal',
-                    title: 'date (month)',
+                    title: [
+                      {
+                        field: 'date',
+                        timeUnit: 'month'
+                      }
+                    ],
                     axis: {
                       format: '%b',
                       formatType: 'time'
@@ -284,7 +295,7 @@ describe('extractTransforms()', () => {
                   y: {
                     field: 'mean_temp_max',
                     type: 'quantitative',
-                    title: 'Mean of temp_max',
+                    title: [{field: 'temp_max', aggregate: 'mean'}],
                     axis: {
                       grid: false
                     },


### PR DESCRIPTION
Replaces #4267. Allows for five more example specs to pass transform extract tests. This is because title merging behavior differs between implicit and explicitly defined titles.