### PR TITLE
Remove "type" field from "x2" and "y2" 

### DIFF
--- a/examples/specs/rect_mosaic_labelled_with_offset.vl.json
+++ b/examples/specs/rect_mosaic_labelled_with_offset.vl.json
@@ -168,8 +168,7 @@
               "axis": null
             },
             "x2": {
-              "field": "nx2",
-              "type": "quantitative"
+              "field": "nx2"
             },
             "y": {
               "field": "ny",
@@ -177,8 +176,7 @@
               "axis": null
             },
             "y2": {
-              "field": "ny2",
-              "type": "quantitative"
+              "field": "ny2"
             },
             "color": {
               "field": "Origin",


### PR DESCRIPTION
Remove "type" field from "x2" and "y2" since they are disallowed by the schema, so this example schema is technically invalid.
