### PR TITLE
Remove unnecessary `config.stack`

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -3238,10 +3238,6 @@
           "$ref": "#/definitions/MarkConfig",
           "description": "Square-Specific Config"
         },
-        "stack": {
-          "$ref": "#/definitions/StackOffset",
-          "description": "Default stack offset for stackable mark."
-        },
         "style": {
           "$ref": "#/definitions/StyleConfigIndex",
           "description": "An object hash that defines key-value mappings to determine default properties for marks with a given [style](https://vega.github.io/vega-lite/docs/mark.html#mark-def).  The keys represent styles names; the values have to be valid [mark configuration objects](https://vega.github.io/vega-lite/docs/mark.html#config)."

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -4,8 +4,8 @@ import {
   Channel,
   GEOPOSITION_CHANNELS,
   NONPOSITION_SCALE_CHANNELS,
-  SCALE_CHANNELS,
   ScaleChannel,
+  SCALE_CHANNELS,
   SingleDefChannel,
   supportLegend,
   X,
@@ -90,7 +90,7 @@ export class UnitModel extends ModelWithField {
     this.markDef = normalizeMarkDef(spec.mark, encoding, config);
 
     // calculate stack properties
-    this.stack = stack(mark, encoding, this.config.stack);
+    this.stack = stack(mark, encoding);
     this.specifiedScales = this.initScales(mark, encoding);
 
     this.specifiedAxes = this.initAxes(encoding);

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,7 +17,6 @@ import {defaultScaleConfig, ScaleConfig} from './scale';
 import {defaultConfig as defaultSelectionConfig, SelectionConfig} from './selection';
 import {BaseViewBackground, CompositionConfigMixins, DEFAULT_SPACING} from './spec/base';
 import {TopLevelProperties} from './spec/toplevel';
-import {StackOffset} from './stack';
 import {extractTitleConfig, TitleConfig} from './title';
 import {duplicate, keys, mergeDeep} from './util';
 import {BaseMarkConfig, SchemeConfig} from './vega.schema';
@@ -141,9 +140,6 @@ export interface VLOnlyConfig {
 
   /** An object hash for defining default properties for each type of selections. */
   selection?: SelectionConfig;
-
-  /** Default stack offset for stackable mark. */
-  stack?: StackOffset;
 }
 
 export interface StyleConfigIndex {
@@ -279,7 +275,6 @@ const VL_ONLY_CONFIG_PROPERTIES: (keyof Config)[] = [
   'timeFormat',
   'countTitle',
   'header',
-  'stack',
   'scale',
   'selection',
   'invalidValues',

--- a/src/normalize/pathoverlay.ts
+++ b/src/normalize/pathoverlay.ts
@@ -114,7 +114,7 @@ export class PathOverlayNormalizer implements NonFacetUnitNormalizer<UnitSpecWit
     // FIXME: determine rules for applying selections.
 
     // Need to copy stack config to overlayed layer
-    const stackProps = stack(markDef, encoding, config ? config.stack : undefined);
+    const stackProps = stack(markDef, encoding);
 
     let overlayEncoding = encoding;
     if (stackProps) {

--- a/src/stack.ts
+++ b/src/stack.ts
@@ -14,7 +14,7 @@ import {channelHasField, Encoding} from './encoding';
 import * as log from './log';
 import {AREA, BAR, CIRCLE, isMarkDef, isPathMark, LINE, Mark, MarkDef, POINT, RULE, SQUARE, TEXT, TICK} from './mark';
 import {ScaleType} from './scale';
-import {contains, Flag, getFirstDefined} from './util';
+import {contains, Flag} from './util';
 
 export type StackOffset = 'zero' | 'center' | 'normalize';
 
@@ -88,7 +88,6 @@ function potentialStackedChannel(encoding: Encoding<Field>): 'x' | 'y' | undefin
 export function stack(
   m: Mark | MarkDef,
   encoding: Encoding<Field>,
-  stackConfig: StackOffset,
   opt: {
     disallowNonLinearStack?: boolean; // This option is for CompassQL
   } = {}
@@ -151,9 +150,7 @@ export function stack(
     }
   } else if (contains(STACK_BY_DEFAULT_MARKS, mark)) {
     // Bar and Area with sum ops are automatically stacked by default
-    offset = getFirstDefined(stackConfig, 'zero');
-  } else {
-    offset = stackConfig;
+    offset = 'zero';
   }
 
   if (!offset || !isStackOffset(offset)) {

--- a/test/compile/mark/line.test.ts
+++ b/test/compile/mark/line.test.ts
@@ -84,10 +84,9 @@ describe('Mark: Line', () => {
       mark: 'line',
       encoding: {
         x: {field: 'year', type: 'ordinal'},
-        y: {field: 'yield', type: 'quantitative', aggregate: 'sum'},
+        y: {field: 'yield', type: 'quantitative', aggregate: 'sum', stack: 'zero'},
         color: {field: 'a', type: 'nominal'}
-      },
-      config: {stack: 'zero'}
+      }
     });
     const props = line.encodeEntry(model);
 
@@ -102,10 +101,9 @@ describe('Mark: Line', () => {
       mark: 'line',
       encoding: {
         y: {field: 'year', type: 'ordinal'},
-        x: {field: 'yield', type: 'quantitative', aggregate: 'sum'},
+        x: {field: 'yield', type: 'quantitative', aggregate: 'sum', stack: 'zero'},
         color: {field: 'a', type: 'nominal'}
-      },
-      config: {stack: 'zero'}
+      }
     });
     const props = line.encodeEntry(model);
 

--- a/test/compile/mark/point.test.ts
+++ b/test/compile/mark/point.test.ts
@@ -48,11 +48,10 @@ describe('Mark: Point', () => {
     const model = parseUnitModelWithScaleAndLayoutSize({
       mark: 'point',
       encoding: {
-        x: {aggregate: 'sum', field: 'a', type: 'quantitative'},
+        x: {aggregate: 'sum', field: 'a', type: 'quantitative', stack: 'zero'},
         color: {field: 'b', type: 'ordinal'}
       },
-      data: {url: 'data/barley.json'},
-      config: {stack: 'zero'}
+      data: {url: 'data/barley.json'}
     });
 
     const props = point.encodeEntry(model);
@@ -89,11 +88,10 @@ describe('Mark: Point', () => {
     const model = parseUnitModelWithScaleAndLayoutSize({
       mark: 'point',
       encoding: {
-        y: {aggregate: 'sum', field: 'a', type: 'quantitative'},
+        y: {aggregate: 'sum', field: 'a', type: 'quantitative', stack: 'zero'},
         color: {field: 'b', type: 'ordinal'}
       },
-      data: {url: 'data/barley.json'},
-      config: {stack: 'zero'}
+      data: {url: 'data/barley.json'}
     });
 
     const props = point.encodeEntry(model);

--- a/test/compile/mark/rule.test.ts
+++ b/test/compile/mark/rule.test.ts
@@ -210,11 +210,10 @@ describe('Mark: Rule', () => {
       mark: 'rule',
       encoding: {
         y: {field: 'a', type: 'ordinal'},
-        x: {aggregate: 'sum', field: 'b', type: 'quantitative'},
+        x: {aggregate: 'sum', field: 'b', type: 'quantitative', stack: 'zero'},
         color: {field: 'Origin', type: 'nominal'}
       },
       config: {
-        stack: 'zero',
         invalidValues: null
       }
     });
@@ -233,11 +232,10 @@ describe('Mark: Rule', () => {
       mark: 'rule',
       encoding: {
         x: {field: 'a', type: 'ordinal'},
-        y: {aggregate: 'sum', field: 'b', type: 'quantitative'},
+        y: {aggregate: 'sum', field: 'b', type: 'quantitative', stack: 'zero'},
         color: {field: 'Origin', type: 'nominal'}
       },
       config: {
-        stack: 'zero',
         invalidValues: null
       }
     });

--- a/test/compile/mark/text.test.ts
+++ b/test/compile/mark/text.test.ts
@@ -11,11 +11,10 @@ describe('Mark: Text', () => {
     const model = parseUnitModelWithScaleAndLayoutSize({
       mark: 'text',
       encoding: {
-        x: {aggregate: 'sum', field: 'a', type: 'quantitative'},
+        x: {aggregate: 'sum', field: 'a', type: 'quantitative', stack: 'zero'},
         color: {field: 'b', type: 'ordinal'}
       },
-      data: {url: 'data/barley.json'},
-      config: {stack: 'zero'}
+      data: {url: 'data/barley.json'}
     });
 
     const props = text.encodeEntry(model);
@@ -31,11 +30,10 @@ describe('Mark: Text', () => {
     const model = parseUnitModelWithScaleAndLayoutSize({
       mark: 'text',
       encoding: {
-        y: {aggregate: 'sum', field: 'a', type: 'quantitative'},
+        y: {aggregate: 'sum', field: 'a', type: 'quantitative', stack: 'zero'},
         color: {field: 'b', type: 'ordinal'}
       },
-      data: {url: 'data/barley.json'},
-      config: {stack: 'zero'}
+      data: {url: 'data/barley.json'}
     });
 
     const props = text.encodeEntry(model);

--- a/test/compile/mark/tick.test.ts
+++ b/test/compile/mark/tick.test.ts
@@ -15,11 +15,10 @@ describe('Mark: Tick', () => {
     const model = parseUnitModelWithScaleAndLayoutSize({
       mark: 'tick',
       encoding: {
-        x: {aggregate: 'sum', field: 'a', type: 'quantitative'},
+        x: {aggregate: 'sum', field: 'a', type: 'quantitative', stack: 'zero'},
         color: {field: 'b', type: 'ordinal'}
       },
-      data: {url: 'data/barley.json'},
-      config: {stack: 'zero'}
+      data: {url: 'data/barley.json'}
     });
 
     const props = tick.encodeEntry(model);
@@ -35,11 +34,10 @@ describe('Mark: Tick', () => {
     const model = parseUnitModelWithScaleAndLayoutSize({
       mark: 'tick',
       encoding: {
-        y: {aggregate: 'sum', field: 'a', type: 'quantitative'},
+        y: {aggregate: 'sum', field: 'a', type: 'quantitative', stack: 'zero'},
         color: {field: 'b', type: 'ordinal'}
       },
-      data: {url: 'data/barley.json'},
-      config: {stack: 'zero'}
+      data: {url: 'data/barley.json'}
     });
 
     const props = tick.encodeEntry(model);

--- a/test/compile/scale/domain.test.ts
+++ b/test/compile/scale/domain.test.ts
@@ -95,13 +95,11 @@ describe('compile/scale', () => {
           y: {
             aggregate: 'sum',
             field: 'origin',
-            type: 'quantitative'
+            type: 'quantitative',
+            stack: 'normalize'
           },
           x: {field: 'x', type: 'ordinal'},
           color: {field: 'color', type: 'ordinal'}
-        },
-        config: {
-          stack: 'normalize'
         }
       });
 

--- a/test/stack.test.ts
+++ b/test/stack.test.ts
@@ -10,23 +10,18 @@ describe('stack', () => {
   const NON_STACKABLE_MARKS = [RECT];
 
   it('should be disabled for non-stackable marks with at least one of the stack channel', () => {
-    for (const stacked of [undefined, 'center', 'zero', 'normalize', null, 'none'] as StackOffset[]) {
-      NON_STACKABLE_MARKS.forEach(nonStackableMark => {
-        const spec: TopLevel<NormalizedUnitSpec> = {
-          data: {url: 'data/barley.json'},
-          mark: nonStackableMark,
-          encoding: {
-            x: {aggregate: 'sum', field: 'yield', type: 'quantitative'},
-            y: {field: 'variety', type: 'nominal'},
-            color: {field: 'site', type: 'nominal'}
-          },
-          config: {
-            stack: stacked
-          }
-        };
-        expect(stack(spec.mark, spec.encoding, spec.config.stack)).toBeNull();
-      });
-    }
+    NON_STACKABLE_MARKS.forEach(nonStackableMark => {
+      const spec: TopLevel<NormalizedUnitSpec> = {
+        data: {url: 'data/barley.json'},
+        mark: nonStackableMark,
+        encoding: {
+          x: {aggregate: 'sum', field: 'yield', type: 'quantitative'},
+          y: {field: 'variety', type: 'nominal'},
+          color: {field: 'site', type: 'nominal'}
+        }
+      };
+      expect(stack(spec.mark, spec.encoding)).toBeNull();
+    });
   });
 
   it('should be allowed for raw plot', () => {
@@ -78,82 +73,70 @@ describe('stack', () => {
   });
 
   it('should always be disabled if there is no stackby channel', () => {
-    for (const stacked of [undefined, 'center', 'zero', 'normalize', null, 'none'] as StackOffset[]) {
+    for (const s of [undefined, 'center', 'zero', 'normalize', null, 'none'] as StackOffset[]) {
       PRIMITIVE_MARKS.forEach(mark => {
         const spec: TopLevel<NormalizedUnitSpec> = {
           data: {url: 'data/barley.json'},
           mark: mark,
           encoding: {
-            x: {aggregate: 'sum', field: 'yield', type: 'quantitative'},
+            x: {aggregate: 'sum', field: 'yield', type: 'quantitative', stack: s},
             y: {field: 'variety', type: 'nominal'}
-          },
-          config: {
-            stack: stacked
           }
         };
-        expect(stack(spec.mark, spec.encoding, spec.config.stack)).toBeNull();
+        expect(stack(spec.mark, spec.encoding)).toBeNull();
       });
     }
   });
 
   it('should always be disabled if the stackby channel is aggregated', () => {
-    for (const stacked of [undefined, 'center', 'zero', 'normalize', null, 'none'] as StackOffset[]) {
+    for (const s of [undefined, 'center', 'zero', 'normalize', null, 'none'] as StackOffset[]) {
       PRIMITIVE_MARKS.forEach(mark => {
         const spec: TopLevel<NormalizedUnitSpec> = {
           data: {url: 'data/barley.json'},
           mark: mark,
           encoding: {
-            x: {aggregate: 'sum', field: 'yield', type: 'quantitative'},
+            x: {aggregate: 'sum', field: 'yield', type: 'quantitative', stacked: s},
             y: {field: 'variety', type: 'nominal'},
             color: {aggregate: 'count', type: 'quantitative'}
-          },
-          config: {
-            stack: stacked
           }
         };
-        expect(stack(spec.mark, spec.encoding, spec.config.stack)).toBeNull();
+        expect(stack(spec.mark, spec.encoding)).toBeNull();
       });
     }
   });
 
   it('should always be disabled if the stackby channel is identical to y', () => {
-    for (const stacked of [undefined, 'center', 'zero', 'normalize', null, 'none'] as StackOffset[]) {
+    for (const s of [undefined, 'center', 'zero', 'normalize', null, 'none'] as StackOffset[]) {
       PRIMITIVE_MARKS.forEach(mark => {
         const spec: TopLevel<NormalizedUnitSpec> = {
           data: {url: 'data/barley.json'},
           mark: mark,
           encoding: {
-            x: {aggregate: 'sum', field: 'yield', type: 'quantitative'},
+            x: {aggregate: 'sum', field: 'yield', type: 'quantitative', stack: s},
             y: {field: 'variety', type: 'nominal'},
             color: {field: 'variety', type: 'nominal'}
-          },
-          config: {
-            stack: stacked
           }
         };
-        expect(stack(spec.mark, spec.encoding, spec.config.stack)).toBeNull();
+        expect(stack(spec.mark, spec.encoding)).toBeNull();
       });
     }
   });
 
   it('can be enabled if one of the stackby channels is not aggregated', () => {
-    for (const stacked of [undefined, 'center', 'zero', 'normalize'] as StackOffset[]) {
-      const marks = stacked === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
+    for (const s of [undefined, 'center', 'zero', 'normalize'] as StackOffset[]) {
+      const marks = s === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
       marks.forEach(mark => {
         const spec: TopLevel<NormalizedUnitSpec> = {
           data: {url: 'data/barley.json'},
           mark: mark,
           encoding: {
-            x: {aggregate: 'sum', field: 'yield', type: 'quantitative'},
+            x: {aggregate: 'sum', field: 'yield', type: 'quantitative', stack: s},
             y: {field: 'variety', type: 'nominal'},
             color: {aggregate: 'count', type: 'quantitative'},
             detail: {field: 'site', type: 'nominal'}
-          },
-          config: {
-            stack: stacked
           }
         };
-        const _stack = stack(spec.mark, spec.encoding, spec.config.stack);
+        const _stack = stack(spec.mark, spec.encoding);
         expect(_stack).toBeTruthy();
 
         expect(_stack.stackBy[0].channel).toEqual(DETAIL);
@@ -205,43 +188,33 @@ describe('stack', () => {
   });
 
   it('should always be disabled if both x and y are aggregate', () => {
-    for (const stacked of [undefined, 'center', 'zero', 'normalize', null, 'none'] as StackOffset[]) {
-      PRIMITIVE_MARKS.forEach(mark => {
-        const spec: TopLevel<NormalizedUnitSpec> = {
-          data: {url: 'data/barley.json'},
-          mark: mark,
-          encoding: {
-            x: {aggregate: 'sum', field: 'yield', type: 'quantitative'},
-            y: {aggregate: 'count', type: 'quantitative'},
-            color: {field: 'site', type: 'nominal'}
-          },
-          config: {
-            stack: stacked
-          }
-        };
-        expect(stack(spec.mark, spec.encoding, spec.config.stack)).toBeNull();
-      });
-    }
+    PRIMITIVE_MARKS.forEach(mark => {
+      const spec: TopLevel<NormalizedUnitSpec> = {
+        data: {url: 'data/barley.json'},
+        mark: mark,
+        encoding: {
+          x: {aggregate: 'sum', field: 'yield', type: 'quantitative'},
+          y: {aggregate: 'count', type: 'quantitative'},
+          color: {field: 'site', type: 'nominal'}
+        }
+      };
+      expect(stack(spec.mark, spec.encoding)).toBeNull();
+    });
   });
 
   it('should always be disabled if neither x nor y is aggregate or stack', () => {
-    for (const stacked of [undefined, 'center', 'zero', 'normalize', null, 'none'] as StackOffset[]) {
-      PRIMITIVE_MARKS.forEach(mark => {
-        const spec: TopLevel<NormalizedUnitSpec> = {
-          data: {url: 'data/barley.json'},
-          mark: mark,
-          encoding: {
-            x: {field: 'variety', type: 'nominal'},
-            y: {field: 'variety', type: 'nominal'},
-            color: {field: 'site', type: 'nominal'}
-          },
-          config: {
-            stack: stacked
-          }
-        };
-        expect(stack(spec.mark, spec.encoding, spec.config.stack)).toBeNull();
-      });
-    }
+    PRIMITIVE_MARKS.forEach(mark => {
+      const spec: TopLevel<NormalizedUnitSpec> = {
+        data: {url: 'data/barley.json'},
+        mark: mark,
+        encoding: {
+          x: {field: 'variety', type: 'nominal'},
+          y: {field: 'variety', type: 'nominal'},
+          color: {field: 'site', type: 'nominal'}
+        }
+      };
+      expect(stack(spec.mark, spec.encoding)).toBeNull();
+    });
   });
 
   it('should always be disabled if there is both x and x2', () => {
@@ -255,12 +228,9 @@ describe('stack', () => {
             x2: {field: 'a', type: 'quantitative', aggregate: 'sum'},
             y: {field: 'variety', type: 'nominal'},
             color: {field: 'site', type: 'nominal'}
-          },
-          config: {
-            stack: stacked
           }
         };
-        expect(stack(spec.mark, spec.encoding, spec.config.stack)).toBeNull();
+        expect(stack(spec.mark, spec.encoding)).toBeNull();
       });
     }
   });
@@ -276,12 +246,9 @@ describe('stack', () => {
             y2: {field: 'a', type: 'quantitative', aggregate: 'sum'},
             x: {field: 'variety', type: 'nominal'},
             color: {field: 'site', type: 'nominal'}
-          },
-          config: {
-            stack: stacked
           }
         };
-        expect(stack(spec.mark, spec.encoding, spec.config.stack)).toBeNull();
+        expect(stack(spec.mark, spec.encoding)).toBeNull();
       });
     }
   });
@@ -289,23 +256,20 @@ describe('stack', () => {
   it(
     'should always be warned if the aggregated axis has non-linear scale',
     log.wrap(localLogger => {
-      for (const stacked of [undefined, 'center', 'zero', 'normalize'] as StackOffset[]) {
+      for (const s of [undefined, 'center', 'zero', 'normalize'] as StackOffset[]) {
         [ScaleType.LOG, ScaleType.POW, ScaleType.SQRT].forEach(scaleType => {
-          const marks = stacked === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
+          const marks = s === undefined ? STACK_BY_DEFAULT_MARKS : STACKABLE_MARKS;
           marks.forEach(mark => {
             const spec: TopLevel<NormalizedUnitSpec> = {
               data: {url: 'data/barley.json'},
               mark: mark,
               encoding: {
-                x: {field: 'a', type: 'quantitative', aggregate: 'sum', scale: {type: scaleType}},
+                x: {field: 'a', type: 'quantitative', aggregate: 'sum', stack: s, scale: {type: scaleType}},
                 y: {field: 'variety', type: 'nominal'},
                 color: {field: 'site', type: 'nominal'}
-              },
-              config: {
-                stack: stacked
               }
             };
-            expect(stack(spec.mark, spec.encoding, spec.config.stack)).not.toBeNull();
+            expect(stack(spec.mark, spec.encoding)).not.toBeNull();
 
             const warns = localLogger.warns;
             expect(warns[warns.length - 1]).toEqual(log.message.cannotStackNonLinearScale(scaleType));
@@ -327,12 +291,9 @@ describe('stack', () => {
               x: {field: 'a', type: 'quantitative', aggregate: 'sum', scale: {type: scaleType}},
               y: {field: 'variety', type: 'nominal'},
               color: {field: 'site', type: 'nominal'}
-            },
-            config: {
-              stack: stacked
             }
           };
-          expect(stack(spec.mark, spec.encoding, spec.config.stack, {disallowNonLinearStack: true})).toBeNull();
+          expect(stack(spec.mark, spec.encoding, {disallowNonLinearStack: true})).toBeNull();
         });
       });
     }
@@ -457,21 +418,18 @@ describe('stack', () => {
     });
 
     it('should be the specified stacked for stackable marks with at least one of the stack channel', () => {
-      for (const stacked of ['center', 'zero', 'normalize'] as StackOffset[]) {
+      for (const s of ['center', 'zero', 'normalize'] as StackOffset[]) {
         [BAR, AREA].forEach(stackableMark => {
           const spec: TopLevel<NormalizedUnitSpec> = {
             data: {url: 'data/barley.json'},
             mark: stackableMark,
             encoding: {
-              x: {aggregate: 'sum', field: 'yield', type: 'quantitative'},
+              x: {aggregate: 'sum', field: 'yield', type: 'quantitative', stack: s},
               y: {field: 'variety', type: 'nominal'},
               color: {field: 'site', type: 'nominal'}
-            },
-            config: {
-              stack: stacked
             }
           };
-          expect(stack(spec.mark, spec.encoding, spec.config.stack).offset).toEqual(stacked);
+          expect(stack(spec.mark, spec.encoding).offset).toEqual(s);
         });
       }
     });


### PR DESCRIPTION
Fix #4823

(In hindsight, no one should want to make stack always center / normalized, so this property is useless. Plus, it's kinda out of nowhere.) 