### PR TITLE
Use common logic for naming bin signals

### DIFF
--- a/src/compile/data/bin.ts
+++ b/src/compile/data/bin.ts
@@ -27,7 +27,7 @@ function rangeFormula(model: ModelWithField, fieldDef: TypedFieldDef<string>, ch
   return {};
 }
 
-export function binKey(bin: BinParams, field: string) {
+function binKey(bin: BinParams, field: string) {
   return `${binToString(bin)}_${field}`;
 }
 
@@ -36,6 +36,12 @@ function getSignalsFromModel(model: Model, key: string) {
     signal: model.getName(`${key}_bins`),
     extentSignal: model.getName(`${key}_extent`)
   };
+}
+
+export function getBinSignalName(model: Model, field: string, bin: boolean | BinParams) {
+  const normalizedBin = normalizeBin(bin, undefined) || {};
+  const key = binKey(normalizedBin, field);
+  return model.getName(`${key}_bins`);
 }
 
 function isBinTransform(t: TypedFieldDef<string> | BinTransform): t is BinTransform {

--- a/src/compile/data/bin.ts
+++ b/src/compile/data/bin.ts
@@ -1,10 +1,10 @@
 import {isString} from 'vega-util';
 import {BinParams, binToString, isBinning} from '../../bin';
 import {Channel} from '../../channel';
-import {FieldName, binRequiresRange, isTypedFieldDef, normalizeBin, TypedFieldDef, vgField} from '../../channeldef';
+import {binRequiresRange, FieldName, isTypedFieldDef, normalizeBin, TypedFieldDef, vgField} from '../../channeldef';
 import {Config} from '../../config';
 import {BinTransform} from '../../transform';
-import {Dict, duplicate, flatten, hash, keys, unique, vals} from '../../util';
+import {Dict, duplicate, flatten, hash, keys, replacePathInField, unique, vals} from '../../util';
 import {VgBinTransform, VgTransform} from '../../vega.schema';
 import {binFormatExpression} from '../common';
 import {isUnitModel, Model, ModelWithField} from '../model';
@@ -27,7 +27,7 @@ function rangeFormula(model: ModelWithField, fieldDef: TypedFieldDef<string>, ch
   return {};
 }
 
-function binKey(bin: BinParams, field: string) {
+export function binKey(bin: BinParams, field: string) {
   return `${binToString(bin)}_${field}`;
 }
 
@@ -163,7 +163,7 @@ export class BinNode extends DataFlowNode {
         const [binAs, ...remainingAs] = bin.as;
         const binTrans: VgBinTransform = {
           type: 'bin',
-          field: bin.field,
+          field: replacePathInField(bin.field),
           as: binAs,
           signal: bin.signal,
           ...bin.bin
@@ -172,7 +172,7 @@ export class BinNode extends DataFlowNode {
         if (!bin.bin.extent && bin.extentSignal) {
           transform.push({
             type: 'extent',
-            field: bin.field,
+            field: replacePathInField(bin.field),
             signal: bin.extentSignal
           });
           binTrans.extent = {signal: bin.extentSignal};

--- a/src/compile/scale/domain.ts
+++ b/src/compile/scale/domain.ts
@@ -23,6 +23,7 @@ import {
   VgSortField,
   VgUnionSortField
 } from '../../vega.schema';
+import {getBinSignalName} from '../data/bin';
 import {sortArrayIndexField} from '../data/calculate';
 import {FACET_SCALE_PREFIX} from '../data/optimize';
 import {isFacetModel, isUnitModel, Model} from '../model';
@@ -278,11 +279,12 @@ function parseSingleChannelDomain(
       ];
     } else {
       // continuous scales
-      if (isBinning(fieldDef.bin)) {
-        const signalName = model.getName(vgField(fieldDef, {suffix: 'bins'}));
+      const {bin} = fieldDef;
+      if (isBinning(bin)) {
+        const binSignal = getBinSignalName(model, fieldDef.field, bin);
         return [
           new SignalRefWrapper(() => {
-            const signal = model.getSignalName(signalName);
+            const signal = model.getSignalName(binSignal);
             return `[${signal}.start, ${signal}.stop]`;
           })
         ];

--- a/src/compile/scale/properties.ts
+++ b/src/compile/scale/properties.ts
@@ -1,7 +1,7 @@
 import {isArray} from 'vega-util';
 import {isBinned, isBinning, isBinParams} from '../../bin';
 import {Channel, COLOR, FILL, ScaleChannel, STROKE, X, Y} from '../../channel';
-import {normalizeBin, ScaleFieldDef, TypedFieldDef} from '../../channeldef';
+import {ScaleFieldDef, TypedFieldDef} from '../../channeldef';
 import {Config} from '../../config';
 import * as log from '../../log';
 import {BarConfig, Mark, MarkDef} from '../../mark';
@@ -22,7 +22,7 @@ import {Type} from '../../type';
 import * as util from '../../util';
 import {contains, getFirstDefined, keys} from '../../util';
 import {VgScale} from '../../vega.schema';
-import {binKey} from '../data/bin';
+import {getBinSignalName} from '../data/bin';
 import {isUnitModel, Model} from '../model';
 import {Explicit, mergeValuesWithExplicit, tieBreakByComparing} from '../split';
 import {UnitModel} from '../unit';
@@ -181,11 +181,9 @@ export function parseNonUnitScaleProperty(model: Model, property: keyof (Scale |
 export function bins(model: Model, fieldDef: TypedFieldDef<string>) {
   const bin = fieldDef.bin;
   if (isBinning(bin)) {
-    const normalizedBin = normalizeBin(bin, undefined) || {};
-    const key = binKey(normalizedBin, fieldDef.field);
-    const signal = model.getName(`${key}_bins`);
+    const binSignal = getBinSignalName(model, fieldDef.field, bin);
     return new SignalRefWrapper(() => {
-      return model.getSignalName(signal);
+      return model.getSignalName(binSignal);
     });
   } else if (isBinned(bin) && isBinParams(bin) && bin.step !== undefined) {
     // start and stop will be determined from the scale domain

--- a/src/compile/scale/properties.ts
+++ b/src/compile/scale/properties.ts
@@ -1,7 +1,7 @@
 import {isArray} from 'vega-util';
 import {isBinned, isBinning, isBinParams} from '../../bin';
 import {Channel, COLOR, FILL, ScaleChannel, STROKE, X, Y} from '../../channel';
-import {ScaleFieldDef, TypedFieldDef, vgField} from '../../channeldef';
+import {normalizeBin, ScaleFieldDef, TypedFieldDef} from '../../channeldef';
 import {Config} from '../../config';
 import * as log from '../../log';
 import {BarConfig, Mark, MarkDef} from '../../mark';
@@ -22,6 +22,7 @@ import {Type} from '../../type';
 import * as util from '../../util';
 import {contains, getFirstDefined, keys} from '../../util';
 import {VgScale} from '../../vega.schema';
+import {binKey} from '../data/bin';
 import {isUnitModel, Model} from '../model';
 import {Explicit, mergeValuesWithExplicit, tieBreakByComparing} from '../split';
 import {UnitModel} from '../unit';
@@ -180,7 +181,9 @@ export function parseNonUnitScaleProperty(model: Model, property: keyof (Scale |
 export function bins(model: Model, fieldDef: TypedFieldDef<string>) {
   const bin = fieldDef.bin;
   if (isBinning(bin)) {
-    const signal = model.getName(vgField(fieldDef, {suffix: 'bins'}));
+    const normalizedBin = normalizeBin(bin, undefined) || {};
+    const key = binKey(normalizedBin, fieldDef.field);
+    const signal = model.getName(`${key}_bins`);
     return new SignalRefWrapper(() => {
       return model.getSignalName(signal);
     });

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -8,8 +8,8 @@ import {
   FILLOPACITY,
   OPACITY,
   POSITION_SCALE_CHANNELS,
-  SCALE_CHANNELS,
   ScaleChannel,
+  SCALE_CHANNELS,
   SHAPE,
   SIZE,
   STROKE,
@@ -18,7 +18,6 @@ import {
   X,
   Y
 } from '../../channel';
-import {vgField} from '../../channeldef';
 import {Config} from '../../config';
 import * as log from '../../log';
 import {Mark} from '../../mark';
@@ -38,6 +37,7 @@ import {
 import {Type} from '../../type';
 import * as util from '../../util';
 import {isSignalRef, isVgRangeStep, SchemeConfig, VgRange} from '../../vega.schema';
+import {getBinSignalName} from '../data/bin';
 import {Rename, SignalRefWrapper} from '../signal';
 import {Explicit, makeExplicit, makeImplicit} from '../split';
 import {UnitModel} from '../unit';
@@ -112,7 +112,7 @@ function getRangeStep(model: UnitModel, channel: 'x' | 'y'): number | SignalRef 
       // TODO: support the case without range step
     }
   } else if (fieldDef && fieldDef.bin && isBinning(fieldDef.bin)) {
-    const binSignal = model.getName(vgField(fieldDef, {suffix: 'bins'}));
+    const binSignal = getBinSignalName(model, fieldDef.field, fieldDef.bin);
 
     // TODO: extract this to be range step signal
     const sizeType = getSizeType(channel);

--- a/test/compile/data/bin.test.ts
+++ b/test/compile/data/bin.test.ts
@@ -1,4 +1,5 @@
-import {BinNode} from '../../../src/compile/data/bin';
+import {VgBinTransform} from './../../../build/src/vega.schema.d';
+import {BinNode, getBinSignalName} from '../../../src/compile/data/bin';
 import {Model, ModelWithField} from '../../../src/compile/model';
 import {BinTransform} from '../../../src/transform';
 import {parseUnitModelWithScale} from '../../util';
@@ -31,269 +32,309 @@ function makeMovieExample(t: BinTransform) {
 }
 
 describe('compile/data/bin', () => {
-  it('should add bin transform and correctly apply bin with custom extent', () => {
-    const model = parseUnitModelWithScale({
-      mark: 'point',
-      encoding: {
-        y: {
-          bin: {extent: [0, 100]},
-          field: 'Acceleration',
-          type: 'quantitative'
+  describe('assembleFromEncoding', () => {
+    it('should add bin transform and correctly apply bin with custom extent', () => {
+      const model = parseUnitModelWithScale({
+        mark: 'point',
+        encoding: {
+          y: {
+            bin: {extent: [0, 100]},
+            field: 'Acceleration',
+            type: 'quantitative'
+          }
         }
-      }
+      });
+
+      expect(assembleFromEncoding(model)[0]).toEqual({
+        type: 'bin',
+        field: 'Acceleration',
+        as: ['bin_extent_0_100_maxbins_10_Acceleration', 'bin_extent_0_100_maxbins_10_Acceleration_end'],
+        maxbins: 10,
+        extent: [0, 100],
+        signal: 'bin_extent_0_100_maxbins_10_Acceleration_bins'
+      });
     });
 
-    expect(assembleFromEncoding(model)[0]).toEqual({
-      type: 'bin',
-      field: 'Acceleration',
-      as: ['bin_extent_0_100_maxbins_10_Acceleration', 'bin_extent_0_100_maxbins_10_Acceleration_end'],
-      maxbins: 10,
-      extent: [0, 100],
-      signal: 'bin_extent_0_100_maxbins_10_Acceleration_bins'
-    });
-  });
-
-  it('should add bin transform and correctly apply bin for binned field without custom extent', () => {
-    const model = parseUnitModelWithScale({
-      mark: 'point',
-      encoding: {
-        y: {
-          bin: true,
-          field: 'Acceleration',
-          type: 'quantitative'
+    it('should add bin transform and correctly apply bin for binned field without custom extent', () => {
+      const model = parseUnitModelWithScale({
+        mark: 'point',
+        encoding: {
+          y: {
+            bin: true,
+            field: 'Acceleration',
+            type: 'quantitative'
+          }
         }
-      }
+      });
+      const transform = assembleFromEncoding(model);
+      expect(transform).toHaveLength(2);
+      expect(transform[0]).toEqual({
+        type: 'extent',
+        field: 'Acceleration',
+        signal: 'bin_maxbins_10_Acceleration_extent'
+      });
+      expect(transform[1]).toEqual({
+        type: 'bin',
+        field: 'Acceleration',
+        as: ['bin_maxbins_10_Acceleration', 'bin_maxbins_10_Acceleration_end'],
+        maxbins: 10,
+        signal: 'bin_maxbins_10_Acceleration_bins',
+        extent: {signal: 'bin_maxbins_10_Acceleration_extent'}
+      });
     });
-    const transform = assembleFromEncoding(model);
-    expect(transform).toHaveLength(2);
-    expect(transform[0]).toEqual({
-      type: 'extent',
-      field: 'Acceleration',
-      signal: 'bin_maxbins_10_Acceleration_extent'
-    });
-    expect(transform[1]).toEqual({
-      type: 'bin',
-      field: 'Acceleration',
-      as: ['bin_maxbins_10_Acceleration', 'bin_maxbins_10_Acceleration_end'],
-      maxbins: 10,
-      signal: 'bin_maxbins_10_Acceleration_bins',
-      extent: {signal: 'bin_maxbins_10_Acceleration_extent'}
-    });
-  });
 
-  it('should apply the bin transform only once for a binned field encoded in multiple channels', () => {
-    const model = parseUnitModelWithScale({
-      data: {url: 'data/movies.json'},
-      mark: 'circle',
-      encoding: {
-        x: {
-          bin: true,
-          field: 'Rotten_Tomatoes_Rating',
-          type: 'quantitative'
-        },
-        color: {
-          bin: {maxbins: 10},
-          field: 'Rotten_Tomatoes_Rating',
-          type: 'ordinal'
+    it('should apply the bin transform only once for a binned field encoded in multiple channels', () => {
+      const model = parseUnitModelWithScale({
+        data: {url: 'data/movies.json'},
+        mark: 'circle',
+        encoding: {
+          x: {
+            bin: true,
+            field: 'Rotten_Tomatoes_Rating',
+            type: 'quantitative'
+          },
+          color: {
+            bin: {maxbins: 10},
+            field: 'Rotten_Tomatoes_Rating',
+            type: 'ordinal'
+          }
         }
-      }
-    });
-    const transform = assembleFromEncoding(model);
-    expect(transform).toHaveLength(3);
-    expect(transform[0]).toEqual({
-      type: 'extent',
-      field: 'Rotten_Tomatoes_Rating',
-      signal: 'bin_maxbins_10_Rotten_Tomatoes_Rating_extent'
-    });
-    expect(transform[1]).toEqual({
-      type: 'bin',
-      field: 'Rotten_Tomatoes_Rating',
-      as: ['bin_maxbins_10_Rotten_Tomatoes_Rating', 'bin_maxbins_10_Rotten_Tomatoes_Rating_end'],
-      signal: 'bin_maxbins_10_Rotten_Tomatoes_Rating_bins',
-      maxbins: 10,
-      extent: {signal: 'bin_maxbins_10_Rotten_Tomatoes_Rating_extent'}
-    });
-    expect(transform[2]).toEqual({
-      type: 'formula',
-      as: 'bin_maxbins_10_Rotten_Tomatoes_Rating_range',
-      expr: `datum["bin_maxbins_10_Rotten_Tomatoes_Rating"] === null || isNaN(datum["bin_maxbins_10_Rotten_Tomatoes_Rating"]) ? "null" : format(datum["bin_maxbins_10_Rotten_Tomatoes_Rating"], "") + " - " + format(datum["bin_maxbins_10_Rotten_Tomatoes_Rating_end"], "")`
-    });
-  });
-
-  it('should add bin transform from transform array and correctly apply bin with custom extent', () => {
-    const t: BinTransform = {
-      bin: {extent: [0, 100]},
-      field: 'Acceleration',
-      as: 'binned_acceleration'
-    };
-    const model = makeMovieExample(t);
-
-    expect(assembleFromTransform(model, t)[0]).toEqual({
-      type: 'bin',
-      field: 'Acceleration',
-      maxbins: 10,
-      as: ['binned_acceleration', 'binned_acceleration_end'],
-      extent: [0, 100],
-      signal: 'bin_extent_0_100_maxbins_10_Acceleration_bins'
+      });
+      const transform = assembleFromEncoding(model);
+      expect(transform).toHaveLength(3);
+      expect(transform[0]).toEqual({
+        type: 'extent',
+        field: 'Rotten_Tomatoes_Rating',
+        signal: 'bin_maxbins_10_Rotten_Tomatoes_Rating_extent'
+      });
+      expect(transform[1]).toEqual({
+        type: 'bin',
+        field: 'Rotten_Tomatoes_Rating',
+        as: ['bin_maxbins_10_Rotten_Tomatoes_Rating', 'bin_maxbins_10_Rotten_Tomatoes_Rating_end'],
+        signal: 'bin_maxbins_10_Rotten_Tomatoes_Rating_bins',
+        maxbins: 10,
+        extent: {signal: 'bin_maxbins_10_Rotten_Tomatoes_Rating_extent'}
+      });
+      expect(transform[2]).toEqual({
+        type: 'formula',
+        as: 'bin_maxbins_10_Rotten_Tomatoes_Rating_range',
+        expr: `datum["bin_maxbins_10_Rotten_Tomatoes_Rating"] === null || isNaN(datum["bin_maxbins_10_Rotten_Tomatoes_Rating"]) ? "null" : format(datum["bin_maxbins_10_Rotten_Tomatoes_Rating"], "") + " - " + format(datum["bin_maxbins_10_Rotten_Tomatoes_Rating_end"], "")`
+      });
     });
   });
 
-  it('should add bin transform from transform array and correctly apply bin with custom extent', () => {
-    const t: BinTransform = {
-      bin: {extent: [0, 100], maxbins: 20},
-      field: 'Acceleration',
-      as: 'binned_acceleration'
-    };
-    const model = makeMovieExample(t);
+  describe('assembleFromTransform', () => {
+    it('should add bin transform from transform array and correctly apply bin with custom extent', () => {
+      const t: BinTransform = {
+        bin: {extent: [0, 100]},
+        field: 'Acceleration',
+        as: 'binned_acceleration'
+      };
+      const model = makeMovieExample(t);
 
-    expect(assembleFromTransform(model, t)[0]).toEqual({
-      type: 'bin',
-      field: 'Acceleration',
-      maxbins: 20,
-      as: ['binned_acceleration', 'binned_acceleration_end'],
-      extent: [0, 100],
-      signal: 'bin_extent_0_100_maxbins_20_Acceleration_bins'
+      expect(assembleFromTransform(model, t)[0]).toEqual({
+        type: 'bin',
+        field: 'Acceleration',
+        maxbins: 10,
+        as: ['binned_acceleration', 'binned_acceleration_end'],
+        extent: [0, 100],
+        signal: 'bin_extent_0_100_maxbins_10_Acceleration_bins'
+      });
+    });
+
+    it('should add bin transform from transform array and correctly apply bin with custom extent', () => {
+      const t: BinTransform = {
+        bin: {extent: [0, 100], maxbins: 20},
+        field: 'Acceleration',
+        as: 'binned_acceleration'
+      };
+      const model = makeMovieExample(t);
+
+      expect(assembleFromTransform(model, t)[0]).toEqual({
+        type: 'bin',
+        field: 'Acceleration',
+        maxbins: 20,
+        as: ['binned_acceleration', 'binned_acceleration_end'],
+        extent: [0, 100],
+        signal: 'bin_extent_0_100_maxbins_20_Acceleration_bins'
+      });
+    });
+
+    it('should add bin transform from transform array with anchor property', () => {
+      const t: BinTransform = {
+        bin: {extent: [0, 100], anchor: 6},
+        field: 'Acceleration',
+        as: 'binned_acceleration'
+      };
+      const model = makeMovieExample(t);
+
+      expect(assembleFromTransform(model, t)[0]).toEqual({
+        type: 'bin',
+        field: 'Acceleration',
+        anchor: 6,
+        maxbins: 10,
+        as: ['binned_acceleration', 'binned_acceleration_end'],
+        extent: [0, 100],
+        signal: 'bin_extent_0_100_anchor_6_maxbins_10_Acceleration_bins'
+      });
+    });
+
+    it('should add bin transform from transform array with array as', () => {
+      const t: BinTransform = {
+        bin: {extent: [0, 100], anchor: 6},
+        field: 'Acceleration',
+        as: ['binned_acceleration_start', 'binned_acceleration_stop']
+      };
+      const model = makeMovieExample(t);
+
+      expect(assembleFromTransform(model, t)[0]).toEqual({
+        type: 'bin',
+        field: 'Acceleration',
+        anchor: 6,
+        maxbins: 10,
+        as: ['binned_acceleration_start', 'binned_acceleration_stop'],
+        extent: [0, 100],
+        signal: 'bin_extent_0_100_anchor_6_maxbins_10_Acceleration_bins'
+      });
     });
   });
 
-  it('should add bin transform from transform array with anchor property', () => {
-    const t: BinTransform = {
-      bin: {extent: [0, 100], anchor: 6},
-      field: 'Acceleration',
-      as: 'binned_acceleration'
-    };
-    const model = makeMovieExample(t);
+  describe('BinNode', () => {
+    it('should generate the correct hash', () => {
+      const t: BinTransform = {
+        bin: {extent: [0, 100], anchor: 6},
+        field: 'Acceleration',
+        as: ['binned_acceleration_start', 'binned_acceleration_stop']
+      };
+      const model = makeMovieExample(t);
 
-    expect(assembleFromTransform(model, t)[0]).toEqual({
-      type: 'bin',
-      field: 'Acceleration',
-      anchor: 6,
-      maxbins: 10,
-      as: ['binned_acceleration', 'binned_acceleration_end'],
-      extent: [0, 100],
-      signal: 'bin_extent_0_100_anchor_6_maxbins_10_Acceleration_bins'
+      const binNode = BinNode.makeFromTransform(null, t, model);
+      expect(binNode.hash()).toBe('Bin 1499261512');
+    });
+
+    it('should generate the correct dependent fields', () => {
+      const t: BinTransform = {
+        bin: {extent: [0, 100], anchor: 6},
+        field: 'Acceleration',
+        as: ['binned_acceleration_start', 'binned_acceleration_stop']
+      };
+      const model = makeMovieExample(t);
+
+      const binNode = BinNode.makeFromTransform(null, t, model);
+      expect(binNode.dependentFields()).toEqual(new Set(['Acceleration']));
+    });
+
+    it('should generate the correct produced fields', () => {
+      const t: BinTransform = {
+        bin: {extent: [0, 100], anchor: 6},
+        field: 'Acceleration',
+        as: ['binned_acceleration_start', 'binned_acceleration_stop']
+      };
+      const model = makeMovieExample(t);
+
+      const binNode = BinNode.makeFromTransform(null, t, model);
+      expect(binNode.hash()).toBe('Bin 1499261512');
+      expect(binNode.producedFields()).toEqual(new Set(['binned_acceleration_start', 'binned_acceleration_stop']));
+    });
+
+    it('should never clone parent', () => {
+      const parent = new DataFlowNode(null);
+      const bin = new BinNode(parent, {});
+      expect(bin.clone().parent).toBeNull();
+    });
+
+    it('should preserve "as" when merging with other node', () => {
+      const parent = new DataFlowNode(null);
+      const binNodeA = new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end']]}});
+      const binNodeB = new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['bar', 'bar_end']]}});
+
+      binNodeA.merge(binNodeB, () => {});
+      expect(binNodeA).toEqual(
+        new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end'], ['bar', 'bar_end']]}})
+      );
+    });
+
+    it('should not have duplicate members of "as" after merging with other node', () => {
+      const parent = new DataFlowNode(null);
+      const binNodeA = new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end']]}});
+      const binNodeB = new BinNode(parent, {
+        foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end'], ['bar', 'bar_end']]}
+      });
+
+      binNodeA.merge(binNodeB, () => {});
+      expect(binNodeA).toEqual(
+        new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end'], ['bar', 'bar_end']]}})
+      );
+    });
+
+    it('should create formulas for members of "as" when assembled', () => {
+      const parent = new DataFlowNode(null);
+      const binNode = new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end'], ['bar', 'bar_end']]}});
+      const transforms = binNode.assemble();
+
+      expect(transforms[1]).toEqual({type: 'formula', expr: 'datum["foo"]', as: 'bar'});
+      expect(transforms[2]).toEqual({type: 'formula', expr: 'datum["foo_end"]', as: 'bar_end'});
+    });
+
+    it('should resassign children of BinNode when merging', () => {
+      const parent = new DataFlowNode(null);
+      const binNodeA = new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end']]}});
+      const binNodeB = new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['bar', 'bar_end']]}});
+      const childA = new DataFlowNode(binNodeA);
+      const childB = new DataFlowNode(binNodeB);
+
+      binNodeA.merge(binNodeB, () => {});
+
+      expect(binNodeB.children.length).toEqual(0);
+      expect(binNodeA.children.length).toEqual(2);
+      expect(binNodeA.children).toContain(childA);
+      expect(binNodeA.children).toContain(childB);
+    });
+
+    it('should keep non-conflicting bins of BinNodes when merging', () => {
+      const parent = new DataFlowNode(null);
+      const binNodeA = new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end']]}});
+      const binNodeB = new BinNode(parent, {bar: {bin: {}, field: 'bar', as: [['bar', 'bar_end']]}});
+
+      binNodeA.merge(binNodeB, () => {});
+      expect(binNodeA).toEqual(
+        new BinNode(parent, {
+          foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end']]},
+          bar: {bin: {}, field: 'bar', as: [['bar', 'bar_end']]}
+        })
+      );
     });
   });
 
-  it('should add bin transform from transform array with array as', () => {
-    const t: BinTransform = {
-      bin: {extent: [0, 100], anchor: 6},
-      field: 'Acceleration',
-      as: ['binned_acceleration_start', 'binned_acceleration_stop']
-    };
-    const model = makeMovieExample(t);
+  describe('getBinSignalName', () => {
+    it('should genrate correct names', () => {
+      const model = parseUnitModelWithScale({
+        mark: 'point'
+      });
 
-    expect(assembleFromTransform(model, t)[0]).toEqual({
-      type: 'bin',
-      field: 'Acceleration',
-      anchor: 6,
-      maxbins: 10,
-      as: ['binned_acceleration_start', 'binned_acceleration_stop'],
-      extent: [0, 100],
-      signal: 'bin_extent_0_100_anchor_6_maxbins_10_Acceleration_bins'
+      expect(getBinSignalName(model, 'foo.bar', true)).toBe('bin_maxbins_10_foo_bar_bins');
+      expect(getBinSignalName(model, 'foo', true)).toBe('bin_maxbins_10_foo_bins');
+      expect(getBinSignalName(model, 'foo', {maxbins: 20})).toBe('bin_maxbins_20_foo_bins');
     });
-  });
 
-  it('should generate the correct hash', () => {
-    const t: BinTransform = {
-      bin: {extent: [0, 100], anchor: 6},
-      field: 'Acceleration',
-      as: ['binned_acceleration_start', 'binned_acceleration_stop']
-    };
-    const model = makeMovieExample(t);
+    it('should generate the same name as signal name from encoding', () => {
+      const model = parseUnitModelWithScale({
+        mark: 'point',
+        encoding: {
+          y: {
+            bin: true,
+            field: 'foo.bar',
+            type: 'quantitative'
+          }
+        }
+      });
 
-    const binNode = BinNode.makeFromTransform(null, t, model);
-    expect(binNode.hash()).toBe('Bin 1499261512');
-  });
+      const signal = getBinSignalName(model, 'foo.bar', true);
+      expect(signal).toBe('bin_maxbins_10_foo_bar_bins');
 
-  it('should generate the correct dependent fields', () => {
-    const t: BinTransform = {
-      bin: {extent: [0, 100], anchor: 6},
-      field: 'Acceleration',
-      as: ['binned_acceleration_start', 'binned_acceleration_stop']
-    };
-    const model = makeMovieExample(t);
+      const bin = assembleFromEncoding(model)[1] as VgBinTransform;
 
-    const binNode = BinNode.makeFromTransform(null, t, model);
-    expect(binNode.dependentFields()).toEqual(new Set(['Acceleration']));
-  });
-
-  it('should generate the correct produced fields', () => {
-    const t: BinTransform = {
-      bin: {extent: [0, 100], anchor: 6},
-      field: 'Acceleration',
-      as: ['binned_acceleration_start', 'binned_acceleration_stop']
-    };
-    const model = makeMovieExample(t);
-
-    const binNode = BinNode.makeFromTransform(null, t, model);
-    expect(binNode.hash()).toBe('Bin 1499261512');
-    expect(binNode.producedFields()).toEqual(new Set(['binned_acceleration_start', 'binned_acceleration_stop']));
-  });
-
-  it('should never clone parent', () => {
-    const parent = new DataFlowNode(null);
-    const bin = new BinNode(parent, {});
-    expect(bin.clone().parent).toBeNull();
-  });
-
-  it('should preserve "as" when merging with other node', () => {
-    const parent = new DataFlowNode(null);
-    const binNodeA = new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end']]}});
-    const binNodeB = new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['bar', 'bar_end']]}});
-
-    binNodeA.merge(binNodeB, () => {});
-    expect(binNodeA).toEqual(
-      new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end'], ['bar', 'bar_end']]}})
-    );
-  });
-
-  it('should not have duplicate members of "as" after merging with other node', () => {
-    const parent = new DataFlowNode(null);
-    const binNodeA = new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end']]}});
-    const binNodeB = new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end'], ['bar', 'bar_end']]}});
-
-    binNodeA.merge(binNodeB, () => {});
-    expect(binNodeA).toEqual(
-      new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end'], ['bar', 'bar_end']]}})
-    );
-  });
-
-  it('should create formulas for members of "as" when assembled', () => {
-    const parent = new DataFlowNode(null);
-    const binNode = new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end'], ['bar', 'bar_end']]}});
-    const transforms = binNode.assemble();
-
-    expect(transforms[1]).toEqual({type: 'formula', expr: 'datum["foo"]', as: 'bar'});
-    expect(transforms[2]).toEqual({type: 'formula', expr: 'datum["foo_end"]', as: 'bar_end'});
-  });
-
-  it('should resassign children of BinNode when merging', () => {
-    const parent = new DataFlowNode(null);
-    const binNodeA = new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end']]}});
-    const binNodeB = new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['bar', 'bar_end']]}});
-    const childA = new DataFlowNode(binNodeA);
-    const childB = new DataFlowNode(binNodeB);
-
-    binNodeA.merge(binNodeB, () => {});
-
-    expect(binNodeB.children.length).toEqual(0);
-    expect(binNodeA.children.length).toEqual(2);
-    expect(binNodeA.children).toContain(childA);
-    expect(binNodeA.children).toContain(childB);
-  });
-
-  it('should keep non-conflicting bins of BinNodes when merging', () => {
-    const parent = new DataFlowNode(null);
-    const binNodeA = new BinNode(parent, {foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end']]}});
-    const binNodeB = new BinNode(parent, {bar: {bin: {}, field: 'bar', as: [['bar', 'bar_end']]}});
-
-    binNodeA.merge(binNodeB, () => {});
-    expect(binNodeA).toEqual(
-      new BinNode(parent, {
-        foo: {bin: {}, field: 'foo', as: [['foo', 'foo_end']]},
-        bar: {bin: {}, field: 'bar', as: [['bar', 'bar_end']]}
-      })
-    );
+      expect(bin.signal).toBe(signal);
+    });
   });
 });


### PR DESCRIPTION
CC @kobben

We now support

```json
{
  "data": {
    "url": "https://kartoweb.itc.nl/Vega-Lite/data/overijssel_centroids.geo.json",
    "format": {
      "type": "json",
      "property": "features"
    }
  },
  "projection": {
    "type": "stereographic"
  },
  "layer": [
    {
      "mark": "geoshape",
      "encoding": {
        "color": {
          "bin": true,
          "field": "properties.bev_dichth",
          "type": "quantitative"
        }
      }
    }
  ]
}
```