### PR TITLE
Fix dependentFields calculation for JoinAggregate, Stack, and Window nodes

### DIFF
--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -15,10 +15,11 @@ import {ScaleType} from '../scale';
 import {formatExpression, TimeUnit} from '../timeunit';
 import {QUANTITATIVE} from '../type';
 import {getFirstDefined, stringify} from '../util';
-import {BaseMarkConfig, VgCompare, VgEncodeEntry} from '../vega.schema';
+import {BaseMarkConfig, VgEncodeEntry} from '../vega.schema';
 import {AxisComponentProps} from './axis/component';
 import {Explicit} from './split';
 import {UnitModel} from './unit';
+import {SortFields} from '../sort';
 
 export function applyMarkConfig(e: VgEncodeEntry, model: UnitModel, propsList: (keyof MarkConfig)[]) {
   for (const property of propsList) {
@@ -176,7 +177,7 @@ export function timeFormatExpression(
 export function sortParams(
   orderDef: OrderFieldDef<string> | OrderFieldDef<string>[],
   fieldRefOption?: FieldRefOption
-): VgCompare {
+): SortFields {
   return (isArray(orderDef) ? orderDef : [orderDef]).reduce(
     (s, orderChannelDef) => {
       s.field.push(vgField(orderChannelDef, fieldRefOption));

--- a/src/compile/data/joinaggregate.ts
+++ b/src/compile/data/joinaggregate.ts
@@ -26,7 +26,9 @@ export class JoinAggregateTransformNode extends DataFlowNode {
   public dependentFields() {
     const out = new Set<string>();
 
-    this.transform.groupby.forEach(f => out.add(f));
+    if (this.transform.groupby) {
+      this.transform.groupby.forEach(f => out.add(f));
+    }
     this.transform.joinaggregate
       .map(w => w.field)
       .filter(f => f !== undefined)

--- a/src/compile/data/stack.ts
+++ b/src/compile/data/stack.ts
@@ -179,10 +179,15 @@ export class StackNode extends DataFlowNode {
 
     out.add(this._stack.stackField);
 
-    this.getGroupbyFields().forEach(out.add);
-    this._stack.facetby.forEach(out.add);
-    const field = this._stack.sort.field as string;
-    isArray(field) ? field.forEach(out.add) : out.add(field);
+    this.getGroupbyFields().forEach(f => out.add(f));
+    this._stack.facetby.forEach(f => out.add(f));
+
+    const field = this._stack.sort.field;
+    if (isArray(field)) {
+      (field as [string]).forEach(f => out.add(f));
+    } else {
+      out.add(field as string);
+    }
 
     return out;
   }

--- a/src/compile/data/window.ts
+++ b/src/compile/data/window.ts
@@ -26,8 +26,12 @@ export class WindowTransformNode extends DataFlowNode {
   public dependentFields() {
     const out = new Set<string>();
 
-    this.transform.groupby.forEach(f => out.add(f));
-    this.transform.sort.forEach(m => out.add(m.field));
+    if (this.transform.groupby) {
+      this.transform.groupby.forEach(f => out.add(f));
+    }
+    if (this.transform.sort) {
+      this.transform.sort.forEach(m => out.add(m.field));
+    }
     this.transform.window
       .map(w => w.field)
       .filter(f => f !== undefined)

--- a/src/compile/data/window.ts
+++ b/src/compile/data/window.ts
@@ -3,9 +3,10 @@ import {isAggregateOp} from '../../aggregate';
 import {vgField} from '../../channeldef';
 import {WindowFieldDef, WindowOnlyOp, WindowTransform} from '../../transform';
 import {duplicate, hash} from '../../util';
-import {VgComparator, VgComparatorOrder, VgJoinAggregateTransform, VgWindowTransform} from '../../vega.schema';
+import {VgComparator, VgJoinAggregateTransform, VgWindowTransform} from '../../vega.schema';
 import {unique} from './../../util';
 import {DataFlowNode} from './dataflow';
+import {SortOrder} from '../../sort';
 
 /**
  * A class for the window transform nodes
@@ -26,12 +27,9 @@ export class WindowTransformNode extends DataFlowNode {
   public dependentFields() {
     const out = new Set<string>();
 
-    if (this.transform.groupby) {
-      this.transform.groupby.forEach(f => out.add(f));
-    }
-    if (this.transform.sort) {
-      this.transform.sort.forEach(m => out.add(m.field));
-    }
+    (this.transform.groupby || []).forEach(f => out.add(f));
+    (this.transform.sort || []).forEach(m => out.add(m.field));
+
     this.transform.window
       .map(w => w.field)
       .filter(f => f !== undefined)
@@ -79,7 +77,7 @@ export class WindowTransformNode extends DataFlowNode {
     }
 
     const sortFields: string[] = [];
-    const sortOrder: VgComparatorOrder[] = [];
+    const sortOrder: SortOrder[] = [];
     if (this.transform.sort !== undefined) {
       for (const sortField of this.transform.sort) {
         sortFields.push(sortField.field);

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -24,6 +24,7 @@ import {NiceTime, ScaleType} from './scale';
 import {StackOffset} from './stack';
 import {WindowOnlyOp} from './transform';
 import {Flag, flagKeys} from './util';
+import {SortOrder} from './sort';
 
 export {VgSortField, VgUnionSortField, VgCompare, VgTitle, LayoutAlign, ProjectionType, VgExprRef};
 
@@ -857,11 +858,9 @@ const VG_MARK_CONFIG_INDEX: Flag<keyof BaseMarkConfig> = {
 
 export const VG_MARK_CONFIGS = flagKeys(VG_MARK_CONFIG_INDEX);
 
-export type VgComparatorOrder = 'ascending' | 'descending';
-
 export interface VgComparator {
   field?: string | string[];
-  order?: VgComparatorOrder | VgComparatorOrder[];
+  order?: SortOrder | SortOrder[];
 }
 
 export interface VgWindowTransform {

--- a/test/compile/data/joinaggregate.test.ts
+++ b/test/compile/data/joinaggregate.test.ts
@@ -99,6 +99,20 @@ describe('compile/data/joinaggregate', () => {
     expect(joinaggregate.dependentFields()).toEqual(new Set(['g', 'f']));
   });
 
+  it('should generate the correct dependent fields when groupby is undefined', () => {
+    const transform: Transform = {
+      joinaggregate: [
+        {
+          field: 'f',
+          op: 'mean',
+          as: 'mean_f'
+        }
+      ]
+    };
+    const joinaggregate = new JoinAggregateTransformNode(null, transform);
+    expect(joinaggregate.dependentFields()).toEqual(new Set(['f']));
+  });
+
   it('should clone to an equivalent version', () => {
     const transform: Transform = {
       joinaggregate: [

--- a/test/compile/data/stack.test.ts
+++ b/test/compile/data/stack.test.ts
@@ -285,6 +285,7 @@ describe('compile/data/stack', () => {
       ]);
     });
   });
+
   describe('StackNode.producedFields', () => {
     it('should give producedfields correctly', () => {
       const transform: Transform = {
@@ -328,6 +329,31 @@ describe('compile/data/stack', () => {
       const parent = new DataFlowNode(null);
       const stack = new StackNode(parent, null);
       expect(stack.clone().parent).toBeNull();
+    });
+  });
+
+  describe('StackNode.dependentFields', () => {
+    it('should give dependentFields correctly', () => {
+      const transform: Transform = {
+        stack: 'foo',
+        groupby: ['bar', 'baz'],
+        as: 'qux'
+      };
+      const stack = StackNode.makeFromTransform(null, transform);
+      expect(stack.dependentFields()).toEqual(new Set(['foo', 'bar', 'baz']));
+    });
+
+    it('should give dependentFields correctly when derived from encoding channel', () => {
+      const model = parseUnitModelWithScale({
+        mark: 'bar',
+        encoding: {
+          x: {aggregate: 'sum', field: 'a', type: 'quantitative'},
+          y: {field: 'b', type: 'nominal'},
+          color: {field: 'c', type: 'ordinal'}
+        }
+      });
+      const stack = StackNode.makeFromEncoding(null, model);
+      expect(stack.dependentFields()).toEqual(new Set(['sum_a', 'b', 'c']));
     });
   });
 });

--- a/test/compile/data/window.test.ts
+++ b/test/compile/data/window.test.ts
@@ -125,6 +125,22 @@ describe('compile/data/window', () => {
     expect(window.dependentFields()).toEqual(new Set(['g', 'f']));
   });
 
+  it('should generate the correct dependent fields when groupby and sort are undefined', () => {
+    const transform: Transform = {
+      window: [
+        {
+          field: 'w',
+          op: 'row_number',
+          as: 'ordered_row_number'
+        }
+      ],
+      ignorePeers: false,
+      frame: [null, 0]
+    };
+    const window = new WindowTransformNode(null, transform);
+    expect(window.dependentFields()).toEqual(new Set(['w']));
+  });
+
   it('should clone to an equivalent version', () => {
     const transform: Transform = {
       window: [


### PR DESCRIPTION
As is, the dependentFields() method in JoinAggregateNode, StackNode, and WindowNode attempt to iterate over optional fields resulting in exceptions when these fields aren't defined. This PR fixes this by checking to see if these fields are defined before iterating over them, and adds relevant tests.