### PR TITLE
[WIP] Make EncodingSortField.field required

### DIFF
--- a/src/sort.ts
+++ b/src/sort.ts
@@ -35,10 +35,8 @@ export const DEFAULT_SORT_OP = 'mean';
 export interface EncodingSortField<F> {
   /**
    * The data [field](https://vega.github.io/vega-lite/docs/field.html) to sort by.
-   *
-   * __Default value:__ If unspecified, defaults to the field specified in the outer data reference.
    */
-  field?: F;
+  field: F;
   /**
    * An [aggregate operation](https://vega.github.io/vega-lite/docs/aggregate.html#ops) to perform on the field prior to sorting (e.g., `"count"`, `"mean"` and `"median"`).
    * An aggregation is required when there are multiple values of the sort field for each encoded data field.


### PR DESCRIPTION
If `EncodingSortField.field` is not required, then `EncodingSortField` has no required fields at all, meaning it can match empty JSON. Having the JSON "sort": { } be interpreted to mean that the scale should be sorted by that field doesn't seem intuitive.

This PR makes `field` a required property of `EncodingSortField`. This could lead to redundant field specifications in the case where the user wants to sort by the same field as the scale, but otherwise is harmless.

An alternative solution could be to have a discriminator property (e.g. a required "sortType": "field" prop), but it seems easier to just make `field` non-optional.

