### PR TITLE
DOC: Add rolling mean example

### DIFF
--- a/_data/examples.json
+++ b/_data/examples.json
@@ -419,6 +419,10 @@
         "title": "Layering mean values over raw values"
       },
       {
+        "name": "layer_line_rolling_mean_point_raw",
+        "title": "Layering rolling mean values over raw values"
+      },
+      {
         "name": "wheat_wages",
         "title": "Wheat and Wages Example",
         "description": "A recreation of William Playfair’s classic chart visualizing the price of wheat, the wages of a mechanic, and the reigning British monarch. Based on a chart by @manzt."

--- a/examples/specs/layer_line_rolling_mean_point_raw.vl.json
+++ b/examples/specs/layer_line_rolling_mean_point_raw.vl.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
+  "description": "Plot showing a 30 day rolling average with raw values in the background.",
+  "width": 400,
+  "height": 300,
+  "data": {"url": "data/seattle-weather.csv"},
+  "transform": [
+        {
+          "frame": [-15, 15],
+          "window": [
+            {
+              "field": "temp_max",
+              "op": "mean",
+              "as": "rolling_mean"
+            }
+          ]
+        }
+      ],
+  "layer": [
+    { 
+      "mark": {"type": "point", "opacity": 0.3},
+      "encoding": {
+        "x": {
+          "field": "date",
+          "type": "temporal"
+        },
+        "y": {
+          "axis": {"title": "Max Temp"},
+          "field": "temp_max",
+          "type": "quantitative"
+        }
+      }
+    },
+    {
+      "mark": {
+        "color": "red",
+        "size": 3,
+        "type": "line"
+      },
+      "encoding": {
+        "x": {
+          "field": "date",
+          "type": "temporal"
+        },
+        "y": {
+          "field": "rolling_mean",
+          "type": "quantitative"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
I recently added a rolling mean example to Altair (https://github.com/altair-viz/altair/pull/1540) and thought it would be a nice addition to the vega-lite examples. 

![visualization (4)](https://user-images.githubusercontent.com/2041969/58662100-64baaf80-82f7-11e9-8962-80409b9776b3.png)

