### PR TITLE
fix: do not merge unioned domains with fixed data

### DIFF
--- a/test/compile/scale/domain.test.ts
+++ b/test/compile/scale/domain.test.ts
@@ -902,6 +902,24 @@ describe('compile/scale', () => {
         fields: [[1, 2, 3, 4], [3, 4, 5, 6]]
       });
     });
+
+    it('should not add sort to explicit domain and sort', () => {
+      log.wrap(localLogger => {
+        const domain = mergeDomains([[1, 2, 3, 4], {field: 'foo', data: 'data', sort: {op: 'sum', field: 'value'}}]);
+
+        expect(domain).toEqual({
+          fields: [[1, 2, 3, 4], {field: 'foo', data: 'data'}],
+          sort: true
+        });
+
+        expect(localLogger.warns[0]).toEqual(
+          log.message.domainSortDropped({
+            op: 'mean',
+            field: 'c'
+          })
+        );
+      });
+    });
   });
 
   describe('domainSort()', () => {


### PR DESCRIPTION
We don't track whether the domain or sort is implicit or explicit right now so we don't have a better way to union domains. 

Going forward, we can either implement the explicit/implicit split and have special rules for sorting by value and by domain and prefer to sort by domain. These two things are orthogonal.  

Part of #3153