### PR TITLE
fix: remove format = color-hex as it's not a a valid format

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -1993,7 +1993,6 @@
       "type": "object"
     },
     "Color": {
-      "format": "color-hex",
       "type": "string"
     },
     "Encoding": {

--- a/examples/examples.test.ts
+++ b/examples/examples.test.ts
@@ -19,7 +19,6 @@ const ajv = new Ajv({
 });
 
 ajv.addMetaSchema(require('ajv/lib/refs/json-schema-draft-06.json'));
-ajv.addFormat('color-hex', () => true);
 
 const validateVl = ajv.compile(vlSchema);
 const validateVg = ajv.compile(vgSchema);

--- a/examples/schema.test.ts
+++ b/examples/schema.test.ts
@@ -11,8 +11,6 @@ describe('Schema', () => {
       extendRefs: 'fail'
     });
 
-    ajv.addFormat('color-hex', () => true);
-
     // now validate our data against the schema
     const valid = ajv.validateSchema(specSchema);
 

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -28,9 +28,6 @@ import {SortOrder} from './sort';
 
 export {VgSortField, VgUnionSortField, VgCompare, VgTitle, LayoutAlign, ProjectionType, VgExprRef};
 
-/**
- * @format color-hex
- */
 export type Color = string;
 
 export interface VgData {


### PR DESCRIPTION
It's breaking the monaco in the editor! https://json-schema.org/understanding-json-schema/reference/string.html
