### PR TITLE
fix: support formatting of discrete headers.

### DIFF
--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -896,13 +896,12 @@ export function isNumberFieldDef(fieldDef: TypedFieldDef<any>) {
 }
 
 /**
- * Check if the field def uses a time format or does not use any format but is temporal (this does not cover field defs that are temporal but use a number format).
+ * Check if the field def uses a time format or does not use any format but is temporal
+ * (this does not cover field defs that are temporal but use a number format).
  */
 export function isTimeFormatFieldDef(fieldDef: TypedFieldDef<string>): boolean {
-  const formatType =
-    (isPositionFieldDef(fieldDef) && fieldDef.axis && fieldDef.axis.formatType) ||
-    (isMarkPropFieldDef(fieldDef) && fieldDef.legend && fieldDef.legend.formatType) ||
-    (isTextFieldDef(fieldDef) && fieldDef.formatType);
+  const guide = getGuide(fieldDef);
+  const formatType = (guide && guide.formatType) || (isTextFieldDef(fieldDef) && fieldDef.formatType);
   return formatType === 'time' || (!formatType && isTimeFieldDef(fieldDef));
 }
 

--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -12,6 +12,7 @@ import {
 import {Config, StyleConfigIndex} from '../config';
 import {MarkConfig, MarkDef} from '../mark';
 import {ScaleType} from '../scale';
+import {SortFields} from '../sort';
 import {formatExpression, TimeUnit} from '../timeunit';
 import {QUANTITATIVE} from '../type';
 import {getFirstDefined, stringify} from '../util';
@@ -19,7 +20,6 @@ import {BaseMarkConfig, VgEncodeEntry} from '../vega.schema';
 import {AxisComponentProps} from './axis/component';
 import {Explicit} from './split';
 import {UnitModel} from './unit';
-import {SortFields} from '../sort';
 
 export function applyMarkConfig(e: VgEncodeEntry, model: UnitModel, propsList: (keyof MarkConfig)[]) {
   for (const property of propsList) {
@@ -103,7 +103,7 @@ export function formatSignalRef(
       return {
         signal: binFormatExpression(startField, endField, format, config)
       };
-    } else if (fieldDef.type === 'quantitative') {
+    } else if (fieldDef.type === 'quantitative' || format) {
       return {
         signal: `${formatExpr(vgField(fieldDef, {expr, binSuffix: 'range'}), format)}`
       };

--- a/src/compile/legend/parse.ts
+++ b/src/compile/legend/parse.ts
@@ -153,7 +153,7 @@ function getProperty<K extends keyof VgLegend>(
       return numberFormat(fieldDef, legend.format, model.config);
 
     case 'formatType':
-      // Same as format, We don't include temporal field here as we apply format in encode block
+      // Same as format, we don't include temporal field here as we apply format in encode block
       if (isTimeFormatFieldDef(fieldDef)) {
         return undefined;
       }

--- a/test/compile/common.test.ts
+++ b/test/compile/common.test.ts
@@ -131,7 +131,7 @@ describe('Common', () => {
   });
 
   describe('formatSignalRef()', () => {
-    it('should format headers that are ordinal', () => {
+    it('should format ordinal field defs if format is present', () => {
       expect(formatSignalRef({field: 'foo', type: 'ordinal'}, '.2f', 'parent', {})).toEqual({
         signal: 'format(parent["foo"], ".2f")'
       });

--- a/test/compile/common.test.ts
+++ b/test/compile/common.test.ts
@@ -1,5 +1,5 @@
 import {vgField} from '../../src/channeldef';
-import {mergeTitle, numberFormat, timeFormatExpression} from '../../src/compile/common';
+import {mergeTitle, numberFormat, timeFormatExpression, formatSignalRef} from '../../src/compile/common';
 import {defaultConfig} from '../../src/config';
 import {TimeUnit} from '../../src/timeunit';
 import {NOMINAL, ORDINAL, QUANTITATIVE, TEMPORAL} from '../../src/type';
@@ -127,6 +127,14 @@ describe('Common', () => {
 
     it('should join 2 titles with comma when both titles are not falsy and difference', () => {
       expect(mergeTitle('title1', 'title2')).toBe('title1, title2');
+    });
+  });
+
+  describe('formatSignalRef()', () => {
+    it('should format headers that are ordinal', () => {
+      expect(formatSignalRef({field: 'foo', type: 'ordinal'}, '.2f', 'parent', {})).toEqual({
+        signal: 'format(parent["foo"], ".2f")'
+      });
     });
   });
 });

--- a/test/compile/mark/mixins.test.ts
+++ b/test/compile/mark/mixins.test.ts
@@ -321,7 +321,7 @@ describe('compile/mark/mixins', () => {
       const model = parseUnitModelWithScaleAndLayoutSize({
         mark: {type: 'point'},
         encoding: {
-          color: {field: 'Foobar', type: 'nominal', legend: {title: 'baz', format: 's'}}
+          color: {field: 'Foobar', type: 'nominal', legend: {title: 'baz'}}
         }
       });
       const props = tooltip(model);


### PR DESCRIPTION
Fixes #5063.

This means that we will automatically treat ordinal and nominal as numbers when a format is present. I think that's a reasonable thing to do. 