### PR TITLE
feat: add selection comparison predicate

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -3448,6 +3448,12 @@
       },
       "type": "object"
     },
+    "DatumSelectionComparisonPredicate": {
+      "additionalProperties": {
+        "$ref": "#/definitions/SelectionComparisonPredicate"
+      },
+      "type": "object"
+    },
     "Day": {
       "maximum": 7,
       "minimum": 1,
@@ -4892,7 +4898,7 @@
       "properties": {
         "filter": {
           "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "The `filter` property must be one of the predicate definitions:\n\n1) an [expression](https://vega.github.io/vega-lite/docs/types.html#expression) string,\nwhere `datum` can be used to refer to the current data object\n\n2) one of the field predicates: [`equal`](https://vega.github.io/vega-lite/docs/filter.html#equal-predicate),\n[`lt`](https://vega.github.io/vega-lite/docs/filter.html#lt-predicate),\n[`lte`](https://vega.github.io/vega-lite/docs/filter.html#lte-predicate),\n[`gt`](https://vega.github.io/vega-lite/docs/filter.html#gt-predicate),\n[`gte`](https://vega.github.io/vega-lite/docs/filter.html#gte-predicate),\n[`range`](https://vega.github.io/vega-lite/docs/filter.html#range-predicate),\n[`oneOf`](https://vega.github.io/vega-lite/docs/filter.html#one-of-predicate),\nor [`valid`](https://vega.github.io/vega-lite/docs/filter.html#valid-predicate),\n\n3) a [selection predicate](https://vega.github.io/vega-lite/docs/filter.html#selection-predicate)\n\n4) a logical operand that combines (1), (2), or (3)."
+          "description": "The `filter` property must be one of the predicate definitions:\n\n1) an [expression](https://vega.github.io/vega-lite/docs/types.html#expression) string,\nwhere `datum` can be used to refer to the current data object\n\n2) one of the field predicates: [`equal`](https://vega.github.io/vega-lite/docs/filter.html#equal-predicate),\n[`lt`](https://vega.github.io/vega-lite/docs/filter.html#lt-predicate),\n[`lte`](https://vega.github.io/vega-lite/docs/filter.html#lte-predicate),\n[`gt`](https://vega.github.io/vega-lite/docs/filter.html#gt-predicate),\n[`gte`](https://vega.github.io/vega-lite/docs/filter.html#gte-predicate),\n[`range`](https://vega.github.io/vega-lite/docs/filter.html#range-predicate),\n[`oneOf`](https://vega.github.io/vega-lite/docs/filter.html#one-of-predicate),\nor [`valid`](https://vega.github.io/vega-lite/docs/filter.html#valid-predicate),\n\n3) a [selection predicate](https://vega.github.io/vega-lite/docs/filter.html#selection-predicate)\n\n4) a [comparison selection predicate]\n\n5) a logical operand that combines (1), (2), (3) or (4)."
         }
       },
       "required": [
@@ -8920,6 +8926,9 @@
         },
         {
           "type": "string"
+        },
+        {
+          "$ref": "#/definitions/DatumSelectionComparisonPredicate"
         }
       ]
     },
@@ -9735,6 +9744,45 @@
           ]
         }
       },
+      "type": "object"
+    },
+    "SelectionComparisonPredicate": {
+      "additionalProperties": false,
+      "properties": {
+        "aggregate": {
+          "$ref": "#/definitions/AggregateOp"
+        },
+        "eql": {
+          "type": "string"
+        },
+        "field": {
+          "type": "string"
+        },
+        "gt": {
+          "type": "string"
+        },
+        "gte": {
+          "type": "string"
+        },
+        "lt": {
+          "type": "string"
+        },
+        "lte": {
+          "type": "string"
+        },
+        "neql": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "eql",
+        "field",
+        "gt",
+        "gte",
+        "lt",
+        "lte",
+        "neql"
+      ],
       "type": "object"
     },
     "SelectionConfig": {

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -57,6 +57,8 @@ export type PositionChannel = 'x' | 'y' | 'x2' | 'y2';
 
 export type GeoPositionChannel = 'longitude' | 'latitude' | 'longitude2' | 'latitude2';
 
+export type TextTooltipChannel = 'text' | 'tooltip';
+
 export function isGeoPositionChannel(c: Channel): c is GeoPositionChannel {
   switch (c) {
     case LATITUDE:
@@ -120,6 +122,11 @@ const UNIT_CHANNEL_INDEX: Flag<keyof Encoding<any>> = {
   key: 1,
   tooltip: 1,
   href: 1
+};
+
+const TEXT_TOOLTIP_CHANNEL_INDEX: Flag<TextTooltipChannel> = {
+  text: 1,
+  tooltip: 1
 };
 
 export type ColorChannel = 'color' | 'fill' | 'stroke';
@@ -300,6 +307,16 @@ export type ScaleChannel = typeof SCALE_CHANNELS[0];
 export function isScaleChannel(channel: Channel): channel is ScaleChannel {
   return !!SCALE_CHANNEL_INDEX[channel];
 }
+
+// Declare CONDITION_CHANNEL_INDEX
+const CONDITION_CHANNEL_INDEX = {
+  ...NONPOSITION_SCALE_CHANNEL_INDEX,
+  ...TEXT_TOOLTIP_CHANNEL_INDEX
+};
+
+/** List of channels that support conditional encoding */
+export const CONDITION_CHANNELS = flagKeys(CONDITION_CHANNEL_INDEX);
+export type ConditionChannel = typeof CONDITION_CHANNELS[0];
 
 export type SupportedMark = {[mark in Mark]?: 'always' | 'binned'};
 

--- a/src/compile/baseconcat.ts
+++ b/src/compile/baseconcat.ts
@@ -10,6 +10,7 @@ import {parseData} from './data/parse';
 import {assembleLayoutSignals} from './layoutsize/assemble';
 import {Model} from './model';
 import {RepeaterValue} from './repeater';
+// import {parseSelectionComparisonFilterTransform} from './selection/parse';
 
 export abstract class BaseConcatModel extends Model {
   constructor(
@@ -40,6 +41,14 @@ export abstract class BaseConcatModel extends Model {
       keys(child.component.selection).forEach(key => {
         this.component.selection[key] = child.component.selection[key];
       });
+    }
+  }
+  public parseSelectionComparisons() {
+    // Parse conditional test in encoding channels and filter transforms
+    // for Selection Comparison predicates and store data for creating
+    // aggregate stores
+    for (const child of this.children) {
+      child.parseSelectionComparisons();
     }
   }
 
@@ -74,6 +83,10 @@ export abstract class BaseConcatModel extends Model {
 
   public assembleSelectionData(data: VgData[]): VgData[] {
     return this.children.reduce((db, child) => child.assembleSelectionData(db), data);
+  }
+
+  public assembleSelectionAggregateData(data: VgData[]): VgData[] {
+    return this.children.reduce((db, child) => child.assembleSelectionAggregateData(db), data);
   }
 
   public assembleMarks(): any[] {

--- a/src/compile/compile.ts
+++ b/src/compile/compile.ts
@@ -13,7 +13,7 @@ import {
 } from '../spec/toplevel';
 import {keys, mergeDeep} from '../util';
 import {buildModel} from './buildmodel';
-import {assembleRootData} from './data/assemble';
+import {assembleRootData, assembleDataPosition} from './data/assemble';
 // import {draw} from './data/debug';
 import {optimizeDataflow} from './data/optimize';
 import {Model} from './model';
@@ -144,10 +144,16 @@ function assembleTopLevelModel(
   // Config with Vega-Lite only config removed.
   const vgConfig = model.config ? stripAndRedirectConfig(model.config) : undefined;
 
-  const data = [].concat(
-    model.assembleSelectionData([]),
-    // only assemble data in the root
-    assembleRootData(model.component.data, datasets)
+  const data = assembleDataPosition(
+    [].concat(
+      model.assembleSelectionData([]),
+      // only assemble data in the root
+      assembleRootData(model.component.data, datasets),
+      // can be merged with assembleSelectionData, keeping
+      // it here as an option to explore other
+      // alternatives to reposition data objects
+      model.assembleSelectionAggregateData([])
+    )
   );
 
   const projections = model.assembleProjections();

--- a/src/compile/data/calculate.ts
+++ b/src/compile/data/calculate.ts
@@ -1,7 +1,7 @@
 import {SingleDefChannel} from '../../channel';
 import {FieldRefOption, isScaleFieldDef, TypedFieldDef, vgField} from '../../channeldef';
 import {DateTime} from '../../datetime';
-import {fieldFilterExpression} from '../../predicate';
+import {fieldFilterExpression, FieldPredicate} from '../../predicate';
 import {isSortArray} from '../../sort';
 import {CalculateTransform} from '../../transform';
 import {duplicate, hash} from '../../util';
@@ -40,7 +40,8 @@ export class CalculateNode extends DataFlowNode {
         const calculate =
           sort
             .map((sortValue, i) => {
-              return `${fieldFilterExpression({field, timeUnit, equal: sortValue})} ? ${i} : `;
+              // Fixing Interface for SelectionComparison in Predicate should fix this
+              return `${fieldFilterExpression({field, timeUnit, equal: sortValue} as FieldPredicate)} ? ${i} : `;
             })
             .join('') + sort.length;
 

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -111,6 +111,10 @@ export class FacetModel extends ModelWithField {
     this.component.selection = this.child.component.selection;
   }
 
+  public parseSelectionComparisons() {
+    this.child.parseSelectionComparisons();
+  }
+
   public parseMarkGroup() {
     this.child.parseMarkGroup();
   }
@@ -132,6 +136,10 @@ export class FacetModel extends ModelWithField {
 
   public assembleSelectionData(data: VgData[]): VgData[] {
     return this.child.assembleSelectionData(data);
+  }
+
+  public assembleSelectionAggregateData(data: VgData[]): VgData[] {
+    return this.child.assembleSelectionAggregateData(data);
   }
 
   private getHeaderLayoutMixins(): VgLayout {

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -76,6 +76,12 @@ export class LayerModel extends Model {
     }
   }
 
+  public parseSelectionComparisons() {
+    for (const child of this.children) {
+      child.parseSelectionComparisons();
+    }
+  }
+
   public parseMarkGroup() {
     for (const child of this.children) {
       child.parseMarkGroup();
@@ -105,6 +111,10 @@ export class LayerModel extends Model {
 
   public assembleSelectionData(data: VgData[]): VgData[] {
     return this.children.reduce((db, child) => child.assembleSelectionData(db), data);
+  }
+
+  public assembleSelectionAggregateData(data: VgData[]): VgData[] {
+    return this.children.reduce((db, child) => child.assembleSelectionAggregateData(db), data);
   }
 
   public assembleTitle(): VgTitle {

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -238,6 +238,8 @@ export abstract class Model {
     this.renameTopLevelLayoutSizeSignal();
 
     this.parseSelections();
+    this.parseSelectionComparisons(); //depends on selections
+
     this.parseProjection();
     this.parseData(); // (pathorder) depends on markDef; selection filters depend on parsed selections; depends on projection because some transforms require the finalized projection name.
     this.parseAxesAndHeaders(); // depends on scale and layout size
@@ -248,6 +250,7 @@ export abstract class Model {
   public abstract parseData(): void;
 
   public abstract parseSelections(): void;
+  public abstract parseSelectionComparisons(): void;
 
   public parseScale() {
     parseScales(this);
@@ -285,6 +288,7 @@ export abstract class Model {
   public abstract assembleSignals(): NewSignal[];
 
   public abstract assembleSelectionData(data: VgData[]): VgData[];
+  public abstract assembleSelectionAggregateData(data: VgData[]): VgData[];
 
   public assembleGroupStyle(): string {
     if (this.type === 'unit' || this.type === 'layer') {
@@ -631,7 +635,7 @@ export abstract class Model {
    * Traverse a model's hierarchy to get a particular selection component.
    */
   public getSelectionComponent(variableName: string, origName: string): SelectionComponent {
-    let sel = this.component.selection[variableName];
+    let sel = this.component.selection && this.component.selection[variableName];
     if (!sel && this.parent) {
       sel = this.parent.getSelectionComponent(variableName, origName);
     }

--- a/src/compile/selection/index.ts
+++ b/src/compile/selection/index.ts
@@ -1,4 +1,4 @@
-import {Binding, NewSignal, SignalRef} from 'vega';
+import {Binding, NewSignal, SignalRef, AggregateOp} from 'vega';
 import {stringValue} from 'vega-util';
 import {FACET_CHANNELS} from '../../channel';
 import {
@@ -20,6 +20,7 @@ import single from './single';
 import {SelectionProjection, SelectionProjectionComponent} from './transforms/project';
 
 export const STORE = '_store';
+export const AGG_STORE = '_aggregate_store';
 export const TUPLE = '_tuple';
 export const MODIFY = '_modify';
 export const SELECTION_DOMAIN = '_selection_domain_';
@@ -51,6 +52,18 @@ export interface SelectionComponent<T extends SelectionType = SelectionType> {
   zoom?: any;
   nearest?: any;
   clear?: any;
+  aggregates?: ComparisonFieldAggregate[];
+  data?: string;
+}
+
+export interface ComparisonFieldAggregate {
+  sfield: string;
+  op: AggregateOp;
+}
+
+export interface SelectionAggregate {
+  selection: string;
+  aggregates: ComparisonFieldAggregate[];
 }
 
 export interface SelectionCompiler<T extends SelectionType = SelectionType> {

--- a/src/compile/selection/parse.ts
+++ b/src/compile/selection/parse.ts
@@ -1,10 +1,79 @@
 import {selector as parseSelector} from 'vega-event-selector';
 import {isString} from 'vega-util';
-import {SelectionComponent} from '.';
+import {SelectionComponent, SelectionAggregate} from '.';
 import {SelectionDef} from '../../selection';
 import {Dict, duplicate, varName} from '../../util';
 import {UnitModel} from '../unit';
 import {forEachTransform} from './transforms/transforms';
+import {CONDITION_CHANNELS, ConditionChannel} from '../../channel';
+import {
+  isSelectionComparisonPredicate,
+  getComparisonOperator,
+  ComparisonOp,
+  DEFAULT_AGGREGATE,
+  Predicate
+} from '../../predicate';
+import {forEachLeaf, LogicalOperand} from '../../logical';
+import {MAIN} from '../../data';
+import {Model} from '../model';
+import {isFilter} from '../../transform';
+
+export function parseEachSelectionAggregate(
+  model: Model,
+  logicalPredicate: LogicalOperand<Predicate>,
+  selectionAggregates: SelectionAggregate[]
+) {
+  forEachLeaf(logicalPredicate, predicate => {
+    if (isSelectionComparisonPredicate(predicate)) {
+      const operator = getComparisonOperator(Object.keys(predicate)) as ComparisonOp;
+      const comparisonSpec = predicate[operator];
+      const selection = varName(comparisonSpec.selection);
+      const sfield = comparisonSpec.field;
+      const aggregate = comparisonSpec.aggregate ? comparisonSpec.aggregate : DEFAULT_AGGREGATE;
+      const hasSelection = selectionAggregates.filter(s => s.selection === selection);
+
+      if (hasSelection.length) {
+        const aggregates = hasSelection[0].aggregates;
+        if (aggregates.findIndex(t => t.sfield === sfield && t.op === aggregate) === -1) {
+          aggregates.push({sfield, op: aggregate});
+        }
+      } else {
+        selectionAggregates.push({selection, aggregates: [{sfield, op: aggregate}]});
+      }
+    }
+  });
+}
+
+export function parseUnitSelectionComparisonTest(model: UnitModel, selCmpts: Dict<SelectionComponent>) {
+  const {encoding} = model;
+  const selectionAggregates: SelectionAggregate[] = [];
+
+  CONDITION_CHANNELS.forEach((channel: ConditionChannel) => {
+    const channelDef = encoding[channel];
+    if (channelDef && channelDef['condition'] && channelDef['condition']['test']) {
+      const logicalPredicate = channelDef['condition']['test'];
+      parseEachSelectionAggregate(model, logicalPredicate, selectionAggregates);
+    }
+  });
+
+  for (const t of model.transforms) {
+    if (isFilter(t)) {
+      const logicalPredicate = t.filter;
+      parseEachSelectionAggregate(model, logicalPredicate, selectionAggregates);
+    }
+  }
+
+  selectionAggregates.forEach(a => {
+    if (selCmpts[a.selection]) {
+      selCmpts[a.selection].aggregates = a.aggregates;
+    } else {
+      const selCmpt = model.getSelectionComponent(a.selection, a.selection);
+      selCmpt.aggregates = a.aggregates;
+    }
+  });
+
+  return selCmpts;
+}
 
 export function parseUnitSelection(model: UnitModel, selDefs: Dict<SelectionDef>) {
   const selCmpts: Dict<SelectionComponent<any /* this has to be "any" so typing won't fail in test files*/>> = {};
@@ -46,7 +115,8 @@ export function parseUnitSelection(model: UnitModel, selDefs: Dict<SelectionDef>
     const selCmpt = (selCmpts[name] = {
       ...selDef,
       name: name,
-      events: isString(selDef.on) ? parseSelector(selDef.on, 'scope') : selDef.on
+      events: isString(selDef.on) ? parseSelector(selDef.on, 'scope') : selDef.on,
+      data: model.requestDataName(MAIN)
     } as any);
 
     forEachTransform(selCmpt, txCompiler => {

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -38,11 +38,12 @@ import {RepeaterValue, replaceRepeaterInEncoding} from './repeater';
 import {ScaleIndex} from './scale/component';
 import {
   assembleTopLevelSignals,
+  assembleUnitSelectionAggregateData,
   assembleUnitSelectionData,
   assembleUnitSelectionMarks,
   assembleUnitSelectionSignals
 } from './selection/assemble';
-import {parseUnitSelection} from './selection/parse';
+import {parseUnitSelection, parseUnitSelectionComparisonTest} from './selection/parse';
 
 /**
  * Internal model of Vega-Lite specification for the compiler.
@@ -204,6 +205,10 @@ export class UnitModel extends ModelWithField {
     this.component.selection = parseUnitSelection(this, this.selection);
   }
 
+  public parseSelectionComparisons() {
+    parseUnitSelectionComparisonTest(this, this.component.selection);
+  }
+
   public parseMarkGroup() {
     this.component.mark = parseMarkGroups(this);
   }
@@ -222,6 +227,10 @@ export class UnitModel extends ModelWithField {
 
   public assembleSelectionData(data: VgData[]): VgData[] {
     return assembleUnitSelectionData(this, data);
+  }
+
+  public assembleSelectionAggregateData(data: VgData[]): VgData[] {
+    return assembleUnitSelectionAggregateData(this, data);
   }
 
   public assembleLayout(): VgLayout {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -26,7 +26,9 @@ export interface FilterTransform {
    *
    * 3) a [selection predicate](https://vega.github.io/vega-lite/docs/filter.html#selection-predicate)
    *
-   * 4) a logical operand that combines (1), (2), or (3).
+   * 4) a [comparison selection predicate]
+   *
+   * 5) a logical operand that combines (1), (2), (3) or (4).
    */
   // TODO: https://github.com/vega/vega-lite/issues/2901
   filter: LogicalOperand<Predicate>;


### PR DESCRIPTION
PR towards Issue #4971 

Approach: 
- *Look at all the places where Selection Comparison Predicates can be defined.*
- *For every selection make an aggregate store which reduces the selection to a single value*
- *Construct an expression which checks whether the test datum satisfies the condition specified in the spec by using the value in the aggregate store*

Can be tested using 
```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v3.json",
  "description": "Drag the sliders to highlight points.",
  "data": {"url": "data/cars.json"},
  "selection": {"CylYr": {"type": "multi"}},
  "mark": "circle",
  "encoding": {
    "x": {"field": "Horsepower", "type": "quantitative"},
    "y": {"field": "Miles_per_Gallon", "type": "quantitative"},
    "color": {
      "condition": {
        "test": {
          "and": [
            {
              "field": "Horsepower",
              "gte": {
                "selection": "CylYr",
                "aggregate": "mean",
                "field": "Horsepower"
              }
            },
            {
              "field": "Miles_per_Gallon",
              "lte": {
                "selection": "CylYr",
                "aggregate": "mean",
                "field": "Miles_per_Gallon"
              }
            }
          ]
        },
        "field": "Origin",
        "type": "nominal"
      },
      "value": "grey"
    }
  }
}
```

![1](https://user-images.githubusercontent.com/4402679/59231330-47ff6100-8bae-11e9-84f9-d1fdb5d990c7.gif)

There are some parts which still need some work. The primary ones being - 

1. Implementing proper interfaces for the new selection comparison predicate such that the previous behaviour of `fieldFilterExpression` is supported without a lot of modification of all the other interfaces. (`predicate.test.ts` is filled with red bars of shame for now).

2. The data objects have to be sorted topologically such that dependencies are satisfied during a top-down parsing of the Vega Spec. Currently, we are using a regex match (in all the filter transformations) for identifying which of the data sources are using selection aggregate store. Is there a better way to do this? 

- [ ] Remove all errors (Resolve interface issue)
- [ ] Resolve Merge Conflicts
- [ ] Write Tests
- [ ] Make sample Visualizations
