### PR TITLE
docs: spelling mistake

### DIFF
--- a/site/docs/projection.md
+++ b/site/docs/projection.md
@@ -36,7 +36,7 @@ Vega-lite includes all cartographic projections provided by the [d3-geo](https:/
 | [albers](https://github.com/d3/d3-geo#geoAlbers) | The Albers’ equal-area conic projection. This is a U.S.-centric configuration of `"conicEqualArea"`. |
 | [albersUsa](https://github.com/d3/d3-geo#geoAlbersUsa) | A U.S.-centric composite with projections for the lower 48 states, Hawaii, and Alaska (scaled to 0.35 times the true relative area). |
 | [azimuthalEqualArea](https://github.com/d3/d3-geo#geoAzimuthalEqualArea) | The azimuthal equal-area projection. |
-| [azimuthalEquidistanct](https://github.com/d3/d3-geo#geoAzimuthalEquidistant) | The azimuthal equidistant projection. |
+| [azimuthalEquidistant](https://github.com/d3/d3-geo#geoAzimuthalEquidistant) | The azimuthal equidistant projection. |
 | [conicConformal](https://github.com/d3/d3-geo#geoConicConformal) | The conic conformal projection. The parallels default to [30&deg;, 30&deg;] resulting in flat top. |
 | [conicEqualArea](https://github.com/d3/d3-geo#geoConicEqualArea) | The Albers’ equal-area conic projection. |
 | [conicEquidistant](https://github.com/d3/d3-geo#geoConicEquidistant) | The conic equidistant projection. |


### PR DESCRIPTION
Change the spelling of `azimuthalEquidistanct` to `azimuthalEquidistant` in the documentation of Projection.
