### PR TITLE
feat!: replace `config.invalidValues` with `mark.invalid` for mark definition and config

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -195,6 +195,17 @@
           "$ref": "#/definitions/Interpolate",
           "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
         },
+        "invalid": {
+          "description": "Defines how Vega-Lite should handle marks for invalid values (`null` and `NaN`).\n- If set to `\"filter\"` (default), all data items with null values will be skipped (for line, trail, and area marks) or filtered (for other marks).\n- If `null`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
+          "enum": [
+            "filter",
+            null
+          ],
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "limit": {
           "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
           "type": "number"
@@ -2948,17 +2959,6 @@
         "headerRow": {
           "$ref": "#/definitions/HeaderConfig",
           "description": "Header configuration, which determines default properties for row [headers](https://vega.github.io/vega-lite/docs/header.html).\n\nFor a full list of header configuration options, please see the [corresponding section of in the header documentation](https://vega.github.io/vega-lite/docs/header.html#config)."
-        },
-        "invalidValues": {
-          "description": "Defines how Vega-Lite should handle invalid values (`null` and `NaN`).\n- If set to `\"filter\"` (default), all data items with null values will be skipped (for line, trail, and area marks) or filtered (for other marks).\n- If `null`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
-          "enum": [
-            "filter",
-            null
-          ],
-          "type": [
-            "string",
-            "null"
-          ]
         },
         "legend": {
           "$ref": "#/definitions/LegendConfig",
@@ -7133,6 +7133,17 @@
           "$ref": "#/definitions/Interpolate",
           "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
         },
+        "invalid": {
+          "description": "Defines how Vega-Lite should handle marks for invalid values (`null` and `NaN`).\n- If set to `\"filter\"` (default), all data items with null values will be skipped (for line, trail, and area marks) or filtered (for other marks).\n- If `null`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
+          "enum": [
+            "filter",
+            null
+          ],
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "limit": {
           "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
           "type": "number"
@@ -7668,6 +7679,17 @@
           "$ref": "#/definitions/Interpolate",
           "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
         },
+        "invalid": {
+          "description": "Defines how Vega-Lite should handle marks for invalid values (`null` and `NaN`).\n- If set to `\"filter\"` (default), all data items with null values will be skipped (for line, trail, and area marks) or filtered (for other marks).\n- If `null`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
+          "enum": [
+            "filter",
+            null
+          ],
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "limit": {
           "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
           "type": "number"
@@ -7923,6 +7945,17 @@
         "interpolate": {
           "$ref": "#/definitions/Interpolate",
           "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+        },
+        "invalid": {
+          "description": "Defines how Vega-Lite should handle marks for invalid values (`null` and `NaN`).\n- If set to `\"filter\"` (default), all data items with null values will be skipped (for line, trail, and area marks) or filtered (for other marks).\n- If `null`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
+          "enum": [
+            "filter",
+            null
+          ],
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "limit": {
           "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
@@ -8519,6 +8552,17 @@
         "interpolate": {
           "$ref": "#/definitions/Interpolate",
           "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+        },
+        "invalid": {
+          "description": "Defines how Vega-Lite should handle marks for invalid values (`null` and `NaN`).\n- If set to `\"filter\"` (default), all data items with null values will be skipped (for line, trail, and area marks) or filtered (for other marks).\n- If `null`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
+          "enum": [
+            "filter",
+            null
+          ],
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "limit": {
           "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
@@ -9340,6 +9384,17 @@
         "interpolate": {
           "$ref": "#/definitions/Interpolate",
           "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+        },
+        "invalid": {
+          "description": "Defines how Vega-Lite should handle marks for invalid values (`null` and `NaN`).\n- If set to `\"filter\"` (default), all data items with null values will be skipped (for line, trail, and area marks) or filtered (for other marks).\n- If `null`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
+          "enum": [
+            "filter",
+            null
+          ],
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "limit": {
           "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
@@ -10892,6 +10947,17 @@
           "$ref": "#/definitions/Interpolate",
           "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
         },
+        "invalid": {
+          "description": "Defines how Vega-Lite should handle marks for invalid values (`null` and `NaN`).\n- If set to `\"filter\"` (default), all data items with null values will be skipped (for line, trail, and area marks) or filtered (for other marks).\n- If `null`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
+          "enum": [
+            "filter",
+            null
+          ],
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "limit": {
           "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
           "type": "number"
@@ -11217,6 +11283,17 @@
         "interpolate": {
           "$ref": "#/definitions/Interpolate",
           "description": "The line interpolation method to use for line and area marks. One of the following:\n- `\"linear\"`: piecewise linear segments, as in a polyline.\n- `\"linear-closed\"`: close the linear segments to form a polygon.\n- `\"step\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"step-before\"`: alternate between vertical and horizontal segments, as in a step function.\n- `\"step-after\"`: alternate between horizontal and vertical segments, as in a step function.\n- `\"basis\"`: a B-spline, with control point duplication on the ends.\n- `\"basis-open\"`: an open B-spline; may not intersect the start or end.\n- `\"basis-closed\"`: a closed B-spline, as in a loop.\n- `\"cardinal\"`: a Cardinal spline, with control point duplication on the ends.\n- `\"cardinal-open\"`: an open Cardinal spline; may not intersect the start or end, but will intersect other control points.\n- `\"cardinal-closed\"`: a closed Cardinal spline, as in a loop.\n- `\"bundle\"`: equivalent to basis, except the tension parameter is used to straighten the spline.\n- `\"monotone\"`: cubic interpolation that preserves monotonicity in y."
+        },
+        "invalid": {
+          "description": "Defines how Vega-Lite should handle marks for invalid values (`null` and `NaN`).\n- If set to `\"filter\"` (default), all data items with null values will be skipped (for line, trail, and area marks) or filtered (for other marks).\n- If `null`, all data items are included. In this case, invalid values will be interpreted as zeroes.",
+          "enum": [
+            "filter",
+            null
+          ],
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "limit": {
           "description": "The maximum length of the text mark in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",

--- a/examples/specs/point_invalid_color.vl.json
+++ b/examples/specs/point_invalid_color.vl.json
@@ -21,6 +21,6 @@
     }
   },
   "config": {
-    "invalidValues": null
+    "mark": {"invalid": null}
   }
 }

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -42,7 +42,7 @@ The rest of this page outlines different types of config properties:
 
 A Vega-Lite `config` object can have the following top-level properties:
 
-{% include table.html props="autosize,background,countTitle,fieldTitle,invalidValues,padding" source="Config" %}
+{% include table.html props="autosize,background,countTitle,fieldTitle,padding" source="Config" %}
 
 {:#format}
 

--- a/site/docs/mark/mark.md
+++ b/site/docs/mark/mark.md
@@ -63,7 +63,7 @@ Note: If [mark property encoding channels](encoding.html#mark-prop) are specifie
 
 ### General Mark Properties
 
-{% include table.html props="type,style,tooltip,clip,order" source="MarkDef" %}
+{% include table.html props="type,style,tooltip,clip,invalid,order" source="MarkDef" %}
 
 {:#offset}
 

--- a/src/compile/common.ts
+++ b/src/compile/common.ts
@@ -35,6 +35,10 @@ export function getStyles(mark: MarkDef): string[] {
   return [].concat(mark.type, mark.style || []);
 }
 
+export function getMarkPropOrConfig<P extends keyof MarkConfig>(channel: P, mark: MarkDef, config: Config) {
+  return getFirstDefined(mark[channel], getMarkConfig(channel, mark, config));
+}
+
 /**
  * Return property value from style or mark specific config property if exists.
  * Otherwise, return general mark specific config.

--- a/src/compile/data/filterinvalid.ts
+++ b/src/compile/data/filterinvalid.ts
@@ -4,6 +4,7 @@ import {isPathMark} from '../../mark';
 import {hasContinuousDomain} from '../../scale';
 import {Dict, keys} from '../../util';
 import {VgFilterTransform} from '../../vega.schema';
+import {getMarkPropOrConfig} from '../common';
 import {UnitModel} from '../unit';
 import {DataFlowNode} from './dataflow';
 
@@ -17,8 +18,10 @@ export class FilterInvalidNode extends DataFlowNode {
   }
 
   public static make(parent: DataFlowNode, model: UnitModel): FilterInvalidNode {
-    const {config, mark} = model;
-    if (config.invalidValues !== 'filter') {
+    const {config, mark, markDef} = model;
+
+    const invalid = getMarkPropOrConfig('invalid', markDef, config);
+    if (invalid !== 'filter') {
       return null;
     }
 

--- a/src/compile/mark/mixins.ts
+++ b/src/compile/mark/mixins.ts
@@ -1,6 +1,6 @@
 import {array, isArray, isObject, isString} from 'vega-util';
 import {isBinned, isBinning} from '../../bin';
-import {Channel, NonPositionScaleChannel, SCALE_CHANNELS, ScaleChannel, X, X2, Y2} from '../../channel';
+import {Channel, NonPositionScaleChannel, ScaleChannel, SCALE_CHANNELS, X, X2, Y2} from '../../channel';
 import {
   ChannelDef,
   getTypedFieldDef,
@@ -15,8 +15,8 @@ import * as log from '../../log';
 import {isPathMark, Mark, MarkDef} from '../../mark';
 import {hasContinuousDomain} from '../../scale';
 import {contains, Dict, getFirstDefined, keys} from '../../util';
-import {VG_MARK_CONFIGS, VgEncodeChannel, VgEncodeEntry, VgValueRef} from '../../vega.schema';
-import {getMarkConfig} from '../common';
+import {VgEncodeChannel, VgEncodeEntry, VgValueRef, VG_MARK_CONFIGS} from '../../vega.schema';
+import {getMarkConfig, getMarkPropOrConfig} from '../common';
 import {expression} from '../predicate';
 import {assembleSelectionPredicate} from '../selection/assemble';
 import {UnitModel} from '../unit';
@@ -128,9 +128,11 @@ export function baseEncodeEntry(model: UnitModel, ignore: Ignore) {
 }
 
 function wrapAllFieldsInvalid(model: UnitModel, channel: Channel, valueRef: VgValueRef | VgValueRef[]): VgEncodeEntry {
-  const {config, mark} = model;
+  const {config, mark, markDef} = model;
 
-  if (config.invalidValues === 'hide' && valueRef && !isPathMark(mark)) {
+  const invalid = getMarkPropOrConfig('invalid', markDef, config);
+
+  if (invalid === 'hide' && valueRef && !isPathMark(mark)) {
     // For non-path marks, we have to exclude invalid values (null and NaN) for scales with continuous domains.
     // For path marks, we will use "defined" property and skip these values instead.
     const test = allFieldsInvalidPredicate(model, {invalid: true, channels: SCALE_CHANNELS});
@@ -190,7 +192,10 @@ function allFieldsInvalidPredicate(
   return undefined;
 }
 export function defined(model: UnitModel): VgEncodeEntry {
-  if (model.config.invalidValues) {
+  const {config, markDef} = model;
+
+  const invalid = getMarkPropOrConfig('invalid', markDef, config);
+  if (invalid) {
     const signal = allFieldsInvalidPredicate(model, {channels: ['x', 'y']});
 
     if (signal) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -89,9 +89,6 @@ export function isVgScheme(rangeConfig: string[] | SchemeConfig): rangeConfig is
   return rangeConfig && !!rangeConfig['scheme'];
 }
 
-/** @hide */
-export type Hide = 'hide';
-
 export interface VLOnlyConfig {
   /**
    * Default axis and legend title for count fields.
@@ -101,13 +98,6 @@ export interface VLOnlyConfig {
    * @type {string}
    */
   countTitle?: string;
-
-  /**
-   * Defines how Vega-Lite should handle invalid values (`null` and `NaN`).
-   * - If set to `"filter"` (default), all data items with null values will be skipped (for line, trail, and area marks) or filtered (for other marks).
-   * - If `null`, all data items are included. In this case, invalid values will be interpreted as zeroes.
-   */
-  invalidValues?: 'filter' | Hide | null;
 
   /**
    * Defines how Vega-Lite generates title for fields.  There are three possible styles:
@@ -190,8 +180,6 @@ export const defaultConfig: Config = {
   padding: 5,
   timeFormat: '%b %d, %Y',
   countTitle: 'Count of Records',
-
-  invalidValues: 'filter',
 
   view: defaultViewConfig,
 
@@ -277,7 +265,6 @@ const VL_ONLY_CONFIG_PROPERTIES: (keyof Config)[] = [
   'header',
   'scale',
   'selection',
-  'invalidValues',
   'overlay' as keyof Config // FIXME: Redesign and unhide this
 ];
 

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -74,6 +74,9 @@ export interface TooltipContent {
   content: 'encoding' | 'data';
 }
 
+/** @hide */
+export type Hide = 'hide';
+
 export interface MarkConfig extends ColorMixins, BaseMarkConfig {
   // ========== VL-Specific ==========
 
@@ -118,6 +121,13 @@ export interface MarkConfig extends ColorMixins, BaseMarkConfig {
    * For line and trail marks, this `order` property can be set to `null` or `false` to make the lines use the original order in the data sources.
    */
   order?: null | boolean;
+
+  /**
+   * Defines how Vega-Lite should handle marks for invalid values (`null` and `NaN`).
+   * - If set to `"filter"` (default), all data items with null values will be skipped (for line, trail, and area marks) or filtered (for other marks).
+   * - If `null`, all data items are included. In this case, invalid values will be interpreted as zeroes.
+   */
+  invalid?: 'filter' | Hide | null;
 }
 
 export interface RectBinSpacingMixins {
@@ -158,7 +168,7 @@ export const FILL_CONFIG = ['fill', 'fillOpacity'];
 
 export const FILL_STROKE_CONFIG = [].concat(STROKE_CONFIG, FILL_CONFIG);
 
-export const VL_ONLY_MARK_CONFIG_PROPERTIES: (keyof MarkConfig)[] = ['filled', 'color', 'tooltip'];
+export const VL_ONLY_MARK_CONFIG_PROPERTIES: (keyof MarkConfig)[] = ['filled', 'color', 'tooltip', 'invalid'];
 
 export const VL_ONLY_MARK_SPECIFIC_CONFIG_PROPERTY_INDEX: {
   [k in typeof PRIMITIVE_MARKS[0]]?: (keyof MarkConfigMixins[k])[];
@@ -172,7 +182,8 @@ export const VL_ONLY_MARK_SPECIFIC_CONFIG_PROPERTY_INDEX: {
 };
 
 export const defaultMarkConfig: MarkConfig = {
-  color: '#4c78a8'
+  color: '#4c78a8',
+  invalid: 'filter'
 };
 
 export interface MarkConfigMixins {

--- a/test/compile/data/filterinvalid.test.ts
+++ b/test/compile/data/filterinvalid.test.ts
@@ -29,11 +29,11 @@ describe('compile/data/nullfilter', () => {
       });
     });
 
-    it('should add filterNull for Q and T when invalidValues is "filter".', () => {
+    it('should add filterNull for Q and T when invalid is "filter".', () => {
       const model = parseUnitModelWithScale(
         mergeDeep<TopLevel<NormalizedUnitSpec>>(spec, {
           config: {
-            invalidValues: 'filter'
+            mark: {invalid: 'filter'}
           }
         })
       );
@@ -43,11 +43,11 @@ describe('compile/data/nullfilter', () => {
       });
     });
 
-    it('should add no null filter if when invalidValues is null', () => {
+    it('should add no null filter if when invalid is null', () => {
       const model = parseUnitModelWithScale(
         mergeDeep<TopLevel<NormalizedUnitSpec>>(spec, {
           config: {
-            invalidValues: null
+            mark: {invalid: null}
           }
         })
       );

--- a/test/compile/mark/point.test.ts
+++ b/test/compile/mark/point.test.ts
@@ -17,7 +17,7 @@ describe('Mark: Point', () => {
         ...moreEncoding
       },
       data: {url: 'data/barley.json'},
-      config: {invalidValues: null, ...moreConfig}
+      config: {mark: {invalid: null}, ...moreConfig}
     };
   }
 

--- a/test/compile/mark/rule.test.ts
+++ b/test/compile/mark/rule.test.ts
@@ -214,7 +214,7 @@ describe('Mark: Rule', () => {
         color: {field: 'Origin', type: 'nominal'}
       },
       config: {
-        invalidValues: null
+        mark: {invalid: null}
       }
     });
 
@@ -236,7 +236,7 @@ describe('Mark: Rule', () => {
         color: {field: 'Origin', type: 'nominal'}
       },
       config: {
-        invalidValues: null
+        mark: {invalid: null}
       }
     });
 

--- a/test/compile/mark/text.test.ts
+++ b/test/compile/mark/text.test.ts
@@ -181,7 +181,7 @@ describe('Mark: Text', () => {
       },
       data: {url: 'data/cars.json'},
       config: {
-        invalidValues: 'hide'
+        mark: {invalid: 'hide'}
       }
     };
     const model = parseModelWithScale(spec);

--- a/test/compile/selection/layers.test.ts
+++ b/test/compile/selection/layers.test.ts
@@ -28,7 +28,7 @@ describe('Layered Selections', () => {
         }
       }
     ],
-    config: {mark: {tooltip: null}, invalidValues: 'hide'}
+    config: {mark: {tooltip: null, invalid: 'hide'}}
   });
 
   layers.parse();

--- a/test/compile/selection/timeunit.test.ts
+++ b/test/compile/selection/timeunit.test.ts
@@ -101,7 +101,7 @@ describe('Selection time unit', () => {
           y: {field: 'price', type: 'quantitative'}
         }
       },
-      {invalidValues: 'hide'}
+      {mark: {invalid: 'hide'}}
     );
     const data0 = getData(model).filter(d => d.name === 'data_0')[0].transform;
     const data1 = getData(model).filter(d => d.name === 'data_1')[0].transform;

--- a/test/transformextract.test.ts
+++ b/test/transformextract.test.ts
@@ -116,8 +116,8 @@ describe('extractTransforms()', () => {
 
         const spec = JSON.parse(specString);
 
-        // Use invalidValues =  "hide" so we don't include filterInvalid in the comparison
-        const config = initConfig({...spec.config, invalidValues: 'hide'});
+        // Use invalid =  "hide" so we don't include filterInvalid in the comparison
+        const config = initConfig({...spec.config, mark: {invalid: 'hide'}});
 
         const extractSpec = extractTransforms(normalize(spec, config), config) as TopLevelSpec;
 

--- a/test/transformextract.test.ts
+++ b/test/transformextract.test.ts
@@ -116,7 +116,7 @@ describe('extractTransforms()', () => {
 
         const spec = JSON.parse(specString);
 
-        // Use invalid =  "hide" so we don't include filterInvalid in the comparison
+        // Use invalid = "hide" so we don't include filterInvalid in the comparison
         const config = initConfig({...spec.config, mark: {invalid: 'hide'}});
 
         const extractSpec = extractTransforms(normalize(spec, config), config) as TopLevelSpec;


### PR DESCRIPTION
This would allow us to customize how we handle null values differently for different marks

Fix #4802

BREAKING CHANGE: `config.invalidValues` no longer works 