### PR TITLE
fix!: remove `config.scale.bar/rectBandPaddingOuter` 

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -9888,12 +9888,6 @@
           "minimum": 0,
           "type": "number"
         },
-        "barBandPaddingOuter": {
-          "description": "Default outer padding for `x` and `y` band-ordinal scales of `\"bar\"` marks.\nIf not specified, by default, band scale's paddingOuter is paddingInner/2.",
-          "maximum": 1,
-          "minimum": 0,
-          "type": "number"
-        },
         "clamp": {
           "description": "If true, values that exceed the data domain are clamped to either the minimum or maximum range value",
           "type": "boolean"
@@ -9981,12 +9975,6 @@
         },
         "rectBandPaddingInner": {
           "description": "Default inner padding for `x` and `y` band-ordinal scales of `\"rect\"` marks.\n\n__Default value:__ `0`",
-          "maximum": 1,
-          "minimum": 0,
-          "type": "number"
-        },
-        "rectBandPaddingOuter": {
-          "description": "Default outer padding for `x` and `y` band-ordinal scales of `\"rect\"` marks.\nIf not specified, by default, band scale's paddingOuter is paddingInner/2.",
           "maximum": 1,
           "minimum": 0,
           "type": "number"

--- a/site/docs/encoding/scale.md
+++ b/site/docs/encoding/scale.md
@@ -390,7 +390,7 @@ To provide themes for all scales, the scale config (`config: {scale: {...}}`) ca
 
 #### Padding
 
-{% include table.html props="bandPaddingInner,bandPaddingOuter,barBandPaddingInner,barBandPaddingOuter,continuousPadding,pointPadding,rectBandPaddingInner,rectBandPaddingOuter," source="ScaleConfig" %}
+{% include table.html props="bandPaddingInner,barBandPaddingInner,rectBandPaddingInner,bandPaddingOuter,continuousPadding,pointPadding" source="ScaleConfig" %}
 
 #### Range
 

--- a/src/compile/scale/properties.ts
+++ b/src/compile/scale/properties.ts
@@ -273,11 +273,10 @@ export function paddingOuter(
     // Padding is only set for X and Y by default.
     // Basically it doesn't make sense to add padding for color and size.
     if (scaleType === ScaleType.BAND) {
-      const {bandPaddingOuter, barBandPaddingOuter, rectBandPaddingOuter} = scaleConfig;
+      const {bandPaddingOuter} = scaleConfig;
 
       return getFirstDefined(
         bandPaddingOuter,
-        mark === 'bar' ? barBandPaddingOuter : rectBandPaddingOuter,
         /* By default, paddingOuter is paddingInner / 2. The reason is that
           size (width/height) = step * (cardinality - paddingInner + 2 * paddingOuter).
           and we want the width/height to be integer by default.

--- a/src/scale.ts
+++ b/src/scale.ts
@@ -215,14 +215,6 @@ export interface ScaleConfig {
   barBandPaddingInner?: number;
 
   /**
-   * Default outer padding for `x` and `y` band-ordinal scales of `"bar"` marks.
-   * If not specified, by default, band scale's paddingOuter is paddingInner/2.
-   * @minimum 0
-   * @maximum 1
-   */
-  barBandPaddingOuter?: number;
-
-  /**
    * Default inner padding for `x` and `y` band-ordinal scales of `"rect"` marks.
    *
    * __Default value:__ `0`
@@ -231,14 +223,6 @@ export interface ScaleConfig {
    * @maximum 1
    */
   rectBandPaddingInner?: number;
-
-  /**
-   * Default outer padding for `x` and `y` band-ordinal scales of `"rect"` marks.
-   * If not specified, by default, band scale's paddingOuter is paddingInner/2.
-   * @minimum 0
-   * @maximum 1
-   */
-  rectBandPaddingOuter?: number;
 
   /**
    * Default padding for continuous scales.


### PR DESCRIPTION
These are unnecessary properties. (I don't see why one would use them.)  Removing them will  simplify the logic and related documentation. 

BREAKING CHANGE: remove `config.scale.bar/rectBandPaddingOuter` 