### PR TITLE
refactor: optimize calculate nodes.

### DIFF
--- a/examples/compiled/area_horizon.vg.json
+++ b/examples/compiled/area_horizon.vg.json
@@ -36,13 +36,9 @@
       "name": "data_0",
       "source": "source_0",
       "transform": [
-        {"type": "formula", "expr": "toNumber(datum[\"x\"])", "as": "x"}
+        {"type": "formula", "expr": "toNumber(datum[\"x\"])", "as": "x"},
+        {"type": "formula", "expr": "datum.y - 50", "as": "ny"}
       ]
-    },
-    {
-      "name": "data_1",
-      "source": "data_0",
-      "transform": [{"type": "formula", "expr": "datum.y - 50", "as": "ny"}]
     }
   ],
   "marks": [
@@ -76,7 +72,7 @@
       "clip": true,
       "style": ["area"],
       "sort": {"field": "datum[\"x\"]"},
-      "from": {"data": "data_1"},
+      "from": {"data": "data_0"},
       "encode": {
         "update": {
           "orient": {"value": "vertical"},
@@ -99,12 +95,7 @@
     {
       "name": "x",
       "type": "linear",
-      "domain": {
-        "fields": [
-          {"data": "data_0", "field": "x"},
-          {"data": "data_1", "field": "x"}
-        ]
-      },
+      "domain": {"data": "data_0", "field": "x"},
       "range": [0, {"signal": "width"}],
       "nice": false,
       "zero": false

--- a/examples/compiled/circle_github_punchcard.vg.json
+++ b/examples/compiled/circle_github_punchcard.vg.json
@@ -12,6 +12,11 @@
       "transform": [
         {
           "type": "formula",
+          "expr": "time(datetime(2006, 0, day(datum[\"time\"])+1, 0, 0, 0, 0))===time(datetime(2006, 0, 1+1, 0, 0, 0, 0)) ? 0 : time(datetime(2006, 0, day(datum[\"time\"])+1, 0, 0, 0, 0))===time(datetime(2006, 0, 2+1, 0, 0, 0, 0)) ? 1 : time(datetime(2006, 0, day(datum[\"time\"])+1, 0, 0, 0, 0))===time(datetime(2006, 0, 3+1, 0, 0, 0, 0)) ? 2 : time(datetime(2006, 0, day(datum[\"time\"])+1, 0, 0, 0, 0))===time(datetime(2006, 0, 4+1, 0, 0, 0, 0)) ? 3 : time(datetime(2006, 0, day(datum[\"time\"])+1, 0, 0, 0, 0))===time(datetime(2006, 0, 5+1, 0, 0, 0, 0)) ? 4 : time(datetime(2006, 0, day(datum[\"time\"])+1, 0, 0, 0, 0))===time(datetime(2006, 0, 6+1, 0, 0, 0, 0)) ? 5 : time(datetime(2006, 0, day(datum[\"time\"])+1, 0, 0, 0, 0))===time(datetime(2006, 0, 0+1, 0, 0, 0, 0)) ? 6 : 7",
+          "as": "y_day_time_sort_index"
+        },
+        {
+          "type": "formula",
           "as": "day_time",
           "expr": "datetime(2006, 0, day(datum[\"time\"])+1, 0, 0, 0, 0)"
         },
@@ -19,11 +24,6 @@
           "type": "formula",
           "as": "hours_time",
           "expr": "datetime(0, 0, 1, hours(datum[\"time\"]), 0, 0, 0)"
-        },
-        {
-          "type": "formula",
-          "expr": "time(datetime(2006, 0, day(datum[\"time\"])+1, 0, 0, 0, 0))===time(datetime(2006, 0, 1+1, 0, 0, 0, 0)) ? 0 : time(datetime(2006, 0, day(datum[\"time\"])+1, 0, 0, 0, 0))===time(datetime(2006, 0, 2+1, 0, 0, 0, 0)) ? 1 : time(datetime(2006, 0, day(datum[\"time\"])+1, 0, 0, 0, 0))===time(datetime(2006, 0, 3+1, 0, 0, 0, 0)) ? 2 : time(datetime(2006, 0, day(datum[\"time\"])+1, 0, 0, 0, 0))===time(datetime(2006, 0, 4+1, 0, 0, 0, 0)) ? 3 : time(datetime(2006, 0, day(datum[\"time\"])+1, 0, 0, 0, 0))===time(datetime(2006, 0, 5+1, 0, 0, 0, 0)) ? 4 : time(datetime(2006, 0, day(datum[\"time\"])+1, 0, 0, 0, 0))===time(datetime(2006, 0, 6+1, 0, 0, 0, 0)) ? 5 : time(datetime(2006, 0, day(datum[\"time\"])+1, 0, 0, 0, 0))===time(datetime(2006, 0, 0+1, 0, 0, 0, 0)) ? 6 : 7",
-          "as": "y_day_time_sort_index"
         }
       ]
     },

--- a/examples/compiled/interactive_layered_crossfilter.vg.json
+++ b/examples/compiled/interactive_layered_crossfilter.vg.json
@@ -11,6 +11,7 @@
       "url": "data/flights-2k.json",
       "format": {"type": "json", "parse": {"date": "date"}},
       "transform": [
+        {"type": "formula", "expr": "hours(datum.date)", "as": "time"},
         {
           "type": "extent",
           "field": "delay",
@@ -41,13 +42,6 @@
             "signal": "child__repeat_column_distance_layer_0_bin_maxbins_20_distance_extent"
           }
         },
-        {"type": "formula", "expr": "hours(datum.date)", "as": "time"}
-      ]
-    },
-    {
-      "name": "data_0",
-      "source": "source_0",
-      "transform": [
         {
           "type": "extent",
           "field": "time",
@@ -66,45 +60,24 @@
       ]
     },
     {
+      "name": "data_0",
+      "source": "source_0",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
+          "ops": ["count"],
+          "fields": [null],
+          "as": ["__count"]
+        },
+        {
+          "type": "filter",
+          "expr": "datum[\"bin_maxbins_20_time\"] !== null && !isNaN(datum[\"bin_maxbins_20_time\"])"
+        }
+      ]
+    },
+    {
       "name": "data_1",
-      "source": "data_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "!(length(data(\"brush_store\"))) || (vlSelectionTest(\"brush_store\", datum))"
-        },
-        {
-          "type": "aggregate",
-          "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
-          "ops": ["count"],
-          "fields": [null],
-          "as": ["__count"]
-        },
-        {
-          "type": "filter",
-          "expr": "datum[\"bin_maxbins_20_time\"] !== null && !isNaN(datum[\"bin_maxbins_20_time\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_2",
-      "source": "data_0",
-      "transform": [
-        {
-          "type": "aggregate",
-          "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
-          "ops": ["count"],
-          "fields": [null],
-          "as": ["__count"]
-        },
-        {
-          "type": "filter",
-          "expr": "datum[\"bin_maxbins_20_time\"] !== null && !isNaN(datum[\"bin_maxbins_20_time\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_3",
       "source": "source_0",
       "transform": [
         {
@@ -114,8 +87,8 @@
       ]
     },
     {
-      "name": "data_4",
-      "source": "data_3",
+      "name": "data_2",
+      "source": "data_1",
       "transform": [
         {
           "type": "aggregate",
@@ -131,8 +104,42 @@
       ]
     },
     {
+      "name": "data_3",
+      "source": "data_1",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["bin_maxbins_20_distance", "bin_maxbins_20_distance_end"],
+          "ops": ["count"],
+          "fields": [null],
+          "as": ["__count"]
+        },
+        {
+          "type": "filter",
+          "expr": "datum[\"bin_maxbins_20_distance\"] !== null && !isNaN(datum[\"bin_maxbins_20_distance\"])"
+        }
+      ]
+    },
+    {
+      "name": "data_4",
+      "source": "data_1",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
+          "ops": ["count"],
+          "fields": [null],
+          "as": ["__count"]
+        },
+        {
+          "type": "filter",
+          "expr": "datum[\"bin_maxbins_20_time\"] !== null && !isNaN(datum[\"bin_maxbins_20_time\"])"
+        }
+      ]
+    },
+    {
       "name": "data_5",
-      "source": "data_3",
+      "source": "source_0",
       "transform": [
         {
           "type": "aggregate",
@@ -149,23 +156,6 @@
     },
     {
       "name": "data_6",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "aggregate",
-          "groupby": ["bin_maxbins_20_distance", "bin_maxbins_20_distance_end"],
-          "ops": ["count"],
-          "fields": [null],
-          "as": ["__count"]
-        },
-        {
-          "type": "filter",
-          "expr": "datum[\"bin_maxbins_20_distance\"] !== null && !isNaN(datum[\"bin_maxbins_20_distance\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_7",
       "source": "source_0",
       "transform": [
         {
@@ -408,7 +398,7 @@
           "name": "child__repeat_column_distance_layer_0_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_6"},
+          "from": {"data": "data_5"},
           "encode": {
             "update": {
               "fill": {"value": "#ddd"},
@@ -448,7 +438,7 @@
           "name": "child__repeat_column_distance_layer_1_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_5"},
+          "from": {"data": "data_3"},
           "encode": {
             "update": {
               "fill": {"value": "#4c78a8"},
@@ -776,7 +766,7 @@
           "name": "child__repeat_column_delay_layer_0_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_7"},
+          "from": {"data": "data_6"},
           "encode": {
             "update": {
               "fill": {"value": "#ddd"},
@@ -816,7 +806,7 @@
           "name": "child__repeat_column_delay_layer_1_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_4"},
+          "from": {"data": "data_2"},
           "encode": {
             "update": {
               "fill": {"value": "#4c78a8"},
@@ -1144,7 +1134,7 @@
           "name": "child__repeat_column_time_layer_0_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_2"},
+          "from": {"data": "data_0"},
           "encode": {
             "update": {
               "fill": {"value": "#ddd"},
@@ -1181,7 +1171,7 @@
           "name": "child__repeat_column_time_layer_1_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_1"},
+          "from": {"data": "data_4"},
           "encode": {
             "update": {
               "fill": {"value": "#4c78a8"},
@@ -1311,8 +1301,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_6", "field": "__count"},
-          {"data": "data_5", "field": "__count"}
+          {"data": "data_5", "field": "__count"},
+          {"data": "data_3", "field": "__count"}
         ]
       },
       "range": [{"signal": "height"}, 0],
@@ -1336,8 +1326,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_7", "field": "__count"},
-          {"data": "data_4", "field": "__count"}
+          {"data": "data_6", "field": "__count"},
+          {"data": "data_2", "field": "__count"}
         ]
       },
       "range": [{"signal": "height"}, 0],
@@ -1361,8 +1351,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_2", "field": "__count"},
-          {"data": "data_1", "field": "__count"}
+          {"data": "data_0", "field": "__count"},
+          {"data": "data_4", "field": "__count"}
         ]
       },
       "range": [{"signal": "height"}, 0],

--- a/examples/compiled/interactive_layered_crossfilter_discrete.vg.json
+++ b/examples/compiled/interactive_layered_crossfilter_discrete.vg.json
@@ -11,6 +11,7 @@
       "url": "data/flights-2k.json",
       "format": {"type": "json", "parse": {"date": "date"}},
       "transform": [
+        {"type": "formula", "expr": "hours(datum.date)", "as": "time"},
         {
           "type": "extent",
           "field": "delay",
@@ -41,13 +42,6 @@
             "signal": "child__repeat_column_distance_layer_0_bin_maxbins_20_distance_extent"
           }
         },
-        {"type": "formula", "expr": "hours(datum.date)", "as": "time"}
-      ]
-    },
-    {
-      "name": "data_0",
-      "source": "source_0",
-      "transform": [
         {
           "type": "extent",
           "field": "time",
@@ -66,45 +60,24 @@
       ]
     },
     {
+      "name": "data_0",
+      "source": "source_0",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
+          "ops": ["count"],
+          "fields": [null],
+          "as": ["__count"]
+        },
+        {
+          "type": "filter",
+          "expr": "datum[\"bin_maxbins_20_time\"] !== null && !isNaN(datum[\"bin_maxbins_20_time\"])"
+        }
+      ]
+    },
+    {
       "name": "data_1",
-      "source": "data_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "!(length(data(\"brush_store\"))) || (vlSelectionTest(\"brush_store\", datum))"
-        },
-        {
-          "type": "aggregate",
-          "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
-          "ops": ["count"],
-          "fields": [null],
-          "as": ["__count"]
-        },
-        {
-          "type": "filter",
-          "expr": "datum[\"bin_maxbins_20_time\"] !== null && !isNaN(datum[\"bin_maxbins_20_time\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_2",
-      "source": "data_0",
-      "transform": [
-        {
-          "type": "aggregate",
-          "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
-          "ops": ["count"],
-          "fields": [null],
-          "as": ["__count"]
-        },
-        {
-          "type": "filter",
-          "expr": "datum[\"bin_maxbins_20_time\"] !== null && !isNaN(datum[\"bin_maxbins_20_time\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_3",
       "source": "source_0",
       "transform": [
         {
@@ -114,8 +87,8 @@
       ]
     },
     {
-      "name": "data_4",
-      "source": "data_3",
+      "name": "data_2",
+      "source": "data_1",
       "transform": [
         {
           "type": "aggregate",
@@ -131,8 +104,42 @@
       ]
     },
     {
+      "name": "data_3",
+      "source": "data_1",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["bin_maxbins_20_distance", "bin_maxbins_20_distance_end"],
+          "ops": ["count"],
+          "fields": [null],
+          "as": ["__count"]
+        },
+        {
+          "type": "filter",
+          "expr": "datum[\"bin_maxbins_20_distance\"] !== null && !isNaN(datum[\"bin_maxbins_20_distance\"])"
+        }
+      ]
+    },
+    {
+      "name": "data_4",
+      "source": "data_1",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
+          "ops": ["count"],
+          "fields": [null],
+          "as": ["__count"]
+        },
+        {
+          "type": "filter",
+          "expr": "datum[\"bin_maxbins_20_time\"] !== null && !isNaN(datum[\"bin_maxbins_20_time\"])"
+        }
+      ]
+    },
+    {
       "name": "data_5",
-      "source": "data_3",
+      "source": "source_0",
       "transform": [
         {
           "type": "aggregate",
@@ -149,23 +156,6 @@
     },
     {
       "name": "data_6",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "aggregate",
-          "groupby": ["bin_maxbins_20_distance", "bin_maxbins_20_distance_end"],
-          "ops": ["count"],
-          "fields": [null],
-          "as": ["__count"]
-        },
-        {
-          "type": "filter",
-          "expr": "datum[\"bin_maxbins_20_distance\"] !== null && !isNaN(datum[\"bin_maxbins_20_distance\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_7",
       "source": "source_0",
       "transform": [
         {
@@ -244,7 +234,7 @@
           "name": "child__repeat_column_distance_layer_0_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_6"},
+          "from": {"data": "data_5"},
           "encode": {
             "update": {
               "fill": {"value": "#ddd"},
@@ -284,7 +274,7 @@
           "name": "child__repeat_column_distance_layer_1_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_5"},
+          "from": {"data": "data_3"},
           "encode": {
             "update": {
               "fill": {"value": "#4c78a8"},
@@ -406,7 +396,7 @@
           "name": "child__repeat_column_delay_layer_0_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_7"},
+          "from": {"data": "data_6"},
           "encode": {
             "update": {
               "fill": {"value": "#ddd"},
@@ -446,7 +436,7 @@
           "name": "child__repeat_column_delay_layer_1_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_4"},
+          "from": {"data": "data_2"},
           "encode": {
             "update": {
               "fill": {"value": "#4c78a8"},
@@ -568,7 +558,7 @@
           "name": "child__repeat_column_time_layer_0_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_2"},
+          "from": {"data": "data_0"},
           "encode": {
             "update": {
               "fill": {"value": "#ddd"},
@@ -605,7 +595,7 @@
           "name": "child__repeat_column_time_layer_1_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_1"},
+          "from": {"data": "data_4"},
           "encode": {
             "update": {
               "fill": {"value": "#4c78a8"},
@@ -693,8 +683,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_6", "field": "__count"},
-          {"data": "data_5", "field": "__count"}
+          {"data": "data_5", "field": "__count"},
+          {"data": "data_3", "field": "__count"}
         ]
       },
       "range": [{"signal": "height"}, 0],
@@ -718,8 +708,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_7", "field": "__count"},
-          {"data": "data_4", "field": "__count"}
+          {"data": "data_6", "field": "__count"},
+          {"data": "data_2", "field": "__count"}
         ]
       },
       "range": [{"signal": "height"}, 0],
@@ -743,8 +733,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_2", "field": "__count"},
-          {"data": "data_1", "field": "__count"}
+          {"data": "data_0", "field": "__count"},
+          {"data": "data_4", "field": "__count"}
         ]
       },
       "range": [{"signal": "height"}, 0],

--- a/examples/compiled/layer_line_errorband_pre_aggregated.vg.json
+++ b/examples/compiled/layer_line_errorband_pre_aggregated.vg.json
@@ -39,7 +39,15 @@
       "name": "data_0",
       "source": "source_0",
       "transform": [
-        {"type": "formula", "expr": "toDate(datum[\"Year\"])", "as": "Year"},
+        {"type": "formula", "expr": "toDate(datum[\"Year\"])", "as": "Year"}
+      ]
+    },
+    {
+      "name": "data_1",
+      "source": "data_0",
+      "transform": [
+        {"type": "formula", "expr": "datum[\"ci0\"]", "as": "upper_ci1"},
+        {"type": "formula", "expr": "datum[\"ci1\"]", "as": "lower_ci1"},
         {
           "type": "formula",
           "as": "year_Year",
@@ -48,11 +56,14 @@
       ]
     },
     {
-      "name": "data_1",
+      "name": "data_2",
       "source": "data_0",
       "transform": [
-        {"type": "formula", "expr": "datum[\"ci0\"]", "as": "upper_ci1"},
-        {"type": "formula", "expr": "datum[\"ci1\"]", "as": "lower_ci1"}
+        {
+          "type": "formula",
+          "as": "year_Year",
+          "expr": "datetime(year(datum[\"Year\"]), 0, 1, 0, 0, 0, 0)"
+        }
       ]
     }
   ],
@@ -85,7 +96,7 @@
       "type": "line",
       "style": ["line"],
       "sort": {"field": "datum[\"year_Year\"]"},
-      "from": {"data": "data_0"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "#4c78a8"},
@@ -108,7 +119,7 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "year_Year"},
-          {"data": "data_0", "field": "year_Year"}
+          {"data": "data_2", "field": "year_Year"}
         ]
       },
       "range": [0, {"signal": "width"}]
@@ -120,7 +131,7 @@
         "fields": [
           {"data": "data_1", "field": "lower_ci1"},
           {"data": "data_1", "field": "upper_ci1"},
-          {"data": "data_0", "field": "center"}
+          {"data": "data_2", "field": "center"}
         ]
       },
       "range": [{"signal": "height"}, 0],

--- a/examples/compiled/layer_point_errorbar_1d_horizontal.vg.json
+++ b/examples/compiled/layer_point_errorbar_1d_horizontal.vg.json
@@ -17,13 +17,7 @@
           "ops": ["mean", "mean", "stderr"],
           "fields": ["yield", "yield", "yield"],
           "as": ["mean_yield", "center_yield", "extent_yield"]
-        }
-      ]
-    },
-    {
-      "name": "data_0",
-      "source": "source_0",
-      "transform": [
+        },
         {
           "type": "formula",
           "expr": "datum[\"center_yield\"] + datum[\"extent_yield\"]",
@@ -33,7 +27,13 @@
           "type": "formula",
           "expr": "datum[\"center_yield\"] - datum[\"extent_yield\"]",
           "as": "lower_yield"
-        },
+        }
+      ]
+    },
+    {
+      "name": "data_0",
+      "source": "source_0",
+      "transform": [
         {
           "type": "filter",
           "expr": "datum[\"lower_yield\"] !== null && !isNaN(datum[\"lower_yield\"])"

--- a/examples/compiled/layer_point_errorbar_1d_vertical.vg.json
+++ b/examples/compiled/layer_point_errorbar_1d_vertical.vg.json
@@ -17,13 +17,7 @@
           "ops": ["mean", "mean", "stderr"],
           "fields": ["yield", "yield", "yield"],
           "as": ["mean_yield", "center_yield", "extent_yield"]
-        }
-      ]
-    },
-    {
-      "name": "data_0",
-      "source": "source_0",
-      "transform": [
+        },
         {
           "type": "formula",
           "expr": "datum[\"center_yield\"] + datum[\"extent_yield\"]",
@@ -33,7 +27,13 @@
           "type": "formula",
           "expr": "datum[\"center_yield\"] - datum[\"extent_yield\"]",
           "as": "lower_yield"
-        },
+        }
+      ]
+    },
+    {
+      "name": "data_0",
+      "source": "source_0",
+      "transform": [
         {
           "type": "filter",
           "expr": "datum[\"lower_yield\"] !== null && !isNaN(datum[\"lower_yield\"])"

--- a/examples/compiled/layer_point_errorbar_2d_horizontal.vg.json
+++ b/examples/compiled/layer_point_errorbar_2d_horizontal.vg.json
@@ -16,13 +16,7 @@
           "ops": ["mean", "mean", "stderr"],
           "fields": ["yield", "yield", "yield"],
           "as": ["mean_yield", "center_yield", "extent_yield"]
-        }
-      ]
-    },
-    {
-      "name": "data_0",
-      "source": "source_0",
-      "transform": [
+        },
         {
           "type": "formula",
           "expr": "datum[\"center_yield\"] + datum[\"extent_yield\"]",
@@ -32,7 +26,13 @@
           "type": "formula",
           "expr": "datum[\"center_yield\"] - datum[\"extent_yield\"]",
           "as": "lower_yield"
-        },
+        }
+      ]
+    },
+    {
+      "name": "data_0",
+      "source": "source_0",
+      "transform": [
         {
           "type": "filter",
           "expr": "datum[\"lower_yield\"] !== null && !isNaN(datum[\"lower_yield\"])"

--- a/examples/compiled/layer_point_errorbar_2d_horizontal_color_encoding.vg.json
+++ b/examples/compiled/layer_point_errorbar_2d_horizontal_color_encoding.vg.json
@@ -16,13 +16,7 @@
           "ops": ["mean", "mean", "stderr"],
           "fields": ["yield", "yield", "yield"],
           "as": ["mean_yield", "center_yield", "extent_yield"]
-        }
-      ]
-    },
-    {
-      "name": "data_0",
-      "source": "source_0",
-      "transform": [
+        },
         {
           "type": "formula",
           "expr": "datum[\"center_yield\"] + datum[\"extent_yield\"]",
@@ -36,8 +30,18 @@
       ]
     },
     {
+      "name": "data_0",
+      "source": "source_0",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "datum[\"upper_yield\"] !== null && !isNaN(datum[\"upper_yield\"])"
+        }
+      ]
+    },
+    {
       "name": "data_1",
-      "source": "data_0",
+      "source": "source_0",
       "transform": [
         {
           "type": "filter",
@@ -47,17 +51,7 @@
     },
     {
       "name": "data_2",
-      "source": "data_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"upper_yield\"] !== null && !isNaN(datum[\"upper_yield\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_3",
-      "source": "data_0",
+      "source": "source_0",
       "transform": [
         {
           "type": "filter",
@@ -100,7 +94,7 @@
       "name": "layer_0_layer_1_marks",
       "type": "rect",
       "style": ["tick", "errorbar-ticks"],
-      "from": {"data": "data_2"},
+      "from": {"data": "data_0"},
       "encode": {
         "update": {
           "opacity": {"value": 0.7},
@@ -125,7 +119,7 @@
       "name": "layer_0_layer_2_marks",
       "type": "rule",
       "style": ["rule", "errorbar-rule"],
-      "from": {"data": "data_3"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "#4682b4"},
@@ -180,9 +174,9 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "lower_yield"},
+          {"data": "data_0", "field": "upper_yield"},
+          {"data": "data_2", "field": "lower_yield"},
           {"data": "data_2", "field": "upper_yield"},
-          {"data": "data_3", "field": "lower_yield"},
-          {"data": "data_3", "field": "upper_yield"},
           {"data": "source_0", "field": "mean_yield"}
         ]
       },
@@ -196,8 +190,8 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "variety"},
+          {"data": "data_0", "field": "variety"},
           {"data": "data_2", "field": "variety"},
-          {"data": "data_3", "field": "variety"},
           {"data": "source_0", "field": "variety"}
         ],
         "sort": true

--- a/examples/compiled/layer_point_errorbar_2d_horizontal_custom_ticks.vg.json
+++ b/examples/compiled/layer_point_errorbar_2d_horizontal_custom_ticks.vg.json
@@ -16,13 +16,7 @@
           "ops": ["mean", "mean", "stderr"],
           "fields": ["yield", "yield", "yield"],
           "as": ["mean_yield", "center_yield", "extent_yield"]
-        }
-      ]
-    },
-    {
-      "name": "data_0",
-      "source": "source_0",
-      "transform": [
+        },
         {
           "type": "formula",
           "expr": "datum[\"center_yield\"] + datum[\"extent_yield\"]",
@@ -36,8 +30,18 @@
       ]
     },
     {
+      "name": "data_0",
+      "source": "source_0",
+      "transform": [
+        {
+          "type": "filter",
+          "expr": "datum[\"upper_yield\"] !== null && !isNaN(datum[\"upper_yield\"])"
+        }
+      ]
+    },
+    {
       "name": "data_1",
-      "source": "data_0",
+      "source": "source_0",
       "transform": [
         {
           "type": "filter",
@@ -47,17 +51,7 @@
     },
     {
       "name": "data_2",
-      "source": "data_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"upper_yield\"] !== null && !isNaN(datum[\"upper_yield\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_3",
-      "source": "data_0",
+      "source": "source_0",
       "transform": [
         {
           "type": "filter",
@@ -100,7 +94,7 @@
       "name": "layer_0_layer_1_marks",
       "type": "rect",
       "style": ["tick", "errorbar-ticks"],
-      "from": {"data": "data_2"},
+      "from": {"data": "data_0"},
       "encode": {
         "update": {
           "opacity": {"value": 0.7},
@@ -125,7 +119,7 @@
       "name": "layer_0_layer_2_marks",
       "type": "rule",
       "style": ["rule", "errorbar-rule"],
-      "from": {"data": "data_3"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -180,9 +174,9 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "lower_yield"},
+          {"data": "data_0", "field": "upper_yield"},
+          {"data": "data_2", "field": "lower_yield"},
           {"data": "data_2", "field": "upper_yield"},
-          {"data": "data_3", "field": "lower_yield"},
-          {"data": "data_3", "field": "upper_yield"},
           {"data": "source_0", "field": "mean_yield"}
         ]
       },
@@ -196,8 +190,8 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "variety"},
+          {"data": "data_0", "field": "variety"},
           {"data": "data_2", "field": "variety"},
-          {"data": "data_3", "field": "variety"},
           {"data": "source_0", "field": "variety"}
         ],
         "sort": true

--- a/examples/compiled/layer_point_errorbar_2d_horizontal_stdev.vg.json
+++ b/examples/compiled/layer_point_errorbar_2d_horizontal_stdev.vg.json
@@ -16,13 +16,7 @@
           "ops": ["mean", "mean", "stdev"],
           "fields": ["yield", "yield", "yield"],
           "as": ["mean_yield", "center_yield", "extent_yield"]
-        }
-      ]
-    },
-    {
-      "name": "data_0",
-      "source": "source_0",
-      "transform": [
+        },
         {
           "type": "formula",
           "expr": "datum[\"center_yield\"] + datum[\"extent_yield\"]",
@@ -32,7 +26,13 @@
           "type": "formula",
           "expr": "datum[\"center_yield\"] - datum[\"extent_yield\"]",
           "as": "lower_yield"
-        },
+        }
+      ]
+    },
+    {
+      "name": "data_0",
+      "source": "source_0",
+      "transform": [
         {
           "type": "filter",
           "expr": "datum[\"lower_yield\"] !== null && !isNaN(datum[\"lower_yield\"])"

--- a/examples/compiled/layer_point_errorbar_2d_vertical.vg.json
+++ b/examples/compiled/layer_point_errorbar_2d_vertical.vg.json
@@ -16,13 +16,7 @@
           "ops": ["mean", "mean", "stderr"],
           "fields": ["yield", "yield", "yield"],
           "as": ["mean_yield", "center_yield", "extent_yield"]
-        }
-      ]
-    },
-    {
-      "name": "data_0",
-      "source": "source_0",
-      "transform": [
+        },
         {
           "type": "formula",
           "expr": "datum[\"center_yield\"] + datum[\"extent_yield\"]",
@@ -32,7 +26,13 @@
           "type": "formula",
           "expr": "datum[\"center_yield\"] - datum[\"extent_yield\"]",
           "as": "lower_yield"
-        },
+        }
+      ]
+    },
+    {
+      "name": "data_0",
+      "source": "source_0",
+      "transform": [
         {
           "type": "filter",
           "expr": "datum[\"lower_yield\"] !== null && !isNaN(datum[\"lower_yield\"])"

--- a/examples/compiled/layer_point_errorbar_stdev.vg.json
+++ b/examples/compiled/layer_point_errorbar_stdev.vg.json
@@ -16,13 +16,7 @@
           "ops": ["stdev", "mean", "mean"],
           "fields": ["yield", "yield", "yield"],
           "as": ["extent_yield", "center_yield", "mean_yield"]
-        }
-      ]
-    },
-    {
-      "name": "data_0",
-      "source": "source_0",
-      "transform": [
+        },
         {
           "type": "formula",
           "expr": "datum[\"center_yield\"] + datum[\"extent_yield\"]",
@@ -32,7 +26,13 @@
           "type": "formula",
           "expr": "datum[\"center_yield\"] - datum[\"extent_yield\"]",
           "as": "lower_yield"
-        },
+        }
+      ]
+    },
+    {
+      "name": "data_0",
+      "source": "source_0",
+      "transform": [
         {
           "type": "filter",
           "expr": "datum[\"lower_yield\"] !== null && !isNaN(datum[\"lower_yield\"])"

--- a/examples/compiled/layer_scatter_errorband_1D_stdev_global_mean.vg.json
+++ b/examples/compiled/layer_scatter_errorband_1D_stdev_global_mean.vg.json
@@ -36,13 +36,7 @@
             "center_Miles_per_Gallon",
             "extent_Miles_per_Gallon"
           ]
-        }
-      ]
-    },
-    {
-      "name": "data_2",
-      "source": "data_1",
-      "transform": [
+        },
         {
           "type": "formula",
           "expr": "datum[\"center_Miles_per_Gallon\"] + datum[\"extent_Miles_per_Gallon\"]",
@@ -52,7 +46,13 @@
           "type": "formula",
           "expr": "datum[\"center_Miles_per_Gallon\"] - datum[\"extent_Miles_per_Gallon\"]",
           "as": "lower_Miles_per_Gallon"
-        },
+        }
+      ]
+    },
+    {
+      "name": "data_2",
+      "source": "data_1",
+      "transform": [
         {
           "type": "filter",
           "expr": "datum[\"lower_Miles_per_Gallon\"] !== null && !isNaN(datum[\"lower_Miles_per_Gallon\"])"

--- a/examples/compiled/rect_mosaic_labelled.vg.json
+++ b/examples/compiled/rect_mosaic_labelled.vg.json
@@ -48,11 +48,8 @@
       "source": "source_0",
       "transform": [
         {
-          "type": "aggregate",
-          "groupby": ["Origin"],
-          "ops": ["min"],
-          "fields": ["xc"],
-          "as": ["min_xc"]
+          "type": "filter",
+          "expr": "datum[\"x\"] !== null && !isNaN(datum[\"x\"]) && datum[\"y\"] !== null && !isNaN(datum[\"y\"]) && datum[\"Cylinders\"] !== null && !isNaN(datum[\"Cylinders\"])"
         }
       ]
     },
@@ -61,8 +58,11 @@
       "source": "source_0",
       "transform": [
         {
-          "type": "filter",
-          "expr": "datum[\"x\"] !== null && !isNaN(datum[\"x\"]) && datum[\"y\"] !== null && !isNaN(datum[\"y\"]) && datum[\"Cylinders\"] !== null && !isNaN(datum[\"Cylinders\"])"
+          "type": "aggregate",
+          "groupby": ["Origin"],
+          "ops": ["min"],
+          "fields": ["xc"],
+          "as": ["min_xc"]
         }
       ]
     },
@@ -99,7 +99,7 @@
           "name": "concat_0_marks",
           "type": "text",
           "style": ["text"],
-          "from": {"data": "data_0"},
+          "from": {"data": "data_1"},
           "encode": {
             "update": {
               "align": {"value": "center"},
@@ -143,7 +143,7 @@
           "name": "concat_1_layer_0_marks",
           "type": "rect",
           "style": ["rect"],
-          "from": {"data": "data_1"},
+          "from": {"data": "data_0"},
           "encode": {
             "update": {
               "fill": {"scale": "color", "field": "Origin"},
@@ -197,9 +197,9 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_0", "field": "min_xc"},
-          {"data": "data_1", "field": "x"},
-          {"data": "data_1", "field": "x2"},
+          {"data": "data_1", "field": "min_xc"},
+          {"data": "data_0", "field": "x"},
+          {"data": "data_0", "field": "x2"},
           {"data": "data_2", "field": "xc"}
         ]
       },
@@ -212,8 +212,8 @@
       "type": "ordinal",
       "domain": {
         "fields": [
-          {"data": "data_0", "field": "Origin"},
-          {"data": "data_1", "field": "Origin"}
+          {"data": "data_1", "field": "Origin"},
+          {"data": "data_0", "field": "Origin"}
         ],
         "sort": true
       },
@@ -222,7 +222,7 @@
     {
       "name": "opacity",
       "type": "linear",
-      "domain": {"data": "data_1", "field": "Cylinders"},
+      "domain": {"data": "data_0", "field": "Cylinders"},
       "range": [0.3, 0.8],
       "zero": false
     },
@@ -231,8 +231,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_1", "field": "y"},
-          {"data": "data_1", "field": "y2"},
+          {"data": "data_0", "field": "y"},
+          {"data": "data_0", "field": "y2"},
           {"data": "data_2", "field": "yc"}
         ]
       },

--- a/examples/compiled/rect_mosaic_labelled_with_offset.vg.json
+++ b/examples/compiled/rect_mosaic_labelled_with_offset.vg.json
@@ -85,11 +85,8 @@
       "source": "source_0",
       "transform": [
         {
-          "type": "aggregate",
-          "groupby": ["Origin"],
-          "ops": ["min"],
-          "fields": ["xc"],
-          "as": ["min_xc"]
+          "type": "filter",
+          "expr": "datum[\"nx\"] !== null && !isNaN(datum[\"nx\"]) && datum[\"ny\"] !== null && !isNaN(datum[\"ny\"]) && datum[\"Cylinders\"] !== null && !isNaN(datum[\"Cylinders\"])"
         }
       ]
     },
@@ -98,8 +95,11 @@
       "source": "source_0",
       "transform": [
         {
-          "type": "filter",
-          "expr": "datum[\"nx\"] !== null && !isNaN(datum[\"nx\"]) && datum[\"ny\"] !== null && !isNaN(datum[\"ny\"]) && datum[\"Cylinders\"] !== null && !isNaN(datum[\"Cylinders\"])"
+          "type": "aggregate",
+          "groupby": ["Origin"],
+          "ops": ["min"],
+          "fields": ["xc"],
+          "as": ["min_xc"]
         }
       ]
     },
@@ -136,7 +136,7 @@
           "name": "concat_0_marks",
           "type": "text",
           "style": ["text"],
-          "from": {"data": "data_0"},
+          "from": {"data": "data_1"},
           "encode": {
             "update": {
               "align": {"value": "center"},
@@ -180,7 +180,7 @@
           "name": "concat_1_layer_0_marks",
           "type": "rect",
           "style": ["rect"],
-          "from": {"data": "data_1"},
+          "from": {"data": "data_0"},
           "encode": {
             "update": {
               "fill": {"scale": "color", "field": "Origin"},
@@ -234,9 +234,9 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_0", "field": "min_xc"},
-          {"data": "data_1", "field": "nx"},
-          {"data": "data_1", "field": "nx2"},
+          {"data": "data_1", "field": "min_xc"},
+          {"data": "data_0", "field": "nx"},
+          {"data": "data_0", "field": "nx2"},
           {"data": "data_2", "field": "xc"}
         ]
       },
@@ -249,8 +249,8 @@
       "type": "ordinal",
       "domain": {
         "fields": [
-          {"data": "data_0", "field": "Origin"},
-          {"data": "data_1", "field": "Origin"}
+          {"data": "data_1", "field": "Origin"},
+          {"data": "data_0", "field": "Origin"}
         ],
         "sort": true
       },
@@ -259,7 +259,7 @@
     {
       "name": "opacity",
       "type": "linear",
-      "domain": {"data": "data_1", "field": "Cylinders"},
+      "domain": {"data": "data_0", "field": "Cylinders"},
       "range": [0.3, 0.8],
       "zero": false
     },
@@ -268,8 +268,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_1", "field": "ny"},
-          {"data": "data_1", "field": "ny2"},
+          {"data": "data_0", "field": "ny"},
+          {"data": "data_0", "field": "ny2"},
           {"data": "data_2", "field": "yc"}
         ]
       },

--- a/examples/compiled/repeat_histogram_flights.vg.json
+++ b/examples/compiled/repeat_histogram_flights.vg.json
@@ -10,6 +10,7 @@
       "url": "data/flights-2k.json",
       "format": {"type": "json", "parse": {"date": "date"}},
       "transform": [
+        {"type": "formula", "expr": "hours(datum.date)", "as": "time"},
         {
           "type": "extent",
           "field": "delay",
@@ -40,13 +41,6 @@
             "signal": "child__repeat_column_distance_bin_maxbins_20_distance_extent"
           }
         },
-        {"type": "formula", "expr": "hours(datum.date)", "as": "time"}
-      ]
-    },
-    {
-      "name": "data_0",
-      "source": "source_0",
-      "transform": [
         {
           "type": "extent",
           "field": "time",
@@ -61,22 +55,11 @@
           "extent": {
             "signal": "child__repeat_column_time_bin_maxbins_20_time_extent"
           }
-        },
-        {
-          "type": "aggregate",
-          "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
-          "ops": ["count"],
-          "fields": [null],
-          "as": ["__count"]
-        },
-        {
-          "type": "filter",
-          "expr": "datum[\"bin_maxbins_20_time\"] !== null && !isNaN(datum[\"bin_maxbins_20_time\"])"
         }
       ]
     },
     {
-      "name": "data_1",
+      "name": "data_0",
       "source": "source_0",
       "transform": [
         {
@@ -93,7 +76,7 @@
       ]
     },
     {
-      "name": "data_2",
+      "name": "data_1",
       "source": "source_0",
       "transform": [
         {
@@ -106,6 +89,23 @@
         {
           "type": "filter",
           "expr": "datum[\"bin_maxbins_20_distance\"] !== null && !isNaN(datum[\"bin_maxbins_20_distance\"])"
+        }
+      ]
+    },
+    {
+      "name": "data_2",
+      "source": "source_0",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
+          "ops": ["count"],
+          "fields": [null],
+          "as": ["__count"]
+        },
+        {
+          "type": "filter",
+          "expr": "datum[\"bin_maxbins_20_time\"] !== null && !isNaN(datum[\"bin_maxbins_20_time\"])"
         }
       ]
     }
@@ -124,7 +124,7 @@
           "name": "child__repeat_column_distance_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_2"},
+          "from": {"data": "data_1"},
           "encode": {
             "update": {
               "fill": {"value": "#4c78a8"},
@@ -208,7 +208,7 @@
           "name": "child__repeat_column_delay_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_1"},
+          "from": {"data": "data_0"},
           "encode": {
             "update": {
               "fill": {"value": "#4c78a8"},
@@ -292,7 +292,7 @@
           "name": "child__repeat_column_time_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_0"},
+          "from": {"data": "data_2"},
           "encode": {
             "update": {
               "fill": {"value": "#4c78a8"},
@@ -378,7 +378,7 @@
     {
       "name": "child__repeat_column_distance_y",
       "type": "linear",
-      "domain": {"data": "data_2", "field": "__count"},
+      "domain": {"data": "data_1", "field": "__count"},
       "range": [{"signal": "height"}, 0],
       "nice": true,
       "zero": true
@@ -398,7 +398,7 @@
     {
       "name": "child__repeat_column_delay_y",
       "type": "linear",
-      "domain": {"data": "data_1", "field": "__count"},
+      "domain": {"data": "data_0", "field": "__count"},
       "range": [{"signal": "height"}, 0],
       "nice": true,
       "zero": true
@@ -416,7 +416,7 @@
     {
       "name": "child__repeat_column_time_y",
       "type": "linear",
-      "domain": {"data": "data_0", "field": "__count"},
+      "domain": {"data": "data_2", "field": "__count"},
       "range": [{"signal": "height"}, 0],
       "nice": true,
       "zero": true

--- a/examples/compiled/trellis_area_sort_array.vg.json
+++ b/examples/compiled/trellis_area_sort_array.vg.json
@@ -16,11 +16,6 @@
           "as": "row_symbol_sort_index"
         },
         {
-          "type": "formula",
-          "expr": "datum[\"symbol\"]===\"MSFT\" ? 0 : datum[\"symbol\"]===\"AAPL\" ? 1 : datum[\"symbol\"]===\"IBM\" ? 2 : datum[\"symbol\"]===\"AMZN\" ? 3 : 4",
-          "as": "row_symbol_sort_index"
-        },
-        {
           "type": "impute",
           "field": "price",
           "groupby": ["symbol", "symbol"],

--- a/examples/compiled/trellis_cross_sort_array.vg.json
+++ b/examples/compiled/trellis_cross_sort_array.vg.json
@@ -22,6 +22,16 @@
       "source": "source_0",
       "transform": [
         {
+          "type": "formula",
+          "expr": "datum[\"a\"]===\"B\" ? 0 : datum[\"a\"]===\"C\" ? 1 : datum[\"a\"]===\"A\" ? 2 : 3",
+          "as": "column_a_sort_index"
+        },
+        {
+          "type": "formula",
+          "expr": "datum[\"b\"]===\"Y\" ? 0 : datum[\"b\"]===\"X\" ? 1 : datum[\"b\"]===\"Z\" ? 2 : 3",
+          "as": "row_b_sort_index"
+        },
+        {
           "type": "joinaggregate",
           "as": ["median_x_by_a"],
           "ops": ["median"],
@@ -34,26 +44,6 @@
           "ops": ["median"],
           "fields": ["y"],
           "groupby": ["b"]
-        },
-        {
-          "type": "formula",
-          "expr": "datum[\"a\"]===\"B\" ? 0 : datum[\"a\"]===\"C\" ? 1 : datum[\"a\"]===\"A\" ? 2 : 3",
-          "as": "column_a_sort_index"
-        },
-        {
-          "type": "formula",
-          "expr": "datum[\"b\"]===\"Y\" ? 0 : datum[\"b\"]===\"X\" ? 1 : datum[\"b\"]===\"Z\" ? 2 : 3",
-          "as": "row_b_sort_index"
-        },
-        {
-          "type": "formula",
-          "expr": "datum[\"a\"]===\"B\" ? 0 : datum[\"a\"]===\"C\" ? 1 : datum[\"a\"]===\"A\" ? 2 : 3",
-          "as": "column_a_sort_index"
-        },
-        {
-          "type": "formula",
-          "expr": "datum[\"b\"]===\"Y\" ? 0 : datum[\"b\"]===\"X\" ? 1 : datum[\"b\"]===\"Z\" ? 2 : 3",
-          "as": "row_b_sort_index"
         }
       ]
     },

--- a/examples/compiled/waterfall_chart.vg.json
+++ b/examples/compiled/waterfall_chart.vg.json
@@ -88,7 +88,7 @@
       "transform": [
         {
           "type": "filter",
-          "expr": "datum[\"previous_sum\"] !== null && !isNaN(datum[\"previous_sum\"])"
+          "expr": "datum[\"sum_inc\"] !== null && !isNaN(datum[\"sum_inc\"])"
         }
       ]
     },
@@ -98,7 +98,7 @@
       "transform": [
         {
           "type": "filter",
-          "expr": "datum[\"sum\"] !== null && !isNaN(datum[\"sum\"])"
+          "expr": "datum[\"previous_sum\"] !== null && !isNaN(datum[\"previous_sum\"])"
         }
       ]
     },
@@ -108,7 +108,7 @@
       "transform": [
         {
           "type": "filter",
-          "expr": "datum[\"sum_inc\"] !== null && !isNaN(datum[\"sum_inc\"])"
+          "expr": "datum[\"sum_dec\"] !== null && !isNaN(datum[\"sum_dec\"])"
         }
       ]
     },
@@ -118,7 +118,7 @@
       "transform": [
         {
           "type": "filter",
-          "expr": "datum[\"sum_dec\"] !== null && !isNaN(datum[\"sum_dec\"])"
+          "expr": "datum[\"sum\"] !== null && !isNaN(datum[\"sum\"])"
         }
       ]
     },
@@ -138,7 +138,7 @@
       "name": "layer_0_marks",
       "type": "rect",
       "style": ["bar"],
-      "from": {"data": "data_1"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "fill": [
@@ -163,7 +163,7 @@
       "name": "layer_1_marks",
       "type": "rule",
       "style": ["rule"],
-      "from": {"data": "data_2"},
+      "from": {"data": "data_4"},
       "encode": {
         "update": {
           "opacity": {"value": 1},
@@ -182,7 +182,7 @@
       "name": "layer_2_marks",
       "type": "text",
       "style": ["text"],
-      "from": {"data": "data_3"},
+      "from": {"data": "data_1"},
       "encode": {
         "update": {
           "baseline": {"value": "bottom"},
@@ -202,7 +202,7 @@
       "name": "layer_3_marks",
       "type": "text",
       "style": ["text"],
-      "from": {"data": "data_4"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "baseline": {"value": "top"},
@@ -251,11 +251,11 @@
       "type": "band",
       "domain": {
         "fields": [
-          {"data": "data_1", "field": "label"},
           {"data": "data_2", "field": "label"},
-          {"data": "data_2", "field": "lead"},
-          {"data": "data_3", "field": "label"},
           {"data": "data_4", "field": "label"},
+          {"data": "data_4", "field": "lead"},
+          {"data": "data_1", "field": "label"},
+          {"data": "data_3", "field": "label"},
           {"data": "data_5", "field": "label"}
         ]
       },
@@ -268,11 +268,11 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_1", "field": "previous_sum"},
-          {"data": "data_1", "field": "sum"},
+          {"data": "data_2", "field": "previous_sum"},
           {"data": "data_2", "field": "sum"},
-          {"data": "data_3", "field": "sum_inc"},
-          {"data": "data_4", "field": "sum_dec"},
+          {"data": "data_4", "field": "sum"},
+          {"data": "data_1", "field": "sum_inc"},
+          {"data": "data_3", "field": "sum_dec"},
           {"data": "data_5", "field": "center"}
         ]
       },

--- a/examples/compiled/wheat_wages.vg.json
+++ b/examples/compiled/wheat_wages.vg.json
@@ -17,11 +17,6 @@
       ]
     },
     {
-      "name": "source_2",
-      "url": "data/monarchs.json",
-      "format": {"type": "json"}
-    },
-    {
       "name": "source_0",
       "url": "data/wheat.json",
       "format": {"type": "json", "parse": {"year": "number"}},
@@ -50,15 +45,32 @@
       ]
     },
     {
-      "name": "data_2",
-      "source": "source_2",
+      "name": "source_2",
+      "url": "data/monarchs.json",
+      "format": {"type": "json"},
       "transform": [
+        {
+          "type": "formula",
+          "expr": "((!datum.commonwealth && datum.index % 2) ? -1: 1) + 95",
+          "as": "off2"
+        },
         {
           "type": "formula",
           "expr": "((!datum.commonwealth && datum.index % 2) ? -1: 1) * 2 + 95",
           "as": "offset"
         },
         {"type": "formula", "expr": "95", "as": "y"},
+        {
+          "type": "formula",
+          "expr": "+datum.start + (+datum.end - +datum.start)/2",
+          "as": "x"
+        }
+      ]
+    },
+    {
+      "name": "data_2",
+      "source": "source_2",
+      "transform": [
         {
           "type": "filter",
           "expr": "datum[\"start\"] !== null && !isNaN(datum[\"start\"]) && datum[\"y\"] !== null && !isNaN(datum[\"y\"])"
@@ -69,16 +81,6 @@
       "name": "data_3",
       "source": "source_2",
       "transform": [
-        {
-          "type": "formula",
-          "expr": "((!datum.commonwealth && datum.index % 2) ? -1: 1) + 95",
-          "as": "off2"
-        },
-        {
-          "type": "formula",
-          "expr": "+datum.start + (+datum.end - +datum.start)/2",
-          "as": "x"
-        },
         {
           "type": "filter",
           "expr": "datum[\"x\"] !== null && !isNaN(datum[\"x\"]) && datum[\"off2\"] !== null && !isNaN(datum[\"off2\"])"

--- a/src/compile/data/assemble.ts
+++ b/src/compile/data/assemble.ts
@@ -87,7 +87,6 @@ function makeWalkTree(data: VgData[]) {
       node instanceof SequenceNode ||
       node instanceof FilterInvalidNode ||
       node instanceof FilterNode ||
-      node instanceof CalculateNode ||
       node instanceof GeoPointNode ||
       node instanceof GeoJSONNode ||
       node instanceof AggregateNode ||
@@ -104,11 +103,12 @@ function makeWalkTree(data: VgData[]) {
 
     if (
       node instanceof BinNode ||
+      node instanceof CalculateNode ||
       node instanceof TimeUnitNode ||
       node instanceof ImputeNode ||
       node instanceof StackNode
     ) {
-      dataSource.transform = dataSource.transform.concat(node.assemble());
+      dataSource.transform.push(...node.assemble());
     }
 
     if (node instanceof OutputNode) {

--- a/src/compile/data/calculate.ts
+++ b/src/compile/data/calculate.ts
@@ -4,7 +4,7 @@ import {DateTime} from '../../datetime';
 import {fieldFilterExpression} from '../../predicate';
 import {isSortArray} from '../../sort';
 import {CalculateTransform} from '../../transform';
-import {duplicate, hash, keys, Dict, vals} from '../../util';
+import {duplicate, hash, keys, Dict, vals, entries} from '../../util';
 import {VgFormulaTransform} from '../../vega.schema';
 import {ModelWithField} from '../model';
 import {DataFlowNode} from './dataflow';
@@ -60,6 +60,7 @@ export class CalculateNode extends DataFlowNode {
       if (key in this.calculates) {
         // make sure we are not merging something incompatible
         if (this.calculates[key].calculate !== other.calculates[key].calculate) {
+          // Assertion.
           throw new Error('Merged incompatible calculates.');
         }
       } else {
@@ -91,11 +92,15 @@ export class CalculateNode extends DataFlowNode {
   public assemble(): VgFormulaTransform[] {
     const transforms: VgFormulaTransform[] = [];
 
-    for (const c of vals(this.calculates)) {
+    for (const {key, value} of entries(this.calculates)) {
+      if (key !== value.as) {
+        // Assertion.
+        throw new Error('The key in calculate nodes needs to be the output field name.');
+      }
       transforms.push({
         type: 'formula',
-        expr: c.calculate,
-        as: c.as
+        expr: value.calculate,
+        as: value.as
       });
     }
 

--- a/src/compile/data/calculate.ts
+++ b/src/compile/data/calculate.ts
@@ -60,7 +60,7 @@ export class CalculateNode extends DataFlowNode {
       if (key in this.calculates) {
         // make sure we are not merging something incompatible
         if (this.calculates[key].calculate !== other.calculates[key].calculate) {
-          // Assertion.
+          /* istanbul ignore next: This should never happen. */
           throw new Error('Merged incompatible calculates.');
         }
       } else {
@@ -94,7 +94,7 @@ export class CalculateNode extends DataFlowNode {
 
     for (const {key, value} of entries(this.calculates)) {
       if (key !== value.as) {
-        // Assertion.
+        /* istanbul ignore next: This should never happen. */
         throw new Error('The key in calculate nodes needs to be the output field name.');
       }
       transforms.push({

--- a/src/compile/data/filterinvalid.ts
+++ b/src/compile/data/filterinvalid.ts
@@ -9,10 +9,10 @@ import {DataFlowNode} from './dataflow';
 
 export class FilterInvalidNode extends DataFlowNode {
   public clone() {
-    return new FilterInvalidNode(null, {...this.fieldDefs});
+    return new FilterInvalidNode(null, {...this.filter});
   }
 
-  constructor(parent: DataFlowNode, private fieldDefs: Dict<FieldDef<string>>) {
+  constructor(parent: DataFlowNode, public readonly filter: Dict<FieldDef<string>>) {
     super(parent);
   }
 
@@ -47,14 +47,14 @@ export class FilterInvalidNode extends DataFlowNode {
     return new FilterInvalidNode(parent, filter);
   }
 
-  get filter() {
-    return this.fieldDefs;
+  public dependentFields() {
+    return new Set(keys(this.filter));
   }
 
   // create the VgTransforms for each of the filtered fields
   public assemble(): VgFilterTransform {
     const filters = keys(this.filter).reduce((vegaFilters, field) => {
-      const fieldDef = this.fieldDefs[field];
+      const fieldDef = this.filter[field];
       const ref = fieldRef(fieldDef, {expr: 'datum'});
 
       if (fieldDef !== null) {

--- a/src/compile/data/optimize.ts
+++ b/src/compile/data/optimize.ts
@@ -65,19 +65,13 @@ function optimizationDataflowHelper(dataComponent: DataComponent, model: Model) 
   roots = roots.filter(r => r.numChildren() > 0);
 
   mutatedFlag = runOptimizer(new optimizers.MoveParseUp(), getLeaves(roots), mutatedFlag);
-
   mutatedFlag = runOptimizer(new optimizers.MergeBins(model), getLeaves(roots), mutatedFlag);
-
+  mutatedFlag = runOptimizer(new optimizers.MergeCalculate(), getLeaves(roots), mutatedFlag);
   mutatedFlag = runOptimizer(new optimizers.RemoveDuplicateTimeUnits(), getLeaves(roots), mutatedFlag);
-
   mutatedFlag = runOptimizer(new optimizers.MergeParse(), getLeaves(roots), mutatedFlag);
-
   mutatedFlag = runOptimizer(new optimizers.MergeAggregateNodes(), getLeaves(roots), mutatedFlag);
-
   mutatedFlag = runOptimizer(new optimizers.MergeTimeUnits(), getLeaves(roots), mutatedFlag);
-
   mutatedFlag = runOptimizer(new optimizers.MergeIdenticalNodes(), roots, mutatedFlag);
-
   mutatedFlag = runOptimizer(new optimizers.MergeOutputs(), getLeaves(roots), mutatedFlag);
 
   dataComponent.sources = roots;

--- a/src/compile/data/optimizer.ts
+++ b/src/compile/data/optimizer.ts
@@ -1,6 +1,15 @@
 import {DataFlowNode} from './dataflow';
 import {OptimizerFlags} from './optimizers';
 import {SourceNode} from './source';
+import {GraticuleNode} from './graticule';
+import {SequenceNode} from './sequence';
+
+/**
+ * Whether this dataflow node is the source of the dataflow that produces data i.e. a source or a generator.
+ */
+export function isDataSourceNode(node: DataFlowNode) {
+  return node instanceof SourceNode || node instanceof GraticuleNode || node instanceof SequenceNode;
+}
 
 /**
  * Abstract base class for BottomUpOptimizer and TopDownOptimizer.
@@ -64,7 +73,7 @@ export abstract class BottomUpOptimizer extends OptimizerBase {
   }
 
   public optimizeNextFromLeaves(node: DataFlowNode): boolean {
-    if (node instanceof SourceNode) {
+    if (isDataSourceNode(node)) {
       return false;
     }
     const next = node.parent;

--- a/src/compile/data/optimizers.ts
+++ b/src/compile/data/optimizers.ts
@@ -438,7 +438,9 @@ export class MergeCalculate extends BottomUpOptimizer {
     const moveCalcssUp = !(
       parent instanceof SourceNode ||
       parent instanceof ParseNode ||
-      // identifier nodes need to stay before filters
+      // Filter nodes stay before calculates to reduce computation.
+      parent instanceof FilterNode ||
+      // Identifier nodes need to stay before calculates.
       parent instanceof IdentifierNode
     );
 

--- a/src/compile/data/optimizers.ts
+++ b/src/compile/data/optimizers.ts
@@ -356,7 +356,7 @@ export class MergeAggregateNodes extends BottomUpOptimizer {
 }
 
 /**
- * Merge bin nodes and move bin nodes up through forks. Stop at filters and parse as we want them to stay before the bin node.
+ * Merge bin nodes and move them up through forks. Stop at filters and parse as we want them to stay before the bin node.
  */
 export class MergeBins extends BottomUpOptimizer {
   constructor(private model: Model) {
@@ -404,7 +404,7 @@ export class MergeBins extends BottomUpOptimizer {
 }
 
 /**
- * Merge calculate nodes and move bin nodes up through forks. Stop at filters and parse as we want them to stay before the calculate node.
+ * Merge calculate nodes and move them up through forks. Stop at filters and parse as we want them to stay before the calculate node.
  *
  * Similar to MergeBins but for Calculate Nodes.
  */
@@ -434,21 +434,21 @@ export class MergeCalculate extends BottomUpOptimizer {
     }
 
     if (promotableCalcs.length > 0) {
-      const promotedBin = promotableCalcs.pop();
-      for (const bin of promotableCalcs) {
-        promotedBin.merge(bin);
+      const promotedCalculate = promotableCalcs.pop();
+      for (const calc of promotableCalcs) {
+        promotedCalculate.merge(calc);
       }
       this.setMutated();
       if (parent instanceof CalculateNode) {
-        parent.merge(promotedBin);
+        parent.merge(promotedCalculate);
       } else {
-        promotedBin.swapWithParent();
+        promotedCalculate.swapWithParent();
       }
     }
     if (remainingCalcs.length > 1) {
-      const remainingBin = remainingCalcs.pop();
-      for (const bin of remainingCalcs) {
-        remainingBin.merge(bin);
+      const remainingCalculates = remainingCalcs.pop();
+      for (const calc of remainingCalcs) {
+        remainingCalculates.merge(calc);
       }
       this.setMutated();
     }

--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -127,7 +127,7 @@ export function parseTransformArray(head: DataFlowNode, model: Model, ancestorPa
     let transformNode: DataFlowNode;
 
     if (isCalculate(t)) {
-      transformNode = head = new CalculateNode(head, t);
+      transformNode = head = CalculateNode.makeFromTransform(head, t);
       derivedType = 'derived';
     } else if (isFilter(t)) {
       transformNode = head = ParseNode.makeImplicitFromFilterTransform(head, t, ancestorParse) || head;

--- a/src/compile/data/sequence.ts
+++ b/src/compile/data/sequence.ts
@@ -11,6 +11,10 @@ export class SequenceNode extends DataFlowNode {
     super(parent);
   }
 
+  public producedFields() {
+    return new Set(this.params.as || 'data');
+  }
+
   public assemble(): VgSequenceTransform {
     return {
       type: 'sequence',

--- a/src/compile/data/sequence.ts
+++ b/src/compile/data/sequence.ts
@@ -12,7 +12,7 @@ export class SequenceNode extends DataFlowNode {
   }
 
   public producedFields() {
-    return new Set(this.params.as || 'data');
+    return new Set([this.params.as || 'data']);
   }
 
   public assemble(): VgSequenceTransform {

--- a/test/compile/data/filterinvalid.test.ts
+++ b/test/compile/data/filterinvalid.test.ts
@@ -1,4 +1,3 @@
-import {assert} from 'chai';
 import {FilterInvalidNode} from '../../../src/compile/data/filterinvalid';
 import {UnitModel} from '../../../src/compile/unit';
 import {NormalizedUnitSpec, TopLevel} from '../../../src/spec';
@@ -9,7 +8,7 @@ function parse(model: UnitModel) {
   return FilterInvalidNode.make(null, model);
 }
 
-describe('compile/data/nullfilter', () => {
+describe('compile/data/filterinvalid', () => {
   describe('compileUnit', () => {
     const spec: NormalizedUnitSpec = {
       mark: 'point',
@@ -23,7 +22,7 @@ describe('compile/data/nullfilter', () => {
 
     it('should add filterNull for Q and T by default', () => {
       const model = parseUnitModelWithScale(spec);
-      assert.deepEqual(parse(model).filter, {
+      expect(parse(model).filter).toEqual({
         qq: {field: 'qq', type: 'quantitative'},
         tt: {field: 'tt', type: 'temporal'}
       });
@@ -37,7 +36,7 @@ describe('compile/data/nullfilter', () => {
           }
         })
       );
-      assert.deepEqual(parse(model).filter, {
+      expect(parse(model).filter).toEqual({
         qq: {field: 'qq', type: 'quantitative'},
         tt: {field: 'tt', type: 'temporal'}
       });
@@ -51,7 +50,7 @@ describe('compile/data/nullfilter', () => {
           }
         })
       );
-      assert.deepEqual(parse(model), null);
+      expect(parse(model)).toBeNull();
     });
 
     it('should add no null filter for count field', () => {
@@ -62,7 +61,14 @@ describe('compile/data/nullfilter', () => {
         }
       });
 
-      assert.deepEqual(parse(model), null);
+      expect(parse(model)).toBeNull();
+    });
+  });
+
+  describe('dependentFields', () => {
+    it('should return the fields it filters', () => {
+      const node = new FilterInvalidNode(null, {foo: {field: 'foo', type: 'quantitative'}});
+      expect(node.dependentFields()).toEqual(new Set(['foo']));
     });
   });
 
@@ -75,7 +81,7 @@ describe('compile/data/nullfilter', () => {
         }
       });
 
-      assert.deepEqual(parse(model).assemble(), {
+      expect(parse(model).assemble()).toEqual({
         type: 'filter',
         expr: 'datum["foo"] !== null && !isNaN(datum["foo"])'
       });
@@ -89,7 +95,7 @@ describe('compile/data/nullfilter', () => {
         }
       });
 
-      assert.deepEqual(parse(model).assemble(), {
+      expect(parse(model).assemble()).toEqual({
         type: 'filter',
         expr: 'datum["foo.bar"] !== null && !isNaN(datum["foo.bar"])'
       });

--- a/test/compile/data/sequence.test.ts
+++ b/test/compile/data/sequence.test.ts
@@ -18,7 +18,29 @@ describe('compile/data/sequence', () => {
         step: 2
       });
     });
+
+    it('should return correct default produced fields', () => {
+      const params = {
+        start: 1,
+        stop: 10,
+        step: 2
+      };
+      const sequence = new SequenceNode(null, params);
+      expect(sequence.producedFields()).toEqual(new Set(['data']));
+    });
+
+    it('should return correct produced fields', () => {
+      const params = {
+        start: 1,
+        stop: 10,
+        step: 2,
+        as: 'foo'
+      };
+      const sequence = new SequenceNode(null, params);
+      expect(sequence.producedFields()).toEqual(new Set(['foo']));
+    });
   });
+
   it('should parse and add generator transform correctly', () => {
     const model = parseUnitModelWithScaleAndLayoutSize({
       data: {


### PR DESCRIPTION
In this PR, I am adding a new optimizer that (similar to the bin optimizer) merges calculate nodes at forks and moves them up in the dataflow (towards the source). I extended the calculate node to support multiple calculates in a single node. 