### PR TITLE
fix: optimize parse correctly, correctly mark sources, remove iterateFromLeaves

### DIFF
--- a/examples/compiled/interactive_layered_crossfilter.vg.json
+++ b/examples/compiled/interactive_layered_crossfilter.vg.json
@@ -11,19 +11,20 @@
       "url": "data/flights-2k.json",
       "format": {"type": "json", "parse": {"date": "date"}},
       "transform": [
+        {"type": "formula", "expr": "hours(datum.date)", "as": "time"},
         {
           "type": "extent",
-          "field": "delay",
-          "signal": "child__repeat_column_delay_layer_1_bin_maxbins_20_delay_extent"
+          "field": "time",
+          "signal": "child__repeat_column_time_layer_1_bin_maxbins_20_time_extent"
         },
         {
           "type": "bin",
-          "field": "delay",
-          "as": ["bin_maxbins_20_delay", "bin_maxbins_20_delay_end"],
-          "signal": "child__repeat_column_delay_layer_1_bin_maxbins_20_delay_bins",
+          "field": "time",
+          "as": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
+          "signal": "child__repeat_column_time_layer_1_bin_maxbins_20_time_bins",
           "maxbins": 20,
           "extent": {
-            "signal": "child__repeat_column_delay_layer_1_bin_maxbins_20_delay_extent"
+            "signal": "child__repeat_column_time_layer_1_bin_maxbins_20_time_extent"
           }
         },
         {
@@ -41,7 +42,21 @@
             "signal": "child__repeat_column_distance_layer_0_bin_maxbins_20_distance_extent"
           }
         },
-        {"type": "formula", "expr": "hours(datum.date)", "as": "time"}
+        {
+          "type": "extent",
+          "field": "delay",
+          "signal": "child__repeat_column_delay_layer_0_bin_maxbins_20_delay_extent"
+        },
+        {
+          "type": "bin",
+          "field": "delay",
+          "as": ["bin_maxbins_20_delay", "bin_maxbins_20_delay_end"],
+          "signal": "child__repeat_column_delay_layer_0_bin_maxbins_20_delay_bins",
+          "maxbins": 20,
+          "extent": {
+            "signal": "child__repeat_column_delay_layer_0_bin_maxbins_20_delay_extent"
+          }
+        }
       ]
     },
     {
@@ -49,19 +64,8 @@
       "source": "source_0",
       "transform": [
         {
-          "type": "extent",
-          "field": "time",
-          "signal": "child__repeat_column_time_layer_1_bin_maxbins_20_time_extent"
-        },
-        {
-          "type": "bin",
-          "field": "time",
-          "as": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
-          "signal": "child__repeat_column_time_layer_1_bin_maxbins_20_time_bins",
-          "maxbins": 20,
-          "extent": {
-            "signal": "child__repeat_column_time_layer_1_bin_maxbins_20_time_extent"
-          }
+          "type": "filter",
+          "expr": "!(length(data(\"brush_store\"))) || (vlSelectionTest(\"brush_store\", datum))"
         }
       ]
     },
@@ -69,10 +73,6 @@
       "name": "data_1",
       "source": "data_0",
       "transform": [
-        {
-          "type": "filter",
-          "expr": "!(length(data(\"brush_store\"))) || (vlSelectionTest(\"brush_store\", datum))"
-        },
         {
           "type": "aggregate",
           "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
@@ -92,30 +92,20 @@
       "transform": [
         {
           "type": "aggregate",
-          "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
+          "groupby": ["bin_maxbins_20_distance", "bin_maxbins_20_distance_end"],
           "ops": ["count"],
           "fields": [null],
           "as": ["__count"]
         },
         {
           "type": "filter",
-          "expr": "datum[\"bin_maxbins_20_time\"] !== null && !isNaN(datum[\"bin_maxbins_20_time\"])"
+          "expr": "datum[\"bin_maxbins_20_distance\"] !== null && !isNaN(datum[\"bin_maxbins_20_distance\"])"
         }
       ]
     },
     {
       "name": "data_3",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "!(length(data(\"brush_store\"))) || (vlSelectionTest(\"brush_store\", datum))"
-        }
-      ]
-    },
-    {
-      "name": "data_4",
-      "source": "data_3",
+      "source": "data_0",
       "transform": [
         {
           "type": "aggregate",
@@ -131,8 +121,8 @@
       ]
     },
     {
-      "name": "data_5",
-      "source": "data_3",
+      "name": "data_4",
+      "source": "source_0",
       "transform": [
         {
           "type": "aggregate",
@@ -144,6 +134,23 @@
         {
           "type": "filter",
           "expr": "datum[\"bin_maxbins_20_distance\"] !== null && !isNaN(datum[\"bin_maxbins_20_distance\"])"
+        }
+      ]
+    },
+    {
+      "name": "data_5",
+      "source": "source_0",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["bin_maxbins_20_delay", "bin_maxbins_20_delay_end"],
+          "ops": ["count"],
+          "fields": [null],
+          "as": ["__count"]
+        },
+        {
+          "type": "filter",
+          "expr": "datum[\"bin_maxbins_20_delay\"] !== null && !isNaN(datum[\"bin_maxbins_20_delay\"])"
         }
       ]
     },
@@ -153,31 +160,14 @@
       "transform": [
         {
           "type": "aggregate",
-          "groupby": ["bin_maxbins_20_distance", "bin_maxbins_20_distance_end"],
+          "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
           "ops": ["count"],
           "fields": [null],
           "as": ["__count"]
         },
         {
           "type": "filter",
-          "expr": "datum[\"bin_maxbins_20_distance\"] !== null && !isNaN(datum[\"bin_maxbins_20_distance\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_7",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "aggregate",
-          "groupby": ["bin_maxbins_20_delay", "bin_maxbins_20_delay_end"],
-          "ops": ["count"],
-          "fields": [null],
-          "as": ["__count"]
-        },
-        {
-          "type": "filter",
-          "expr": "datum[\"bin_maxbins_20_delay\"] !== null && !isNaN(datum[\"bin_maxbins_20_delay\"])"
+          "expr": "datum[\"bin_maxbins_20_time\"] !== null && !isNaN(datum[\"bin_maxbins_20_time\"])"
         }
       ]
     }
@@ -408,7 +398,7 @@
           "name": "child__repeat_column_distance_layer_0_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_6"},
+          "from": {"data": "data_4"},
           "encode": {
             "update": {
               "fill": {"value": "#ddd"},
@@ -448,7 +438,7 @@
           "name": "child__repeat_column_distance_layer_1_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_5"},
+          "from": {"data": "data_2"},
           "encode": {
             "update": {
               "fill": {"value": "#4c78a8"},
@@ -776,7 +766,7 @@
           "name": "child__repeat_column_delay_layer_0_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_7"},
+          "from": {"data": "data_5"},
           "encode": {
             "update": {
               "fill": {"value": "#ddd"},
@@ -816,7 +806,7 @@
           "name": "child__repeat_column_delay_layer_1_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_4"},
+          "from": {"data": "data_3"},
           "encode": {
             "update": {
               "fill": {"value": "#4c78a8"},
@@ -1144,7 +1134,7 @@
           "name": "child__repeat_column_time_layer_0_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_2"},
+          "from": {"data": "data_6"},
           "encode": {
             "update": {
               "fill": {"value": "#ddd"},
@@ -1311,8 +1301,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_6", "field": "__count"},
-          {"data": "data_5", "field": "__count"}
+          {"data": "data_4", "field": "__count"},
+          {"data": "data_2", "field": "__count"}
         ]
       },
       "range": [{"signal": "height"}, 0],
@@ -1323,11 +1313,11 @@
       "name": "child__repeat_column_delay_x",
       "type": "linear",
       "domain": {
-        "signal": "[child__repeat_column_delay_layer_1_bin_maxbins_20_delay_bins.start, child__repeat_column_delay_layer_1_bin_maxbins_20_delay_bins.stop]"
+        "signal": "[child__repeat_column_delay_layer_0_bin_maxbins_20_delay_bins.start, child__repeat_column_delay_layer_0_bin_maxbins_20_delay_bins.stop]"
       },
       "range": [0, {"signal": "width"}],
       "bins": {
-        "signal": "child__repeat_column_delay_layer_1_bin_maxbins_20_delay_bins"
+        "signal": "child__repeat_column_delay_layer_0_bin_maxbins_20_delay_bins"
       },
       "zero": false
     },
@@ -1336,8 +1326,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_7", "field": "__count"},
-          {"data": "data_4", "field": "__count"}
+          {"data": "data_5", "field": "__count"},
+          {"data": "data_3", "field": "__count"}
         ]
       },
       "range": [{"signal": "height"}, 0],
@@ -1361,7 +1351,7 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_2", "field": "__count"},
+          {"data": "data_6", "field": "__count"},
           {"data": "data_1", "field": "__count"}
         ]
       },

--- a/examples/compiled/interactive_layered_crossfilter_discrete.vg.json
+++ b/examples/compiled/interactive_layered_crossfilter_discrete.vg.json
@@ -11,19 +11,20 @@
       "url": "data/flights-2k.json",
       "format": {"type": "json", "parse": {"date": "date"}},
       "transform": [
+        {"type": "formula", "expr": "hours(datum.date)", "as": "time"},
         {
           "type": "extent",
-          "field": "delay",
-          "signal": "child__repeat_column_delay_layer_1_bin_maxbins_20_delay_extent"
+          "field": "time",
+          "signal": "child__repeat_column_time_layer_1_bin_maxbins_20_time_extent"
         },
         {
           "type": "bin",
-          "field": "delay",
-          "as": ["bin_maxbins_20_delay", "bin_maxbins_20_delay_end"],
-          "signal": "child__repeat_column_delay_layer_1_bin_maxbins_20_delay_bins",
+          "field": "time",
+          "as": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
+          "signal": "child__repeat_column_time_layer_1_bin_maxbins_20_time_bins",
           "maxbins": 20,
           "extent": {
-            "signal": "child__repeat_column_delay_layer_1_bin_maxbins_20_delay_extent"
+            "signal": "child__repeat_column_time_layer_1_bin_maxbins_20_time_extent"
           }
         },
         {
@@ -41,7 +42,21 @@
             "signal": "child__repeat_column_distance_layer_0_bin_maxbins_20_distance_extent"
           }
         },
-        {"type": "formula", "expr": "hours(datum.date)", "as": "time"}
+        {
+          "type": "extent",
+          "field": "delay",
+          "signal": "child__repeat_column_delay_layer_0_bin_maxbins_20_delay_extent"
+        },
+        {
+          "type": "bin",
+          "field": "delay",
+          "as": ["bin_maxbins_20_delay", "bin_maxbins_20_delay_end"],
+          "signal": "child__repeat_column_delay_layer_0_bin_maxbins_20_delay_bins",
+          "maxbins": 20,
+          "extent": {
+            "signal": "child__repeat_column_delay_layer_0_bin_maxbins_20_delay_extent"
+          }
+        }
       ]
     },
     {
@@ -49,19 +64,8 @@
       "source": "source_0",
       "transform": [
         {
-          "type": "extent",
-          "field": "time",
-          "signal": "child__repeat_column_time_layer_1_bin_maxbins_20_time_extent"
-        },
-        {
-          "type": "bin",
-          "field": "time",
-          "as": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
-          "signal": "child__repeat_column_time_layer_1_bin_maxbins_20_time_bins",
-          "maxbins": 20,
-          "extent": {
-            "signal": "child__repeat_column_time_layer_1_bin_maxbins_20_time_extent"
-          }
+          "type": "filter",
+          "expr": "!(length(data(\"brush_store\"))) || (vlSelectionTest(\"brush_store\", datum))"
         }
       ]
     },
@@ -69,10 +73,6 @@
       "name": "data_1",
       "source": "data_0",
       "transform": [
-        {
-          "type": "filter",
-          "expr": "!(length(data(\"brush_store\"))) || (vlSelectionTest(\"brush_store\", datum))"
-        },
         {
           "type": "aggregate",
           "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
@@ -92,30 +92,20 @@
       "transform": [
         {
           "type": "aggregate",
-          "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
+          "groupby": ["bin_maxbins_20_distance", "bin_maxbins_20_distance_end"],
           "ops": ["count"],
           "fields": [null],
           "as": ["__count"]
         },
         {
           "type": "filter",
-          "expr": "datum[\"bin_maxbins_20_time\"] !== null && !isNaN(datum[\"bin_maxbins_20_time\"])"
+          "expr": "datum[\"bin_maxbins_20_distance\"] !== null && !isNaN(datum[\"bin_maxbins_20_distance\"])"
         }
       ]
     },
     {
       "name": "data_3",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "!(length(data(\"brush_store\"))) || (vlSelectionTest(\"brush_store\", datum))"
-        }
-      ]
-    },
-    {
-      "name": "data_4",
-      "source": "data_3",
+      "source": "data_0",
       "transform": [
         {
           "type": "aggregate",
@@ -131,8 +121,8 @@
       ]
     },
     {
-      "name": "data_5",
-      "source": "data_3",
+      "name": "data_4",
+      "source": "source_0",
       "transform": [
         {
           "type": "aggregate",
@@ -144,6 +134,23 @@
         {
           "type": "filter",
           "expr": "datum[\"bin_maxbins_20_distance\"] !== null && !isNaN(datum[\"bin_maxbins_20_distance\"])"
+        }
+      ]
+    },
+    {
+      "name": "data_5",
+      "source": "source_0",
+      "transform": [
+        {
+          "type": "aggregate",
+          "groupby": ["bin_maxbins_20_delay", "bin_maxbins_20_delay_end"],
+          "ops": ["count"],
+          "fields": [null],
+          "as": ["__count"]
+        },
+        {
+          "type": "filter",
+          "expr": "datum[\"bin_maxbins_20_delay\"] !== null && !isNaN(datum[\"bin_maxbins_20_delay\"])"
         }
       ]
     },
@@ -153,31 +160,14 @@
       "transform": [
         {
           "type": "aggregate",
-          "groupby": ["bin_maxbins_20_distance", "bin_maxbins_20_distance_end"],
+          "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
           "ops": ["count"],
           "fields": [null],
           "as": ["__count"]
         },
         {
           "type": "filter",
-          "expr": "datum[\"bin_maxbins_20_distance\"] !== null && !isNaN(datum[\"bin_maxbins_20_distance\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_7",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "aggregate",
-          "groupby": ["bin_maxbins_20_delay", "bin_maxbins_20_delay_end"],
-          "ops": ["count"],
-          "fields": [null],
-          "as": ["__count"]
-        },
-        {
-          "type": "filter",
-          "expr": "datum[\"bin_maxbins_20_delay\"] !== null && !isNaN(datum[\"bin_maxbins_20_delay\"])"
+          "expr": "datum[\"bin_maxbins_20_time\"] !== null && !isNaN(datum[\"bin_maxbins_20_time\"])"
         }
       ]
     }
@@ -244,7 +234,7 @@
           "name": "child__repeat_column_distance_layer_0_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_6"},
+          "from": {"data": "data_4"},
           "encode": {
             "update": {
               "fill": {"value": "#ddd"},
@@ -284,7 +274,7 @@
           "name": "child__repeat_column_distance_layer_1_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_5"},
+          "from": {"data": "data_2"},
           "encode": {
             "update": {
               "fill": {"value": "#4c78a8"},
@@ -406,7 +396,7 @@
           "name": "child__repeat_column_delay_layer_0_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_7"},
+          "from": {"data": "data_5"},
           "encode": {
             "update": {
               "fill": {"value": "#ddd"},
@@ -446,7 +436,7 @@
           "name": "child__repeat_column_delay_layer_1_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_4"},
+          "from": {"data": "data_3"},
           "encode": {
             "update": {
               "fill": {"value": "#4c78a8"},
@@ -568,7 +558,7 @@
           "name": "child__repeat_column_time_layer_0_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_2"},
+          "from": {"data": "data_6"},
           "encode": {
             "update": {
               "fill": {"value": "#ddd"},
@@ -693,8 +683,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_6", "field": "__count"},
-          {"data": "data_5", "field": "__count"}
+          {"data": "data_4", "field": "__count"},
+          {"data": "data_2", "field": "__count"}
         ]
       },
       "range": [{"signal": "height"}, 0],
@@ -705,11 +695,11 @@
       "name": "child__repeat_column_delay_x",
       "type": "linear",
       "domain": {
-        "signal": "[child__repeat_column_delay_layer_1_bin_maxbins_20_delay_bins.start, child__repeat_column_delay_layer_1_bin_maxbins_20_delay_bins.stop]"
+        "signal": "[child__repeat_column_delay_layer_0_bin_maxbins_20_delay_bins.start, child__repeat_column_delay_layer_0_bin_maxbins_20_delay_bins.stop]"
       },
       "range": [0, {"signal": "width"}],
       "bins": {
-        "signal": "child__repeat_column_delay_layer_1_bin_maxbins_20_delay_bins"
+        "signal": "child__repeat_column_delay_layer_0_bin_maxbins_20_delay_bins"
       },
       "zero": false
     },
@@ -718,8 +708,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_7", "field": "__count"},
-          {"data": "data_4", "field": "__count"}
+          {"data": "data_5", "field": "__count"},
+          {"data": "data_3", "field": "__count"}
         ]
       },
       "range": [{"signal": "height"}, 0],
@@ -743,7 +733,7 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_2", "field": "__count"},
+          {"data": "data_6", "field": "__count"},
           {"data": "data_1", "field": "__count"}
         ]
       },

--- a/examples/compiled/line_color_binned.vg.json
+++ b/examples/compiled/line_color_binned.vg.json
@@ -10,7 +10,7 @@
     {
       "name": "source_0",
       "url": "data/cars.json",
-      "format": {"type": "json", "parse": {"Year": "date"}},
+      "format": {"type": "json"},
       "transform": [
         {
           "type": "extent",
@@ -28,6 +28,7 @@
           "maxbins": 6,
           "extent": {"signal": "bin_maxbins_6_Acceleration_extent"}
         },
+        {"type": "formula", "expr": "toDate(datum[\"Year\"])", "as": "Year"},
         {
           "type": "aggregate",
           "groupby": [

--- a/examples/compiled/repeat_histogram_flights.vg.json
+++ b/examples/compiled/repeat_histogram_flights.vg.json
@@ -10,19 +10,20 @@
       "url": "data/flights-2k.json",
       "format": {"type": "json", "parse": {"date": "date"}},
       "transform": [
+        {"type": "formula", "expr": "hours(datum.date)", "as": "time"},
         {
           "type": "extent",
-          "field": "delay",
-          "signal": "child__repeat_column_delay_bin_maxbins_20_delay_extent"
+          "field": "time",
+          "signal": "child__repeat_column_time_bin_maxbins_20_time_extent"
         },
         {
           "type": "bin",
-          "field": "delay",
-          "as": ["bin_maxbins_20_delay", "bin_maxbins_20_delay_end"],
-          "signal": "child__repeat_column_delay_bin_maxbins_20_delay_bins",
+          "field": "time",
+          "as": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
+          "signal": "child__repeat_column_time_bin_maxbins_20_time_bins",
           "maxbins": 20,
           "extent": {
-            "signal": "child__repeat_column_delay_bin_maxbins_20_delay_extent"
+            "signal": "child__repeat_column_time_bin_maxbins_20_time_extent"
           }
         },
         {
@@ -40,28 +41,27 @@
             "signal": "child__repeat_column_distance_bin_maxbins_20_distance_extent"
           }
         },
-        {"type": "formula", "expr": "hours(datum.date)", "as": "time"}
+        {
+          "type": "extent",
+          "field": "delay",
+          "signal": "child__repeat_column_delay_bin_maxbins_20_delay_extent"
+        },
+        {
+          "type": "bin",
+          "field": "delay",
+          "as": ["bin_maxbins_20_delay", "bin_maxbins_20_delay_end"],
+          "signal": "child__repeat_column_delay_bin_maxbins_20_delay_bins",
+          "maxbins": 20,
+          "extent": {
+            "signal": "child__repeat_column_delay_bin_maxbins_20_delay_extent"
+          }
+        }
       ]
     },
     {
       "name": "data_0",
       "source": "source_0",
       "transform": [
-        {
-          "type": "extent",
-          "field": "time",
-          "signal": "child__repeat_column_time_bin_maxbins_20_time_extent"
-        },
-        {
-          "type": "bin",
-          "field": "time",
-          "as": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
-          "signal": "child__repeat_column_time_bin_maxbins_20_time_bins",
-          "maxbins": 20,
-          "extent": {
-            "signal": "child__repeat_column_time_bin_maxbins_20_time_extent"
-          }
-        },
         {
           "type": "aggregate",
           "groupby": ["bin_maxbins_20_time", "bin_maxbins_20_time_end"],
@@ -81,14 +81,14 @@
       "transform": [
         {
           "type": "aggregate",
-          "groupby": ["bin_maxbins_20_delay", "bin_maxbins_20_delay_end"],
+          "groupby": ["bin_maxbins_20_distance", "bin_maxbins_20_distance_end"],
           "ops": ["count"],
           "fields": [null],
           "as": ["__count"]
         },
         {
           "type": "filter",
-          "expr": "datum[\"bin_maxbins_20_delay\"] !== null && !isNaN(datum[\"bin_maxbins_20_delay\"])"
+          "expr": "datum[\"bin_maxbins_20_distance\"] !== null && !isNaN(datum[\"bin_maxbins_20_distance\"])"
         }
       ]
     },
@@ -98,14 +98,14 @@
       "transform": [
         {
           "type": "aggregate",
-          "groupby": ["bin_maxbins_20_distance", "bin_maxbins_20_distance_end"],
+          "groupby": ["bin_maxbins_20_delay", "bin_maxbins_20_delay_end"],
           "ops": ["count"],
           "fields": [null],
           "as": ["__count"]
         },
         {
           "type": "filter",
-          "expr": "datum[\"bin_maxbins_20_distance\"] !== null && !isNaN(datum[\"bin_maxbins_20_distance\"])"
+          "expr": "datum[\"bin_maxbins_20_delay\"] !== null && !isNaN(datum[\"bin_maxbins_20_delay\"])"
         }
       ]
     }
@@ -124,7 +124,7 @@
           "name": "child__repeat_column_distance_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_2"},
+          "from": {"data": "data_1"},
           "encode": {
             "update": {
               "fill": {"value": "#4c78a8"},
@@ -208,7 +208,7 @@
           "name": "child__repeat_column_delay_marks",
           "type": "rect",
           "style": ["bar"],
-          "from": {"data": "data_1"},
+          "from": {"data": "data_2"},
           "encode": {
             "update": {
               "fill": {"value": "#4c78a8"},
@@ -378,7 +378,7 @@
     {
       "name": "child__repeat_column_distance_y",
       "type": "linear",
-      "domain": {"data": "data_2", "field": "__count"},
+      "domain": {"data": "data_1", "field": "__count"},
       "range": [{"signal": "height"}, 0],
       "nice": true,
       "zero": true
@@ -398,7 +398,7 @@
     {
       "name": "child__repeat_column_delay_y",
       "type": "linear",
-      "domain": {"data": "data_1", "field": "__count"},
+      "domain": {"data": "data_2", "field": "__count"},
       "range": [{"signal": "height"}, 0],
       "nice": true,
       "zero": true

--- a/src/compile/data/assemble.ts
+++ b/src/compile/data/assemble.ts
@@ -108,7 +108,7 @@ function makeWalkTree(data: VgData[]) {
       node instanceof ImputeNode ||
       node instanceof StackNode
     ) {
-      dataSource.transform = dataSource.transform.concat(node.assemble());
+      dataSource.transform.push(...node.assemble());
     }
 
     if (node instanceof OutputNode) {

--- a/src/compile/data/filterinvalid.ts
+++ b/src/compile/data/filterinvalid.ts
@@ -9,10 +9,10 @@ import {DataFlowNode} from './dataflow';
 
 export class FilterInvalidNode extends DataFlowNode {
   public clone() {
-    return new FilterInvalidNode(null, {...this.fieldDefs});
+    return new FilterInvalidNode(null, {...this.filter});
   }
 
-  constructor(parent: DataFlowNode, private fieldDefs: Dict<FieldDef<string>>) {
+  constructor(parent: DataFlowNode, public readonly filter: Dict<FieldDef<string>>) {
     super(parent);
   }
 
@@ -47,14 +47,14 @@ export class FilterInvalidNode extends DataFlowNode {
     return new FilterInvalidNode(parent, filter);
   }
 
-  get filter() {
-    return this.fieldDefs;
+  public dependentFields() {
+    return new Set(keys(this.filter));
   }
 
   // create the VgTransforms for each of the filtered fields
   public assemble(): VgFilterTransform {
     const filters = keys(this.filter).reduce((vegaFilters, field) => {
-      const fieldDef = this.fieldDefs[field];
+      const fieldDef = this.filter[field];
       const ref = fieldRef(fieldDef, {expr: 'datum'});
 
       if (fieldDef !== null) {

--- a/src/compile/data/optimize.ts
+++ b/src/compile/data/optimize.ts
@@ -65,19 +65,12 @@ function optimizationDataflowHelper(dataComponent: DataComponent, model: Model) 
   roots = roots.filter(r => r.numChildren() > 0);
 
   mutatedFlag = runOptimizer(new optimizers.MoveParseUp(), getLeaves(roots), mutatedFlag);
-
   mutatedFlag = runOptimizer(new optimizers.MergeBins(model), getLeaves(roots), mutatedFlag);
-
   mutatedFlag = runOptimizer(new optimizers.RemoveDuplicateTimeUnits(), getLeaves(roots), mutatedFlag);
-
   mutatedFlag = runOptimizer(new optimizers.MergeParse(), getLeaves(roots), mutatedFlag);
-
-  mutatedFlag = runOptimizer(new optimizers.MergeAggregateNodes(), getLeaves(roots), mutatedFlag);
-
+  mutatedFlag = runOptimizer(new optimizers.MergeAggregates(), getLeaves(roots), mutatedFlag);
   mutatedFlag = runOptimizer(new optimizers.MergeTimeUnits(), getLeaves(roots), mutatedFlag);
-
   mutatedFlag = runOptimizer(new optimizers.MergeIdenticalNodes(), roots, mutatedFlag);
-
   mutatedFlag = runOptimizer(new optimizers.MergeOutputs(), getLeaves(roots), mutatedFlag);
 
   dataComponent.sources = roots;

--- a/src/compile/data/optimizer.ts
+++ b/src/compile/data/optimizer.ts
@@ -1,6 +1,15 @@
 import {DataFlowNode} from './dataflow';
 import {OptimizerFlags} from './optimizers';
 import {SourceNode} from './source';
+import {GraticuleNode} from './graticule';
+import {SequenceNode} from './sequence';
+
+/**
+ * Whether this dataflow node is the source of the dataflow that produces data i.e. a source or a generator.
+ */
+export function isDataSourceNode(node: DataFlowNode) {
+  return node instanceof SourceNode || node instanceof GraticuleNode || node instanceof SequenceNode;
+}
 
 /**
  * Abstract base class for BottomUpOptimizer and TopDownOptimizer.
@@ -64,7 +73,7 @@ export abstract class BottomUpOptimizer extends OptimizerBase {
   }
 
   public optimizeNextFromLeaves(node: DataFlowNode): boolean {
-    if (node instanceof SourceNode) {
+    if (isDataSourceNode(node)) {
       return false;
     }
     const next = node.parent;

--- a/src/compile/data/optimizers.ts
+++ b/src/compile/data/optimizers.ts
@@ -285,12 +285,11 @@ export class MergeParse extends BottomUpOptimizer {
           if (commonParse[k] === undefined) {
             commonParse[k] = parse[k];
           } else if (commonParse[k] !== parse[k]) {
-            conflictingParse.add(k); // conflicting parse field
+            conflictingParse.add(k);
           }
         }
       }
 
-      // remove all conflicting parse fields here
       for (const field of conflictingParse) {
         delete commonParse[field];
       }

--- a/src/compile/data/sequence.ts
+++ b/src/compile/data/sequence.ts
@@ -11,6 +11,10 @@ export class SequenceNode extends DataFlowNode {
     super(parent);
   }
 
+  public producedFields() {
+    return new Set([this.params.as || 'data']);
+  }
+
   public assemble(): VgSequenceTransform {
     return {
       type: 'sequence',

--- a/test/compile/data/filterinvalid.test.ts
+++ b/test/compile/data/filterinvalid.test.ts
@@ -1,4 +1,3 @@
-import {assert} from 'chai';
 import {FilterInvalidNode} from '../../../src/compile/data/filterinvalid';
 import {UnitModel} from '../../../src/compile/unit';
 import {NormalizedUnitSpec, TopLevel} from '../../../src/spec';
@@ -9,7 +8,7 @@ function parse(model: UnitModel) {
   return FilterInvalidNode.make(null, model);
 }
 
-describe('compile/data/nullfilter', () => {
+describe('compile/data/filterinvalid', () => {
   describe('compileUnit', () => {
     const spec: NormalizedUnitSpec = {
       mark: 'point',
@@ -23,7 +22,7 @@ describe('compile/data/nullfilter', () => {
 
     it('should add filterNull for Q and T by default', () => {
       const model = parseUnitModelWithScale(spec);
-      assert.deepEqual(parse(model).filter, {
+      expect(parse(model).filter).toEqual({
         qq: {field: 'qq', type: 'quantitative'},
         tt: {field: 'tt', type: 'temporal'}
       });
@@ -37,7 +36,7 @@ describe('compile/data/nullfilter', () => {
           }
         })
       );
-      assert.deepEqual(parse(model).filter, {
+      expect(parse(model).filter).toEqual({
         qq: {field: 'qq', type: 'quantitative'},
         tt: {field: 'tt', type: 'temporal'}
       });
@@ -51,7 +50,7 @@ describe('compile/data/nullfilter', () => {
           }
         })
       );
-      assert.deepEqual(parse(model), null);
+      expect(parse(model)).toBeNull();
     });
 
     it('should add no null filter for count field', () => {
@@ -62,7 +61,14 @@ describe('compile/data/nullfilter', () => {
         }
       });
 
-      assert.deepEqual(parse(model), null);
+      expect(parse(model)).toBeNull();
+    });
+  });
+
+  describe('dependentFields', () => {
+    it('should return the fields it filters', () => {
+      const node = new FilterInvalidNode(null, {foo: {field: 'foo', type: 'quantitative'}});
+      expect(node.dependentFields()).toEqual(new Set(['foo']));
     });
   });
 
@@ -75,7 +81,7 @@ describe('compile/data/nullfilter', () => {
         }
       });
 
-      assert.deepEqual(parse(model).assemble(), {
+      expect(parse(model).assemble()).toEqual({
         type: 'filter',
         expr: 'datum["foo"] !== null && !isNaN(datum["foo"])'
       });
@@ -89,7 +95,7 @@ describe('compile/data/nullfilter', () => {
         }
       });
 
-      assert.deepEqual(parse(model).assemble(), {
+      expect(parse(model).assemble()).toEqual({
         type: 'filter',
         expr: 'datum["foo.bar"] !== null && !isNaN(datum["foo.bar"])'
       });

--- a/test/compile/data/sequence.test.ts
+++ b/test/compile/data/sequence.test.ts
@@ -3,7 +3,7 @@ import {SequenceNode} from '../../../src/compile/data/sequence';
 import {parseUnitModelWithScaleAndLayoutSize} from '../../util';
 
 describe('compile/data/sequence', () => {
-  describe('SequenceNode', () => {
+  describe('assembled', () => {
     it('should return a proper vg transform', () => {
       const params = {
         start: 1,
@@ -19,6 +19,30 @@ describe('compile/data/sequence', () => {
       });
     });
   });
+
+  describe('producedFields', () => {
+    it('should return correct default', () => {
+      const params = {
+        start: 1,
+        stop: 10,
+        step: 2
+      };
+      const sequence = new SequenceNode(null, params);
+      expect(sequence.producedFields()).toEqual(new Set(['data']));
+    });
+
+    it('should return specified field', () => {
+      const params = {
+        start: 1,
+        stop: 10,
+        step: 2,
+        as: 'foo'
+      };
+      const sequence = new SequenceNode(null, params);
+      expect(sequence.producedFields()).toEqual(new Set(['foo']));
+    });
+  });
+
   it('should parse and add generator transform correctly', () => {
     const model = parseUnitModelWithScaleAndLayoutSize({
       data: {


### PR DESCRIPTION
In this PR, I am cleaning up some of the optimizer code so I can clean up some bugs. 

* Fix optimization of parse nodes. We had a bug right now where we may ignore a field because it has a conflict but then add it back again. 
* Correct check for whether a node is a source or generator.
* Implement `producedFields` for sequences. 
* Remove unused `iterateFromLeaves`.  
* Simplify `FilterInvalidNode `
* Implement `dependentFields ` for invalid filter.