### PR TITLE
fix: correct projection `precision`'s type to number (not string)

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -8982,7 +8982,7 @@
         },
         "precision": {
           "description": "Sets the threshold for the projection’s [adaptive resampling](http://bl.ocks.org/mbostock/3795544) to the specified value in pixels. This value corresponds to the [Douglas–Peucker distance](http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm). If precision is not specified, returns the projection’s current resampling precision which defaults to `√0.5 ≅ 0.70710…`.",
-          "type": "string"
+          "type": "number"
         },
         "radius": {
           "type": "number"

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -47,7 +47,7 @@ export interface Projection {
   /**
    * Sets the threshold for the projection’s [adaptive resampling](http://bl.ocks.org/mbostock/3795544) to the specified value in pixels. This value corresponds to the [Douglas–Peucker distance](http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm). If precision is not specified, returns the projection’s current resampling precision which defaults to `√0.5 ≅ 0.70710…`.
    */
-  precision?: string;
+  precision?: number;
   /*
    * Sets whether or not the x-dimension is reflected (negated) in the output.
    */

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -153,7 +153,7 @@ export interface VgProjection {
   /*
    * The desired precision of the projection.
    */
-  precision?: string;
+  precision?: number;
   /*
    * GeoJSON data to which the projection should attempt to automatically fit the translate and scale parameters..
    */


### PR DESCRIPTION
Fixes #5190
