### PR TITLE
fix: use `0.5*a + 0.5*b` for stack mid formula instead of `(a+b)/2` to avoid overflow

### DIFF
--- a/src/compile/data/stack.ts
+++ b/src/compile/data/stack.ts
@@ -1,5 +1,6 @@
 import {isArray, isString} from 'vega-util';
 import {FieldName, getTypedFieldDef, isFieldDef, TypedFieldDef, vgField} from '../../channeldef';
+import {SortFields, SortOrder} from '../../sort';
 import {StackOffset} from '../../stack';
 import {StackTransform} from '../../transform';
 import {duplicate, getFirstDefined, hash} from '../../util';
@@ -7,7 +8,6 @@ import {VgTransform} from '../../vega.schema';
 import {sortParams} from '../common';
 import {UnitModel} from '../unit';
 import {DataFlowNode} from './dataflow';
-import {SortFields, SortOrder} from '../../sort';
 
 function getStackByFields(model: UnitModel): string[] {
   return model.stack.stackBy.reduce(
@@ -227,11 +227,10 @@ export class StackNode extends DataFlowNode {
         transform.push({
           type: 'formula',
           expr:
-            '(' +
+            '0.5*' +
             vgField(dimensionFieldDef, {expr: 'datum'}) +
-            '+' +
-            vgField(dimensionFieldDef, {expr: 'datum', binSuffix: 'end'}) +
-            ')/2',
+            '+0.5*' +
+            vgField(dimensionFieldDef, {expr: 'datum', binSuffix: 'end'}),
           as: vgField(dimensionFieldDef, {binSuffix: 'mid', forAs: true})
         });
       }

--- a/test/compile/data/stack.test.ts
+++ b/test/compile/data/stack.test.ts
@@ -176,7 +176,7 @@ describe('compile/data/stack', () => {
       expect(assemble(model)).toEqual([
         {
           type: 'formula',
-          expr: '(datum["bin_maxbins_10_b"]+datum["bin_maxbins_10_b_end"])/2',
+          expr: '0.5*datum["bin_maxbins_10_b"]+0.5*datum["bin_maxbins_10_b_end"]',
           as: 'bin_maxbins_10_b_mid'
         },
         {


### PR DESCRIPTION
This is especially important for temporal in a follow up PR (#5096).