### PR TITLE
refactor: consistent error messages

### DIFF
--- a/src/log/message.ts
+++ b/src/log/message.ts
@@ -38,11 +38,11 @@ export function nearestNotSupportForContinuous(mark: string) {
 }
 
 export function selectionNotSupported(mark: CompositeMark) {
-  return `Selection not supported for ${mark} yet`;
+  return `Selection not supported for ${mark} yet.`;
 }
 
 export function selectionNotFound(name: string) {
-  return `Cannot find a selection named "${name}"`;
+  return `Cannot find a selection named "${name}".`;
 }
 
 export const SCALE_BINDINGS_CONTINUOUS =
@@ -87,7 +87,7 @@ export const NO_FIELDS_NEEDS_AS =
 // ENCODING & FACET
 
 export function encodingOverridden(channels: Channel[]) {
-  return `Layer's shared ${channels.join(',')} channel ${channels.length === 1 ? 'is' : 'are'} overriden`;
+  return `Layer's shared ${channels.join(',')} channel ${channels.length === 1 ? 'is' : 'are'} overriden.`;
 }
 export function projectionOverridden(opt: {parentProjection: Projection; projection: Projection}) {
   const {parentProjection, projection} = opt;
@@ -105,7 +105,7 @@ export function primitiveChannelDef(
 }
 
 export function invalidFieldType(type: Type) {
-  return `Invalid field type "${type}"`;
+  return `Invalid field type "${type}".`;
 }
 
 export function nonZeroScaleUsedWithLengthMark(
@@ -129,7 +129,7 @@ export function invalidFieldTypeForCountAggregate(type: Type, aggregate: Aggrega
 }
 
 export function invalidAggregate(aggregate: AggregateOp | string) {
-  return `Invalid aggregation operator "${aggregate}"`;
+  return `Invalid aggregation operator "${aggregate}".`;
 }
 
 export function missingFieldType(channel: Channel, newType: Type) {
@@ -137,9 +137,9 @@ export function missingFieldType(channel: Channel, newType: Type) {
 }
 export function droppingColor(type: 'encoding' | 'property', opt: {fill?: boolean; stroke?: boolean}) {
   const {fill, stroke} = opt;
-  return (
-    `Dropping color ${type} as the plot also has ` + (fill && stroke ? 'fill and stroke' : fill ? 'fill' : 'stroke')
-  );
+  return `Dropping color ${type} as the plot also has ${
+    fill && stroke ? 'fill and stroke' : fill ? 'fill' : 'stroke'
+  }.`;
 }
 
 export function emptyFieldDef(fieldDef: TypedFieldDef<string>, channel: Channel) {
@@ -181,14 +181,14 @@ export function lineWithRange(hasX2: boolean, hasY2: boolean) {
 }
 
 export function orientOverridden(original: string, actual: string) {
-  return `Specified orient "${original}" overridden with "${actual}"`;
+  return `Specified orient "${original}" overridden with "${actual}".`;
 }
 
 // SCALE
 export const CANNOT_UNION_CUSTOM_DOMAIN_WITH_FIELD_DOMAIN =
-  'custom domain scale cannot be unioned with default field-based domain';
+  'Custom domain scale cannot be unioned with default field-based domain.';
 
-export const RANGE_STEP_DEPRECATED = `Scale's "rangeStep" is deprecated and will be removed in Vega-Lite 5.0. Please use "width"/"height": {"step": ...} instead. See https://vega.github.io/vega-lite/docs/size.html`;
+export const RANGE_STEP_DEPRECATED = `Scale's "rangeStep" is deprecated and will be removed in Vega-Lite 5.0. Please use "width"/"height": {"step": ...} instead. See https://vega.github.io/vega-lite/docs/size.html.`;
 
 export function cannotUseScalePropertyWithNonColor(prop: string) {
   return `Cannot use the scale property "${prop}" with non-color channel.`;
@@ -238,13 +238,13 @@ export function mergeConflictingProperty<T>(
 ) {
   return `Conflicting ${propertyOf.toString()} property "${property.toString()}" (${stringify(v1)} and ${stringify(
     v2
-  )}).  Using ${stringify(v1)}.`;
+  )}). Using ${stringify(v1)}.`;
 }
 
 export function mergeConflictingDomainProperty<T>(property: 'domains', propertyOf: SplitParentProperty, v1: T, v2: T) {
   return `Conflicting ${propertyOf.toString()} property "${property.toString()}" (${stringify(v1)} and ${stringify(
     v2
-  )}).  Using the union of the two domains.`;
+  )}). Using the union of the two domains.`;
 }
 
 export function independentScaleMeansIndependentGuide(channel: Channel) {
@@ -255,7 +255,7 @@ export function domainSortDropped(sort: VgSortField) {
   return `Dropping sort property ${stringify(sort)} as unioned domains only support boolean or op 'count'.`;
 }
 
-export const UNABLE_TO_MERGE_DOMAINS = 'Unable to merge domains';
+export const UNABLE_TO_MERGE_DOMAINS = 'Unable to merge domains.';
 
 export const MORE_THAN_ONE_SORT =
   'Domains that should be unioned has conflicting sort properties. Sort will be set to true.';
@@ -265,20 +265,20 @@ export const INVALID_CHANNEL_FOR_AXIS = 'Invalid channel for axis.';
 
 // STACK
 export function cannotStackRangedMark(channel: Channel) {
-  return `Cannot stack "${channel}" if there is already "${channel}2"`;
+  return `Cannot stack "${channel}" if there is already "${channel}2".`;
 }
 
 export function cannotStackNonLinearScale(scaleType: ScaleType) {
-  return `Cannot stack non-linear scale (${scaleType})`;
+  return `Cannot stack non-linear scale (${scaleType}).`;
 }
 
 export function stackNonSummativeAggregate(aggregate: Aggregate | string) {
-  return `Stacking is applied even though the aggregate function is non-summative ("${aggregate}")`;
+  return `Stacking is applied even though the aggregate function is non-summative ("${aggregate}").`;
 }
 
 // TIMEUNIT
 export function invalidTimeUnit(unitName: string, value: string | number) {
-  return `Invalid ${unitName}: ${stringify(value)}`;
+  return `Invalid ${unitName}: ${stringify(value)}.`;
 }
 
 export function dayReplacedWithDate(fullTimeUnit: string) {
@@ -318,14 +318,14 @@ export function errorBarCenterIsNotNeeded(extent: ErrorBarExtent, mark: 'errorba
 }
 
 export function errorBand1DNotSupport(property: 'interpolate' | 'tension') {
-  return `1D error band does not support ${property}`;
+  return `1D error band does not support ${property}.`;
 }
 
 // CHANNEL
 export function channelRequiredForBinned(channel: Channel) {
-  return `Channel ${channel} is required for "binned" bin`;
+  return `Channel ${channel} is required for "binned" bin.`;
 }
 
 export function domainRequiredForThresholdScale(channel: Channel) {
-  return `Domain for ${channel} is required for threshold scale`;
+  return `Domain for ${channel} is required for threshold scale.`;
 }

--- a/test/compile/scale/parse.test.ts
+++ b/test/compile/scale/parse.test.ts
@@ -560,7 +560,7 @@ describe('src/compile', () => {
           expect(model.children[1].component.scales.y.get('domains')).toEqual([[2, 3, 4]]);
 
           expect(localLogger.warns).toEqual([
-            'Conflicting scale property "domains" ([[1,2,3]] and [[2,3,4]]).  Using the union of the two domains.'
+            'Conflicting scale property "domains" ([[1,2,3]] and [[2,3,4]]). Using the union of the two domains.'
           ]);
         })
       );


### PR DESCRIPTION
* Use sentences that end in .
* Single space between sentences.
