### PR TITLE
chore(package): update rollup to version 1.19.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "mkdirp": "^0.5.1",
     "prettier": "^1.18.2",
     "puppeteer": "^1.19.0",
-    "rollup": "^1.17.0",
+    "rollup": "^1.19.2",
     "rollup-plugin-commonjs": "^10.0.1",
     "rollup-plugin-json": "^4.0.0",
     "rollup-plugin-node-resolve": "^5.2.0",


### PR DESCRIPTION
Fixes https://github.com/vega/vega-lite/issues/5267