### PR TITLE
 fix: set orient of bar in boxpolot macro

### DIFF
--- a/examples/specs/normalized/boxplot_1D_horizontal_custom_mark_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_1D_horizontal_custom_mark_normalized.vl.json
@@ -168,7 +168,12 @@
       ],
       "layer": [
         {
-          "mark": {"type": "bar", "size": 14, "style": "boxplot-box"},
+          "mark": {
+            "type": "bar",
+            "size": 14,
+            "orient": "horizontal",
+            "style": "boxplot-box"
+          },
           "encoding": {
             "x": {
               "field": "lower_box_people",

--- a/examples/specs/normalized/boxplot_1D_horizontal_explicit_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_1D_horizontal_explicit_normalized.vl.json
@@ -112,7 +112,12 @@
       ],
       "layer": [
         {
-          "mark": {"type": "bar", "size": 14, "style": "boxplot-box"},
+          "mark": {
+            "type": "bar",
+            "size": 14,
+            "orient": "horizontal",
+            "style": "boxplot-box"
+          },
           "encoding": {
             "x": {
               "field": "lower_box_people",

--- a/examples/specs/normalized/boxplot_1D_horizontal_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_1D_horizontal_normalized.vl.json
@@ -112,7 +112,12 @@
       ],
       "layer": [
         {
-          "mark": {"type": "bar", "size": 14, "style": "boxplot-box"},
+          "mark": {
+            "type": "bar",
+            "size": 14,
+            "orient": "horizontal",
+            "style": "boxplot-box"
+          },
           "encoding": {
             "x": {
               "field": "lower_box_people",

--- a/examples/specs/normalized/boxplot_1D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_1D_vertical_normalized.vl.json
@@ -112,7 +112,12 @@
       ],
       "layer": [
         {
-          "mark": {"type": "bar", "size": 14, "style": "boxplot-box"},
+          "mark": {
+            "type": "bar",
+            "size": 14,
+            "orient": "vertical",
+            "style": "boxplot-box"
+          },
           "encoding": {
             "y": {
               "field": "lower_box_people",

--- a/examples/specs/normalized/boxplot_2D_horizontal_color_size_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_2D_horizontal_color_size_normalized.vl.json
@@ -119,7 +119,12 @@
       ],
       "layer": [
         {
-          "mark": {"type": "bar", "size": 14, "style": "boxplot-box"},
+          "mark": {
+            "type": "bar",
+            "size": 14,
+            "orient": "horizontal",
+            "style": "boxplot-box"
+          },
           "encoding": {
             "x": {
               "field": "lower_box_people",

--- a/examples/specs/normalized/boxplot_2D_horizontal_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_2D_horizontal_normalized.vl.json
@@ -119,7 +119,12 @@
       ],
       "layer": [
         {
-          "mark": {"type": "bar", "size": 14, "style": "boxplot-box"},
+          "mark": {
+            "type": "bar",
+            "size": 14,
+            "orient": "horizontal",
+            "style": "boxplot-box"
+          },
           "encoding": {
             "x": {
               "field": "lower_box_people",

--- a/examples/specs/normalized/boxplot_2D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_2D_vertical_normalized.vl.json
@@ -119,7 +119,12 @@
       ],
       "layer": [
         {
-          "mark": {"type": "bar", "size": 14, "style": "boxplot-box"},
+          "mark": {
+            "type": "bar",
+            "size": 14,
+            "orient": "vertical",
+            "style": "boxplot-box"
+          },
           "encoding": {
             "y": {
               "field": "lower_box_people",

--- a/examples/specs/normalized/boxplot_minmax_2D_horizontal_custom_midtick_color_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_horizontal_custom_midtick_color_normalized.vl.json
@@ -97,7 +97,12 @@
       }
     },
     {
-      "mark": {"type": "bar", "size": 14, "style": "boxplot-box"},
+      "mark": {
+        "type": "bar",
+        "size": 14,
+        "orient": "horizontal",
+        "style": "boxplot-box"
+      },
       "encoding": {
         "x": {
           "field": "lower_box_people",

--- a/examples/specs/normalized/boxplot_minmax_2D_horizontal_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_horizontal_normalized.vl.json
@@ -96,7 +96,12 @@
       }
     },
     {
-      "mark": {"type": "bar", "size": 14, "style": "boxplot-box"},
+      "mark": {
+        "type": "bar",
+        "size": 14,
+        "orient": "horizontal",
+        "style": "boxplot-box"
+      },
       "encoding": {
         "x": {
           "field": "lower_box_people",

--- a/examples/specs/normalized/boxplot_minmax_2D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_vertical_normalized.vl.json
@@ -96,7 +96,12 @@
       }
     },
     {
-      "mark": {"type": "bar", "size": 14, "style": "boxplot-box"},
+      "mark": {
+        "type": "bar",
+        "size": 14,
+        "orient": "vertical",
+        "style": "boxplot-box"
+      },
       "encoding": {
         "y": {
           "field": "lower_box_people",

--- a/examples/specs/normalized/boxplot_tooltip_aggregate_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_tooltip_aggregate_normalized.vl.json
@@ -104,7 +104,12 @@
       ],
       "layer": [
         {
-          "mark": {"type": "bar", "size": 14, "style": "boxplot-box"},
+          "mark": {
+            "type": "bar",
+            "size": 14,
+            "orient": "vertical",
+            "style": "boxplot-box"
+          },
           "encoding": {
             "y": {
               "field": "lower_box_people",

--- a/examples/specs/normalized/boxplot_tooltip_not_aggregate_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_tooltip_not_aggregate_normalized.vl.json
@@ -119,7 +119,12 @@
       ],
       "layer": [
         {
-          "mark": {"type": "bar", "size": 14, "style": "boxplot-box"},
+          "mark": {
+            "type": "bar",
+            "size": 14,
+            "orient": "vertical",
+            "style": "boxplot-box"
+          },
           "encoding": {
             "y": {
               "field": "lower_box_people",

--- a/examples/specs/normalized/layer_boxplot_circle_normalized.vl.json
+++ b/examples/specs/normalized/layer_boxplot_circle_normalized.vl.json
@@ -104,7 +104,12 @@
           ],
           "layer": [
             {
-              "mark": {"type": "bar", "size": 14, "style": "boxplot-box"},
+              "mark": {
+                "type": "bar",
+                "size": 14,
+                "orient": "horizontal",
+                "style": "boxplot-box"
+              },
               "encoding": {
                 "x": {
                   "field": "lower_box_people",

--- a/src/compile/mark/init.ts
+++ b/src/compile/mark/init.ts
@@ -98,10 +98,10 @@ function orient(mark: Mark, encoding: Encoding<string>, specifiedOrient: Orienta
 
   switch (mark) {
     case BAR:
-      if (isFieldDef(x) && isBinned(x.bin)) {
+      if (isFieldDef(x) && (isBinned(x.bin) || (isFieldDef(y) && y.aggregate && !x.aggregate))) {
         return 'vertical';
       }
-      if (isFieldDef(y) && isBinned(y.bin)) {
+      if (isFieldDef(y) && (isBinned(y.bin) || (isFieldDef(x) && x.aggregate && !y.aggregate))) {
         return 'horizontal';
       }
       if (y2 || x2) {
@@ -144,9 +144,9 @@ function orient(mark: Mark, encoding: Encoding<string>, specifiedOrient: Orienta
           return 'horizontal';
         }
       } else if (mark === RULE) {
-        if (encoding.x && !encoding.y) {
+        if (x && !y) {
           return 'vertical';
-        } else if (encoding.y && !encoding.x) {
+        } else if (y && !x) {
           return 'horizontal';
         }
       }
@@ -155,15 +155,15 @@ function orient(mark: Mark, encoding: Encoding<string>, specifiedOrient: Orienta
     case LINE:
     case TICK: {
       // Tick is opposite to bar, line, area and never have ranged mark.
-      const xIsContinuous = isFieldDef(encoding.x) && isContinuous(encoding.x);
-      const yIsContinuous = isFieldDef(encoding.y) && isContinuous(encoding.y);
+      const xIsContinuous = isFieldDef(x) && isContinuous(x);
+      const yIsContinuous = isFieldDef(y) && isContinuous(y);
       if (xIsContinuous && !yIsContinuous) {
         return mark !== 'tick' ? 'horizontal' : 'vertical';
       } else if (!xIsContinuous && yIsContinuous) {
         return mark !== 'tick' ? 'vertical' : 'horizontal';
       } else if (xIsContinuous && yIsContinuous) {
-        const xDef = encoding.x as TypedFieldDef<string>; // we can cast here since they are surely fieldDef
-        const yDef = encoding.y as TypedFieldDef<string>;
+        const xDef = x as TypedFieldDef<string>; // we can cast here since they are surely fieldDef
+        const yDef = y as TypedFieldDef<string>;
 
         const xIsTemporal = xDef.type === TEMPORAL;
         const yIsTemporal = yDef.type === TEMPORAL;

--- a/test/compile/mark/init.test.ts
+++ b/test/compile/mark/init.test.ts
@@ -133,6 +133,17 @@ describe('compile/mark/init', () => {
       expect(model.markDef.orient).toBe('horizontal');
     });
 
+    it('should return correct orient for vertical with aggregation', () => {
+      const model = parseUnitModelWithScaleAndLayoutSize({
+        mark: 'bar',
+        encoding: {
+          x: {type: 'quantitative', field: 'foo', aggregate: 'mean'},
+          y: {type: 'quantitative', field: 'bar'}
+        }
+      });
+      expect(model.markDef.orient).toBe('horizontal');
+    });
+
     it('should return correct orient for vertical tick', () => {
       const model = parseUnitModelWithScaleAndLayoutSize({
         mark: 'tick',

--- a/test/compositemark/boxplot.test.ts
+++ b/test/compositemark/boxplot.test.ts
@@ -858,7 +858,8 @@ describe('normalizeBoxIQR', () => {
       mark: {
         type: 'bar',
         style: 'boxplot-box',
-        size: 14
+        size: 14,
+        orient: 'vertical'
       },
       encoding: {
         x: {field: 'age', type: 'quantitative'},


### PR DESCRIPTION
fixes #5263, fixes #4849

Also detect the orientation of bar marks from aggregation. 