### PR TITLE
feat!: by default, disable direct manipulation for widget-bound selections.

### DIFF
--- a/examples/compiled/interactive_query_widgets.vg.json
+++ b/examples/compiled/interactive_query_widgets.vg.json
@@ -64,25 +64,11 @@
     {
       "name": "CylYr_Year",
       "init": "1977",
-      "on": [
-        {
-          "events": [{"source": "scope", "type": "click"}],
-          "update": "datum && item().mark.marktype !== 'group' ? datum[\"Year\"] : null"
-        },
-        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
-      ],
       "bind": {"input": "range", "min": 1969, "max": 1981, "step": 1}
     },
     {
       "name": "CylYr_Cylinders",
       "init": "4",
-      "on": [
-        {
-          "events": [{"source": "scope", "type": "click"}],
-          "update": "datum && item().mark.marktype !== 'group' ? datum[\"Cylinders\"] : null"
-        },
-        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
-      ],
       "bind": {"input": "range", "min": 3, "max": 8, "step": 1}
     },
     {"name": "CylYr", "update": "vlSelectionResolve(\"CylYr_store\")"},

--- a/examples/compiled/selection_bind_cylyr.vg.json
+++ b/examples/compiled/selection_bind_cylyr.vg.json
@@ -31,25 +31,11 @@
     {
       "name": "CylYr_Year",
       "value": null,
-      "on": [
-        {
-          "events": [{"source": "scope", "type": "click"}],
-          "update": "datum && item().mark.marktype !== 'group' ? datum[\"Year\"] : null"
-        },
-        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
-      ],
       "bind": {"input": "range", "min": 1969, "max": 1981, "step": 1}
     },
     {
       "name": "CylYr_Cylinders",
       "value": null,
-      "on": [
-        {
-          "events": [{"source": "scope", "type": "click"}],
-          "update": "datum && item().mark.marktype !== 'group' ? datum[\"Cylinders\"] : null"
-        },
-        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
-      ],
       "bind": {"input": "range", "min": 3, "max": 8, "step": 1}
     },
     {"name": "CylYr", "update": "vlSelectionResolve(\"CylYr_store\")"},

--- a/examples/compiled/selection_bind_origin.vg.json
+++ b/examples/compiled/selection_bind_origin.vg.json
@@ -30,13 +30,6 @@
     {
       "name": "org_Origin",
       "value": null,
-      "on": [
-        {
-          "events": [{"source": "scope", "type": "click"}],
-          "update": "datum && item().mark.marktype !== 'group' ? datum[\"Origin\"] : null"
-        },
-        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
-      ],
       "bind": {"input": "select", "options": [null, "Europe", "Japan", "USA"]}
     },
     {"name": "org", "update": "vlSelectionResolve(\"org_store\")"},

--- a/examples/compiled/trellis_selections.vg.json
+++ b/examples/compiled/trellis_selections.vg.json
@@ -41,8 +41,7 @@
         {
           "events": [{"source": "scope", "type": "mouseover"}],
           "update": "datum && item().mark.marktype !== 'group' ? (item().isVoronoi ? datum.datum : datum)[\"X\"] : null"
-        },
-        {"events": [{"source": "scope", "type": "dblclick"}], "update": "null"}
+        }
       ],
       "bind": {"input": "number"}
     },

--- a/site/docs/selection/bind.md
+++ b/site/docs/selection/bind.md
@@ -22,6 +22,8 @@ If multiple projections are specified, customized bindings can be specified by m
 
 <div class="vl-example" data-name="selection_bind_cylyr"></div>
 
+**Note:** When a single selection is bound to input widgets, direct manipulation interaction (e.g., clicking or double clicking the visualization) is disabled by default. It can be re-enabled by explicitly specifying the [`on`](selection.html#selection-props) and [`clear`](clear.html) properties.
+
 ## Scale Binding
 
 With interval selections, the `bind` property can be set to the value `"scales"` to enable a two-way binding between the selection and the scales used within the same view. This binding first populates the interval selection with the scale domains, and then uses the selection to drive the scale domains. As a result, the view now functions like an interval selection and can be [panned](translate.html) and [zoomed](zoom.html).

--- a/src/compile/selection/assemble.ts
+++ b/src/compile/selection/assemble.ts
@@ -59,7 +59,7 @@ export function assembleUnitSelectionSignals(model: UnitModel, signals: Signal[]
     });
   });
 
-  return signals;
+  return cleanupEmptyOnArray(signals);
 }
 
 export function assembleFacetSignals(model: FacetModel, signals: Signal[]) {
@@ -77,7 +77,7 @@ export function assembleFacetSignals(model: FacetModel, signals: Signal[]) {
     });
   }
 
-  return signals;
+  return cleanupEmptyOnArray(signals);
 }
 
 export function assembleTopLevelSignals(model: UnitModel, signals: Signal[]) {
@@ -118,7 +118,7 @@ export function assembleTopLevelSignals(model: UnitModel, signals: Signal[]) {
     }
   }
 
-  return signals;
+  return cleanupEmptyOnArray(signals);
 }
 
 export function assembleUnitSelectionData(model: UnitModel, data: VgData[]): VgData[] {
@@ -210,4 +210,11 @@ export function assembleSelectionScaleDomain(model: Model, domainRaw: SignalRef)
   }
 
   return {signal: 'null'};
+}
+
+function cleanupEmptyOnArray(signals: Signal[]) {
+  return signals.map(s => {
+    if (s.on && !s.on.length) delete s.on;
+    return s;
+  });
 }

--- a/src/compile/selection/multi.ts
+++ b/src/compile/selection/multi.ts
@@ -31,13 +31,15 @@ export function singleOrMultiSignals(model: UnitModel, selCmpt: SelectionCompone
   const signals: Signal[] = [
     {
       name: name + TUPLE,
-      on: [
-        {
-          events: selCmpt.events,
-          update: `datum && item().mark.marktype !== 'group' ? {${update}: [${values}]} : null`,
-          force: true
-        }
-      ]
+      on: selCmpt.events
+        ? [
+            {
+              events: selCmpt.events,
+              update: `datum && item().mark.marktype !== 'group' ? {${update}: [${values}]} : null`,
+              force: true
+            }
+          ]
+        : []
     }
   ];
 

--- a/src/compile/selection/parse.ts
+++ b/src/compile/selection/parse.ts
@@ -13,16 +13,12 @@ export function parseUnitSelection(model: UnitModel, selDefs: Dict<SelectionDef>
   const selCmpts: Dict<SelectionComponent<any /* this has to be "any" so typing won't fail in test files*/>> = {};
   const selectionConfig = model.config.selection;
 
-  if (selDefs) {
-    selDefs = duplicate(selDefs); // duplicate to avoid side effects to original spec
-  }
-
   for (let name in selDefs) {
     if (!selDefs.hasOwnProperty(name)) {
       continue;
     }
 
-    const selDef = selDefs[name];
+    const selDef = duplicate(selDefs[name]);
     const {fields, encodings, ...cfg} = selectionConfig[selDef.type]; // Project transform applies its defaults.
 
     // Set default values from config if a property hasn't been specified,
@@ -54,7 +50,7 @@ export function parseUnitSelection(model: UnitModel, selDefs: Dict<SelectionDef>
 
     forEachTransform(selCmpt, txCompiler => {
       if (txCompiler.parse) {
-        txCompiler.parse(model, selDef, selCmpt);
+        txCompiler.parse(model, selCmpt, selDef, selDefs[name]);
       }
     });
   }

--- a/src/compile/selection/transforms/clear.ts
+++ b/src/compile/selection/transforms/clear.ts
@@ -8,10 +8,10 @@ import {TransformCompiler} from './transforms';
 
 const clear: TransformCompiler = {
   has: selCmpt => {
-    return selCmpt.clear !== false;
+    return selCmpt.clear !== undefined && selCmpt.clear !== false;
   },
 
-  parse: (model, selDef, selCmpt) => {
+  parse: (model, selCmpt, selDef, origDef) => {
     if (selDef.clear) {
       selCmpt.clear = parseSelector(selDef.clear, 'scope');
     }

--- a/src/compile/selection/transforms/clear.ts
+++ b/src/compile/selection/transforms/clear.ts
@@ -11,7 +11,7 @@ const clear: TransformCompiler = {
     return selCmpt.clear !== undefined && selCmpt.clear !== false;
   },
 
-  parse: (model, selCmpt, selDef, origDef) => {
+  parse: (model, selCmpt, selDef) => {
     if (selDef.clear) {
       selCmpt.clear = parseSelector(selDef.clear, 'scope');
     }

--- a/src/compile/selection/transforms/inputs.ts
+++ b/src/compile/selection/transforms/inputs.ts
@@ -10,6 +10,13 @@ const inputBindings: TransformCompiler = {
     return selCmpt.type === 'single' && selCmpt.resolve === 'global' && selCmpt.bind && selCmpt.bind !== 'scales';
   },
 
+  parse: (model, selCmpt, selDef, origDef) => {
+    // Binding a selection to input widgets disables default direct manipulation interaction.
+    // A user can choose to re-enable it by explicitly specifying triggering input events.
+    if (!origDef.on) delete selCmpt.events;
+    if (!origDef.clear) delete selCmpt.clear;
+  },
+
   topLevelSignals: (model, selCmpt, signals) => {
     const name = selCmpt.name;
     const proj = selCmpt.project;
@@ -24,12 +31,14 @@ const inputBindings: TransformCompiler = {
         signals.unshift({
           name: sgname,
           ...(init ? {init: assembleInit(init[i])} : {value: null}),
-          on: [
-            {
-              events: selCmpt.events,
-              update: `datum && item().mark.marktype !== 'group' ? ${accessPathWithDatum(p.field, datum)} : null`
-            }
-          ],
+          on: selCmpt.events
+            ? [
+                {
+                  events: selCmpt.events,
+                  update: `datum && item().mark.marktype !== 'group' ? ${accessPathWithDatum(p.field, datum)} : null`
+                }
+              ]
+            : [],
           bind: bind[p.field] || bind[p.channel] || bind
         });
       }

--- a/src/compile/selection/transforms/project.ts
+++ b/src/compile/selection/transforms/project.ts
@@ -39,7 +39,7 @@ const project: TransformCompiler = {
     return true; // This transform handles its own defaults, so always run parse.
   },
 
-  parse: (model, selDef, selCmpt) => {
+  parse: (model, selCmpt, selDef, origDef) => {
     const name = selCmpt.name;
     const proj = selCmpt.project || (selCmpt.project = new SelectionProjectionComponent());
     const parsed: Dict<SelectionProjection> = {};

--- a/src/compile/selection/transforms/project.ts
+++ b/src/compile/selection/transforms/project.ts
@@ -39,7 +39,7 @@ const project: TransformCompiler = {
     return true; // This transform handles its own defaults, so always run parse.
   },
 
-  parse: (model, selCmpt, selDef, origDef) => {
+  parse: (model, selCmpt, selDef) => {
     const name = selCmpt.name;
     const proj = selCmpt.project || (selCmpt.project = new SelectionProjectionComponent());
     const parsed: Dict<SelectionProjection> = {};

--- a/src/compile/selection/transforms/scales.ts
+++ b/src/compile/selection/transforms/scales.ts
@@ -13,7 +13,7 @@ const scaleBindings: TransformCompiler = {
     return selCmpt.type === 'interval' && selCmpt.resolve === 'global' && selCmpt.bind && selCmpt.bind === 'scales';
   },
 
-  parse: (model, selDef, selCmpt) => {
+  parse: (model, selCmpt, selDef, origDef) => {
     const name = varName(selCmpt.name);
     const bound: SelectionProjection[] = (selCmpt.scales = []);
 

--- a/src/compile/selection/transforms/scales.ts
+++ b/src/compile/selection/transforms/scales.ts
@@ -13,7 +13,7 @@ const scaleBindings: TransformCompiler = {
     return selCmpt.type === 'interval' && selCmpt.resolve === 'global' && selCmpt.bind && selCmpt.bind === 'scales';
   },
 
-  parse: (model, selCmpt, selDef, origDef) => {
+  parse: (model, selCmpt) => {
     const name = varName(selCmpt.name);
     const bound: SelectionProjection[] = (selCmpt.scales = []);
 

--- a/src/compile/selection/transforms/transforms.ts
+++ b/src/compile/selection/transforms/transforms.ts
@@ -14,7 +14,7 @@ import zoom from './zoom';
 
 export interface TransformCompiler {
   has: (selCmpt: SelectionComponent | SelectionDef) => boolean;
-  parse?: (model: UnitModel, def: SelectionDef, selCmpt: SelectionComponent) => void;
+  parse?: (model: UnitModel, selCmpt: SelectionComponent, def: SelectionDef, origDef: SelectionDef) => void;
   signals?: (model: UnitModel, selCmpt: SelectionComponent, signals: NewSignal[]) => Signal[]; // the output can be a new or a push signal
   topLevelSignals?: (model: Model, selCmpt: SelectionComponent, signals: NewSignal[]) => NewSignal[];
   modifyExpr?: (model: UnitModel, selCmpt: SelectionComponent, expr: string) => string;

--- a/test/compile/selection/clear.test.ts
+++ b/test/compile/selection/clear.test.ts
@@ -31,6 +31,14 @@ describe('Clear selection transform, single and multi types', () => {
       bind: {
         Year: {input: 'range', min: 1970, max: 1980, step: 1}
       }
+    },
+    eight: {
+      type: 'single',
+      fields: ['Year'],
+      clear: 'click',
+      bind: {
+        Year: {input: 'range', min: 1970, max: 1980, step: 1}
+      }
     }
   }));
 
@@ -43,7 +51,7 @@ describe('Clear selection transform, single and multi types', () => {
     expect(clear.has(selCmpts['six'])).toBeFalsy();
   });
 
-  it('appends clear transform', () => {
+  it('appends clear event trigger', () => {
     const singleOneSg = single.signals(model, selCmpts['one']);
     const oneSg = clear.signals(model, selCmpts['one'], singleOneSg);
     expect(oneSg).toEqual([
@@ -111,22 +119,28 @@ describe('Clear selection transform, single and multi types', () => {
         ]
       }
     ]);
+  });
 
+  it('does not append clear event trigger for bound selections by default', () => {
     expect(assembleTopLevelSignals(model, [])).toEqual(
       expect.arrayContaining([
         {
           name: 'seven_Year',
           value: null,
-          on: [
-            {
-              events: [{source: 'scope', type: 'click'}],
-              update: 'datum && item().mark.marktype !== \'group\' ? datum["Year"] : null'
-            },
-            {
-              events: [{source: 'scope', type: 'dblclick'}],
-              update: 'null'
-            }
-          ],
+          on: [],
+          bind: {input: 'range', min: 1970, max: 1980, step: 1}
+        }
+      ])
+    );
+  });
+
+  it('appends an explicit clear event trigger for bound selections', () => {
+    expect(assembleTopLevelSignals(model, [])).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'eight_Year',
+          value: null,
+          on: [{events: parseSelector('click', 'scope'), update: 'null'}],
           bind: {input: 'range', min: 1970, max: 1980, step: 1}
         }
       ])

--- a/test/compile/selection/clear.test.ts
+++ b/test/compile/selection/clear.test.ts
@@ -127,7 +127,6 @@ describe('Clear selection transform, single and multi types', () => {
         {
           name: 'seven_Year',
           value: null,
-          on: [],
           bind: {input: 'range', min: 1970, max: 1980, step: 1}
         }
       ])

--- a/test/compile/selection/inputs.test.ts
+++ b/test/compile/selection/inputs.test.ts
@@ -86,7 +86,6 @@ describe('Inputs Selection Transform', () => {
     expect(assembleTopLevelSignals(model, [])).toContainEqual({
       name: 'one__vgsid_',
       value: null,
-      on: [],
       bind: {input: 'range', min: 0, max: 10, step: 1}
     });
   });
@@ -104,13 +103,11 @@ describe('Inputs Selection Transform', () => {
         {
           name: 'two_Horsepower',
           value: null,
-          on: [],
           bind: {input: 'range', min: 0, max: 10, step: 1}
         },
         {
           name: 'two_Cylinders',
           value: null,
-          on: [],
           bind: {input: 'range', min: 0, max: 10, step: 1}
         }
       ])
@@ -130,7 +127,6 @@ describe('Inputs Selection Transform', () => {
         {
           name: 'three_Origin',
           value: null,
-          on: [],
           bind: {
             input: 'select',
             options: ['Japan', 'USA', 'Europe']
@@ -139,7 +135,6 @@ describe('Inputs Selection Transform', () => {
         {
           name: 'three_Cylinders',
           value: null,
-          on: [],
           bind: {
             Horsepower: {input: 'range', min: 0, max: 10, step: 1},
             Origin: {
@@ -168,7 +163,6 @@ describe('Inputs Selection Transform', () => {
         {
           name: 'seven_Year',
           init: 'datetime(1970, 1, 1+1, 0, 0, 0, 0)',
-          on: [],
           bind: {input: 'range', min: 1970, max: 1980, step: 1}
         }
       ])

--- a/test/compile/selection/inputs.test.ts
+++ b/test/compile/selection/inputs.test.ts
@@ -1,3 +1,4 @@
+import {selector as parseSelector} from 'vega-event-selector';
 import {assembleTopLevelSignals, assembleUnitSelectionSignals} from '../../../src/compile/selection/assemble';
 import {parseUnitSelection} from '../../../src/compile/selection/parse';
 import inputs from '../../../src/compile/selection/transforms/inputs';
@@ -17,18 +18,15 @@ describe('Inputs Selection Transform', () => {
   const selCmpts = parseUnitSelection(model, {
     one: {
       type: 'single',
-      clear: false,
       bind: {input: 'range', min: 0, max: 10, step: 1}
     },
     two: {
       type: 'single',
-      clear: false,
       fields: ['Cylinders', 'Horsepower'],
       bind: {input: 'range', min: 0, max: 10, step: 1}
     },
     three: {
       type: 'single',
-      clear: false,
       nearest: true,
       fields: ['Cylinders', 'Origin'],
       bind: {
@@ -38,17 +36,14 @@ describe('Inputs Selection Transform', () => {
     },
     four: {
       type: 'single',
-      clear: false,
       bind: null
     },
     six: {
       type: 'interval',
-      clear: false,
       bind: 'scales'
     },
     seven: {
       type: 'single',
-      clear: false,
       fields: ['Year'],
       bind: {
         Year: {input: 'range', min: 1970, max: 1980, step: 1}
@@ -56,6 +51,17 @@ describe('Inputs Selection Transform', () => {
       init: {
         Year: {year: 1970, month: 1, day: 1}
       }
+    },
+    eight: {
+      type: 'single',
+      on: 'dblclick',
+      bind: {input: 'range', min: 0, max: 10, step: 1}
+    },
+    nine: {
+      type: 'single',
+      on: 'click',
+      clear: 'dblclick',
+      bind: {input: 'range', min: 0, max: 10, step: 1}
     }
   });
 
@@ -66,6 +72,8 @@ describe('Inputs Selection Transform', () => {
     expect(inputs.has(selCmpts['four'])).toBeFalsy();
     expect(inputs.has(selCmpts['six'])).toBeFalsy();
     expect(inputs.has(selCmpts['seven'])).toBeTruthy();
+    expect(inputs.has(selCmpts['eight'])).toBeTruthy();
+    expect(inputs.has(selCmpts['nine'])).toBeTruthy();
   });
 
   it('adds widget binding for default projection', () => {
@@ -78,12 +86,7 @@ describe('Inputs Selection Transform', () => {
     expect(assembleTopLevelSignals(model, [])).toContainEqual({
       name: 'one__vgsid_',
       value: null,
-      on: [
-        {
-          events: [{source: 'scope', type: 'click'}],
-          update: 'datum && item().mark.marktype !== \'group\' ? datum["_vgsid_"] : null'
-        }
-      ],
+      on: [],
       bind: {input: 'range', min: 0, max: 10, step: 1}
     });
   });
@@ -101,23 +104,13 @@ describe('Inputs Selection Transform', () => {
         {
           name: 'two_Horsepower',
           value: null,
-          on: [
-            {
-              events: [{source: 'scope', type: 'click'}],
-              update: 'datum && item().mark.marktype !== \'group\' ? datum["Horsepower"] : null'
-            }
-          ],
+          on: [],
           bind: {input: 'range', min: 0, max: 10, step: 1}
         },
         {
           name: 'two_Cylinders',
           value: null,
-          on: [
-            {
-              events: [{source: 'scope', type: 'click'}],
-              update: 'datum && item().mark.marktype !== \'group\' ? datum["Cylinders"] : null'
-            }
-          ],
+          on: [],
           bind: {input: 'range', min: 0, max: 10, step: 1}
         }
       ])
@@ -137,13 +130,7 @@ describe('Inputs Selection Transform', () => {
         {
           name: 'three_Origin',
           value: null,
-          on: [
-            {
-              events: [{source: 'scope', type: 'click'}],
-              update:
-                'datum && item().mark.marktype !== \'group\' ? (item().isVoronoi ? datum.datum : datum)["Origin"] : null'
-            }
-          ],
+          on: [],
           bind: {
             input: 'select',
             options: ['Japan', 'USA', 'Europe']
@@ -152,13 +139,7 @@ describe('Inputs Selection Transform', () => {
         {
           name: 'three_Cylinders',
           value: null,
-          on: [
-            {
-              events: [{source: 'scope', type: 'click'}],
-              update:
-                'datum && item().mark.marktype !== \'group\' ? (item().isVoronoi ? datum.datum : datum)["Cylinders"] : null'
-            }
-          ],
+          on: [],
           bind: {
             Horsepower: {input: 'range', min: 0, max: 10, step: 1},
             Origin: {
@@ -187,13 +168,40 @@ describe('Inputs Selection Transform', () => {
         {
           name: 'seven_Year',
           init: 'datetime(1970, 1, 1+1, 0, 0, 0, 0)',
+          on: [],
+          bind: {input: 'range', min: 1970, max: 1980, step: 1}
+        }
+      ])
+    );
+  });
+
+  it('preserves explicit event triggers', () => {
+    model.component.selection = {eight: selCmpts['eight'], nine: selCmpts['nine']};
+
+    expect(assembleTopLevelSignals(model, [])).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'eight__vgsid_',
+          value: null,
+          on: [
+            {
+              events: [{source: 'scope', type: 'dblclick'}],
+              update: 'datum && item().mark.marktype !== \'group\' ? datum["_vgsid_"] : null'
+            }
+          ],
+          bind: {input: 'range', min: 0, max: 10, step: 1}
+        },
+        {
+          name: 'nine__vgsid_',
+          value: null,
           on: [
             {
               events: [{source: 'scope', type: 'click'}],
-              update: 'datum && item().mark.marktype !== \'group\' ? datum["Year"] : null'
-            }
+              update: 'datum && item().mark.marktype !== \'group\' ? datum["_vgsid_"] : null'
+            },
+            {events: parseSelector('dblclick', 'scope'), update: 'null'}
           ],
-          bind: {input: 'range', min: 1970, max: 1980, step: 1}
+          bind: {input: 'range', min: 0, max: 10, step: 1}
         }
       ])
     );


### PR DESCRIPTION
As per #4936 and altair-viz/altair#1553, our previous default of leaving direct manipulation interaction enabled for selections bound to input widgets was confusing to users. This PR switches the default such that direct manipulation interaction is disabled by default, but users may choose to explicitly re-enable it by specifying an `on` or `clear` properties. 