### PR TITLE
fix: toggling initialized values from multi selections 

### DIFF
--- a/examples/compiled/interactive_brush.vg.json
+++ b/examples/compiled/interactive_brush.vg.json
@@ -11,7 +11,7 @@
       "name": "brush_store",
       "values": [
         {
-          "unit": "\"\"",
+          "unit": "",
           "fields": [
             {"field": "Horsepower", "channel": "x", "type": "R"},
             {"field": "Miles_per_Gallon", "channel": "y", "type": "R"}

--- a/examples/compiled/interactive_query_widgets.vg.json
+++ b/examples/compiled/interactive_query_widgets.vg.json
@@ -11,7 +11,7 @@
       "name": "CylYr_store",
       "values": [
         {
-          "unit": "\"layer_0\"",
+          "unit": "layer_0",
           "fields": [
             {"type": "E", "field": "Cylinders"},
             {"type": "E", "field": "Year"}

--- a/examples/compiled/selection_clear_brush.vg.json
+++ b/examples/compiled/selection_clear_brush.vg.json
@@ -10,7 +10,7 @@
       "name": "brush_store",
       "values": [
         {
-          "unit": "\"\"",
+          "unit": "",
           "fields": [
             {"field": "Horsepower", "channel": "x", "type": "R"},
             {"field": "Miles_per_Gallon", "channel": "y", "type": "R"}

--- a/src/compile/selection/assemble.ts
+++ b/src/compile/selection/assemble.ts
@@ -123,8 +123,8 @@ export function assembleUnitSelectionData(model: UnitModel, data: VgData[]): VgD
       const insert = selCmpt.init.map(i => assembleInit(i, false));
       init.values =
         selCmpt.type === 'interval'
-          ? [{unit: unitName(model, false), fields, values: insert}]
-          : insert.map(i => ({unit: unitName(model, false), fields, values: i}));
+          ? [{unit: unitName(model, {escape: false}), fields, values: insert}]
+          : insert.map(i => ({unit: unitName(model, {escape: false}), fields, values: i}));
     }
     const contains = data.filter(d => d.name === selCmpt.name + STORE);
     if (!contains.length) {

--- a/src/compile/selection/assemble.ts
+++ b/src/compile/selection/assemble.ts
@@ -119,11 +119,12 @@ export function assembleUnitSelectionData(model: UnitModel, data: VgData[]): VgD
         const {signals, ...rest} = proj;
         return rest;
       });
-      const insert = selCmpt.init.map((i: SelectionInit | SelectionInit[]) => assembleInit(i, false));
+
+      const insert = selCmpt.init.map(i => assembleInit(i, false));
       init.values =
         selCmpt.type === 'interval'
-          ? [{unit: unitName(model), fields, values: insert}]
-          : insert.map(i => ({unit: unitName(model), fields, values: i}));
+          ? [{unit: unitName(model, false), fields, values: insert}]
+          : insert.map(i => ({unit: unitName(model, false), fields, values: i}));
     }
     const contains = data.filter(d => d.name === selCmpt.name + STORE);
     if (!contains.length) {

--- a/src/compile/selection/index.ts
+++ b/src/compile/selection/index.ts
@@ -87,8 +87,8 @@ function getFacetModel(model: Model): FacetModel {
   return parent as FacetModel;
 }
 
-export function unitName(model: Model) {
-  let name = stringValue(model.name);
+export function unitName(model: Model, escape = true) {
+  let name = escape ? stringValue(model.name) : model.name;
   const facetModel = getFacetModel(model);
   if (facetModel) {
     const {facet} = facetModel;

--- a/src/compile/selection/index.ts
+++ b/src/compile/selection/index.ts
@@ -87,7 +87,7 @@ function getFacetModel(model: Model): FacetModel {
   return parent as FacetModel;
 }
 
-export function unitName(model: Model, escape = true) {
+export function unitName(model: Model, {escape} = {escape: true}) {
   let name = escape ? stringValue(model.name) : model.name;
   const facetModel = getFacetModel(model);
   if (facetModel) {

--- a/src/compile/selection/interval.ts
+++ b/src/compile/selection/interval.ts
@@ -224,7 +224,7 @@ function channelSignals(
     : [
         {
           name: vname,
-          ...(init ? {init: assembleInit(init, scaled)} : {value: []}),
+          ...(init ? {init: assembleInit(init, true, scaled)} : {value: []}),
           on: on
         },
         {

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -265,9 +265,9 @@ export function dateTimeExpr(d: DateTime | DateTimeExpr, normalize = false, toJS
 
   if (toJSON) {
     if (d.utc) {
-      return new Function(`return new Date(Date.UTC(${unitsString}))`)().toJSON();
+      return new Function(`return +new Date(Date.UTC(${unitsString}))`)();
     } else {
-      return new Function(`return new Date(${unitsString})`)().toJSON();
+      return new Function(`return +new Date(${unitsString})`)();
     }
   }
 

--- a/test/compile/selection/multi.test.ts
+++ b/test/compile/selection/multi.test.ts
@@ -166,12 +166,12 @@ describe('Multi Selection', () => {
           {
             unit: '',
             fields: [{type: 'E', field: 'Year'}, {type: 'E', field: 'Origin'}],
-            values: [new Date(1970, 1, 2, 0, 0, 0, 0).toJSON(), 'Japan']
+            values: [+new Date(1970, 1, 2, 0, 0, 0, 0), 'Japan']
           },
           {
             unit: '',
             fields: [{type: 'E', field: 'Year'}, {type: 'E', field: 'Origin'}],
-            values: [new Date(1980, 1, 2, 0, 0, 0, 0).toJSON(), 'USA']
+            values: [+new Date(1980, 1, 2, 0, 0, 0, 0), 'USA']
           }
         ]
       }

--- a/test/compile/selection/multi.test.ts
+++ b/test/compile/selection/multi.test.ts
@@ -137,15 +137,14 @@ describe('Multi Selection', () => {
   });
 
   it('builds unit datasets', () => {
-    const data: any[] = [];
-    expect(assembleUnitSelectionData(model, data)).toEqual([
+    expect(assembleUnitSelectionData(model, [])).toEqual([
       {name: 'one_store'},
       {name: 'two_store'},
       {
         name: 'thr_ee_store',
         values: [
           {
-            unit: '""',
+            unit: '',
             fields: [{type: 'E', field: 'Horsepower'}],
             values: [50]
           }
@@ -155,7 +154,7 @@ describe('Multi Selection', () => {
         name: 'four_store',
         values: [
           {
-            unit: '""',
+            unit: '',
             fields: [{field: 'Horsepower', channel: 'x', type: 'E'}, {field: 'Origin', channel: 'color', type: 'E'}],
             values: [50, 'Japan']
           }
@@ -165,12 +164,12 @@ describe('Multi Selection', () => {
         name: 'five_store',
         values: [
           {
-            unit: '""',
+            unit: '',
             fields: [{type: 'E', field: 'Year'}, {type: 'E', field: 'Origin'}],
             values: [new Date(1970, 1, 2, 0, 0, 0, 0).toJSON(), 'Japan']
           },
           {
-            unit: '""',
+            unit: '',
             fields: [{type: 'E', field: 'Year'}, {type: 'E', field: 'Origin'}],
             values: [new Date(1980, 1, 2, 0, 0, 0, 0).toJSON(), 'USA']
           }

--- a/test/compile/selection/single.test.ts
+++ b/test/compile/selection/single.test.ts
@@ -161,7 +161,7 @@ describe('Single Selection', () => {
         name: 'thr_ee_store',
         values: [
           {
-            unit: '""',
+            unit: '',
             fields: [{type: 'E', field: 'Horsepower'}],
             values: [50]
           }
@@ -171,7 +171,7 @@ describe('Single Selection', () => {
         name: 'four_store',
         values: [
           {
-            unit: '""',
+            unit: '',
             fields: [{field: 'Horsepower', channel: 'x', type: 'E'}, {field: 'Origin', channel: 'color', type: 'E'}],
             values: [50, 'Japan']
           }

--- a/test/datetime.test.ts
+++ b/test/datetime.test.ts
@@ -159,7 +159,7 @@ describe('datetime', () => {
         day: '1'
       };
       const expr = dateTimeExpr(d, false, true);
-      expect(expr).toBe(new Date(1970, 1, 2, 0, 0, 0, 0).toJSON());
+      expect(expr).toBe(+new Date(1970, 1, 2, 0, 0, 0, 0));
     });
 
     it('should throw error for invalid day', () => {
@@ -177,7 +177,7 @@ describe('datetime', () => {
       const expr = dateTimeExpr(d, true);
       expect(expr).toBe('utc(2007, 0, 1, 0, 0, 0, 0)');
       const exprJSON = dateTimeExpr(d, true, true);
-      expect(exprJSON).toBe(new Date(Date.UTC(2007, 0, 1, 0, 0, 0, 0)).toJSON());
+      expect(exprJSON).toBe(+new Date(Date.UTC(2007, 0, 1, 0, 0, 0, 0)));
     });
 
     // Note: Other part of coverage handled by timeUnit.fieldExpr's test


### PR DESCRIPTION
Fixes #5199, which revealed several minor bugs:

1. Now that initial values for selections are embedded directly as dataset values (rather than embedded in signal expressions), we no longer need to string escape model names. 

2. Datetime expressions should evaluate to numerical timestamps, rather than strings. 

3. Vega's `modify` expression should also test for object equality (which wasn't previously necessary for our logic because the same object was being reused in every tuple and thus strict equality testing `===` would correctly evaluate to `true`). vega/vega#1909.

4. ~~Although the typings/schema disallow it (and I believe should continue to disallow it, for simplicity/disambiguity), when a multi selection is projected over a single field, it is reasonable to expect people to use a short form initialization as seen in #5199. i.e., `{init: {Origin: ['Japan', 'USA']}}`. Now, we test for this one corner case, and expand it to what it should be `{init: [{Origin: 'Japan'}, {Origin: 'USA'}]}`~~