### PR TITLE
fix!: drop SelectionInitMapping as a possible type for multi selection init.

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -9701,18 +9701,11 @@
           "type": "array"
         },
         "init": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SelectionInitMapping"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/SelectionInitMapping"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "Initialize the selection with a mapping between [projected channels or field names](https://vega.github.io/vega-lite/docs/project.html) and an initial\nvalue (or array of values).\n\n__See also:__ [`init`](https://vega.github.io/vega-lite/docs/init.html) documentation."
+          "description": "Initialize the selection with a mapping between [projected channels or field names](https://vega.github.io/vega-lite/docs/project.html) and an initial\nvalue (or array of values).\n\n__See also:__ [`init`](https://vega.github.io/vega-lite/docs/init.html) documentation.",
+          "items": {
+            "$ref": "#/definitions/SelectionInitMapping"
+          },
+          "type": "array"
         },
         "nearest": {
           "description": "When true, an invisible voronoi diagram is computed to accelerate discrete\nselection. The data value _nearest_ the mouse cursor is added to the selection.\n\n__See also:__ [`nearest`](https://vega.github.io/vega-lite/docs/nearest.html) documentation.",
@@ -9783,18 +9776,11 @@
           "type": "array"
         },
         "init": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SelectionInitMapping"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/SelectionInitMapping"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "Initialize the selection with a mapping between [projected channels or field names](https://vega.github.io/vega-lite/docs/project.html) and an initial\nvalue (or array of values).\n\n__See also:__ [`init`](https://vega.github.io/vega-lite/docs/init.html) documentation."
+          "description": "Initialize the selection with a mapping between [projected channels or field names](https://vega.github.io/vega-lite/docs/project.html) and an initial\nvalue (or array of values).\n\n__See also:__ [`init`](https://vega.github.io/vega-lite/docs/init.html) documentation.",
+          "items": {
+            "$ref": "#/definitions/SelectionInitMapping"
+          },
+          "type": "array"
         },
         "nearest": {
           "description": "When true, an invisible voronoi diagram is computed to accelerate discrete\nselection. The data value _nearest_ the mouse cursor is added to the selection.\n\n__See also:__ [`nearest`](https://vega.github.io/vega-lite/docs/nearest.html) documentation.",

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -121,7 +121,7 @@ export interface MultiSelectionConfig extends BaseSelectionConfig {
    *
    * __See also:__ [`init`](https://vega.github.io/vega-lite/docs/init.html) documentation.
    */
-  init?: SelectionInitMapping | SelectionInitMapping[];
+  init?: SelectionInitMapping[];
 }
 
 export interface BrushConfig {

--- a/test/compile/selection/multi.test.ts
+++ b/test/compile/selection/multi.test.ts
@@ -31,13 +31,13 @@ describe('Multi Selection', () => {
       type: 'multi',
       fields: ['Horsepower'],
       clear: false,
-      init: {Horsepower: 50}
+      init: [{Horsepower: 50}]
     },
     four: {
       type: 'multi',
       encodings: ['x', 'color'],
       clear: false,
-      init: {Horsepower: 50, color: 'Japan'}
+      init: [{Horsepower: 50, color: 'Japan'}]
     },
     five: {
       type: 'multi',

--- a/test/compile/selection/parse.test.ts
+++ b/test/compile/selection/parse.test.ts
@@ -262,7 +262,7 @@ describe('Selection', () => {
     it('infers from initial values', () => {
       const component = parseUnitSelection(model, {
         one: {type: 'single', init: {Origin: 5}},
-        two: {type: 'multi', init: {color: 10}},
+        two: {type: 'multi', init: [{color: 10}]},
         three: {type: 'interval', init: {x: [10, 100]}}
       });
 


### PR DESCRIPTION
This will reduce confusion and propensity for users to adopt a short hand initialization scheme until such a time that we support columnar initialization (#4766, #5199, #5298).

/cc @gordonwoodhull