### PR TITLE
fix: improve invalid spec error message

### DIFF
--- a/src/compile/buildmodel.ts
+++ b/src/compile/buildmodel.ts
@@ -27,23 +27,14 @@ export function buildModel(
 ): Model {
   if (isFacetSpec(spec)) {
     return new FacetModel(spec, parent, parentGivenName, repeater, config);
-  }
-
-  if (isLayerSpec(spec)) {
+  } else if (isLayerSpec(spec)) {
     return new LayerModel(spec, parent, parentGivenName, unitSize, repeater, config);
-  }
-
-  if (isUnitSpec(spec)) {
+  } else if (isUnitSpec(spec)) {
     return new UnitModel(spec, parent, parentGivenName, unitSize, repeater, config);
-  }
-
-  if (isRepeatSpec(spec)) {
+  } else if (isRepeatSpec(spec)) {
     return new RepeatModel(spec, parent, parentGivenName, repeater, config);
-  }
-
-  if (isAnyConcatSpec(spec)) {
+  } else if (isAnyConcatSpec(spec)) {
     return new ConcatModel(spec, parent, parentGivenName, repeater, config);
   }
-
-  throw new Error(log.message.INVALID_SPEC);
+  throw new Error(log.message.invalidSpec(spec));
 }

--- a/src/compile/layer.ts
+++ b/src/compile/layer.ts
@@ -39,13 +39,11 @@ export class LayerModel extends Model {
     this.children = spec.layer.map((layer, i) => {
       if (isLayerSpec(layer)) {
         return new LayerModel(layer, this, this.getName('layer_' + i), layoutSize, repeater, config);
-      }
-
-      if (isUnitSpec(layer)) {
+      } else if (isUnitSpec(layer)) {
         return new UnitModel(layer, this, this.getName('layer_' + i), layoutSize, repeater, config);
       }
 
-      throw new Error(log.message.INVALID_SPEC);
+      throw new Error(log.message.invalidSpec(layer));
     });
   }
 

--- a/src/log/message.ts
+++ b/src/log/message.ts
@@ -9,6 +9,7 @@ import {DateTime, DateTimeExpr} from '../datetime';
 import {Mark} from '../mark';
 import {Projection} from '../projection';
 import {ScaleType} from '../scale';
+import {GenericSpec} from '../spec/index';
 import {Type} from '../type';
 import {stringify} from '../util';
 import {VgSortField} from '../vega.schema';
@@ -17,7 +18,11 @@ import {VgSortField} from '../vega.schema';
  * Collection of all Vega-Lite Error Messages
  */
 
-export const INVALID_SPEC = 'Invalid spec';
+export function invalidSpec(spec: GenericSpec<any, any>) {
+  return `Invalid specification ${JSON.stringify(
+    spec
+  )}.  Make sure the specification include one of the following properties: "mark", "layer", "facet", "hconcat", "vconcat", "concat", or "repeat".`;
+}
 
 // FIT
 export const FIT_NON_SINGLE = 'Autosize "fit" only works for single views and layered views.';

--- a/src/log/message.ts
+++ b/src/log/message.ts
@@ -21,7 +21,7 @@ import {VgSortField} from '../vega.schema';
 export function invalidSpec(spec: GenericSpec<any, any>) {
   return `Invalid specification ${JSON.stringify(
     spec
-  )}.  Make sure the specification include one of the following properties: "mark", "layer", "facet", "hconcat", "vconcat", "concat", or "repeat".`;
+  )}.  Make sure the specification includes at least one of the following properties: "mark", "layer", "facet", "hconcat", "vconcat", "concat", or "repeat".`;
 }
 
 // FIT

--- a/src/spec/map.ts
+++ b/src/spec/map.ts
@@ -41,7 +41,7 @@ export abstract class SpecMapper<
     } else if (isUnitSpec(spec)) {
       return this.mapUnit(spec, params);
     }
-    throw new Error(log.message.INVALID_SPEC);
+    throw new Error(log.message.invalidSpec(spec));
   }
 
   public abstract mapUnit(spec: UI, params: P): UO | GenericLayerSpec<UO>;

--- a/test/normalize/core.test.ts
+++ b/test/normalize/core.test.ts
@@ -8,6 +8,10 @@ import {TopLevelSpec} from '../../src/spec/index';
 // describe('isStacked()') -- tested as part of stackOffset in stack.test.ts
 
 describe('normalize()', () => {
+  it('throws errors for invalid spec', () => {
+    expect(() => normalize({} as any)).toThrowError(log.message.invalidSpec({}));
+  });
+
   describe('normalizeRepeat', () => {
     it(
       'should drop columns from repeat with row/column',


### PR DESCRIPTION
Motivation: a user has a typo in the syntax and was a bit shocked to see just  "Invalid spec" error, which isn't very helpful.


