### PR TITLE
fix: correct key output

### DIFF
--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -161,7 +161,7 @@ function getMarkGroups(
       type: markCompiler[mark].vgMark,
       ...(clip ? {clip: true} : {}),
       ...(style ? {style} : {}),
-      ...(key ? {key: {field: key.field}} : {}),
+      ...(key ? {key: key.field} : {}),
       ...(sort ? {sort} : {}),
       from: {data: opt.fromPrefix + model.requestDataName(MAIN)},
       encode: {

--- a/test/compile/mark/mark.test.ts
+++ b/test/compile/mark/mark.test.ts
@@ -86,7 +86,7 @@ describe('Mark', () => {
       it('should have mark group with proper data and key', () => {
         const markGroup = parseMarkGroups(model)[0];
         expect(markGroup.type).toBe('symbol');
-        expect(markGroup.key.field).toBe('k');
+        expect(markGroup.key).toBe('k');
         expect(markGroup.from.data).toBe('main');
       });
 


### PR DESCRIPTION
(See https://observablehq.com/d/f1ada87d23956054 -- the right way to use key is to specify the field name directly)

