### PR TITLE
fix: property `y2` should accept `height` not `width`

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -438,7 +438,7 @@
             },
             {
               "enum": [
-                "width"
+                "height"
               ],
               "type": "string"
             }
@@ -1677,7 +1677,7 @@
             },
             {
               "enum": [
-                "width"
+                "height"
               ],
               "type": "string"
             }
@@ -8683,7 +8683,7 @@
             },
             {
               "enum": [
-                "width"
+                "height"
               ],
               "type": "string"
             }
@@ -9294,7 +9294,7 @@
             },
             {
               "enum": [
-                "width"
+                "height"
               ],
               "type": "string"
             }
@@ -9658,7 +9658,7 @@
             },
             {
               "enum": [
-                "width"
+                "height"
               ],
               "type": "string"
             }
@@ -10278,7 +10278,7 @@
             },
             {
               "enum": [
-                "width"
+                "height"
               ],
               "type": "string"
             }
@@ -11214,7 +11214,7 @@
             },
             {
               "enum": [
-                "width"
+                "height"
               ],
               "type": "string"
             }
@@ -12884,7 +12884,7 @@
             },
             {
               "enum": [
-                "width"
+                "height"
               ],
               "type": "string"
             }
@@ -13264,7 +13264,7 @@
             },
             {
               "enum": [
-                "width"
+                "height"
               ],
               "type": "string"
             }

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -574,7 +574,7 @@ export interface BaseMarkConfig {
    *
    * The `value` of this channel can be a number or a string `"height"` for the height of the plot.
    */
-  y2?: number | 'width';
+  y2?: number | 'height';
 
   /**
    * Whether to keep aspect ratio of image marks.


### PR DESCRIPTION
This seems to be a typo. We may want to consider porting the fix back to the 3.2 branch, since the schema is incorrect there as well.