### PR TITLE
fix: correct references to flattened fields in selection signals.

### DIFF
--- a/src/compile/data/formatparse.ts
+++ b/src/compile/data/formatparse.ts
@@ -58,6 +58,129 @@ function parseExpression(field: string, parse: string): string {
   }
 }
 
+export function getImplicitFromFilterTransform(transform: FilterTransform) {
+  const implicit: Dict<string> = {};
+  forEachLeaf(transform.filter, filter => {
+    if (isFieldPredicate(filter)) {
+      // Automatically add a parse node for filters with filter objects
+      let val: string | number | boolean | DateTime = null;
+
+      // For EqualFilter, just use the equal property.
+      // For RangeFilter and OneOfFilter, all array members should have
+      // the same type, so we only use the first one.
+      if (isFieldEqualPredicate(filter)) {
+        val = filter.equal;
+      } else if (isFieldRangePredicate(filter)) {
+        val = filter.range[0];
+      } else if (isFieldOneOfPredicate(filter)) {
+        val = (filter.oneOf || filter['in'])[0];
+      } // else -- for filter expression, we can't infer anything
+      if (val) {
+        if (isDateTime(val)) {
+          implicit[filter.field] = 'date';
+        } else if (isNumber(val)) {
+          implicit[filter.field] = 'number';
+        } else if (isString(val)) {
+          implicit[filter.field] = 'string';
+        }
+      }
+
+      if (filter.timeUnit) {
+        implicit[filter.field] = 'date';
+      }
+    }
+  });
+
+  return implicit;
+}
+
+/**
+ * Creates a parse node for implicit parsing from a model and updates ancestorParse.
+ */
+export function getImplicitFromEncoding(model: Model) {
+  const implicit: Dict<string> = {};
+
+  function add(fieldDef: TypedFieldDef<string>) {
+    if (isTimeFormatFieldDef(fieldDef)) {
+      implicit[fieldDef.field] = 'date';
+    } else if (
+      fieldDef.type === 'quantitative' &&
+      isMinMaxOp(fieldDef.aggregate) // we need to parse numbers to support correct min and max
+    ) {
+      implicit[fieldDef.field] = 'number';
+    } else if (accessPathDepth(fieldDef.field) > 1) {
+      // For non-date/non-number (strings and booleans), derive a flattened field for a referenced nested field.
+      // (Parsing numbers / dates already flattens numeric and temporal fields.)
+      if (!(fieldDef.field in implicit)) {
+        implicit[fieldDef.field] = 'flatten';
+      }
+    } else if (isScaleFieldDef(fieldDef) && isSortField(fieldDef.sort) && accessPathDepth(fieldDef.sort.field) > 1) {
+      // Flatten fields that we sort by but that are not otherwise flattened.
+      if (!(fieldDef.sort.field in implicit)) {
+        implicit[fieldDef.sort.field] = 'flatten';
+      }
+    }
+  }
+
+  if (isUnitModel(model) || isFacetModel(model)) {
+    // Parse encoded fields
+    model.forEachFieldDef((fieldDef, channel) => {
+      if (isTypedFieldDef(fieldDef)) {
+        add(fieldDef);
+      } else {
+        const mainChannel = getMainRangeChannel(channel);
+        const mainFieldDef = model.fieldDef(mainChannel as SingleDefChannel) as TypedFieldDef<string>;
+        add({
+          ...fieldDef,
+          type: mainFieldDef.type
+        });
+      }
+    });
+  }
+
+  // Parse quantitative dimension fields of path marks as numbers so that we sort them correctly.
+  if (isUnitModel(model)) {
+    const {mark, markDef, encoding} = model;
+    if (
+      isPathMark(mark) &&
+      // No need to sort by dimension if we have a connected scatterplot (order channel is present)
+      !model.encoding.order
+    ) {
+      const dimensionChannel = markDef.orient === 'horizontal' ? 'y' : 'x';
+      const dimensionChannelDef = encoding[dimensionChannel];
+      if (
+        isFieldDef(dimensionChannelDef) &&
+        dimensionChannelDef.type === 'quantitative' &&
+        !(dimensionChannelDef.field in implicit)
+      ) {
+        implicit[dimensionChannelDef.field] = 'number';
+      }
+    }
+  }
+
+  return implicit;
+}
+
+/**
+ * Creates a parse node for implicit parsing from a model and updates ancestorParse.
+ */
+export function getImplicitFromSelection(model: Model) {
+  const implicit: Dict<string> = {};
+
+  if (isUnitModel(model) && model.component.selection) {
+    for (const name of keys(model.component.selection)) {
+      const selCmpt = model.component.selection[name];
+      for (const proj of selCmpt.project.items) {
+        if (!proj.channel && accessPathDepth(proj.field) > 1) {
+          implicit[proj.field] = 'flatten';
+        }
+      }
+    }
+  }
+
+  return implicit;
+}
+
 export class ParseNode extends DataFlowNode {
   private _parse: Parse;
 
@@ -89,141 +212,10 @@ export class ParseNode extends DataFlowNode {
     return this.makeWithAncestors(parent, explicit, {}, ancestorParse);
   }
 
-  public static makeImplicitFromFilterTransform(
-    parent: DataFlowNode,
-    transform: FilterTransform,
-    ancestorParse: AncestorParse
-  ) {
-    const parse: Dict<string> = {};
-    forEachLeaf(transform.filter, filter => {
-      if (isFieldPredicate(filter)) {
-        // Automatically add a parse node for filters with filter objects
-        let val: string | number | boolean | DateTime = null;
-
-        // For EqualFilter, just use the equal property.
-        // For RangeFilter and OneOfFilter, all array members should have
-        // the same type, so we only use the first one.
-        if (isFieldEqualPredicate(filter)) {
-          val = filter.equal;
-        } else if (isFieldRangePredicate(filter)) {
-          val = filter.range[0];
-        } else if (isFieldOneOfPredicate(filter)) {
-          val = (filter.oneOf || filter['in'])[0];
-        } // else -- for filter expression, we can't infer anything
-        if (val) {
-          if (isDateTime(val)) {
-            parse[filter.field] = 'date';
-          } else if (isNumber(val)) {
-            parse[filter.field] = 'number';
-          } else if (isString(val)) {
-            parse[filter.field] = 'string';
-          }
-        }
-
-        if (filter.timeUnit) {
-          parse[filter.field] = 'date';
-        }
-      }
-    });
-
-    if (keys(parse).length === 0) {
-      return null;
-    }
-
-    return this.makeWithAncestors(parent, {}, parse, ancestorParse);
-  }
-
-  /**
-   * Creates a parse node for implicit parsing from a model and updates ancestorParse.
-   */
-  public static makeImplicitFromEncoding(parent: DataFlowNode, model: Model, ancestorParse: AncestorParse) {
-    const implicit: Dict<string> = {};
-
-    function add(fieldDef: TypedFieldDef<string>) {
-      if (isTimeFormatFieldDef(fieldDef)) {
-        implicit[fieldDef.field] = 'date';
-      } else if (
-        fieldDef.type === 'quantitative' &&
-        isMinMaxOp(fieldDef.aggregate) // we need to parse numbers to support correct min and max
-      ) {
-        implicit[fieldDef.field] = 'number';
-      } else if (accessPathDepth(fieldDef.field) > 1) {
-        // For non-date/non-number (strings and booleans), derive a flattened field for a referenced nested field.
-        // (Parsing numbers / dates already flattens numeric and temporal fields.)
-        if (!(fieldDef.field in implicit)) {
-          implicit[fieldDef.field] = 'flatten';
-        }
-      } else if (isScaleFieldDef(fieldDef) && isSortField(fieldDef.sort) && accessPathDepth(fieldDef.sort.field) > 1) {
-        // Flatten fields that we sort by but that are not otherwise flattened.
-        if (!(fieldDef.sort.field in implicit)) {
-          implicit[fieldDef.sort.field] = 'flatten';
-        }
-      }
-    }
-
-    if (isUnitModel(model) || isFacetModel(model)) {
-      // Parse encoded fields
-      model.forEachFieldDef((fieldDef, channel) => {
-        if (isTypedFieldDef(fieldDef)) {
-          add(fieldDef);
-        } else {
-          const mainChannel = getMainRangeChannel(channel);
-          const mainFieldDef = model.fieldDef(mainChannel as SingleDefChannel) as TypedFieldDef<string>;
-          add({
-            ...fieldDef,
-            type: mainFieldDef.type
-          });
-        }
-      });
-    }
-
-    // Parse quantitative dimension fields of path marks as numbers so that we sort them correctly.
-    if (isUnitModel(model)) {
-      const {mark, markDef, encoding} = model;
-      if (
-        isPathMark(mark) &&
-        // No need to sort by dimension if we have a connected scatterplot (order channel is present)
-        !model.encoding.order
-      ) {
-        const dimensionChannel = markDef.orient === 'horizontal' ? 'y' : 'x';
-        const dimensionChannelDef = encoding[dimensionChannel];
-        if (
-          isFieldDef(dimensionChannelDef) &&
-          dimensionChannelDef.type === 'quantitative' &&
-          !(dimensionChannelDef.field in implicit)
-        ) {
-          implicit[dimensionChannelDef.field] = 'number';
-        }
-      }
-    }
-
-    return this.makeWithAncestors(parent, {}, implicit, ancestorParse);
-  }
-
-  /**
-   * Creates a parse node for implicit parsing from a model and updates ancestorParse.
-   */
-  public static makeImplicitFromSelection(parent: DataFlowNode, model: Model, ancestorParse: AncestorParse) {
-    const implicit: Dict<string> = {};
-
-    if (isUnitModel(model) && model.component.selection) {
-      for (const name of keys(model.component.selection)) {
-        const selCmpt = model.component.selection[name];
-        for (const proj of selCmpt.project.items) {
-          if (!proj.channel && accessPathDepth(proj.field) > 1) {
-            implicit[proj.field] = 'flatten';
-          }
-        }
-      }
-    }
-
-    return this.makeWithAncestors(parent, {}, implicit, ancestorParse);
-  }
-
   /**
    * Creates a parse node from "explicit" parse and "implicit" parse and updates ancestorParse.
    */
-  private static makeWithAncestors(
+  public static makeWithAncestors(
     parent: DataFlowNode,
     explicit: Parse,
     implicit: Parse,

--- a/src/compile/data/formatparse.ts
+++ b/src/compile/data/formatparse.ts
@@ -201,6 +201,26 @@ export class ParseNode extends DataFlowNode {
   }
 
   /**
+   * Creates a parse node for implicit parsing from a model and updates ancestorParse.
+   */
+  public static makeImplicitFromSelection(parent: DataFlowNode, model: Model, ancestorParse: AncestorParse) {
+    const implicit: Dict<string> = {};
+
+    if (isUnitModel(model) && model.component.selection) {
+      for (const name of keys(model.component.selection)) {
+        const selCmpt = model.component.selection[name];
+        for (const proj of selCmpt.project.items) {
+          if (!proj.channel && accessPathDepth(proj.field) > 1) {
+            implicit[proj.field] = 'flatten';
+          }
+        }
+      }
+    }
+
+    return this.makeWithAncestors(parent, {}, implicit, ancestorParse);
+  }
+
+  /**
    * Creates a parse node from "explicit" parse and "implicit" parse and updates ancestorParse.
    */
   private static makeWithAncestors(

--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -322,6 +322,7 @@ export function parseData(model: Model): DataComponent {
   }
 
   head = ParseNode.makeImplicitFromEncoding(head, model, ancestorParse) || head;
+  head = ParseNode.makeImplicitFromSelection(head, model, ancestorParse) || head;
 
   if (isUnitModel(model)) {
     head = GeoJSONNode.parseAll(head, model);

--- a/src/compile/selection/assemble.ts
+++ b/src/compile/selection/assemble.ts
@@ -5,7 +5,7 @@ import {forEachSelection, MODIFY, SELECTION_DOMAIN, STORE, unitName, VL_SELECTIO
 import {dateTimeExpr, isDateTime} from '../../datetime';
 import {warn} from '../../log';
 import {SelectionInit, SelectionInitInterval} from '../../selection';
-import {accessPathWithDatum, keys, varName} from '../../util';
+import {keys, varName} from '../../util';
 import {VgData} from '../../vega.schema';
 import {FacetModel} from '../facet';
 import {LayerModel} from '../layer';
@@ -197,7 +197,7 @@ export function assembleSelectionScaleDomain(model: Model, domainRaw: SignalRef)
       }
     }
 
-    return {signal: accessPathWithDatum(field, name)};
+    return {signal: `${name}[${stringValue(field)}]`};
   }
 
   return {signal: 'null'};

--- a/src/compile/selection/index.ts
+++ b/src/compile/selection/index.ts
@@ -9,7 +9,7 @@ import {
   SelectionType,
   SELECTION_ID
 } from '../../selection';
-import {accessPathWithDatum, Dict} from '../../util';
+import {Dict} from '../../util';
 import {FacetModel} from '../facet';
 import {isFacetModel, Model} from '../model';
 import {UnitModel} from '../unit';
@@ -92,7 +92,7 @@ export function unitName(model: Model, {escape} = {escape: true}) {
     const {facet} = facetModel;
     for (const channel of FACET_CHANNELS) {
       if (facet[channel]) {
-        name += ` + '__facet_${channel}_' + (${accessPathWithDatum(facetModel.vgField(channel), 'facet')})`;
+        name += ` + '__facet_${channel}_' + (facet[${stringValue(facetModel.vgField(channel))}])`;
       }
     }
   }

--- a/src/compile/selection/multi.ts
+++ b/src/compile/selection/multi.ts
@@ -1,6 +1,6 @@
 import {Signal} from 'vega';
+import {stringValue} from 'vega-util';
 import {SelectionCompiler, SelectionComponent, TUPLE, unitName} from '.';
-import {accessPathWithDatum} from '../../util';
 import {UnitModel} from '../unit';
 import {TUPLE_FIELDS} from './transforms/project';
 
@@ -14,9 +14,9 @@ export function singleOrMultiSignals(model: UnitModel, selCmpt: SelectionCompone
       const fieldDef = model.fieldDef(p.channel);
       // Binned fields should capture extents, for a range test against the raw field.
       return fieldDef && fieldDef.bin
-        ? `[${accessPathWithDatum(model.vgField(p.channel, {}), datum)}, ` +
-            `${accessPathWithDatum(model.vgField(p.channel, {binSuffix: 'end'}), datum)}]`
-        : `${accessPathWithDatum(p.field, datum)}`;
+        ? `[${datum}[${stringValue(model.vgField(p.channel, {}))}], ` +
+            `${datum}[${stringValue(model.vgField(p.channel, {binSuffix: 'end'}))}]]`
+        : `${datum}[${stringValue(p.field)}]`;
     })
     .join(', ');
 

--- a/src/compile/selection/transforms/inputs.ts
+++ b/src/compile/selection/transforms/inputs.ts
@@ -1,5 +1,6 @@
+import {stringValue} from 'vega-util';
 import {TUPLE} from '..';
-import {accessPathWithDatum, varName} from '../../../util';
+import {varName} from '../../../util';
 import {assembleInit} from '../assemble';
 import nearest from './nearest';
 import {TUPLE_FIELDS} from './project';
@@ -35,7 +36,7 @@ const inputBindings: TransformCompiler = {
             ? [
                 {
                   events: selCmpt.events,
-                  update: `datum && item().mark.marktype !== 'group' ? ${accessPathWithDatum(p.field, datum)} : null`
+                  update: `datum && item().mark.marktype !== 'group' ? ${datum}[${stringValue(p.field)}] : null`
                 }
               ]
             : [],

--- a/src/compile/selection/transforms/project.ts
+++ b/src/compile/selection/transforms/project.ts
@@ -3,7 +3,7 @@ import {isSingleDefUnitChannel, ScaleChannel, SingleDefUnitChannel} from '../../
 import * as log from '../../../log';
 import {hasContinuousDomain} from '../../../scale';
 import {SelectionInit, SelectionInitInterval} from '../../../selection';
-import {Dict, hash, keys, varName} from '../../../util';
+import {Dict, hash, keys, varName, replacePathInField, duplicate} from '../../../util';
 import {TimeUnitComponent, TimeUnitNode} from '../../data/timeunit';
 import {TransformCompiler} from './transforms';
 
@@ -161,7 +161,9 @@ const project: TransformCompiler = {
           name,
           value: selCmpt.project.items.map(proj => {
             const {signals, ...rest} = proj;
-            return rest;
+            const p = duplicate(rest);
+            p.field = replacePathInField(p.field);
+            return p;
           })
         });
   }

--- a/src/compile/selection/transforms/scales.ts
+++ b/src/compile/selection/transforms/scales.ts
@@ -3,7 +3,7 @@ import {VL_SELECTION_RESOLVE} from '..';
 import {Channel, isScaleChannel, X, Y} from '../../../channel';
 import * as log from '../../../log';
 import {hasContinuousDomain} from '../../../scale';
-import {accessPathWithDatum, varName} from '../../../util';
+import {varName} from '../../../util';
 import {UnitModel} from '../../unit';
 import {SelectionProjection} from './project';
 import {TransformCompiler} from './transforms';
@@ -33,13 +33,13 @@ const scaleBindings: TransformCompiler = {
         continue;
       }
 
-      scale.set('domainRaw', {signal: accessPathWithDatum(proj.field, name)}, true);
+      scale.set('domainRaw', {signal: `${name}[${stringValue(proj.field)}]`}, true);
       bound.push(proj);
 
       // Bind both x/y for diag plot of repeated views.
       if (model.repeater && model.repeater.row === model.repeater.column) {
         const scale2 = model.getScaleComponent(channel === X ? Y : X);
-        scale2.set('domainRaw', {signal: accessPathWithDatum(proj.field, name)}, true);
+        scale2.set('domainRaw', {signal: `${name}[${stringValue(proj.field)}]`}, true);
       }
     }
   },

--- a/test/compile/data/formatparse.test.ts
+++ b/test/compile/data/formatparse.test.ts
@@ -164,7 +164,7 @@ describe('compile/data/formatparse', () => {
       expect(ParseNode.makeImplicitFromEncoding(null, model, new AncestorParse())).toBeNull();
     });
 
-    it('should add flatten for nested fields', () => {
+    it('should add flatten for nested fields in encoding', () => {
       const model = parseUnitModel({
         mark: 'point',
         encoding: {
@@ -174,6 +174,24 @@ describe('compile/data/formatparse', () => {
       });
 
       expect(ParseNode.makeImplicitFromEncoding(null, model, new AncestorParse()).parse).toEqual({
+        'foo.bar': 'flatten',
+        'foo.baz': 'flatten'
+      });
+    });
+
+    it('should add flatten for nested fields in selection', () => {
+      const model = parseUnitModel({
+        selection: {foo: {type: 'single', fields: ['foo.bar', 'foo.baz']}},
+        mark: 'point',
+        encoding: {
+          x: {field: 'bar', type: 'quantitative'},
+          y: {field: 'baz', type: 'ordinal'}
+        }
+      });
+
+      model.parseSelections();
+
+      expect(ParseNode.makeImplicitFromSelection(null, model, new AncestorParse()).parse).toEqual({
         'foo.bar': 'flatten',
         'foo.baz': 'flatten'
       });

--- a/test/compile/selection/inputs.test.ts
+++ b/test/compile/selection/inputs.test.ts
@@ -62,6 +62,17 @@ describe('Inputs Selection Transform', () => {
       on: 'click',
       clear: 'dblclick',
       bind: {input: 'range', min: 0, max: 10, step: 1}
+    },
+    ten: {
+      type: 'single',
+      fields: ['nested.a'],
+      bind: {input: 'range', min: 0, max: 10, step: 1}
+    },
+    eleven: {
+      type: 'single',
+      fields: ['nested.a'],
+      on: 'click',
+      bind: {input: 'range', min: 0, max: 10, step: 1}
     }
   });
 
@@ -74,6 +85,8 @@ describe('Inputs Selection Transform', () => {
     expect(inputs.has(selCmpts['seven'])).toBeTruthy();
     expect(inputs.has(selCmpts['eight'])).toBeTruthy();
     expect(inputs.has(selCmpts['nine'])).toBeTruthy();
+    expect(inputs.has(selCmpts['ten'])).toBeTruthy();
+    expect(inputs.has(selCmpts['eleven'])).toBeTruthy();
   });
 
   it('adds widget binding for default projection', () => {
@@ -145,6 +158,38 @@ describe('Inputs Selection Transform', () => {
         }
       ])
     );
+  });
+
+  it('adds widget binding for flattened projection', () => {
+    model.component.selection = {one: selCmpts['ten']};
+    expect(assembleUnitSelectionSignals(model, [])).toContainEqual({
+      name: 'ten_tuple',
+      update: 'ten_nested_a !== null ? {fields: ten_tuple_fields, values: [ten_nested_a]} : null'
+    });
+
+    expect(assembleTopLevelSignals(model, [])).toContainEqual({
+      name: 'ten_nested_a',
+      value: null,
+      bind: {input: 'range', min: 0, max: 10, step: 1}
+    });
+
+    model.component.selection = {one: selCmpts['eleven']};
+    expect(assembleUnitSelectionSignals(model, [])).toContainEqual({
+      name: 'eleven_tuple',
+      update: 'eleven_nested_a !== null ? {fields: eleven_tuple_fields, values: [eleven_nested_a]} : null'
+    });
+
+    expect(assembleTopLevelSignals(model, [])).toContainEqual({
+      name: 'eleven_nested_a',
+      value: null,
+      on: [
+        {
+          events: [{source: 'scope', type: 'click'}],
+          update: 'datum && item().mark.marktype !== \'group\' ? datum["nested.a"] : null'
+        }
+      ],
+      bind: {input: 'range', min: 0, max: 10, step: 1}
+    });
   });
 
   it('respects initialization', () => {

--- a/test/compile/selection/multi.test.ts
+++ b/test/compile/selection/multi.test.ts
@@ -53,6 +53,11 @@ describe('Multi Selection', () => {
           Year: {year: 1980, month: 1, day: 1}
         }
       ]
+    },
+    six: {
+      type: 'multi',
+      fields: ['nested.a', 'nested.b'],
+      clear: false
     }
   }));
 
@@ -132,8 +137,23 @@ describe('Multi Selection', () => {
       }
     ]);
 
+    const sixSg = multi.signals(model, selCmpts['six']);
+    expect(sixSg).toEqual([
+      {
+        name: 'six_tuple',
+        on: [
+          {
+            events: [{source: 'scope', type: 'click'}],
+            update:
+              'datum && item().mark.marktype !== \'group\' ? {unit: "", fields: six_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)["nested.a"], (item().isVoronoi ? datum.datum : datum)["nested.b"]]} : null',
+            force: true
+          }
+        ]
+      }
+    ]);
+
     const signals = assembleUnitSelectionSignals(model, []);
-    expect(signals).toEqual(expect.arrayContaining([...oneSg, ...twoSg, ...threeSg, ...fourSg, ...fiveSg]));
+    expect(signals).toEqual(expect.arrayContaining([...oneSg, ...twoSg, ...threeSg, ...fourSg, ...fiveSg, ...sixSg]));
   });
 
   it('builds unit datasets', () => {
@@ -174,7 +194,8 @@ describe('Multi Selection', () => {
             values: [+new Date(1980, 1, 2, 0, 0, 0, 0), 'USA']
           }
         ]
-      }
+      },
+      {name: 'six_store'}
     ]);
   });
 

--- a/test/compile/selection/parse.test.ts
+++ b/test/compile/selection/parse.test.ts
@@ -2,6 +2,7 @@ import {selector as parseSelector} from 'vega-event-selector';
 import {parseUnitSelection} from '../../../src/compile/selection/parse';
 import {keys} from '../../../src/util';
 import {parseUnitModel} from '../../util';
+import project from '../../../src/compile/selection/transforms/project';
 
 describe('Selection', () => {
   const model = parseUnitModel({
@@ -281,6 +282,21 @@ describe('Selection', () => {
           {field: 'Horsepower', channel: 'x', type: 'R', signals: {data: 'three_Horsepower', visual: 'three_x'}}
         ])
       );
+    });
+
+    it('escapes flattened fields', () => {
+      const component = parseUnitSelection(model, {
+        one: {type: 'single', fields: ['nested.a', 'nested.b.aa']}
+      });
+
+      expect(component['one'].project.items).toEqual([
+        {field: 'nested.a', type: 'E', signals: {data: 'one_nested_a'}},
+        {field: 'nested.b.aa', type: 'E', signals: {data: 'one_nested_b_aa'}}
+      ]);
+
+      expect(project.signals(null, component['one'], [])).toEqual([
+        {name: 'one_tuple_fields', value: [{field: 'nested\\.a', type: 'E'}, {field: 'nested\\.b\\.aa', type: 'E'}]}
+      ]);
     });
   });
 });

--- a/test/compile/selection/single.test.ts
+++ b/test/compile/selection/single.test.ts
@@ -41,6 +41,11 @@ describe('Single Selection', () => {
       clear: false,
       encodings: ['x', 'color'],
       init: {x: 50, Origin: 'Japan'}
+    },
+    five: {
+      type: 'single',
+      fields: ['nested.a', 'nested.b'],
+      clear: false
     }
   }));
 
@@ -105,8 +110,23 @@ describe('Single Selection', () => {
       }
     ]);
 
+    const fiveSg = single.signals(model, selCmpts['five']);
+    expect(fiveSg).toEqual([
+      {
+        name: 'five_tuple',
+        on: [
+          {
+            events: [{source: 'scope', type: 'click'}],
+            update:
+              'datum && item().mark.marktype !== \'group\' ? {unit: "", fields: five_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)["nested.a"], (item().isVoronoi ? datum.datum : datum)["nested.b"]]} : null',
+            force: true
+          }
+        ]
+      }
+    ]);
+
     const signals = assembleUnitSelectionSignals(model, []);
-    expect(signals).toEqual(expect.arrayContaining([...oneSg, ...twoSg, ...threeSg, ...fourSg]));
+    expect(signals).toEqual(expect.arrayContaining([...oneSg, ...twoSg, ...threeSg, ...fourSg, ...fiveSg]));
   });
 
   it('builds modify signals', () => {
@@ -176,7 +196,8 @@ describe('Single Selection', () => {
             values: [50, 'Japan']
           }
         ]
-      }
+      },
+      {name: 'five_store'}
     ]);
   });
 


### PR DESCRIPTION
Fields are only flattened if they participate in encoding rules. Thus, we continue to use bracket notation to access datum values in signal expressions as we cannot be guaranteed that the flattened field will be present. However, the field name stored as part of a SelectionProjection will *always* use dot notation as these names are either returned to us flattened by `model.vgField` or users explicitly specify them in the input spec (in which case, dot notation is their only recourse). Thus, when referencing the field via a selection's top-level signal, we just directly access the flattened field name, rather than unpacking it via bracket notation.

Fixes #5334.