### PR TITLE
feat: enable initialization of scale-bound selections.

### DIFF
--- a/src/compile/selection/transforms/project.ts
+++ b/src/compile/selection/transforms/project.ts
@@ -5,7 +5,6 @@ import {hasContinuousDomain} from '../../../scale';
 import {SelectionInit, SelectionInitInterval} from '../../../selection';
 import {Dict, hash, keys, varName} from '../../../util';
 import {TimeUnitComponent, TimeUnitNode} from '../../data/timeunit';
-import scales from './scales';
 import {TransformCompiler} from './transforms';
 
 export const TUPLE_FIELDS = '_tuple_fields';
@@ -136,19 +135,15 @@ const project: TransformCompiler = {
     }
 
     if (selDef.init) {
-      if (scales.has(selCmpt)) {
-        log.warn(log.message.NO_INIT_SCALE_BINDINGS);
-      } else {
-        const parseInit = <T extends SelectionInit | SelectionInitInterval>(i: Dict<T>): T[] => {
-          return proj.items.map(p => (i[p.channel] !== undefined ? i[p.channel] : i[p.field]));
-        };
+      const parseInit = <T extends SelectionInit | SelectionInitInterval>(i: Dict<T>): T[] => {
+        return proj.items.map(p => (i[p.channel] !== undefined ? i[p.channel] : i[p.field]));
+      };
 
-        if (selDef.type === 'interval') {
-          selCmpt.init = parseInit(selDef.init);
-        } else {
-          const init = isArray(selDef.init) ? selDef.init : [selDef.init];
-          selCmpt.init = init.map(parseInit);
-        }
+      if (selDef.type === 'interval') {
+        selCmpt.init = parseInit(selDef.init);
+      } else {
+        const init = isArray(selDef.init) ? selDef.init : [selDef.init];
+        selCmpt.init = init.map(parseInit);
       }
     }
 

--- a/src/log/message.ts
+++ b/src/log/message.ts
@@ -53,8 +53,6 @@ export function selectionNotFound(name: string) {
 export const SCALE_BINDINGS_CONTINUOUS =
   'Scale bindings are currently only supported for scales with unbinned, continuous domains.';
 
-export const NO_INIT_SCALE_BINDINGS = 'Selections bound to scales cannot be separately initialized.';
-
 // REPEAT
 export function noSuchRepeatedValue(field: string) {
   return `Unknown repeated value "${field}".`;


### PR DESCRIPTION
We used to prevent scale-bound selections from being initialized (users instead would have to explicitly define scale domains to initialize these type of selections). This is because selections used to be initialized via signals (#4139), which would populate the selection store on the second pulse and thus would not be ready in time for scale initialization. However, after switching selection initialization to happen directly in the store (#4943), this limitation no longer exists and scale-bound selections can be initialized directly rather than via the scale domain workaround.

Closes #5319.