### PR TITLE
fix: make composite mark preserve null `title`, `scale`, `axis`

### DIFF
--- a/examples/specs/normalized/boxplot_1D_horizontal_custom_mark_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_1D_horizontal_custom_mark_normalized.vl.json
@@ -21,7 +21,13 @@
             }
           ],
           "mark": {"type": "point", "style": "boxplot-outliers"},
-          "encoding": {"x": {"field": "people", "type": "quantitative"}}
+          "encoding": {
+            "x": {
+              "field": "people",
+              "type": "quantitative",
+              "axis": {"title": "population"}
+            }
+          }
         },
         {
           "transform": [

--- a/examples/specs/normalized/boxplot_1D_horizontal_explicit_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_1D_horizontal_explicit_normalized.vl.json
@@ -21,7 +21,13 @@
             }
           ],
           "mark": {"type": "point", "style": "boxplot-outliers"},
-          "encoding": {"x": {"field": "people", "type": "quantitative"}}
+          "encoding": {
+            "x": {
+              "field": "people",
+              "type": "quantitative",
+              "axis": {"title": "population"}
+            }
+          }
         },
         {
           "transform": [

--- a/examples/specs/normalized/boxplot_1D_horizontal_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_1D_horizontal_normalized.vl.json
@@ -21,7 +21,13 @@
             }
           ],
           "mark": {"type": "point", "style": "boxplot-outliers"},
-          "encoding": {"x": {"field": "people", "type": "quantitative"}}
+          "encoding": {
+            "x": {
+              "field": "people",
+              "type": "quantitative",
+              "axis": {"title": "population"}
+            }
+          }
         },
         {
           "transform": [

--- a/examples/specs/normalized/boxplot_1D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_1D_vertical_normalized.vl.json
@@ -21,7 +21,13 @@
             }
           ],
           "mark": {"type": "point", "style": "boxplot-outliers"},
-          "encoding": {"y": {"field": "people", "type": "quantitative"}}
+          "encoding": {
+            "y": {
+              "field": "people",
+              "type": "quantitative",
+              "axis": {"title": "population"}
+            }
+          }
         },
         {
           "transform": [

--- a/examples/specs/normalized/boxplot_2D_horizontal_color_size_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_2D_horizontal_color_size_normalized.vl.json
@@ -22,7 +22,11 @@
           ],
           "mark": {"type": "point", "style": "boxplot-outliers"},
           "encoding": {
-            "x": {"field": "people", "type": "quantitative"},
+            "x": {
+              "field": "people",
+              "type": "quantitative",
+              "axis": {"title": "population"}
+            },
             "y": {"field": "age", "type": "ordinal"}
           }
         },

--- a/examples/specs/normalized/boxplot_2D_horizontal_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_2D_horizontal_normalized.vl.json
@@ -22,7 +22,11 @@
           ],
           "mark": {"type": "point", "style": "boxplot-outliers"},
           "encoding": {
-            "x": {"field": "people", "type": "quantitative"},
+            "x": {
+              "field": "people",
+              "type": "quantitative",
+              "axis": {"title": "population"}
+            },
             "y": {"field": "age", "type": "ordinal"}
           }
         },

--- a/examples/specs/normalized/boxplot_2D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_2D_vertical_normalized.vl.json
@@ -22,7 +22,11 @@
           ],
           "mark": {"type": "point", "style": "boxplot-outliers"},
           "encoding": {
-            "y": {"field": "people", "type": "quantitative"},
+            "y": {
+              "field": "people",
+              "type": "quantitative",
+              "axis": {"title": "population"}
+            },
             "x": {"field": "age", "type": "ordinal"}
           }
         },

--- a/examples/specs/normalized/boxplot_tooltip_aggregate_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_tooltip_aggregate_normalized.vl.json
@@ -21,7 +21,7 @@
           ],
           "mark": {"type": "point", "style": "boxplot-outliers"},
           "encoding": {
-            "y": {"field": "people", "type": "quantitative"},
+            "y": {"field": "people", "type": "quantitative", "title": "people"},
             "x": {"field": "age", "type": "ordinal"}
           }
         },

--- a/examples/specs/normalized/boxplot_tooltip_not_aggregate_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_tooltip_not_aggregate_normalized.vl.json
@@ -21,7 +21,7 @@
           ],
           "mark": {"type": "point", "style": "boxplot-outliers"},
           "encoding": {
-            "y": {"field": "people", "type": "quantitative"},
+            "y": {"field": "people", "type": "quantitative", "title": "people"},
             "x": {"field": "age", "type": "ordinal"},
             "tooltip": {"field": "year", "type": "quantitative"}
           }

--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -15,6 +15,7 @@ import {
   filterTooltipWithAggregatedField,
   GenericCompositeMarkDef,
   getCompositeMarkTooltip,
+  getTitle,
   makeCompositeAggregatePartFactory,
   partLayerMixins,
   PartsMixins
@@ -267,13 +268,20 @@ export function normalizeBoxPlot(
     }
 
     const {tooltip, ...encodingWithoutSizeColorContinuousAxisAndTooltip} = encodingWithoutSizeColorAndContinuousAxis;
+
+    const {scale, axis} = continuousAxisChannelDef;
+    const title = getTitle(continuousAxisChannelDef);
+
     const outlierLayersMixins = partLayerMixins<BoxPlotPartsMixins>(markDef, 'outliers', config.boxplot, {
       transform: [{filter: `(${fieldExpr} < ${lowerWhiskerExpr}) || (${fieldExpr} > ${upperWhiskerExpr})`}],
       mark: 'point',
       encoding: {
         [continuousAxis]: {
           field: continuousAxisChannelDef.field,
-          type: continuousAxisChannelDef.type
+          type: continuousAxisChannelDef.type,
+          ...(title !== undefined ? {title} : {}),
+          ...(scale !== undefined ? {scale} : {}),
+          ...(axis !== undefined ? {axis} : {})
         },
         ...encodingWithoutSizeColorContinuousAxisAndTooltip,
         ...(customTooltipWithoutAggregatedField ? {tooltip: customTooltipWithoutAggregatedField} : {})

--- a/src/compositemark/common.ts
+++ b/src/compositemark/common.ts
@@ -155,9 +155,9 @@ export function makeCompositeAggregatePartFactory<P extends PartsMixins<any>>(
         [continuousAxis]: {
           field: positionPrefix + '_' + continuousAxisChannelDef.field,
           type: continuousAxisChannelDef.type,
-          ...(title ? {title} : {}),
-          ...(scale ? {scale} : {}),
-          ...(axis ? {axis} : {})
+          ...(title !== undefined ? {title} : {}),
+          ...(scale !== undefined ? {scale} : {}),
+          ...(axis !== undefined ? {axis} : {})
         },
         ...(isString(endPositionPrefix)
           ? {

--- a/src/compositemark/common.ts
+++ b/src/compositemark/common.ts
@@ -16,6 +16,7 @@ import {Encoding, fieldDefs} from '../encoding';
 import * as log from '../log';
 import {ColorMixins, GenericMarkDef, isMarkDef, Mark, MarkConfig, MarkDef} from '../mark';
 import {GenericUnitSpec, NormalizedUnitSpec} from '../spec';
+import {getFirstDefined} from '../util';
 
 export type PartsMixins<P extends string> = Partial<Record<P, boolean | MarkConfig>>;
 
@@ -120,6 +121,11 @@ export function getCompositeMarkTooltip(
   };
 }
 
+export function getTitle(continuousAxisChannelDef: PositionFieldDef<string>) {
+  const {axis, title, field} = continuousAxisChannelDef;
+  return axis && axis.title !== undefined ? undefined : getFirstDefined(title, field);
+}
+
 export function makeCompositeAggregatePartFactory<P extends PartsMixins<any>>(
   compositeMarkDef: GenericCompositeMarkDef<any> & P,
   continuousAxis: 'x' | 'y',
@@ -142,12 +148,7 @@ export function makeCompositeAggregatePartFactory<P extends PartsMixins<any>>(
     endPositionPrefix?: string;
     extraEncoding?: Encoding<string>;
   }) => {
-    const title =
-      axis && axis.title !== undefined
-        ? undefined
-        : continuousAxisChannelDef.title !== undefined
-        ? continuousAxisChannelDef.title
-        : continuousAxisChannelDef.field;
+    const title = getTitle(continuousAxisChannelDef);
 
     return partLayerMixins<P>(compositeMarkDef, partName, compositeMarkConfig, {
       mark, // TODO better remove this method and just have mark as a parameter of the method


### PR DESCRIPTION
Part of https://github.com/vega/vega-lite/issues/5407

The remaining issue is that `axis: null` won't get merged across layer -- see [this example](https://vega.github.io/editor/#/url/vega-lite/N4KABGBEAkDODGALApgWwIaQFxUQFzwAdYsB6UgN2QHN0A6agSz0QFcAjOxge1IRQyUa6ALQAbZskoBmOgCtY3AHaQANOCgATdHkw5gkVgCcx2LTvSlU3Co2Sx5ilQF91ESGPQBPZEbMBtUAh3DCMAazNIdnQ-N2DIZCV4bk1GJWozIOD3AA9MjWz3djSzPCNWZDjCqAAzOzFNSIBJAFkAEQAhAH0AJR00jKrCyDwvQmRIgEdWdCU8Zn6qSALg1xX3L3zq93RqaiNhPAmcSGTWObV1+NHxqZm5hfmlq+cV14hXLJCYiJPysQmQwSSRSAy2wzy+iuOz2B1oR0iqGQs0u21q9UaJ1anV6-XSqO2IzGxyg01m810T0B0Kg6ByjFgZiUrDEYheQ3cyTE3D8+kgFHQYgqkQOjTW1UgsEYAC8SQYBUKSQBWd6rDTOAC6IFeQA).

