### PR TITLE
fix: do not generate unnecessary invalid filter for boxplots

### DIFF
--- a/examples/compiled/boxplot_1D_horizontal.vg.json
+++ b/examples/compiled/boxplot_1D_horizontal.vg.json
@@ -68,26 +68,6 @@
     },
     {
       "name": "data_3",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_whisker_people\"] !== null && isFinite(datum[\"lower_whisker_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_4",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"upper_box_people\"] !== null && isFinite(datum[\"upper_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_5",
       "source": "source_0",
       "transform": [
         {
@@ -102,26 +82,6 @@
             "min_people",
             "max_people"
           ]
-        }
-      ]
-    },
-    {
-      "name": "data_6",
-      "source": "data_5",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_box_people\"] !== null && isFinite(datum[\"lower_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_7",
-      "source": "data_5",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"mid_box_people\"] !== null && isFinite(datum[\"mid_box_people\"])"
         }
       ]
     }
@@ -147,7 +107,7 @@
       "name": "layer_0_layer_1_layer_0_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_3"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -164,7 +124,7 @@
       "name": "layer_0_layer_1_layer_1_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_4"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -181,7 +141,7 @@
       "name": "layer_1_layer_0_marks",
       "type": "rect",
       "style": ["bar", "boxplot-box"],
-      "from": {"data": "data_6"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "fill": {"value": "#4c78a8"},
@@ -199,7 +159,7 @@
       "name": "layer_1_layer_1_marks",
       "type": "rect",
       "style": ["tick", "boxplot-median"],
-      "from": {"data": "data_7"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "opacity": {"value": 0.7},
@@ -222,13 +182,13 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "people"},
-          {"data": "data_3", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_box_people"},
+          {"data": "data_2", "field": "upper_box_people"},
+          {"data": "data_2", "field": "upper_whisker_people"},
           {"data": "data_3", "field": "lower_box_people"},
-          {"data": "data_4", "field": "upper_box_people"},
-          {"data": "data_4", "field": "upper_whisker_people"},
-          {"data": "data_6", "field": "lower_box_people"},
-          {"data": "data_6", "field": "upper_box_people"},
-          {"data": "data_7", "field": "mid_box_people"}
+          {"data": "data_3", "field": "upper_box_people"},
+          {"data": "data_3", "field": "mid_box_people"}
         ]
       },
       "range": [0, {"signal": "width"}],

--- a/examples/compiled/boxplot_1D_horizontal_custom_mark.vg.json
+++ b/examples/compiled/boxplot_1D_horizontal_custom_mark.vg.json
@@ -68,36 +68,6 @@
     },
     {
       "name": "data_3",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_whisker_people\"] !== null && isFinite(datum[\"lower_whisker_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_4",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"upper_box_people\"] !== null && isFinite(datum[\"upper_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_5",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"upper_whisker_people\"] !== null && isFinite(datum[\"upper_whisker_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_6",
       "source": "source_0",
       "transform": [
         {
@@ -112,26 +82,6 @@
             "min_people",
             "max_people"
           ]
-        }
-      ]
-    },
-    {
-      "name": "data_7",
-      "source": "data_6",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_box_people\"] !== null && isFinite(datum[\"lower_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_8",
-      "source": "data_6",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"mid_box_people\"] !== null && isFinite(datum[\"mid_box_people\"])"
         }
       ]
     }
@@ -157,7 +107,7 @@
       "name": "layer_0_layer_1_layer_0_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_3"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -174,7 +124,7 @@
       "name": "layer_0_layer_1_layer_1_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_4"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -191,7 +141,7 @@
       "name": "layer_0_layer_1_layer_2_marks",
       "type": "rect",
       "style": ["tick", "boxplot-ticks"],
-      "from": {"data": "data_3"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "opacity": {"value": 1},
@@ -210,7 +160,7 @@
       "name": "layer_0_layer_1_layer_3_marks",
       "type": "rect",
       "style": ["tick", "boxplot-ticks"],
-      "from": {"data": "data_5"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "opacity": {"value": 1},
@@ -229,7 +179,7 @@
       "name": "layer_1_layer_0_marks",
       "type": "rect",
       "style": ["bar", "boxplot-box"],
-      "from": {"data": "data_7"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "fill": {"value": "#4c78a8"},
@@ -247,7 +197,7 @@
       "name": "layer_1_layer_1_marks",
       "type": "rect",
       "style": ["tick", "boxplot-median"],
-      "from": {"data": "data_8"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "opacity": {"value": 0.7},
@@ -270,14 +220,13 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "people"},
-          {"data": "data_3", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_box_people"},
+          {"data": "data_2", "field": "upper_box_people"},
+          {"data": "data_2", "field": "upper_whisker_people"},
           {"data": "data_3", "field": "lower_box_people"},
-          {"data": "data_4", "field": "upper_box_people"},
-          {"data": "data_4", "field": "upper_whisker_people"},
-          {"data": "data_5", "field": "upper_whisker_people"},
-          {"data": "data_7", "field": "lower_box_people"},
-          {"data": "data_7", "field": "upper_box_people"},
-          {"data": "data_8", "field": "mid_box_people"}
+          {"data": "data_3", "field": "upper_box_people"},
+          {"data": "data_3", "field": "mid_box_people"}
         ]
       },
       "range": [0, {"signal": "width"}],

--- a/examples/compiled/boxplot_1D_horizontal_explicit.vg.json
+++ b/examples/compiled/boxplot_1D_horizontal_explicit.vg.json
@@ -68,26 +68,6 @@
     },
     {
       "name": "data_3",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_whisker_people\"] !== null && isFinite(datum[\"lower_whisker_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_4",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"upper_box_people\"] !== null && isFinite(datum[\"upper_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_5",
       "source": "source_0",
       "transform": [
         {
@@ -102,26 +82,6 @@
             "min_people",
             "max_people"
           ]
-        }
-      ]
-    },
-    {
-      "name": "data_6",
-      "source": "data_5",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_box_people\"] !== null && isFinite(datum[\"lower_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_7",
-      "source": "data_5",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"mid_box_people\"] !== null && isFinite(datum[\"mid_box_people\"])"
         }
       ]
     }
@@ -147,7 +107,7 @@
       "name": "layer_0_layer_1_layer_0_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_3"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -164,7 +124,7 @@
       "name": "layer_0_layer_1_layer_1_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_4"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -181,7 +141,7 @@
       "name": "layer_1_layer_0_marks",
       "type": "rect",
       "style": ["bar", "boxplot-box"],
-      "from": {"data": "data_6"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "fill": {"value": "#4c78a8"},
@@ -199,7 +159,7 @@
       "name": "layer_1_layer_1_marks",
       "type": "rect",
       "style": ["tick", "boxplot-median"],
-      "from": {"data": "data_7"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "opacity": {"value": 0.7},
@@ -222,13 +182,13 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "people"},
-          {"data": "data_3", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_box_people"},
+          {"data": "data_2", "field": "upper_box_people"},
+          {"data": "data_2", "field": "upper_whisker_people"},
           {"data": "data_3", "field": "lower_box_people"},
-          {"data": "data_4", "field": "upper_box_people"},
-          {"data": "data_4", "field": "upper_whisker_people"},
-          {"data": "data_6", "field": "lower_box_people"},
-          {"data": "data_6", "field": "upper_box_people"},
-          {"data": "data_7", "field": "mid_box_people"}
+          {"data": "data_3", "field": "upper_box_people"},
+          {"data": "data_3", "field": "mid_box_people"}
         ]
       },
       "range": [0, {"signal": "width"}],

--- a/examples/compiled/boxplot_1D_vertical.vg.json
+++ b/examples/compiled/boxplot_1D_vertical.vg.json
@@ -68,26 +68,6 @@
     },
     {
       "name": "data_3",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_whisker_people\"] !== null && isFinite(datum[\"lower_whisker_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_4",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"upper_box_people\"] !== null && isFinite(datum[\"upper_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_5",
       "source": "source_0",
       "transform": [
         {
@@ -102,26 +82,6 @@
             "min_people",
             "max_people"
           ]
-        }
-      ]
-    },
-    {
-      "name": "data_6",
-      "source": "data_5",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_box_people\"] !== null && isFinite(datum[\"lower_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_7",
-      "source": "data_5",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"mid_box_people\"] !== null && isFinite(datum[\"mid_box_people\"])"
         }
       ]
     }
@@ -147,7 +107,7 @@
       "name": "layer_0_layer_1_layer_0_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_3"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -164,7 +124,7 @@
       "name": "layer_0_layer_1_layer_1_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_4"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -181,7 +141,7 @@
       "name": "layer_1_layer_0_marks",
       "type": "rect",
       "style": ["bar", "boxplot-box"],
-      "from": {"data": "data_6"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "fill": {"value": "#4c78a8"},
@@ -199,7 +159,7 @@
       "name": "layer_1_layer_1_marks",
       "type": "rect",
       "style": ["tick", "boxplot-median"],
-      "from": {"data": "data_7"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "opacity": {"value": 0.7},
@@ -222,13 +182,13 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "people"},
-          {"data": "data_3", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_box_people"},
+          {"data": "data_2", "field": "upper_box_people"},
+          {"data": "data_2", "field": "upper_whisker_people"},
           {"data": "data_3", "field": "lower_box_people"},
-          {"data": "data_4", "field": "upper_box_people"},
-          {"data": "data_4", "field": "upper_whisker_people"},
-          {"data": "data_6", "field": "lower_box_people"},
-          {"data": "data_6", "field": "upper_box_people"},
-          {"data": "data_7", "field": "mid_box_people"}
+          {"data": "data_3", "field": "upper_box_people"},
+          {"data": "data_3", "field": "mid_box_people"}
         ]
       },
       "range": [{"signal": "height"}, 0],

--- a/examples/compiled/boxplot_2D_horizontal.vg.json
+++ b/examples/compiled/boxplot_2D_horizontal.vg.json
@@ -67,26 +67,6 @@
     },
     {
       "name": "data_3",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_whisker_people\"] !== null && isFinite(datum[\"lower_whisker_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_4",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"upper_box_people\"] !== null && isFinite(datum[\"upper_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_5",
       "source": "source_0",
       "transform": [
         {
@@ -101,26 +81,6 @@
             "min_people",
             "max_people"
           ]
-        }
-      ]
-    },
-    {
-      "name": "data_6",
-      "source": "data_5",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_box_people\"] !== null && isFinite(datum[\"lower_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_7",
-      "source": "data_5",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"mid_box_people\"] !== null && isFinite(datum[\"mid_box_people\"])"
         }
       ]
     }
@@ -149,7 +109,7 @@
       "name": "layer_0_layer_1_layer_0_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_3"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -166,7 +126,7 @@
       "name": "layer_0_layer_1_layer_1_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_4"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -183,7 +143,7 @@
       "name": "layer_1_layer_0_marks",
       "type": "rect",
       "style": ["bar", "boxplot-box"],
-      "from": {"data": "data_6"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "fill": {"value": "#4c78a8"},
@@ -201,7 +161,7 @@
       "name": "layer_1_layer_1_marks",
       "type": "rect",
       "style": ["tick", "boxplot-median"],
-      "from": {"data": "data_7"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "opacity": {"value": 0.7},
@@ -224,13 +184,13 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "people"},
-          {"data": "data_3", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_box_people"},
+          {"data": "data_2", "field": "upper_box_people"},
+          {"data": "data_2", "field": "upper_whisker_people"},
           {"data": "data_3", "field": "lower_box_people"},
-          {"data": "data_4", "field": "upper_box_people"},
-          {"data": "data_4", "field": "upper_whisker_people"},
-          {"data": "data_6", "field": "lower_box_people"},
-          {"data": "data_6", "field": "upper_box_people"},
-          {"data": "data_7", "field": "mid_box_people"}
+          {"data": "data_3", "field": "upper_box_people"},
+          {"data": "data_3", "field": "mid_box_people"}
         ]
       },
       "range": [0, {"signal": "width"}],
@@ -243,10 +203,8 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "age"},
-          {"data": "data_3", "field": "age"},
-          {"data": "data_4", "field": "age"},
-          {"data": "data_6", "field": "age"},
-          {"data": "data_7", "field": "age"}
+          {"data": "data_2", "field": "age"},
+          {"data": "data_3", "field": "age"}
         ],
         "sort": true
       },

--- a/examples/compiled/boxplot_2D_horizontal_color_size.vg.json
+++ b/examples/compiled/boxplot_2D_horizontal_color_size.vg.json
@@ -67,26 +67,6 @@
     },
     {
       "name": "data_3",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_whisker_people\"] !== null && isFinite(datum[\"lower_whisker_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_4",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"upper_box_people\"] !== null && isFinite(datum[\"upper_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_5",
       "source": "source_0",
       "transform": [
         {
@@ -101,26 +81,6 @@
             "min_people",
             "max_people"
           ]
-        }
-      ]
-    },
-    {
-      "name": "data_6",
-      "source": "data_5",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_box_people\"] !== null && isFinite(datum[\"lower_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_7",
-      "source": "data_5",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"mid_box_people\"] !== null && isFinite(datum[\"mid_box_people\"])"
         }
       ]
     }
@@ -149,7 +109,7 @@
       "name": "layer_0_layer_1_layer_0_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_3"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -166,7 +126,7 @@
       "name": "layer_0_layer_1_layer_1_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_4"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -183,7 +143,7 @@
       "name": "layer_1_layer_0_marks",
       "type": "rect",
       "style": ["bar", "boxplot-box"],
-      "from": {"data": "data_6"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "fill": {"value": "teal"},
@@ -201,7 +161,7 @@
       "name": "layer_1_layer_1_marks",
       "type": "rect",
       "style": ["tick", "boxplot-median"],
-      "from": {"data": "data_7"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "opacity": {"value": 0.7},
@@ -224,13 +184,13 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "people"},
-          {"data": "data_3", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_box_people"},
+          {"data": "data_2", "field": "upper_box_people"},
+          {"data": "data_2", "field": "upper_whisker_people"},
           {"data": "data_3", "field": "lower_box_people"},
-          {"data": "data_4", "field": "upper_box_people"},
-          {"data": "data_4", "field": "upper_whisker_people"},
-          {"data": "data_6", "field": "lower_box_people"},
-          {"data": "data_6", "field": "upper_box_people"},
-          {"data": "data_7", "field": "mid_box_people"}
+          {"data": "data_3", "field": "upper_box_people"},
+          {"data": "data_3", "field": "mid_box_people"}
         ]
       },
       "range": [0, {"signal": "width"}],
@@ -243,10 +203,8 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "age"},
-          {"data": "data_3", "field": "age"},
-          {"data": "data_4", "field": "age"},
-          {"data": "data_6", "field": "age"},
-          {"data": "data_7", "field": "age"}
+          {"data": "data_2", "field": "age"},
+          {"data": "data_3", "field": "age"}
         ],
         "sort": true
       },

--- a/examples/compiled/boxplot_2D_vertical.vg.json
+++ b/examples/compiled/boxplot_2D_vertical.vg.json
@@ -67,26 +67,6 @@
     },
     {
       "name": "data_3",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_whisker_people\"] !== null && isFinite(datum[\"lower_whisker_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_4",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"upper_box_people\"] !== null && isFinite(datum[\"upper_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_5",
       "source": "source_0",
       "transform": [
         {
@@ -101,26 +81,6 @@
             "min_people",
             "max_people"
           ]
-        }
-      ]
-    },
-    {
-      "name": "data_6",
-      "source": "data_5",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_box_people\"] !== null && isFinite(datum[\"lower_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_7",
-      "source": "data_5",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"mid_box_people\"] !== null && isFinite(datum[\"mid_box_people\"])"
         }
       ]
     }
@@ -149,7 +109,7 @@
       "name": "layer_0_layer_1_layer_0_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_3"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -166,7 +126,7 @@
       "name": "layer_0_layer_1_layer_1_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_4"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -183,7 +143,7 @@
       "name": "layer_1_layer_0_marks",
       "type": "rect",
       "style": ["bar", "boxplot-box"],
-      "from": {"data": "data_6"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "fill": {"value": "#4c78a8"},
@@ -201,7 +161,7 @@
       "name": "layer_1_layer_1_marks",
       "type": "rect",
       "style": ["tick", "boxplot-median"],
-      "from": {"data": "data_7"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "opacity": {"value": 0.7},
@@ -224,10 +184,8 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "age"},
-          {"data": "data_3", "field": "age"},
-          {"data": "data_4", "field": "age"},
-          {"data": "data_6", "field": "age"},
-          {"data": "data_7", "field": "age"}
+          {"data": "data_2", "field": "age"},
+          {"data": "data_3", "field": "age"}
         ],
         "sort": true
       },
@@ -241,13 +199,13 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "people"},
-          {"data": "data_3", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_box_people"},
+          {"data": "data_2", "field": "upper_box_people"},
+          {"data": "data_2", "field": "upper_whisker_people"},
           {"data": "data_3", "field": "lower_box_people"},
-          {"data": "data_4", "field": "upper_box_people"},
-          {"data": "data_4", "field": "upper_whisker_people"},
-          {"data": "data_6", "field": "lower_box_people"},
-          {"data": "data_6", "field": "upper_box_people"},
-          {"data": "data_7", "field": "mid_box_people"}
+          {"data": "data_3", "field": "upper_box_people"},
+          {"data": "data_3", "field": "mid_box_people"}
         ]
       },
       "range": [{"signal": "height"}, 0],

--- a/examples/compiled/boxplot_minmax_2D_horizontal.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_horizontal.vg.json
@@ -25,46 +25,6 @@
           ]
         }
       ]
-    },
-    {
-      "name": "data_0",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_whisker_people\"] !== null && isFinite(datum[\"lower_whisker_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_1",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"upper_box_people\"] !== null && isFinite(datum[\"upper_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_2",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_box_people\"] !== null && isFinite(datum[\"lower_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_3",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"mid_box_people\"] !== null && isFinite(datum[\"mid_box_people\"])"
-        }
-      ]
     }
   ],
   "signals": [
@@ -76,7 +36,7 @@
       "name": "layer_0_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_0"},
+      "from": {"data": "source_0"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -93,7 +53,7 @@
       "name": "layer_1_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_1"},
+      "from": {"data": "source_0"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -110,7 +70,7 @@
       "name": "layer_2_marks",
       "type": "rect",
       "style": ["bar", "boxplot-box"],
-      "from": {"data": "data_2"},
+      "from": {"data": "source_0"},
       "encode": {
         "update": {
           "fill": {"value": "#4c78a8"},
@@ -128,7 +88,7 @@
       "name": "layer_3_marks",
       "type": "rect",
       "style": ["tick", "boxplot-median"],
-      "from": {"data": "data_3"},
+      "from": {"data": "source_0"},
       "encode": {
         "update": {
           "opacity": {"value": 0.7},
@@ -149,14 +109,13 @@
       "name": "x",
       "type": "linear",
       "domain": {
+        "data": "source_0",
         "fields": [
-          {"data": "data_0", "field": "lower_whisker_people"},
-          {"data": "data_0", "field": "lower_box_people"},
-          {"data": "data_1", "field": "upper_box_people"},
-          {"data": "data_1", "field": "upper_whisker_people"},
-          {"data": "data_2", "field": "lower_box_people"},
-          {"data": "data_2", "field": "upper_box_people"},
-          {"data": "data_3", "field": "mid_box_people"}
+          "lower_whisker_people",
+          "lower_box_people",
+          "upper_box_people",
+          "upper_whisker_people",
+          "mid_box_people"
         ]
       },
       "range": [0, {"signal": "width"}],
@@ -166,15 +125,7 @@
     {
       "name": "y",
       "type": "band",
-      "domain": {
-        "fields": [
-          {"data": "data_0", "field": "age"},
-          {"data": "data_1", "field": "age"},
-          {"data": "data_2", "field": "age"},
-          {"data": "data_3", "field": "age"}
-        ],
-        "sort": true
-      },
+      "domain": {"data": "source_0", "field": "age", "sort": true},
       "range": {"step": {"signal": "y_step"}},
       "paddingInner": 0,
       "paddingOuter": 0

--- a/examples/compiled/boxplot_minmax_2D_horizontal_custom_midtick_color.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_horizontal_custom_midtick_color.vg.json
@@ -25,46 +25,6 @@
           ]
         }
       ]
-    },
-    {
-      "name": "data_0",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_whisker_people\"] !== null && isFinite(datum[\"lower_whisker_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_1",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"upper_box_people\"] !== null && isFinite(datum[\"upper_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_2",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_box_people\"] !== null && isFinite(datum[\"lower_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_3",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"mid_box_people\"] !== null && isFinite(datum[\"mid_box_people\"])"
-        }
-      ]
     }
   ],
   "signals": [
@@ -76,7 +36,7 @@
       "name": "layer_0_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_0"},
+      "from": {"data": "source_0"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -93,7 +53,7 @@
       "name": "layer_1_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_1"},
+      "from": {"data": "source_0"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -110,7 +70,7 @@
       "name": "layer_2_marks",
       "type": "rect",
       "style": ["bar", "boxplot-box"],
-      "from": {"data": "data_2"},
+      "from": {"data": "source_0"},
       "encode": {
         "update": {
           "fill": {"value": "#4c78a8"},
@@ -128,7 +88,7 @@
       "name": "layer_3_marks",
       "type": "rect",
       "style": ["tick", "boxplot-median"],
-      "from": {"data": "data_3"},
+      "from": {"data": "source_0"},
       "encode": {
         "update": {
           "opacity": {"value": 0.7},
@@ -149,14 +109,13 @@
       "name": "x",
       "type": "linear",
       "domain": {
+        "data": "source_0",
         "fields": [
-          {"data": "data_0", "field": "lower_whisker_people"},
-          {"data": "data_0", "field": "lower_box_people"},
-          {"data": "data_1", "field": "upper_box_people"},
-          {"data": "data_1", "field": "upper_whisker_people"},
-          {"data": "data_2", "field": "lower_box_people"},
-          {"data": "data_2", "field": "upper_box_people"},
-          {"data": "data_3", "field": "mid_box_people"}
+          "lower_whisker_people",
+          "lower_box_people",
+          "upper_box_people",
+          "upper_whisker_people",
+          "mid_box_people"
         ]
       },
       "range": [0, {"signal": "width"}],
@@ -166,15 +125,7 @@
     {
       "name": "y",
       "type": "band",
-      "domain": {
-        "fields": [
-          {"data": "data_0", "field": "age"},
-          {"data": "data_1", "field": "age"},
-          {"data": "data_2", "field": "age"},
-          {"data": "data_3", "field": "age"}
-        ],
-        "sort": true
-      },
+      "domain": {"data": "source_0", "field": "age", "sort": true},
       "range": {"step": {"signal": "y_step"}},
       "paddingInner": 0,
       "paddingOuter": 0

--- a/examples/compiled/boxplot_minmax_2D_vertical.vg.json
+++ b/examples/compiled/boxplot_minmax_2D_vertical.vg.json
@@ -25,46 +25,6 @@
           ]
         }
       ]
-    },
-    {
-      "name": "data_0",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_whisker_people\"] !== null && isFinite(datum[\"lower_whisker_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_1",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"upper_box_people\"] !== null && isFinite(datum[\"upper_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_2",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_box_people\"] !== null && isFinite(datum[\"lower_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_3",
-      "source": "source_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"mid_box_people\"] !== null && isFinite(datum[\"mid_box_people\"])"
-        }
-      ]
     }
   ],
   "signals": [
@@ -76,7 +36,7 @@
       "name": "layer_0_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_0"},
+      "from": {"data": "source_0"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -93,7 +53,7 @@
       "name": "layer_1_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_1"},
+      "from": {"data": "source_0"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -110,7 +70,7 @@
       "name": "layer_2_marks",
       "type": "rect",
       "style": ["bar", "boxplot-box"],
-      "from": {"data": "data_2"},
+      "from": {"data": "source_0"},
       "encode": {
         "update": {
           "fill": {"value": "#4c78a8"},
@@ -128,7 +88,7 @@
       "name": "layer_3_marks",
       "type": "rect",
       "style": ["tick", "boxplot-median"],
-      "from": {"data": "data_3"},
+      "from": {"data": "source_0"},
       "encode": {
         "update": {
           "opacity": {"value": 0.7},
@@ -148,15 +108,7 @@
     {
       "name": "x",
       "type": "band",
-      "domain": {
-        "fields": [
-          {"data": "data_0", "field": "age"},
-          {"data": "data_1", "field": "age"},
-          {"data": "data_2", "field": "age"},
-          {"data": "data_3", "field": "age"}
-        ],
-        "sort": true
-      },
+      "domain": {"data": "source_0", "field": "age", "sort": true},
       "range": {"step": {"signal": "x_step"}},
       "paddingInner": 0,
       "paddingOuter": 0
@@ -165,14 +117,13 @@
       "name": "y",
       "type": "linear",
       "domain": {
+        "data": "source_0",
         "fields": [
-          {"data": "data_0", "field": "lower_whisker_people"},
-          {"data": "data_0", "field": "lower_box_people"},
-          {"data": "data_1", "field": "upper_box_people"},
-          {"data": "data_1", "field": "upper_whisker_people"},
-          {"data": "data_2", "field": "lower_box_people"},
-          {"data": "data_2", "field": "upper_box_people"},
-          {"data": "data_3", "field": "mid_box_people"}
+          "lower_whisker_people",
+          "lower_box_people",
+          "upper_box_people",
+          "upper_whisker_people",
+          "mid_box_people"
         ]
       },
       "range": [{"signal": "height"}, 0],

--- a/examples/compiled/boxplot_tooltip_aggregate.vg.json
+++ b/examples/compiled/boxplot_tooltip_aggregate.vg.json
@@ -68,26 +68,6 @@
     },
     {
       "name": "data_3",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_whisker_people\"] !== null && isFinite(datum[\"lower_whisker_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_4",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"upper_box_people\"] !== null && isFinite(datum[\"upper_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_5",
       "source": "source_0",
       "transform": [
         {
@@ -110,26 +90,6 @@
             "min_people",
             "max_people"
           ]
-        }
-      ]
-    },
-    {
-      "name": "data_6",
-      "source": "data_5",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_box_people\"] !== null && isFinite(datum[\"lower_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_7",
-      "source": "data_5",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"mid_box_people\"] !== null && isFinite(datum[\"mid_box_people\"])"
         }
       ]
     }
@@ -158,7 +118,7 @@
       "name": "layer_0_layer_1_layer_0_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_3"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -173,7 +133,7 @@
       "name": "layer_0_layer_1_layer_1_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_4"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -188,7 +148,7 @@
       "name": "layer_1_layer_0_marks",
       "type": "rect",
       "style": ["bar", "boxplot-box"],
-      "from": {"data": "data_6"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "fill": {"value": "#4c78a8"},
@@ -204,7 +164,7 @@
       "name": "layer_1_layer_1_marks",
       "type": "rect",
       "style": ["tick", "boxplot-median"],
-      "from": {"data": "data_7"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "opacity": {"value": 0.7},
@@ -225,10 +185,8 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "age"},
-          {"data": "data_3", "field": "age"},
-          {"data": "data_4", "field": "age"},
-          {"data": "data_6", "field": "age"},
-          {"data": "data_7", "field": "age"}
+          {"data": "data_2", "field": "age"},
+          {"data": "data_3", "field": "age"}
         ],
         "sort": true
       },
@@ -242,13 +200,13 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "people"},
-          {"data": "data_3", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_box_people"},
+          {"data": "data_2", "field": "upper_box_people"},
+          {"data": "data_2", "field": "upper_whisker_people"},
           {"data": "data_3", "field": "lower_box_people"},
-          {"data": "data_4", "field": "upper_box_people"},
-          {"data": "data_4", "field": "upper_whisker_people"},
-          {"data": "data_6", "field": "lower_box_people"},
-          {"data": "data_6", "field": "upper_box_people"},
-          {"data": "data_7", "field": "mid_box_people"}
+          {"data": "data_3", "field": "upper_box_people"},
+          {"data": "data_3", "field": "mid_box_people"}
         ]
       },
       "range": [{"signal": "height"}, 0],

--- a/examples/compiled/boxplot_tooltip_not_aggregate.vg.json
+++ b/examples/compiled/boxplot_tooltip_not_aggregate.vg.json
@@ -66,26 +66,6 @@
     },
     {
       "name": "data_3",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_whisker_people\"] !== null && isFinite(datum[\"lower_whisker_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_4",
-      "source": "data_2",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"upper_box_people\"] !== null && isFinite(datum[\"upper_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_5",
       "source": "source_0",
       "transform": [
         {
@@ -100,26 +80,6 @@
             "min_people",
             "max_people"
           ]
-        }
-      ]
-    },
-    {
-      "name": "data_6",
-      "source": "data_5",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_box_people\"] !== null && isFinite(datum[\"lower_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_7",
-      "source": "data_5",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"mid_box_people\"] !== null && isFinite(datum[\"mid_box_people\"])"
         }
       ]
     }
@@ -149,7 +109,7 @@
       "name": "layer_0_layer_1_layer_0_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_3"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -166,7 +126,7 @@
       "name": "layer_0_layer_1_layer_1_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_4"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -183,7 +143,7 @@
       "name": "layer_1_layer_0_marks",
       "type": "rect",
       "style": ["bar", "boxplot-box"],
-      "from": {"data": "data_6"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "fill": {"value": "#4c78a8"},
@@ -201,7 +161,7 @@
       "name": "layer_1_layer_1_marks",
       "type": "rect",
       "style": ["tick", "boxplot-median"],
-      "from": {"data": "data_7"},
+      "from": {"data": "data_3"},
       "encode": {
         "update": {
           "opacity": {"value": 0.7},
@@ -224,10 +184,8 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "age"},
-          {"data": "data_3", "field": "age"},
-          {"data": "data_4", "field": "age"},
-          {"data": "data_6", "field": "age"},
-          {"data": "data_7", "field": "age"}
+          {"data": "data_2", "field": "age"},
+          {"data": "data_3", "field": "age"}
         ],
         "sort": true
       },
@@ -241,13 +199,13 @@
       "domain": {
         "fields": [
           {"data": "data_1", "field": "people"},
-          {"data": "data_3", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_whisker_people"},
+          {"data": "data_2", "field": "lower_box_people"},
+          {"data": "data_2", "field": "upper_box_people"},
+          {"data": "data_2", "field": "upper_whisker_people"},
           {"data": "data_3", "field": "lower_box_people"},
-          {"data": "data_4", "field": "upper_box_people"},
-          {"data": "data_4", "field": "upper_whisker_people"},
-          {"data": "data_6", "field": "lower_box_people"},
-          {"data": "data_6", "field": "upper_box_people"},
-          {"data": "data_7", "field": "mid_box_people"}
+          {"data": "data_3", "field": "upper_box_people"},
+          {"data": "data_3", "field": "mid_box_people"}
         ]
       },
       "range": [{"signal": "height"}, 0],

--- a/examples/compiled/layer_boxplot_circle.vg.json
+++ b/examples/compiled/layer_boxplot_circle.vg.json
@@ -47,26 +47,6 @@
     },
     {
       "name": "data_1",
-      "source": "data_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_whisker_people\"] !== null && isFinite(datum[\"lower_whisker_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_2",
-      "source": "data_0",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"upper_box_people\"] !== null && isFinite(datum[\"upper_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_3",
       "source": "source_0",
       "transform": [
         {
@@ -85,27 +65,7 @@
       ]
     },
     {
-      "name": "data_4",
-      "source": "data_3",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"lower_box_people\"] !== null && isFinite(datum[\"lower_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_5",
-      "source": "data_3",
-      "transform": [
-        {
-          "type": "filter",
-          "expr": "datum[\"mid_box_people\"] !== null && isFinite(datum[\"mid_box_people\"])"
-        }
-      ]
-    },
-    {
-      "name": "data_6",
+      "name": "data_2",
       "source": "source_0",
       "transform": [
         {
@@ -124,7 +84,7 @@
       "name": "layer_0_layer_0_layer_0_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_1"},
+      "from": {"data": "data_0"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -141,7 +101,7 @@
       "name": "layer_0_layer_0_layer_1_marks",
       "type": "rule",
       "style": ["rule", "boxplot-rule"],
-      "from": {"data": "data_2"},
+      "from": {"data": "data_0"},
       "encode": {
         "update": {
           "stroke": {"value": "black"},
@@ -158,7 +118,7 @@
       "name": "layer_0_layer_1_layer_0_marks",
       "type": "rect",
       "style": ["bar", "boxplot-box"],
-      "from": {"data": "data_4"},
+      "from": {"data": "data_1"},
       "encode": {
         "update": {
           "fill": {"value": "#4c78a8"},
@@ -176,7 +136,7 @@
       "name": "layer_0_layer_1_layer_1_marks",
       "type": "rect",
       "style": ["tick", "boxplot-median"],
-      "from": {"data": "data_5"},
+      "from": {"data": "data_1"},
       "encode": {
         "update": {
           "opacity": {"value": 0.7},
@@ -195,7 +155,7 @@
       "name": "layer_1_marks",
       "type": "symbol",
       "style": ["circle"],
-      "from": {"data": "data_6"},
+      "from": {"data": "data_2"},
       "encode": {
         "update": {
           "opacity": {"value": 0.2},
@@ -213,14 +173,14 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_1", "field": "lower_whisker_people"},
+          {"data": "data_0", "field": "lower_whisker_people"},
+          {"data": "data_0", "field": "lower_box_people"},
+          {"data": "data_0", "field": "upper_box_people"},
+          {"data": "data_0", "field": "upper_whisker_people"},
           {"data": "data_1", "field": "lower_box_people"},
-          {"data": "data_2", "field": "upper_box_people"},
-          {"data": "data_2", "field": "upper_whisker_people"},
-          {"data": "data_4", "field": "lower_box_people"},
-          {"data": "data_4", "field": "upper_box_people"},
-          {"data": "data_5", "field": "mid_box_people"},
-          {"data": "data_6", "field": "people"}
+          {"data": "data_1", "field": "upper_box_people"},
+          {"data": "data_1", "field": "mid_box_people"},
+          {"data": "data_2", "field": "people"}
         ]
       },
       "range": [0, {"signal": "width"}],
@@ -232,11 +192,9 @@
       "type": "band",
       "domain": {
         "fields": [
+          {"data": "data_0", "field": "age"},
           {"data": "data_1", "field": "age"},
-          {"data": "data_2", "field": "age"},
-          {"data": "data_4", "field": "age"},
-          {"data": "data_5", "field": "age"},
-          {"data": "data_6", "field": "age"}
+          {"data": "data_2", "field": "age"}
         ],
         "sort": true
       },

--- a/examples/specs/normalized/boxplot_1D_horizontal_custom_mark_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_1D_horizontal_custom_mark_normalized.vl.json
@@ -48,7 +48,11 @@
           ],
           "layer": [
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "x": {
                   "field": "lower_whisker_people",
@@ -71,7 +75,11 @@
               }
             },
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "x": {
                   "field": "upper_box_people",
@@ -99,6 +107,7 @@
                 "color": "black",
                 "opacity": 1,
                 "orient": "vertical",
+                "invalid": null,
                 "style": "boxplot-ticks"
               },
               "encoding": {
@@ -127,6 +136,7 @@
                 "color": "black",
                 "opacity": 1,
                 "orient": "vertical",
+                "invalid": null,
                 "style": "boxplot-ticks"
               },
               "encoding": {
@@ -172,6 +182,7 @@
             "type": "bar",
             "size": 14,
             "orient": "horizontal",
+            "invalid": null,
             "style": "boxplot-box"
           },
           "encoding": {
@@ -214,6 +225,7 @@
           "mark": {
             "color": "red",
             "type": "tick",
+            "invalid": null,
             "size": 14,
             "orient": "vertical",
             "style": "boxplot-median"

--- a/examples/specs/normalized/boxplot_1D_horizontal_explicit_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_1D_horizontal_explicit_normalized.vl.json
@@ -48,7 +48,11 @@
           ],
           "layer": [
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "x": {
                   "field": "lower_whisker_people",
@@ -71,7 +75,11 @@
               }
             },
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "x": {
                   "field": "upper_box_people",
@@ -116,6 +124,7 @@
             "type": "bar",
             "size": 14,
             "orient": "horizontal",
+            "invalid": null,
             "style": "boxplot-box"
           },
           "encoding": {
@@ -158,6 +167,7 @@
           "mark": {
             "color": "white",
             "type": "tick",
+            "invalid": null,
             "size": 14,
             "orient": "vertical",
             "style": "boxplot-median"

--- a/examples/specs/normalized/boxplot_1D_horizontal_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_1D_horizontal_normalized.vl.json
@@ -48,7 +48,11 @@
           ],
           "layer": [
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "x": {
                   "field": "lower_whisker_people",
@@ -71,7 +75,11 @@
               }
             },
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "x": {
                   "field": "upper_box_people",
@@ -116,6 +124,7 @@
             "type": "bar",
             "size": 14,
             "orient": "horizontal",
+            "invalid": null,
             "style": "boxplot-box"
           },
           "encoding": {
@@ -158,6 +167,7 @@
           "mark": {
             "color": "white",
             "type": "tick",
+            "invalid": null,
             "size": 14,
             "orient": "vertical",
             "style": "boxplot-median"

--- a/examples/specs/normalized/boxplot_1D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_1D_vertical_normalized.vl.json
@@ -48,7 +48,11 @@
           ],
           "layer": [
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "y": {
                   "field": "lower_whisker_people",
@@ -71,7 +75,11 @@
               }
             },
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "y": {
                   "field": "upper_box_people",
@@ -116,6 +124,7 @@
             "type": "bar",
             "size": 14,
             "orient": "vertical",
+            "invalid": null,
             "style": "boxplot-box"
           },
           "encoding": {
@@ -158,6 +167,7 @@
           "mark": {
             "color": "white",
             "type": "tick",
+            "invalid": null,
             "size": 14,
             "orient": "horizontal",
             "style": "boxplot-median"

--- a/examples/specs/normalized/boxplot_2D_horizontal_color_size_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_2D_horizontal_color_size_normalized.vl.json
@@ -51,7 +51,11 @@
           ],
           "layer": [
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "x": {
                   "field": "lower_whisker_people",
@@ -76,7 +80,11 @@
               }
             },
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "x": {
                   "field": "upper_box_people",
@@ -123,6 +131,7 @@
             "type": "bar",
             "size": 14,
             "orient": "horizontal",
+            "invalid": null,
             "style": "boxplot-box"
           },
           "encoding": {
@@ -169,6 +178,7 @@
           "mark": {
             "color": "white",
             "type": "tick",
+            "invalid": null,
             "size": 14,
             "orient": "vertical",
             "style": "boxplot-median"

--- a/examples/specs/normalized/boxplot_2D_horizontal_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_2D_horizontal_normalized.vl.json
@@ -51,7 +51,11 @@
           ],
           "layer": [
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "x": {
                   "field": "lower_whisker_people",
@@ -76,7 +80,11 @@
               }
             },
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "x": {
                   "field": "upper_box_people",
@@ -123,6 +131,7 @@
             "type": "bar",
             "size": 14,
             "orient": "horizontal",
+            "invalid": null,
             "style": "boxplot-box"
           },
           "encoding": {
@@ -167,6 +176,7 @@
           "mark": {
             "color": "white",
             "type": "tick",
+            "invalid": null,
             "size": 14,
             "orient": "vertical",
             "style": "boxplot-median"

--- a/examples/specs/normalized/boxplot_2D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_2D_vertical_normalized.vl.json
@@ -51,7 +51,11 @@
           ],
           "layer": [
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "y": {
                   "field": "lower_whisker_people",
@@ -76,7 +80,11 @@
               }
             },
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "y": {
                   "field": "upper_box_people",
@@ -123,6 +131,7 @@
             "type": "bar",
             "size": 14,
             "orient": "vertical",
+            "invalid": null,
             "style": "boxplot-box"
           },
           "encoding": {
@@ -168,6 +177,7 @@
           "mark": {
             "color": "white",
             "type": "tick",
+            "invalid": null,
             "size": 14,
             "orient": "horizontal",
             "style": "boxplot-median"

--- a/examples/specs/normalized/boxplot_minmax_2D_horizontal_custom_midtick_color_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_horizontal_custom_midtick_color_normalized.vl.json
@@ -17,7 +17,7 @@
   ],
   "layer": [
     {
-      "mark": {"type": "rule", "style": "boxplot-rule"},
+      "mark": {"type": "rule", "invalid": null, "style": "boxplot-rule"},
       "encoding": {
         "x": {
           "field": "lower_whisker_people",
@@ -57,7 +57,7 @@
       }
     },
     {
-      "mark": {"type": "rule", "style": "boxplot-rule"},
+      "mark": {"type": "rule", "invalid": null, "style": "boxplot-rule"},
       "encoding": {
         "x": {
           "field": "upper_box_people",
@@ -101,6 +101,7 @@
         "type": "bar",
         "size": 14,
         "orient": "horizontal",
+        "invalid": null,
         "style": "boxplot-box"
       },
       "encoding": {
@@ -145,6 +146,7 @@
       "mark": {
         "color": "orange",
         "type": "tick",
+        "invalid": null,
         "size": 14,
         "orient": "vertical",
         "style": "boxplot-median"

--- a/examples/specs/normalized/boxplot_minmax_2D_horizontal_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_horizontal_normalized.vl.json
@@ -16,7 +16,7 @@
   ],
   "layer": [
     {
-      "mark": {"type": "rule", "style": "boxplot-rule"},
+      "mark": {"type": "rule", "invalid": null, "style": "boxplot-rule"},
       "encoding": {
         "x": {
           "field": "lower_whisker_people",
@@ -56,7 +56,7 @@
       }
     },
     {
-      "mark": {"type": "rule", "style": "boxplot-rule"},
+      "mark": {"type": "rule", "invalid": null, "style": "boxplot-rule"},
       "encoding": {
         "x": {
           "field": "upper_box_people",
@@ -100,6 +100,7 @@
         "type": "bar",
         "size": 14,
         "orient": "horizontal",
+        "invalid": null,
         "style": "boxplot-box"
       },
       "encoding": {
@@ -144,6 +145,7 @@
       "mark": {
         "color": "white",
         "type": "tick",
+        "invalid": null,
         "size": 14,
         "orient": "vertical",
         "style": "boxplot-median"

--- a/examples/specs/normalized/boxplot_minmax_2D_vertical_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_minmax_2D_vertical_normalized.vl.json
@@ -16,7 +16,7 @@
   ],
   "layer": [
     {
-      "mark": {"type": "rule", "style": "boxplot-rule"},
+      "mark": {"type": "rule", "invalid": null, "style": "boxplot-rule"},
       "encoding": {
         "y": {
           "field": "lower_whisker_people",
@@ -56,7 +56,7 @@
       }
     },
     {
-      "mark": {"type": "rule", "style": "boxplot-rule"},
+      "mark": {"type": "rule", "invalid": null, "style": "boxplot-rule"},
       "encoding": {
         "y": {
           "field": "upper_box_people",
@@ -100,6 +100,7 @@
         "type": "bar",
         "size": 14,
         "orient": "vertical",
+        "invalid": null,
         "style": "boxplot-box"
       },
       "encoding": {
@@ -144,6 +145,7 @@
       "mark": {
         "color": "white",
         "type": "tick",
+        "invalid": null,
         "size": 14,
         "orient": "horizontal",
         "style": "boxplot-median"

--- a/examples/specs/normalized/boxplot_tooltip_aggregate_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_tooltip_aggregate_normalized.vl.json
@@ -51,7 +51,11 @@
           ],
           "layer": [
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "y": {
                   "field": "lower_whisker_people",
@@ -68,7 +72,11 @@
               }
             },
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "y": {
                   "field": "upper_box_people",
@@ -108,6 +116,7 @@
             "type": "bar",
             "size": 14,
             "orient": "vertical",
+            "invalid": null,
             "style": "boxplot-box"
           },
           "encoding": {
@@ -129,6 +138,7 @@
           "mark": {
             "color": "white",
             "type": "tick",
+            "invalid": null,
             "size": 14,
             "orient": "horizontal",
             "style": "boxplot-median"

--- a/examples/specs/normalized/boxplot_tooltip_not_aggregate_normalized.vl.json
+++ b/examples/specs/normalized/boxplot_tooltip_not_aggregate_normalized.vl.json
@@ -51,7 +51,11 @@
           ],
           "layer": [
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "y": {
                   "field": "lower_whisker_people",
@@ -76,7 +80,11 @@
               }
             },
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "y": {
                   "field": "upper_box_people",
@@ -123,6 +131,7 @@
             "type": "bar",
             "size": 14,
             "orient": "vertical",
+            "invalid": null,
             "style": "boxplot-box"
           },
           "encoding": {
@@ -167,6 +176,7 @@
           "mark": {
             "color": "white",
             "type": "tick",
+            "invalid": null,
             "size": 14,
             "orient": "horizontal",
             "style": "boxplot-median"

--- a/examples/specs/normalized/layer_boxplot_circle_normalized.vl.json
+++ b/examples/specs/normalized/layer_boxplot_circle_normalized.vl.json
@@ -38,7 +38,11 @@
           ],
           "layer": [
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "x": {
                   "field": "lower_whisker_people",
@@ -63,7 +67,11 @@
               }
             },
             {
-              "mark": {"type": "rule", "style": "boxplot-rule"},
+              "mark": {
+                "type": "rule",
+                "invalid": null,
+                "style": "boxplot-rule"
+              },
               "encoding": {
                 "x": {
                   "field": "upper_box_people",
@@ -108,6 +116,7 @@
                 "type": "bar",
                 "size": 14,
                 "orient": "horizontal",
+                "invalid": null,
                 "style": "boxplot-box"
               },
               "encoding": {
@@ -152,6 +161,7 @@
               "mark": {
                 "color": "white",
                 "type": "tick",
+                "invalid": null,
                 "size": 14,
                 "orient": "vertical",
                 "style": "boxplot-median"

--- a/src/compositemark/boxplot.ts
+++ b/src/compositemark/boxplot.ts
@@ -142,7 +142,7 @@ export function normalizeBoxPlot(
 
   // ## Whisker Layers
 
-  const endTick: MarkDef = {type: 'tick', color: 'black', opacity: 1, orient: ticksOrient};
+  const endTick: MarkDef = {type: 'tick', color: 'black', opacity: 1, orient: ticksOrient, invalid: null};
   const whiskerTooltipEncoding: Encoding<string> =
     boxPlotType === 'min-max'
       ? fiveSummaryTooltipEncoding // for min-max, show five-summary tooltip for whisker
@@ -159,14 +159,14 @@ export function normalizeBoxPlot(
   const whiskerLayers = [
     ...makeBoxPlotExtent({
       partName: 'rule',
-      mark: 'rule',
+      mark: {type: 'rule', invalid: null},
       positionPrefix: 'lower_whisker',
       endPositionPrefix: 'lower_box',
       extraEncoding: whiskerTooltipEncoding
     }),
     ...makeBoxPlotExtent({
       partName: 'rule',
-      mark: 'rule',
+      mark: {type: 'rule', invalid: null},
       positionPrefix: 'upper_box',
       endPositionPrefix: 'upper_whisker',
       extraEncoding: whiskerTooltipEncoding
@@ -192,7 +192,7 @@ export function normalizeBoxPlot(
     ...(boxPlotType !== 'tukey' ? whiskerLayers : []),
     ...makeBoxPlotBox({
       partName: 'box',
-      mark: {type: 'bar', ...(sizeValue ? {size: sizeValue} : {}), orient: boxOrient},
+      mark: {type: 'bar', ...(sizeValue ? {size: sizeValue} : {}), orient: boxOrient, invalid: null},
       positionPrefix: 'lower_box',
       endPositionPrefix: 'upper_box',
       extraEncoding: fiveSummaryTooltipEncoding
@@ -201,6 +201,7 @@ export function normalizeBoxPlot(
       partName: 'median',
       mark: {
         type: 'tick',
+        invalid: null,
         ...(isObject(config.boxplot.median) && config.boxplot.median.color ? {color: config.boxplot.median.color} : {}),
         ...(sizeValue ? {size: sizeValue} : {}),
         orient: ticksOrient

--- a/test/compositemark/boxplot.test.ts
+++ b/test/compositemark/boxplot.test.ts
@@ -859,7 +859,8 @@ describe('normalizeBoxIQR', () => {
         type: 'bar',
         style: 'boxplot-box',
         size: 14,
-        orient: 'vertical'
+        orient: 'vertical',
+        invalid: null
       },
       encoding: {
         x: {field: 'age', type: 'quantitative'},


### PR DESCRIPTION
This will help simplify the number of data sources in the Vega outputs

Part of https://github.com/vega/vega-lite/issues/5404

