### PR TITLE
feat: Add missing parallels property in projection

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -11041,6 +11041,13 @@
         "parallel": {
           "type": "number"
         },
+        "parallels": {
+          "description": "Sets the desired parallels of the projection",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },        
         "precision": {
           "description": "Sets the threshold for the projection’s [adaptive resampling](http://bl.ocks.org/mbostock/3795544) to the specified value in pixels. This value corresponds to the [Douglas–Peucker distance](http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm). If precision is not specified, returns the projection’s current resampling precision which defaults to `√0.5 ≅ 0.70710…`.",
           "type": "number"

--- a/site/docs/projection.md
+++ b/site/docs/projection.md
@@ -17,7 +17,7 @@ See [the example gallery for more examples with geographic projection](../exampl
 
 ## Projection Properties
 
-{% include table.html props="type,clipAngle,clipExtent,center,scale,translate,rotate,precision" source="Projection" %}
+{% include table.html props="type,clipAngle,clipExtent,center,scale,translate,rotate,parallels,precision" source="Projection" %}
 
 If you want to explore the various available properties in more depth, Vega's projection documentation [hosts a useful demo](https://vega.github.io/vega/docs/projections/)
 

--- a/src/projection.ts
+++ b/src/projection.ts
@@ -44,6 +44,11 @@ export interface Projection {
    */
   rotate?: number[];
 
+  /*
+   * The desired parallels of the projection.
+   */    
+  parallels?: number[];   
+  
   /**
    * Sets the threshold for the projection’s [adaptive resampling](http://bl.ocks.org/mbostock/3795544) to the specified value in pixels. This value corresponds to the [Douglas–Peucker distance](http://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm). If precision is not specified, returns the projection’s current resampling precision which defaults to `√0.5 ≅ 0.70710…`.
    */

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -150,8 +150,12 @@ export interface VgProjection {
    */
   rotate?: number[];
   /*
+   * The desired parallels of the projection.
+   */    
+  parallels?: number[];    
+  /*
    * The desired precision of the projection.
-   */
+   */  
   precision?: number;
   /*
    * GeoJSON data to which the projection should attempt to automatically fit the translate and scale parameters..


### PR DESCRIPTION
This PR adds the missing `parallels` property to Vega-Lite.

The property is available in Vega: https://github.com/vega/vega/blob/master/packages/vega-projection/src/projections.js#L31
But not yet available in Vega-Lite.