### PR TITLE
ci: enable coverage comment

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,7 +1,7 @@
 codecov:
   notify:
     require_ci_to_pass: true
-comment: false
+comment: true
 coverage:
   precision: 2
   range:


### PR DESCRIPTION
Temporarily enable coverage comments so that we see coverage even if we have updates to the schema or examples. 