### PR TITLE
fix: optimizer DuplicateTimeNode should remove bottom-most node first

### DIFF
--- a/examples/compiled/interactive_area_brush.vg.json
+++ b/examples/compiled/interactive_area_brush.vg.json
@@ -10,16 +10,22 @@
     {
       "name": "source_0",
       "url": "data/unemployment-across-industries.json",
-      "format": {"type": "json", "parse": {"date": "date"}}
+      "format": {"type": "json", "parse": {"date": "date"}},
+      "transform": [
+        {
+          "type": "formula",
+          "as": "yearmonth_date",
+          "expr": "datetime(year(datum[\"date\"]), month(datum[\"date\"]), 1, 0, 0, 0, 0)"
+        }
+      ]
     },
     {
       "name": "data_0",
       "source": "source_0",
       "transform": [
         {
-          "type": "formula",
-          "as": "yearmonth_date",
-          "expr": "datetime(year(datum[\"date\"]), month(datum[\"date\"]), 1, 0, 0, 0, 0)"
+          "type": "filter",
+          "expr": "!(length(data(\"brush_store\"))) || (vlSelectionTest(\"brush_store\", datum))"
         },
         {
           "type": "aggregate",
@@ -34,15 +40,6 @@
       "name": "data_1",
       "source": "source_0",
       "transform": [
-        {
-          "type": "filter",
-          "expr": "!(length(data(\"brush_store\"))) || (vlSelectionTest(\"brush_store\", datum))"
-        },
-        {
-          "type": "formula",
-          "as": "yearmonth_date",
-          "expr": "datetime(year(datum[\"date\"]), month(datum[\"date\"]), 1, 0, 0, 0, 0)"
-        },
         {
           "type": "aggregate",
           "groupby": ["yearmonth_date"],
@@ -262,7 +259,7 @@
       "type": "area",
       "style": ["area"],
       "sort": {"field": "datum[\"yearmonth_date\"]"},
-      "from": {"data": "data_0"},
+      "from": {"data": "data_1"},
       "encode": {
         "update": {
           "orient": {"value": "vertical"},
@@ -281,7 +278,7 @@
       "type": "area",
       "style": ["area"],
       "sort": {"field": "datum[\"yearmonth_date\"]"},
-      "from": {"data": "data_1"},
+      "from": {"data": "data_0"},
       "encode": {
         "update": {
           "orient": {"value": "vertical"},
@@ -344,8 +341,8 @@
       "type": "time",
       "domain": {
         "fields": [
-          {"data": "data_0", "field": "yearmonth_date"},
-          {"data": "data_1", "field": "yearmonth_date"}
+          {"data": "data_1", "field": "yearmonth_date"},
+          {"data": "data_0", "field": "yearmonth_date"}
         ]
       },
       "range": [0, {"signal": "width"}]
@@ -355,8 +352,8 @@
       "type": "linear",
       "domain": {
         "fields": [
-          {"data": "data_0", "field": "sum_count"},
-          {"data": "data_1", "field": "sum_count"}
+          {"data": "data_1", "field": "sum_count"},
+          {"data": "data_0", "field": "sum_count"}
         ]
       },
       "range": [{"signal": "height"}, 0],

--- a/src/compile/data/optimizers.ts
+++ b/src/compile/data/optimizers.ts
@@ -124,20 +124,25 @@ export class RemoveUnusedSubtrees extends BottomUpOptimizer {
  * Removes duplicate time unit nodes (as determined by the name of the
  * output field) that may be generated due to selections projected over
  * time units.
+ *
+ * TODO: Try to make this a top down optimizer that keeps only the first
+ * insance of a time unit node.
+ * TODO: Try to make a generic version of this that only keeps one node per hash.
  */
-
 export class RemoveDuplicateTimeUnits extends BottomUpOptimizer {
   private fields = new Set<string>();
+  private prev: DataFlowNode = null;
   public run(node: DataFlowNode): OptimizerFlags {
     this.setContinue();
     if (node instanceof TimeUnitNode) {
       const pfields = node.producedFields();
       if (hasIntersection(pfields, this.fields)) {
         this.setMutated();
-        node.remove();
+        this.prev.remove();
       } else {
         this.fields = new Set([...this.fields, ...pfields]);
       }
+      this.prev = node;
     }
     return this.flags;
   }

--- a/test/compile/selection/timeunit.test.ts
+++ b/test/compile/selection/timeunit.test.ts
@@ -83,7 +83,7 @@ describe('Selection time unit', () => {
         }
       }
     });
-    const data1 = getData(model).filter(d => d.name === 'data_1')[0].transform;
+    const data1 = getData(model).filter(d => d.name === 'data_0')[0].transform;
     expect(data1.filter(tx => tx.type === 'formula' && tx.as === 'seconds_date').length).toEqual(1);
   });
 
@@ -136,7 +136,7 @@ describe('Selection time unit', () => {
         y: {field: 'price', type: 'quantitative'}
       }
     });
-    const data1 = getData(model).filter(d => d.name === 'data_1')[0].transform;
+    const data1 = getData(model).filter(d => d.name === 'data_0')[0].transform;
     expect(data1.filter(tx => tx.type === 'formula' && tx.as === 'seconds_date').length).toEqual(1);
   });
 });

--- a/test/transformextract.test.ts
+++ b/test/transformextract.test.ts
@@ -43,6 +43,7 @@ describe('extractTransforms()', () => {
     'histogram_ordinal.vl.json',
     'histogram_sort_mean.vl.json',
     'histogram.vl.json',
+    'interactive_area_brush.vl.json',
     'interactive_concat_layer.vl.json',
     'interactive_layered_crossfilter_discrete.vl.json',
     'interactive_layered_crossfilter.vl.json',


### PR DESCRIPTION
I suspect this will resolve several of the bugs with selections projected over time units. 

The `RemoveDuplicateTimeNode` optimizer is a `BottomUpOptimizer` but, as previously written, would preserve the bottom-most time unit node and consider ones further upstream to be duplicates. As a result, you would get weird orderings like the one found in [interactive_area_brush](https://vega.github.io/editor/#/examples/vega-lite/interactive_area_brush) where the selection filter would come _before_ the time unit it depends on:

```json
"transform": [
  {
    "type": "filter",
    "expr": "!(length(data(\"brush_store\"))) || (vlSelectionTest(\"brush_store\", datum))"
  },
  {
    "type": "formula",
    "as": "yearmonth_date",
    "expr": "datetime(year(datum[\"date\"]), month(datum[\"date\"]), 1, 0, 0, 0, 0)"
  }
```

With the above ordering, initializing the selection would yield buggy behavior as, on the first run of the dataflow, `yearmonth_date` would be undefined when the selection predicate test would occur. 

In this PR, we continue to optimize from the bottom up and remove the bottom-most node when we encounter a duplicate further upstream. As a result, this should often allow time unit nodes to be pushed to the source dataset and reduce the amount of time unit recomputation in derived datasets.