### PR TITLE
fix: scope events to voronoi mark to prevent misfires from group

### DIFF
--- a/examples/compiled/airport_connections.vg.json
+++ b/examples/compiled/airport_connections.vg.json
@@ -129,7 +129,13 @@
       "name": "single_tuple",
       "on": [
         {
-          "events": [{"source": "scope", "type": "mouseover"}],
+          "events": [
+            {
+              "source": "scope",
+              "type": "mouseover",
+              "markname": "layer_2_voronoi"
+            }
+          ],
           "update": "datum && item().mark.marktype !== 'group' ? {unit: \"layer_2\", fields: single_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"origin\"]]} : null",
           "force": true
         },

--- a/examples/compiled/interactive_multi_line_label.vg.json
+++ b/examples/compiled/interactive_multi_line_label.vg.json
@@ -63,7 +63,13 @@
       "name": "label_tuple",
       "on": [
         {
-          "events": [{"source": "scope", "type": "mouseover"}],
+          "events": [
+            {
+              "source": "scope",
+              "type": "mouseover",
+              "markname": "layer_0_layer_1_voronoi"
+            }
+          ],
           "update": "datum && item().mark.marktype !== 'group' ? {unit: \"layer_0_layer_1\", fields: label_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"date\"]]} : null",
           "force": true
         },

--- a/examples/compiled/interactive_paintbrush.vg.json
+++ b/examples/compiled/interactive_paintbrush.vg.json
@@ -37,7 +37,9 @@
       "name": "paintbrush_tuple",
       "on": [
         {
-          "events": [{"source": "scope", "type": "mouseover"}],
+          "events": [
+            {"source": "scope", "type": "mouseover", "markname": "voronoi"}
+          ],
           "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", fields: paintbrush_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null",
           "force": true
         },
@@ -53,7 +55,9 @@
       "value": false,
       "on": [
         {
-          "events": [{"source": "scope", "type": "mouseover"}],
+          "events": [
+            {"source": "scope", "type": "mouseover", "markname": "voronoi"}
+          ],
           "update": "event.shiftKey"
         },
         {"events": [{"source": "scope", "type": "dblclick"}], "update": "false"}

--- a/examples/compiled/interactive_paintbrush_color_nearest.vg.json
+++ b/examples/compiled/interactive_paintbrush_color_nearest.vg.json
@@ -37,7 +37,9 @@
       "name": "paintbrush_tuple",
       "on": [
         {
-          "events": [{"source": "scope", "type": "mouseover"}],
+          "events": [
+            {"source": "scope", "type": "mouseover", "markname": "voronoi"}
+          ],
           "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", fields: paintbrush_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null",
           "force": true
         },
@@ -53,7 +55,9 @@
       "value": false,
       "on": [
         {
-          "events": [{"source": "scope", "type": "mouseover"}],
+          "events": [
+            {"source": "scope", "type": "mouseover", "markname": "voronoi"}
+          ],
           "update": "event.shiftKey"
         },
         {"events": [{"source": "scope", "type": "dblclick"}], "update": "false"}

--- a/examples/compiled/interactive_stocks_nearest_index.vg.json
+++ b/examples/compiled/interactive_stocks_nearest_index.vg.json
@@ -50,7 +50,13 @@
       "name": "index_tuple",
       "on": [
         {
-          "events": [{"source": "scope", "type": "mousemove"}],
+          "events": [
+            {
+              "source": "scope",
+              "type": "mousemove",
+              "markname": "layer_1_voronoi"
+            }
+          ],
           "update": "datum && item().mark.marktype !== 'group' ? {unit: \"layer_1\", fields: index_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"date\"]]} : null",
           "force": true
         },

--- a/examples/compiled/selection_multi_condition.vg.json
+++ b/examples/compiled/selection_multi_condition.vg.json
@@ -256,7 +256,9 @@
       "name": "hoverbrush_tuple",
       "on": [
         {
-          "events": [{"source": "scope", "type": "mouseover"}],
+          "events": [
+            {"source": "scope", "type": "mouseover", "markname": "voronoi"}
+          ],
           "update": "datum && item().mark.marktype !== 'group' ? {unit: \"\", fields: hoverbrush_tuple_fields, values: [(item().isVoronoi ? datum.datum : datum)[\"_vgsid_\"]]} : null",
           "force": true
         },
@@ -272,7 +274,9 @@
       "value": false,
       "on": [
         {
-          "events": [{"source": "scope", "type": "mouseover"}],
+          "events": [
+            {"source": "scope", "type": "mouseover", "markname": "voronoi"}
+          ],
           "update": "event.shiftKey"
         },
         {"events": [{"source": "scope", "type": "dblclick"}], "update": "false"}

--- a/examples/compiled/trellis_selections.vg.json
+++ b/examples/compiled/trellis_selections.vg.json
@@ -39,7 +39,13 @@
       "value": null,
       "on": [
         {
-          "events": [{"source": "scope", "type": "mouseover"}],
+          "events": [
+            {
+              "source": "scope",
+              "type": "mouseover",
+              "markname": "child_voronoi"
+            }
+          ],
           "update": "datum && item().mark.marktype !== 'group' ? (item().isVoronoi ? datum.datum : datum)[\"X\"] : null"
         }
       ],

--- a/src/compile/selection/transforms/nearest.ts
+++ b/src/compile/selection/transforms/nearest.ts
@@ -10,6 +10,16 @@ const nearest: TransformCompiler = {
     return selCmpt.type !== 'interval' && selCmpt.nearest;
   },
 
+  parse: (model, selCmpt) => {
+    // Scope selection events to the voronoi mark to prevent capturing
+    // events that occur on the group mark (https://github.com/vega/vega/issues/2112).
+    if (selCmpt.events) {
+      for (const s of selCmpt.events) {
+        s.markname = model.getName(VORONOI);
+      }
+    }
+  },
+
   marks: (model, selCmpt, marks) => {
     const {x, y} = selCmpt.project.has;
     const markType = model.mark;

--- a/test/compile/selection/nearest.test.ts
+++ b/test/compile/selection/nearest.test.ts
@@ -27,9 +27,8 @@ function getModel(markType: any) {
     seven: {type: 'single', nearest: true, encodings: ['x']},
     eight: {type: 'single', nearest: true, encodings: ['y']},
     nine: {type: 'single', nearest: true, encodings: ['color']},
-
-    singleNearestOnMouseover: {type: 'single', nearest: true, on: 'mouseover'},
-    multiNearestOnMouseover: {type: 'multi', nearest: true, on: 'mouseover'}
+    ten: {type: 'single', nearest: true, on: 'mouseover'},
+    eleven: {type: 'multi', nearest: true, on: 'mouseover, dblclick'}
   });
 
   return model;
@@ -72,6 +71,16 @@ describe('Nearest Selection Transform', () => {
     expect(nearest.has(selCmpts['four'])).not.toBe(true);
     expect(nearest.has(selCmpts['five'])).not.toBe(true);
     expect(nearest.has(selCmpts['six'])).not.toBe(true);
+  });
+
+  it('scopes events to the voronoi mark', () => {
+    const selCmpts = getModel('circle').component.selection;
+    expect(selCmpts['one'].events).toEqual([{source: 'scope', type: 'click', markname: 'voronoi'}]);
+    expect(selCmpts['ten'].events).toEqual([{source: 'scope', type: 'mouseover', markname: 'voronoi'}]);
+    expect(selCmpts['eleven'].events).toEqual([
+      {source: 'scope', type: 'mouseover', markname: 'voronoi'},
+      {source: 'scope', type: 'dblclick', markname: 'voronoi'}
+    ]);
   });
 
   it('adds voronoi with tooltip for non-path marks', () => {


### PR DESCRIPTION
The `nearest` selection transform adds a voronoi tessellation that completely covers a group mark's data rectangle. However, it seems like events originating on the group mark still fire on the bottom and right edges of the group/voronoi mark (see vega/vega#2112) which can cause odd flickering issues (which I observed when working on the interactive index chart, #5286)

This PR resolves this issue by updating the `nearest` transform to scope events to the voronoi mark it adds. 