### PR TITLE
docs: fix typo in "Initializing a Selection" title

### DIFF
--- a/site/docs/selection/init.md
+++ b/site/docs/selection/init.md
@@ -1,7 +1,7 @@
 ---
 layout: docs
 menu: docs
-title: Initialzing a Selection
+title: Initializing a Selection
 permalink: /docs/init.html
 ---
 


### PR DESCRIPTION
"Initialzing" -> "Initializing" in the title.
