### PR TITLE
Bump vega-embed to v6.0.0 and vega to 5.7.3 to fix #5526

### DIFF
--- a/site/_data/versions.yml
+++ b/site/_data/versions.yml
@@ -1,4 +1,4 @@
-vega: 5.7.2
+vega: 5.7.3
 vega-lite: 4.0.0-beta.10
-vega-embed: 5.1.3
+vega-embed: 6.0.0
 vega-tooltip: 0.19.1


### PR DESCRIPTION
Fixes #5526 
Updates vega & vega-embed in versions.yml to use the newest releases in the usage documentation: https://vega.github.io/vega-lite/usage/embed.html

Vega: from 5.7.3 to 5.7.3
Vega-Embed: from 5.1.3 to 6.0.0

Please:

- [X] Make the PR atomic. (Fix one issue at a time.) Multiple relevant issues that must be fixed together? Make atomic commits so we can easily review each issue.

- [ ] Provide a concise title so we can easily copy it to the release note.

  - Use imperative mood and present tense.
  - Mention relevant issues. (e.g., `Fix #1` / `Fix part of #1`)

- [X] Lint and test (Run `yarn test`)

- [X] Rebase onto the latest `master` branch

- [X] Review your changeset first (to ensure code quality)

