### PR TITLE
fix: always add IdentifierNode, remove unnecessaries during optimization

### DIFF
--- a/src/compile/data/debug.ts
+++ b/src/compile/data/debug.ts
@@ -1,5 +1,5 @@
 import {entries, uniqueId} from './../../util';
-import {DataFlowNode} from './dataflow';
+import {DataFlowNode, OutputNode} from './dataflow';
 import {SourceNode} from './source';
 
 /**
@@ -54,6 +54,9 @@ export function draw(roots: readonly DataFlowNode[]) {
     const prod = node.producedFields();
     if (prod && prod.size) {
       out.push(`<font color="grey" point-size="10">OUT:</font> ${[...node.producedFields()].join(', ')}`);
+    }
+    if (node instanceof OutputNode) {
+      out.push(`<font color="grey" point-size="10">required:</font> ${node.isRequired()}`);
     }
     return out.join('<br/>');
   }

--- a/src/compile/data/optimize.ts
+++ b/src/compile/data/optimize.ts
@@ -54,7 +54,8 @@ function optimizationDataflowHelper(dataComponent: DataComponent, model: Model) 
   let roots = dataComponent.sources;
   const mutatedFlags: Set<boolean> = new Set();
 
-  mutatedFlags.add(runOptimizer(new optimizers.RemoveUnnecessaryNodes(model), roots));
+  mutatedFlags.add(runOptimizer(new optimizers.RemoveUnnecessaryOutputNodes(), roots));
+  mutatedFlags.add(runOptimizer(new optimizers.RemoveUnnecessaryIdentifierNodes(model), roots));
 
   // remove source nodes that don't have any children because they also don't have output nodes
   roots = roots.filter(r => r.numChildren() > 0);

--- a/src/compile/data/optimize.ts
+++ b/src/compile/data/optimize.ts
@@ -54,7 +54,7 @@ function optimizationDataflowHelper(dataComponent: DataComponent, model: Model) 
   let roots = dataComponent.sources;
   const mutatedFlags: Set<boolean> = new Set();
 
-  mutatedFlags.add(runOptimizer(new optimizers.RemoveUnnecessaryNodes(), roots));
+  mutatedFlags.add(runOptimizer(new optimizers.RemoveUnnecessaryNodes(model), roots));
 
   // remove source nodes that don't have any children because they also don't have output nodes
   roots = roots.filter(r => r.numChildren() > 0);

--- a/src/compile/data/parse.ts
+++ b/src/compile/data/parse.ts
@@ -305,19 +305,14 @@ export function parseData(model: Model): DataComponent {
 
   head = ParseNode.makeExplicit(head, model, ancestorParse) || head;
 
-  // Default discrete selections require an identifier transform to
-  // uniquely identify data points as the _id field is volatile. Add
-  // this transform at the head of our pipeline such that the identifier
-  // field is available for all subsequent datasets. Additional identifier
+  // Default discrete selections require an identifer transform to
+  // uniquely identify data points. Add this transform at the head of
+  // the pipeline such that the identifier field is available for all
+  // subsequent datasets. During optimization, we will remove this
+  // transform if it proves to be unnecessary. Additional identifier
   // transforms will be necessary when new tuples are constructed
   // (e.g., post-aggregation).
-  if (
-    requiresSelectionId(model) &&
-    // only add identifier to unit/layer models that do not have layer parents to avoid redundant identifier transforms
-    ((isUnitModel(model) || isLayerModel(model)) && (!model.parent || !isLayerModel(model.parent)))
-  ) {
-    head = new IdentifierNode(head);
-  }
+  head = new IdentifierNode(head);
 
   // HACK: This is equivalent for merging bin extent for union scale.
   // FIXME(https://github.com/vega/vega-lite/issues/2270): Correctly merge extent / bin node for shared bin scale

--- a/src/compile/selection/index.ts
+++ b/src/compile/selection/index.ts
@@ -65,10 +65,12 @@ export function forEachSelection(
   cb: (selCmpt: SelectionComponent, selCompiler: SelectionCompiler) => void
 ) {
   const selections = model.component.selection;
-  for (const name in selections) {
-    if (hasOwnProperty(selections, name)) {
-      const sel = selections[name];
-      cb(sel, compilers[sel.type]);
+  if (selections) {
+    for (const name in selections) {
+      if (hasOwnProperty(selections, name)) {
+        const sel = selections[name];
+        cb(sel, compilers[sel.type]);
+      }
     }
   }
 }

--- a/test/compile/data/graticule.test.ts
+++ b/test/compile/data/graticule.test.ts
@@ -51,14 +51,7 @@ describe('compile/data/graticule', () => {
     });
     model.parseData();
 
-    const node = model.component.data.raw.parent;
-    expect(node).toBeInstanceOf(GraticuleNode);
-
-    expect(assembleRootData(model.component.data, {})).toEqual([
-      {
-        name: 'source_0',
-        transform: [{type: 'graticule'}]
-      }
-    ]);
+    const data = assembleRootData(model.component.data, {});
+    expect(data[0].transform[0]).toEqual({type: 'graticule'});
   });
 });

--- a/test/compile/data/sequence.test.ts
+++ b/test/compile/data/sequence.test.ts
@@ -64,14 +64,7 @@ describe('compile/data/sequence', () => {
     });
     model.parseData();
 
-    const node = model.component.data.raw.parent;
-    expect(node).toBeInstanceOf(SequenceNode);
-
-    expect(assembleRootData(model.component.data, {})).toEqual([
-      {
-        name: 'source_0',
-        transform: [{type: 'sequence', start: 0, stop: 20, step: 2}]
-      }
-    ]);
+    const data = assembleRootData(model.component.data, {});
+    expect(data[0].transform[0]).toEqual({type: 'sequence', start: 0, stop: 20, step: 2});
   });
 });

--- a/test/compile/selection/identifier.test.ts
+++ b/test/compile/selection/identifier.test.ts
@@ -2,12 +2,12 @@ import {assembleRootData} from '../../../src/compile/data/assemble';
 import {optimizeDataflow} from '../../../src/compile/data/optimize';
 import {Mark} from '../../../src/mark';
 import {VgTransform} from '../../../src/vega.schema';
-import {parseModel} from '../../util';
+import {parseUnitModelWithScaleAndSelection, parseConcatModel} from '../../util';
 import {IdentifierNode} from '../../../src/compile/data/identifier';
 import {SELECTION_ID} from '../../../src/selection';
 
 function getVgData(selection: any, x?: any, y?: any, mark?: Mark, enc?: any, transform?: any) {
-  const model = parseModel({
+  const model = parseUnitModelWithScaleAndSelection({
     data: {url: 'data/cars.json'},
     transform,
     selection,
@@ -19,8 +19,8 @@ function getVgData(selection: any, x?: any, y?: any, mark?: Mark, enc?: any, tra
       ...enc
     }
   });
-  model.parse();
-  optimizeDataflow(model.component.data, null);
+  model.parseData();
+  optimizeDataflow(model.component.data, model);
   return assembleRootData(model.component.data, {});
 }
 
@@ -72,6 +72,43 @@ describe('compile/data/identifier', () => {
         data[0].transform.some((t, i) => ((calc = i), t.type === 'formula' && t.as === 'foo'));
         expect(data[0].transform[calc - 1].type).toBe('identifier');
       }
+    });
+
+    it('is added to the source dataset in multi-views', () => {
+      const vgData = (bin: boolean) => {
+        const model = parseConcatModel({
+          data: {url: 'data/cars.json'},
+          hconcat: [
+            {
+              selection: {
+                pt: {type: 'single'}
+              },
+              mark: 'circle',
+              encoding: {
+                x: {field: 'Horsepower', type: 'quantitative'},
+                y: {field: 'Miles-per-Gallon', type: 'quantitative'},
+                color: {field: 'Year', type: 'temporal'}
+              }
+            },
+            {
+              mark: 'circle',
+              encoding: {
+                x: {field: 'Horsepower', type: 'quantitative', bin},
+                y: {field: 'Miles-per-Gallon', type: 'quantitative'},
+                color: {field: 'Origin', type: 'nominal'}
+              }
+            }
+          ]
+        });
+        model.parseScale();
+        model.parseSelections();
+        model.parseData();
+        optimizeDataflow(model.component.data, model);
+        return assembleRootData(model.component.data, {});
+      };
+
+      expect(vgData(false)[0].transform[0].type).toBe('identifier');
+      expect(vgData(true)[0].transform[0].type).toBe('identifier');
     });
   });
 


### PR DESCRIPTION
Fixes #5512. Previously, we would try to add `IdentifierNodes` during parsing as needed (i.e., when the model tree contained a default discrete selection). However, this approach was quite brittle requiring [an ugly set of tests](https://github.com/vega/vega-lite/compare/as/identifierTransform?expand=1#diff-6ff9ac68ad5af5ba27bd1c51a6d58548L317) that would place the node _after_ forks thus not persisting the identifier field across derived datasets. 

Instead, in this PR, we _always_ add `IdentifierNodes` during parsing and then removing the unnecessary ones during optimization. Additional unit tests ensures correct behavior during multi-views and binning.