### PR TITLE
fix: axis typing for strictNullCheck

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -579,83 +579,22 @@
           "type": "boolean"
         },
         "gridColor": {
-          "anyOf": [
-            {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "#/definitions/Color"
-                }
-              ],
-              "description": "Color of gridlines.\n\n__Default value:__ `\"lightGray\"`."
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)2086385775|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "gridDash": {
-          "anyOf": [
-            {
-              "description": "An array of alternating [stroke, space] lengths for dashed grid lines.",
-              "items": {
-                "type": "number"
-              },
-              "type": "array"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number[]|undefined)927251285|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "gridDashOffset": {
-          "anyOf": [
-            {
-              "description": "The pixel offset at which to start drawing with the grid dash array.",
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number|undefined)1806960624|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "gridOpacity": {
-          "anyOf": [
-            {
-              "description": "The stroke opacity of grid (value between [0,1])\n\n__Default value:__ `1`",
-              "maximum": 1,
-              "minimum": 0,
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number|undefined)702672441|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "gridWidth": {
-          "anyOf": [
-            {
-              "description": "The grid width, in pixels.\n\n__Default value:__ `1`",
-              "minimum": 0,
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number|undefined)742391737|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelAlign": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Align",
-              "description": "Horizontal text alignment of axis tick labels, overriding the default setting for the current axis orientation."
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((def-alias-981995915-6039-6088-981995915-0-10055|undefined)870796116|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelAngle": {
           "description": "The rotation angle of the axis labels.\n\n__Default value:__ `-90` for nominal and ordinal fields; `0` otherwise.",
@@ -664,15 +603,7 @@
           "type": "number"
         },
         "labelBaseline": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TextBaseline",
-              "description": "Vertical text baseline of axis tick labels, overriding the default setting for the current axis orientation. Can be `\"top\"`, `\"middle\"`, `\"bottom\"`, or `\"alphabetic\"`."
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((def-alias-981995915-8592-8644-981995915-0-10055|undefined)186452232|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelBound": {
           "description": "Indicates if labels should be hidden if they exceed the axis range. If `false` (the default) no bounds overlap analysis is performed. If `true`, labels will be hidden if they exceed the axis range by more than 1 pixel. If this property is a number, it specifies the pixel tolerance: the maximum amount by which a label bounding box may exceed the axis range.\n\n__Default value:__ `false`.",
@@ -682,22 +613,7 @@
           ]
         },
         "labelColor": {
-          "anyOf": [
-            {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "#/definitions/Color"
-                }
-              ],
-              "description": "The color of the tick label, can be in hex color code or regular color name."
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)1719818830|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelExpr": {
           "description": "[Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels.\n\n__Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.",
@@ -715,64 +631,23 @@
           "type": "number"
         },
         "labelFont": {
-          "anyOf": [
-            {
-              "description": "The font of the tick label.",
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((string|undefined)1723860780|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelFontSize": {
-          "anyOf": [
-            {
-              "description": "The font size of the label, in pixels.",
-              "minimum": 0,
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number|undefined)720879958|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelFontStyle": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/FontStyle",
-              "description": "Font style of the title."
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((def-alias-981995915-8836-8977-981995915-0-10055|undefined)679934267|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelFontWeight": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/FontWeight",
-              "description": "Font weight of axis tick labels."
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((def-alias-981995915-8687-8836-981995915-0-10055|undefined)1209375024|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelLimit": {
           "description": "Maximum allowed pixel width of axis tick labels.\n\n__Default value:__ `180`",
           "type": "number"
         },
         "labelOpacity": {
-          "anyOf": [
-            {
-              "description": "The opacity of the labels.",
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number|undefined)377890894|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelOverlap": {
           "$ref": "#/definitions/LabelOverlap",
@@ -811,51 +686,17 @@
           "type": "number"
         },
         "tickColor": {
-          "anyOf": [
-            {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "#/definitions/Color"
-                }
-              ],
-              "description": "The color of the axis's tick.\n\n__Default value:__ `\"gray\"`"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)565543918|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "tickCount": {
           "description": "A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are \"nice\" (multiples of 2, 5, 10) and lie within the underlying scale's range.",
           "type": "number"
         },
         "tickDash": {
-          "anyOf": [
-            {
-              "description": "An array of alternating [stroke, space] lengths for dashed tick mark lines.",
-              "items": {
-                "type": "number"
-              },
-              "type": "array"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number[]|undefined)105503503|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "tickDashOffset": {
-          "anyOf": [
-            {
-              "description": "The pixel offset at which to start drawing with the tick mark dash array.",
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number|undefined)61636408|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "tickExtra": {
           "description": "Boolean flag indicating if an extra axis tick should be added for the initial position of the axis. This flag is useful for styling axes for `band` scales such that ticks are placed on band boundaries rather in the middle of a band. Use in conjunction with `\"bandPosition\": 1` and an axis `\"padding\"` value of `0`.",
@@ -870,15 +711,7 @@
           "type": "number"
         },
         "tickOpacity": {
-          "anyOf": [
-            {
-              "description": "Opacity of the ticks.",
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number|undefined)1791665056|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "tickRound": {
           "description": "Boolean flag indicating if pixel position values should be rounded to the nearest integer.\n\n__Default value:__ `true`",
@@ -890,16 +723,7 @@
           "type": "number"
         },
         "tickWidth": {
-          "anyOf": [
-            {
-              "description": "The width, in pixels, of ticks.\n\n__Default value:__ `1`",
-              "minimum": 0,
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number|undefined)1626350768|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "ticks": {
           "description": "Boolean value that determines whether the axis should include ticks.\n\n__Default value:__ `true`",
@@ -1068,83 +892,22 @@
           "type": "boolean"
         },
         "gridColor": {
-          "anyOf": [
-            {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "#/definitions/Color"
-                }
-              ],
-              "description": "Color of gridlines.\n\n__Default value:__ `\"lightGray\"`."
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)2086385775|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "gridDash": {
-          "anyOf": [
-            {
-              "description": "An array of alternating [stroke, space] lengths for dashed grid lines.",
-              "items": {
-                "type": "number"
-              },
-              "type": "array"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number[]|undefined)927251285|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "gridDashOffset": {
-          "anyOf": [
-            {
-              "description": "The pixel offset at which to start drawing with the grid dash array.",
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number|undefined)1806960624|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "gridOpacity": {
-          "anyOf": [
-            {
-              "description": "The stroke opacity of grid (value between [0,1])\n\n__Default value:__ `1`",
-              "maximum": 1,
-              "minimum": 0,
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number|undefined)702672441|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "gridWidth": {
-          "anyOf": [
-            {
-              "description": "The grid width, in pixels.\n\n__Default value:__ `1`",
-              "minimum": 0,
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number|undefined)742391737|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelAlign": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Align",
-              "description": "Horizontal text alignment of axis tick labels, overriding the default setting for the current axis orientation."
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((def-alias-981995915-6039-6088-981995915-0-10055|undefined)870796116|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelAngle": {
           "description": "The rotation angle of the axis labels.\n\n__Default value:__ `-90` for nominal and ordinal fields; `0` otherwise.",
@@ -1153,15 +916,7 @@
           "type": "number"
         },
         "labelBaseline": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TextBaseline",
-              "description": "Vertical text baseline of axis tick labels, overriding the default setting for the current axis orientation. Can be `\"top\"`, `\"middle\"`, `\"bottom\"`, or `\"alphabetic\"`."
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((def-alias-981995915-8592-8644-981995915-0-10055|undefined)186452232|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelBound": {
           "description": "Indicates if labels should be hidden if they exceed the axis range. If `false` (the default) no bounds overlap analysis is performed. If `true`, labels will be hidden if they exceed the axis range by more than 1 pixel. If this property is a number, it specifies the pixel tolerance: the maximum amount by which a label bounding box may exceed the axis range.\n\n__Default value:__ `false`.",
@@ -1171,22 +926,7 @@
           ]
         },
         "labelColor": {
-          "anyOf": [
-            {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "#/definitions/Color"
-                }
-              ],
-              "description": "The color of the tick label, can be in hex color code or regular color name."
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)1719818830|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelFlush": {
           "description": "Indicates if the first and last axis labels should be aligned flush with the scale range. Flush alignment for a horizontal axis will left-align the first label and right-align the last label. For vertical axes, bottom and top text baselines are applied instead. If this property is a number, it also indicates the number of pixels by which to offset the first and last labels; for example, a value of 2 will flush-align the first and last labels and also push them 2 pixels outward from the center of the axis. The additional adjustment can sometimes help the labels better visually group with corresponding axis ticks.\n\n__Default value:__ `true` for axis of a continuous x-scale. Otherwise, `false`.",
@@ -1200,64 +940,23 @@
           "type": "number"
         },
         "labelFont": {
-          "anyOf": [
-            {
-              "description": "The font of the tick label.",
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((string|undefined)1723860780|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelFontSize": {
-          "anyOf": [
-            {
-              "description": "The font size of the label, in pixels.",
-              "minimum": 0,
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number|undefined)720879958|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelFontStyle": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/FontStyle",
-              "description": "Font style of the title."
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((def-alias-981995915-8836-8977-981995915-0-10055|undefined)679934267|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelFontWeight": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/FontWeight",
-              "description": "Font weight of axis tick labels."
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((def-alias-981995915-8687-8836-981995915-0-10055|undefined)1209375024|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelLimit": {
           "description": "Maximum allowed pixel width of axis tick labels.\n\n__Default value:__ `180`",
           "type": "number"
         },
         "labelOpacity": {
-          "anyOf": [
-            {
-              "description": "The opacity of the labels.",
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number|undefined)377890894|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "labelOverlap": {
           "$ref": "#/definitions/LabelOverlap",
@@ -1292,47 +991,13 @@
           "type": "boolean"
         },
         "tickColor": {
-          "anyOf": [
-            {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "#/definitions/Color"
-                }
-              ],
-              "description": "The color of the axis's tick.\n\n__Default value:__ `\"gray\"`"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)565543918|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "tickDash": {
-          "anyOf": [
-            {
-              "description": "An array of alternating [stroke, space] lengths for dashed tick mark lines.",
-              "items": {
-                "type": "number"
-              },
-              "type": "array"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number[]|undefined)105503503|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "tickDashOffset": {
-          "anyOf": [
-            {
-              "description": "The pixel offset at which to start drawing with the tick mark dash array.",
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number|undefined)61636408|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "tickExtra": {
           "description": "Boolean flag indicating if an extra axis tick should be added for the initial position of the axis. This flag is useful for styling axes for `band` scales such that ticks are placed on band boundaries rather in the middle of a band. Use in conjunction with `\"bandPosition\": 1` and an axis `\"padding\"` value of `0`.",
@@ -1343,15 +1008,7 @@
           "type": "number"
         },
         "tickOpacity": {
-          "anyOf": [
-            {
-              "description": "Opacity of the ticks.",
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number|undefined)1791665056|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "tickRound": {
           "description": "Boolean flag indicating if pixel position values should be rounded to the nearest integer.\n\n__Default value:__ `true`",
@@ -1363,16 +1020,7 @@
           "type": "number"
         },
         "tickWidth": {
-          "anyOf": [
-            {
-              "description": "The width, in pixels, of ticks.\n\n__Default value:__ `1`",
-              "minimum": 0,
-              "type": "number"
-            },
-            {
-              "$ref": "#/definitions/ConditionalAxisProperty<((number|undefined)1626350768|null)>"
-            }
-          ]
+          "$ref": "#/definitions/ConditionalAxisProperty<null>"
         },
         "ticks": {
           "description": "Boolean value that determines whether the axis should include ticks.\n\n__Default value:__ `true`",
@@ -2897,647 +2545,30 @@
         }
       ]
     },
-    "ConditionalAxisProperty<((def-alias-981995915-6039-6088-981995915-0-10055|undefined)870796116|null)>": {
+    "ConditionalAxisProperty<null>": {
       "additionalProperties": false,
       "properties": {
         "condition": {
           "anyOf": [
             {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((def-alias-981995915-6039-6088-981995915-0-10055|undefined)870796116|null)>>"
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<null>>"
             },
             {
               "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((def-alias-981995915-6039-6088-981995915-0-10055|undefined)870796116|null)>>"
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<null>>"
               },
               "type": "array"
             }
           ]
         },
         "value": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Align",
-              "description": "Horizontal text alignment of axis tick labels, overriding the default setting for the current axis orientation."
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity).",
+          "type": "null"
         }
       },
       "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((def-alias-981995915-8592-8644-981995915-0-10055|undefined)186452232|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((def-alias-981995915-8592-8644-981995915-0-10055|undefined)186452232|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((def-alias-981995915-8592-8644-981995915-0-10055|undefined)186452232|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TextBaseline",
-              "description": "Vertical text baseline of axis tick labels, overriding the default setting for the current axis orientation. Can be `\"top\"`, `\"middle\"`, `\"bottom\"`, or `\"alphabetic\"`."
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((def-alias-981995915-8687-8836-981995915-0-10055|undefined)1209375024|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((def-alias-981995915-8687-8836-981995915-0-10055|undefined)1209375024|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((def-alias-981995915-8687-8836-981995915-0-10055|undefined)1209375024|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/FontWeight",
-              "description": "Font weight of axis tick labels."
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((def-alias-981995915-8836-8977-981995915-0-10055|undefined)679934267|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((def-alias-981995915-8836-8977-981995915-0-10055|undefined)679934267|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((def-alias-981995915-8836-8977-981995915-0-10055|undefined)679934267|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/FontStyle",
-              "description": "Font style of the title."
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)1719818830|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)1719818830|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)1719818830|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "#/definitions/Color"
-                }
-              ],
-              "description": "The color of the tick label, can be in hex color code or regular color name."
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)2086385775|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)2086385775|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)2086385775|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "#/definitions/Color"
-                }
-              ],
-              "description": "Color of gridlines.\n\n__Default value:__ `\"lightGray\"`."
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)565543918|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)565543918|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)565543918|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "#/definitions/Color"
-                }
-              ],
-              "description": "The color of the axis's tick.\n\n__Default value:__ `\"gray\"`"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((number[]|undefined)105503503|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number[]|undefined)105503503|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number[]|undefined)105503503|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "An array of alternating [stroke, space] lengths for dashed tick mark lines.",
-              "items": {
-                "type": "number"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((number[]|undefined)927251285|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number[]|undefined)927251285|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number[]|undefined)927251285|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "An array of alternating [stroke, space] lengths for dashed grid lines.",
-              "items": {
-                "type": "number"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((number|undefined)1626350768|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number|undefined)1626350768|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number|undefined)1626350768|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "The width, in pixels, of ticks.\n\n__Default value:__ `1`",
-              "minimum": 0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((number|undefined)1791665056|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number|undefined)1791665056|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number|undefined)1791665056|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "Opacity of the ticks.",
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((number|undefined)1806960624|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number|undefined)1806960624|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number|undefined)1806960624|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "The pixel offset at which to start drawing with the grid dash array.",
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((number|undefined)377890894|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number|undefined)377890894|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number|undefined)377890894|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "The opacity of the labels.",
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((number|undefined)61636408|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number|undefined)61636408|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number|undefined)61636408|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "The pixel offset at which to start drawing with the tick mark dash array.",
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((number|undefined)702672441|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number|undefined)702672441|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number|undefined)702672441|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "The stroke opacity of grid (value between [0,1])\n\n__Default value:__ `1`",
-              "maximum": 1,
-              "minimum": 0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((number|undefined)720879958|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number|undefined)720879958|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number|undefined)720879958|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "The font size of the label, in pixels.",
-              "minimum": 0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((number|undefined)742391737|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number|undefined)742391737|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((number|undefined)742391737|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "The grid width, in pixels.\n\n__Default value:__ `1`",
-              "minimum": 0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
-      ],
-      "type": "object"
-    },
-    "ConditionalAxisProperty<((string|undefined)1723860780|null)>": {
-      "additionalProperties": false,
-      "properties": {
-        "condition": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<((string|undefined)1723860780|null)>>"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<((string|undefined)1723860780|null)>>"
-              },
-              "type": "array"
-            }
-          ]
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "The font of the tick label.",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "condition"
+        "condition",
+        "value"
       ],
       "type": "object"
     },
@@ -3780,488 +2811,6 @@
       ],
       "type": "object"
     },
-    "ConditionalPredicate<ValueDef<((def-alias-981995915-6039-6088-981995915-0-10055|undefined)870796116|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Align",
-              "description": "Horizontal text alignment of axis tick labels, overriding the default setting for the current axis orientation."
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((def-alias-981995915-8592-8644-981995915-0-10055|undefined)186452232|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/TextBaseline",
-              "description": "Vertical text baseline of axis tick labels, overriding the default setting for the current axis orientation. Can be `\"top\"`, `\"middle\"`, `\"bottom\"`, or `\"alphabetic\"`."
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((def-alias-981995915-8687-8836-981995915-0-10055|undefined)1209375024|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/FontWeight",
-              "description": "Font weight of axis tick labels."
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((def-alias-981995915-8836-8977-981995915-0-10055|undefined)679934267|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/FontStyle",
-              "description": "Font style of the title."
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)1719818830|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "#/definitions/Color"
-                }
-              ],
-              "description": "The color of the tick label, can be in hex color code or regular color name."
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)2086385775|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "#/definitions/Color"
-                }
-              ],
-              "description": "Color of gridlines.\n\n__Default value:__ `\"lightGray\"`."
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)565543918|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "anyOf": [
-                {
-                  "type": "null"
-                },
-                {
-                  "$ref": "#/definitions/Color"
-                }
-              ],
-              "description": "The color of the axis's tick.\n\n__Default value:__ `\"gray\"`"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((number[]|undefined)105503503|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "An array of alternating [stroke, space] lengths for dashed tick mark lines.",
-              "items": {
-                "type": "number"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((number[]|undefined)927251285|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "An array of alternating [stroke, space] lengths for dashed grid lines.",
-              "items": {
-                "type": "number"
-              },
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((number|undefined)1626350768|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "The width, in pixels, of ticks.\n\n__Default value:__ `1`",
-              "minimum": 0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((number|undefined)1791665056|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "Opacity of the ticks.",
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((number|undefined)1806960624|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "The pixel offset at which to start drawing with the grid dash array.",
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((number|undefined)377890894|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "The opacity of the labels.",
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((number|undefined)61636408|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "The pixel offset at which to start drawing with the tick mark dash array.",
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((number|undefined)702672441|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "The stroke opacity of grid (value between [0,1])\n\n__Default value:__ `1`",
-              "maximum": 1,
-              "minimum": 0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((number|undefined)720879958|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "The font size of the label, in pixels.",
-              "minimum": 0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((number|undefined)742391737|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "The grid width, in pixels.\n\n__Default value:__ `1`",
-              "minimum": 0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<((string|undefined)1723860780|null)>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "anyOf": [
-            {
-              "description": "The font of the tick label.",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test"
-      ],
-      "type": "object"
-    },
     "ConditionalPredicate<ValueDef<(Gradient|string|null)>>": {
       "additionalProperties": false,
       "properties": {
@@ -4321,6 +2870,24 @@
         "value": {
           "$ref": "#/definitions/Text",
           "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<null>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity).",
+          "type": "null"
         }
       },
       "required": [

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -579,22 +579,83 @@
           "type": "boolean"
         },
         "gridColor": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/definitions/Color"
+                }
+              ],
+              "description": "Color of gridlines.\n\n__Default value:__ `\"lightGray\"`."
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)2086385775,undefined>2086385775|null)>"
+            }
+          ]
         },
         "gridDash": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "An array of alternating [stroke, space] lengths for dashed grid lines.",
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number[]|undefined)927251285,undefined>927251285|null)>"
+            }
+          ]
         },
         "gridDashOffset": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "The pixel offset at which to start drawing with the grid dash array.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1806960624,undefined>1806960624|null)>"
+            }
+          ]
         },
         "gridOpacity": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "The stroke opacity of grid (value between [0,1])\n\n__Default value:__ `1`",
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)702672441,undefined>702672441|null)>"
+            }
+          ]
         },
         "gridWidth": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "The grid width, in pixels.\n\n__Default value:__ `1`",
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)742391737,undefined>742391737|null)>"
+            }
+          ]
         },
         "labelAlign": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Align",
+              "description": "Horizontal text alignment of axis tick labels, overriding the default setting for the current axis orientation."
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-6039-6088-981995915-0-10055|undefined)870796116,undefined>870796116|null)>"
+            }
+          ]
         },
         "labelAngle": {
           "description": "The rotation angle of the axis labels.\n\n__Default value:__ `-90` for nominal and ordinal fields; `0` otherwise.",
@@ -603,7 +664,15 @@
           "type": "number"
         },
         "labelBaseline": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextBaseline",
+              "description": "Vertical text baseline of axis tick labels, overriding the default setting for the current axis orientation. Can be `\"top\"`, `\"middle\"`, `\"bottom\"`, or `\"alphabetic\"`."
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8592-8644-981995915-0-10055|undefined)186452232,undefined>186452232|null)>"
+            }
+          ]
         },
         "labelBound": {
           "description": "Indicates if labels should be hidden if they exceed the axis range. If `false` (the default) no bounds overlap analysis is performed. If `true`, labels will be hidden if they exceed the axis range by more than 1 pixel. If this property is a number, it specifies the pixel tolerance: the maximum amount by which a label bounding box may exceed the axis range.\n\n__Default value:__ `false`.",
@@ -613,7 +682,22 @@
           ]
         },
         "labelColor": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/definitions/Color"
+                }
+              ],
+              "description": "The color of the tick label, can be in hex color code or regular color name."
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)1719818830,undefined>1719818830|null)>"
+            }
+          ]
         },
         "labelExpr": {
           "description": "[Vega expression](https://vega.github.io/vega/docs/expressions/) for customizing labels.\n\n__Note:__ The label text and value can be assessed via the `label` and `value` properties of the axis's backing `datum` object.",
@@ -631,23 +715,64 @@
           "type": "number"
         },
         "labelFont": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "The font of the tick label.",
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(string|undefined)1723860780,undefined>1723860780|null)>"
+            }
+          ]
         },
         "labelFontSize": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "The font size of the label, in pixels.",
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)720879958,undefined>720879958|null)>"
+            }
+          ]
         },
         "labelFontStyle": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FontStyle",
+              "description": "Font style of the title."
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8836-8977-981995915-0-10055|undefined)679934267,undefined>679934267|null)>"
+            }
+          ]
         },
         "labelFontWeight": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FontWeight",
+              "description": "Font weight of axis tick labels."
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8687-8836-981995915-0-10055|undefined)1209375024,undefined>1209375024|null)>"
+            }
+          ]
         },
         "labelLimit": {
           "description": "Maximum allowed pixel width of axis tick labels.\n\n__Default value:__ `180`",
           "type": "number"
         },
         "labelOpacity": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "The opacity of the labels.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)377890894,undefined>377890894|null)>"
+            }
+          ]
         },
         "labelOverlap": {
           "$ref": "#/definitions/LabelOverlap",
@@ -686,17 +811,51 @@
           "type": "number"
         },
         "tickColor": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/definitions/Color"
+                }
+              ],
+              "description": "The color of the axis's tick.\n\n__Default value:__ `\"gray\"`"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)565543918,undefined>565543918|null)>"
+            }
+          ]
         },
         "tickCount": {
           "description": "A desired number of ticks, for axes visualizing quantitative scales. The resulting number may be different so that values are \"nice\" (multiples of 2, 5, 10) and lie within the underlying scale's range.",
           "type": "number"
         },
         "tickDash": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "An array of alternating [stroke, space] lengths for dashed tick mark lines.",
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number[]|undefined)105503503,undefined>105503503|null)>"
+            }
+          ]
         },
         "tickDashOffset": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "The pixel offset at which to start drawing with the tick mark dash array.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)61636408,undefined>61636408|null)>"
+            }
+          ]
         },
         "tickExtra": {
           "description": "Boolean flag indicating if an extra axis tick should be added for the initial position of the axis. This flag is useful for styling axes for `band` scales such that ticks are placed on band boundaries rather in the middle of a band. Use in conjunction with `\"bandPosition\": 1` and an axis `\"padding\"` value of `0`.",
@@ -711,7 +870,15 @@
           "type": "number"
         },
         "tickOpacity": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "Opacity of the ticks.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1791665056,undefined>1791665056|null)>"
+            }
+          ]
         },
         "tickRound": {
           "description": "Boolean flag indicating if pixel position values should be rounded to the nearest integer.\n\n__Default value:__ `true`",
@@ -723,7 +890,16 @@
           "type": "number"
         },
         "tickWidth": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "The width, in pixels, of ticks.\n\n__Default value:__ `1`",
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1626350768,undefined>1626350768|null)>"
+            }
+          ]
         },
         "ticks": {
           "description": "Boolean value that determines whether the axis should include ticks.\n\n__Default value:__ `true`",
@@ -892,22 +1068,83 @@
           "type": "boolean"
         },
         "gridColor": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/definitions/Color"
+                }
+              ],
+              "description": "Color of gridlines.\n\n__Default value:__ `\"lightGray\"`."
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)2086385775,undefined>2086385775|null)>"
+            }
+          ]
         },
         "gridDash": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "An array of alternating [stroke, space] lengths for dashed grid lines.",
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number[]|undefined)927251285,undefined>927251285|null)>"
+            }
+          ]
         },
         "gridDashOffset": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "The pixel offset at which to start drawing with the grid dash array.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1806960624,undefined>1806960624|null)>"
+            }
+          ]
         },
         "gridOpacity": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "The stroke opacity of grid (value between [0,1])\n\n__Default value:__ `1`",
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)702672441,undefined>702672441|null)>"
+            }
+          ]
         },
         "gridWidth": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "The grid width, in pixels.\n\n__Default value:__ `1`",
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)742391737,undefined>742391737|null)>"
+            }
+          ]
         },
         "labelAlign": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Align",
+              "description": "Horizontal text alignment of axis tick labels, overriding the default setting for the current axis orientation."
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-6039-6088-981995915-0-10055|undefined)870796116,undefined>870796116|null)>"
+            }
+          ]
         },
         "labelAngle": {
           "description": "The rotation angle of the axis labels.\n\n__Default value:__ `-90` for nominal and ordinal fields; `0` otherwise.",
@@ -916,7 +1153,15 @@
           "type": "number"
         },
         "labelBaseline": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextBaseline",
+              "description": "Vertical text baseline of axis tick labels, overriding the default setting for the current axis orientation. Can be `\"top\"`, `\"middle\"`, `\"bottom\"`, or `\"alphabetic\"`."
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8592-8644-981995915-0-10055|undefined)186452232,undefined>186452232|null)>"
+            }
+          ]
         },
         "labelBound": {
           "description": "Indicates if labels should be hidden if they exceed the axis range. If `false` (the default) no bounds overlap analysis is performed. If `true`, labels will be hidden if they exceed the axis range by more than 1 pixel. If this property is a number, it specifies the pixel tolerance: the maximum amount by which a label bounding box may exceed the axis range.\n\n__Default value:__ `false`.",
@@ -926,7 +1171,22 @@
           ]
         },
         "labelColor": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/definitions/Color"
+                }
+              ],
+              "description": "The color of the tick label, can be in hex color code or regular color name."
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)1719818830,undefined>1719818830|null)>"
+            }
+          ]
         },
         "labelFlush": {
           "description": "Indicates if the first and last axis labels should be aligned flush with the scale range. Flush alignment for a horizontal axis will left-align the first label and right-align the last label. For vertical axes, bottom and top text baselines are applied instead. If this property is a number, it also indicates the number of pixels by which to offset the first and last labels; for example, a value of 2 will flush-align the first and last labels and also push them 2 pixels outward from the center of the axis. The additional adjustment can sometimes help the labels better visually group with corresponding axis ticks.\n\n__Default value:__ `true` for axis of a continuous x-scale. Otherwise, `false`.",
@@ -940,23 +1200,64 @@
           "type": "number"
         },
         "labelFont": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "The font of the tick label.",
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(string|undefined)1723860780,undefined>1723860780|null)>"
+            }
+          ]
         },
         "labelFontSize": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "The font size of the label, in pixels.",
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)720879958,undefined>720879958|null)>"
+            }
+          ]
         },
         "labelFontStyle": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FontStyle",
+              "description": "Font style of the title."
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8836-8977-981995915-0-10055|undefined)679934267,undefined>679934267|null)>"
+            }
+          ]
         },
         "labelFontWeight": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FontWeight",
+              "description": "Font weight of axis tick labels."
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8687-8836-981995915-0-10055|undefined)1209375024,undefined>1209375024|null)>"
+            }
+          ]
         },
         "labelLimit": {
           "description": "Maximum allowed pixel width of axis tick labels.\n\n__Default value:__ `180`",
           "type": "number"
         },
         "labelOpacity": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "The opacity of the labels.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)377890894,undefined>377890894|null)>"
+            }
+          ]
         },
         "labelOverlap": {
           "$ref": "#/definitions/LabelOverlap",
@@ -991,13 +1292,47 @@
           "type": "boolean"
         },
         "tickColor": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/definitions/Color"
+                }
+              ],
+              "description": "The color of the axis's tick.\n\n__Default value:__ `\"gray\"`"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)565543918,undefined>565543918|null)>"
+            }
+          ]
         },
         "tickDash": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "An array of alternating [stroke, space] lengths for dashed tick mark lines.",
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number[]|undefined)105503503,undefined>105503503|null)>"
+            }
+          ]
         },
         "tickDashOffset": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "The pixel offset at which to start drawing with the tick mark dash array.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)61636408,undefined>61636408|null)>"
+            }
+          ]
         },
         "tickExtra": {
           "description": "Boolean flag indicating if an extra axis tick should be added for the initial position of the axis. This flag is useful for styling axes for `band` scales such that ticks are placed on band boundaries rather in the middle of a band. Use in conjunction with `\"bandPosition\": 1` and an axis `\"padding\"` value of `0`.",
@@ -1008,7 +1343,15 @@
           "type": "number"
         },
         "tickOpacity": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "Opacity of the ticks.",
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1791665056,undefined>1791665056|null)>"
+            }
+          ]
         },
         "tickRound": {
           "description": "Boolean flag indicating if pixel position values should be rounded to the nearest integer.\n\n__Default value:__ `true`",
@@ -1020,7 +1363,16 @@
           "type": "number"
         },
         "tickWidth": {
-          "$ref": "#/definitions/ConditionalAxisProperty<null>"
+          "anyOf": [
+            {
+              "description": "The width, in pixels, of ticks.\n\n__Default value:__ `1`",
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "$ref": "#/definitions/ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1626350768,undefined>1626350768|null)>"
+            }
+          ]
         },
         "ticks": {
           "description": "Boolean value that determines whether the axis should include ticks.\n\n__Default value:__ `true`",
@@ -2545,25 +2897,660 @@
         }
       ]
     },
-    "ConditionalAxisProperty<null>": {
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-6039-6088-981995915-0-10055|undefined)870796116,undefined>870796116|null)>": {
       "additionalProperties": false,
       "properties": {
         "condition": {
           "anyOf": [
             {
-              "$ref": "#/definitions/ConditionalPredicate<ValueDef<null>>"
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-6039-6088-981995915-0-10055|undefined)870796116,undefined>870796116|null)>>"
             },
             {
               "items": {
-                "$ref": "#/definitions/ConditionalPredicate<ValueDef<null>>"
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-6039-6088-981995915-0-10055|undefined)870796116,undefined>870796116|null)>>"
               },
               "type": "array"
             }
           ]
         },
         "value": {
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity).",
-          "type": "null"
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Align",
+              "description": "Horizontal text alignment of axis tick labels, overriding the default setting for the current axis orientation."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8592-8644-981995915-0-10055|undefined)186452232,undefined>186452232|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8592-8644-981995915-0-10055|undefined)186452232,undefined>186452232|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8592-8644-981995915-0-10055|undefined)186452232,undefined>186452232|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextBaseline",
+              "description": "Vertical text baseline of axis tick labels, overriding the default setting for the current axis orientation. Can be `\"top\"`, `\"middle\"`, `\"bottom\"`, or `\"alphabetic\"`."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8687-8836-981995915-0-10055|undefined)1209375024,undefined>1209375024|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8687-8836-981995915-0-10055|undefined)1209375024,undefined>1209375024|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8687-8836-981995915-0-10055|undefined)1209375024,undefined>1209375024|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FontWeight",
+              "description": "Font weight of axis tick labels."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8836-8977-981995915-0-10055|undefined)679934267,undefined>679934267|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8836-8977-981995915-0-10055|undefined)679934267,undefined>679934267|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8836-8977-981995915-0-10055|undefined)679934267,undefined>679934267|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FontStyle",
+              "description": "Font style of the title."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)1719818830,undefined>1719818830|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)1719818830,undefined>1719818830|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)1719818830,undefined>1719818830|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/definitions/Color"
+                }
+              ],
+              "description": "The color of the tick label, can be in hex color code or regular color name."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)2086385775,undefined>2086385775|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)2086385775,undefined>2086385775|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)2086385775,undefined>2086385775|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/definitions/Color"
+                }
+              ],
+              "description": "Color of gridlines.\n\n__Default value:__ `\"lightGray\"`."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)565543918,undefined>565543918|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)565543918,undefined>565543918|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)565543918,undefined>565543918|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/definitions/Color"
+                }
+              ],
+              "description": "The color of the axis's tick.\n\n__Default value:__ `\"gray\"`"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number[]|undefined)105503503,undefined>105503503|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number[]|undefined)105503503,undefined>105503503|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number[]|undefined)105503503,undefined>105503503|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "An array of alternating [stroke, space] lengths for dashed tick mark lines.",
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number[]|undefined)927251285,undefined>927251285|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number[]|undefined)927251285,undefined>927251285|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number[]|undefined)927251285,undefined>927251285|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "An array of alternating [stroke, space] lengths for dashed grid lines.",
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1626350768,undefined>1626350768|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1626350768,undefined>1626350768|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1626350768,undefined>1626350768|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "The width, in pixels, of ticks.\n\n__Default value:__ `1`",
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1791665056,undefined>1791665056|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1791665056,undefined>1791665056|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1791665056,undefined>1791665056|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "Opacity of the ticks.",
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1806960624,undefined>1806960624|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1806960624,undefined>1806960624|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1806960624,undefined>1806960624|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "The pixel offset at which to start drawing with the grid dash array.",
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)377890894,undefined>377890894|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)377890894,undefined>377890894|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)377890894,undefined>377890894|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "The opacity of the labels.",
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)61636408,undefined>61636408|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)61636408,undefined>61636408|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)61636408,undefined>61636408|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "The pixel offset at which to start drawing with the tick mark dash array.",
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)702672441,undefined>702672441|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)702672441,undefined>702672441|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)702672441,undefined>702672441|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "The stroke opacity of grid (value between [0,1])\n\n__Default value:__ `1`",
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)720879958,undefined>720879958|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)720879958,undefined>720879958|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)720879958,undefined>720879958|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "The font size of the label, in pixels.",
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)742391737,undefined>742391737|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)742391737,undefined>742391737|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)742391737,undefined>742391737|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "The grid width, in pixels.\n\n__Default value:__ `1`",
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "condition",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalAxisProperty<(alias-724931800-67988-68103-724931800-0-208413<(string|undefined)1723860780,undefined>1723860780|null)>": {
+      "additionalProperties": false,
+      "properties": {
+        "condition": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(string|undefined)1723860780,undefined>1723860780|null)>>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(string|undefined)1723860780,undefined>1723860780|null)>>"
+              },
+              "type": "array"
+            }
+          ]
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "The font of the tick label.",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
         }
       },
       "required": [
@@ -2839,6 +3826,506 @@
       ],
       "type": "object"
     },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-6039-6088-981995915-0-10055|undefined)870796116,undefined>870796116|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Align",
+              "description": "Horizontal text alignment of axis tick labels, overriding the default setting for the current axis orientation."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8592-8644-981995915-0-10055|undefined)186452232,undefined>186452232|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/TextBaseline",
+              "description": "Vertical text baseline of axis tick labels, overriding the default setting for the current axis orientation. Can be `\"top\"`, `\"middle\"`, `\"bottom\"`, or `\"alphabetic\"`."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8687-8836-981995915-0-10055|undefined)1209375024,undefined>1209375024|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FontWeight",
+              "description": "Font weight of axis tick labels."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(def-alias-981995915-8836-8977-981995915-0-10055|undefined)679934267,undefined>679934267|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FontStyle",
+              "description": "Font style of the title."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)1719818830,undefined>1719818830|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/definitions/Color"
+                }
+              ],
+              "description": "The color of the tick label, can be in hex color code or regular color name."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)2086385775,undefined>2086385775|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/definitions/Color"
+                }
+              ],
+              "description": "Color of gridlines.\n\n__Default value:__ `\"lightGray\"`."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(null|def-alias-1203634144-2468-2565-1203634144-0-2566|undefined)565543918,undefined>565543918|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "type": "null"
+                },
+                {
+                  "$ref": "#/definitions/Color"
+                }
+              ],
+              "description": "The color of the axis's tick.\n\n__Default value:__ `\"gray\"`"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number[]|undefined)105503503,undefined>105503503|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "An array of alternating [stroke, space] lengths for dashed tick mark lines.",
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number[]|undefined)927251285,undefined>927251285|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "An array of alternating [stroke, space] lengths for dashed grid lines.",
+              "items": {
+                "type": "number"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1626350768,undefined>1626350768|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "The width, in pixels, of ticks.\n\n__Default value:__ `1`",
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1791665056,undefined>1791665056|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "Opacity of the ticks.",
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)1806960624,undefined>1806960624|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "The pixel offset at which to start drawing with the grid dash array.",
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)377890894,undefined>377890894|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "The opacity of the labels.",
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)61636408,undefined>61636408|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "The pixel offset at which to start drawing with the tick mark dash array.",
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)702672441,undefined>702672441|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "The stroke opacity of grid (value between [0,1])\n\n__Default value:__ `1`",
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)720879958,undefined>720879958|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "The font size of the label, in pixels.",
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(number|undefined)742391737,undefined>742391737|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "The grid width, in pixels.\n\n__Default value:__ `1`",
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
+    "ConditionalPredicate<ValueDef<(alias-724931800-67988-68103-724931800-0-208413<(string|undefined)1723860780,undefined>1723860780|null)>>": {
+      "additionalProperties": false,
+      "properties": {
+        "test": {
+          "$ref": "#/definitions/LogicalOperand<Predicate>",
+          "description": "Predicate for triggering the condition"
+        },
+        "value": {
+          "anyOf": [
+            {
+              "description": "The font of the tick label.",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
+        }
+      },
+      "required": [
+        "test",
+        "value"
+      ],
+      "type": "object"
+    },
     "ConditionalPredicate<StringValueDef>": {
       "additionalProperties": false,
       "properties": {
@@ -2870,24 +4357,6 @@
         "value": {
           "$ref": "#/definitions/Text",
           "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity)."
-        }
-      },
-      "required": [
-        "test",
-        "value"
-      ],
-      "type": "object"
-    },
-    "ConditionalPredicate<ValueDef<null>>": {
-      "additionalProperties": false,
-      "properties": {
-        "test": {
-          "$ref": "#/definitions/LogicalOperand<Predicate>",
-          "description": "Predicate for triggering the condition"
-        },
-        "value": {
-          "description": "A constant value in visual domain (e.g., `\"red\"` / `\"#0099ff\"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity).",
-          "type": "null"
         }
       },
       "required": [

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -118,9 +118,9 @@ export function isConditionalAxisValue<V extends Value | number[]>(v: any): v is
 // Vega axis config is the same as Vega axis base. If this is not the case, add specific type.
 export type VgAxisConfigNoSignals = Omit<BaseAxisNoSignals, ConditionalAxisProp> &
   {
-    [k in ConditionalAxisProp]?: BaseAxisNoSignals[k] extends string | number | boolean | null | number[]
-      ? BaseAxisNoSignals[k] | ConditionalAxisProperty<BaseAxisNoSignals[k] | null>
-      : ConditionalAxisProperty<null>;
+    [k in ConditionalAxisProp]?:
+      | BaseAxisNoSignals[k]
+      | ConditionalAxisProperty<Exclude<BaseAxisNoSignals[k], undefined> | null>;
   };
 
 // Change comments to be Vega-Lite specific

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -118,9 +118,9 @@ export function isConditionalAxisValue<V extends Value | number[]>(v: any): v is
 // Vega axis config is the same as Vega axis base. If this is not the case, add specific type.
 export type VgAxisConfigNoSignals = Omit<BaseAxisNoSignals, ConditionalAxisProp> &
   {
-    [k in ConditionalAxisProp]?: BaseAxisNoSignals[k] extends undefined
-      ? ConditionalAxisProperty<null>
-      : BaseAxisNoSignals[k] | ConditionalAxisProperty<BaseAxisNoSignals[k] | null>;
+    [k in ConditionalAxisProp]?: BaseAxisNoSignals[k] extends string | number | boolean | null | number[]
+      ? BaseAxisNoSignals[k] | ConditionalAxisProperty<BaseAxisNoSignals[k] | null>
+      : ConditionalAxisProperty<null>;
   };
 
 // Change comments to be Vega-Lite specific

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -118,7 +118,9 @@ export function isConditionalAxisValue<V extends Value | number[]>(v: any): v is
 // Vega axis config is the same as Vega axis base. If this is not the case, add specific type.
 export type VgAxisConfigNoSignals = Omit<BaseAxisNoSignals, ConditionalAxisProp> &
   {
-    [k in ConditionalAxisProp]?: BaseAxisNoSignals[k] | ConditionalAxisProperty<BaseAxisNoSignals[k] | null>;
+    [k in ConditionalAxisProp]?: BaseAxisNoSignals[k] extends undefined
+      ? ConditionalAxisProperty<null>
+      : BaseAxisNoSignals[k] | ConditionalAxisProperty<BaseAxisNoSignals[k] | null>;
   };
 
 // Change comments to be Vega-Lite specific

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,14 @@
   "compilerOptions": {
     "noEmit": true
   },
-  "files": ["src/index.ts"],
-  "include": ["src/**/*.ts", "test/**/*.ts", "test-runtime/**/*.ts", "site/static/**/*.ts", "examples/*.test.ts"]
+  "files": [
+    "src/index.ts"
+  ],
+  "include": [
+    "src/**/*.ts",
+    "test/**/*.ts",
+    "test-runtime/**/*.ts",
+    "site/static/**/*.ts",
+    "examples/*.test.ts"
+  ]
 }


### PR DESCRIPTION
This fixes #5477 with a one-line change in `axis.ts`
