### PR TITLE
fix: selection modify signal should only fire on tuple signal change

### DIFF
--- a/examples/compiled/airport_connections.vg.json
+++ b/examples/compiled/airport_connections.vg.json
@@ -151,7 +151,12 @@
     },
     {
       "name": "single_modify",
-      "update": "modify(\"single_store\", single_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "single_tuple"},
+          "update": "modify(\"single_store\", single_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/bar_count_minimap.vg.json
+++ b/examples/compiled/bar_count_minimap.vg.json
@@ -291,7 +291,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/brush_table.vg.json
+++ b/examples/compiled/brush_table.vg.json
@@ -317,7 +317,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/circle_bubble_health_income.vg.json
+++ b/examples/compiled/circle_bubble_health_income.vg.json
@@ -124,7 +124,12 @@
     },
     {
       "name": "view_modify",
-      "update": "modify(\"view_store\", view_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "view_tuple"},
+          "update": "modify(\"view_store\", view_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/concat_bar_layer_circle.vg.json
+++ b/examples/compiled/concat_bar_layer_circle.vg.json
@@ -287,7 +287,12 @@
         },
         {
           "name": "pts_modify",
-          "update": "modify(\"pts_store\", pts_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "pts_tuple"},
+              "update": "modify(\"pts_store\", pts_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/concat_hover.vg.json
+++ b/examples/compiled/concat_hover.vg.json
@@ -81,7 +81,12 @@
         },
         {
           "name": "hover_modify",
-          "update": "modify(\"hover_store\", hover_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "hover_tuple"},
+              "update": "modify(\"hover_store\", hover_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -188,7 +193,12 @@
         },
         {
           "name": "hover_modify",
-          "update": "modify(\"hover_store\", hover_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "hover_tuple"},
+              "update": "modify(\"hover_store\", hover_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/concat_hover_filter.vg.json
+++ b/examples/compiled/concat_hover_filter.vg.json
@@ -108,7 +108,12 @@
         },
         {
           "name": "hover_modify",
-          "update": "modify(\"hover_store\", hover_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "hover_tuple"},
+              "update": "modify(\"hover_store\", hover_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -224,7 +229,12 @@
         },
         {
           "name": "hover_modify",
-          "update": "modify(\"hover_store\", hover_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "hover_tuple"},
+              "update": "modify(\"hover_store\", hover_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/interactive_area_brush.vg.json
+++ b/examples/compiled/interactive_area_brush.vg.json
@@ -215,7 +215,12 @@
     },
     {
       "name": "brush_modify",
-      "update": "modify(\"brush_store\", brush_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "brush_tuple"},
+          "update": "modify(\"brush_store\", brush_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/interactive_bar_select_highlight.vg.json
+++ b/examples/compiled/interactive_bar_select_highlight.vg.json
@@ -72,7 +72,12 @@
     },
     {
       "name": "highlight_modify",
-      "update": "modify(\"highlight_store\", highlight_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "highlight_tuple"},
+          "update": "modify(\"highlight_store\", highlight_tuple, true)"
+        }
+      ]
     },
     {
       "name": "select_tuple",
@@ -102,7 +107,12 @@
     },
     {
       "name": "select_modify",
-      "update": "modify(\"select_store\", select_toggle ? null : select_tuple, select_toggle ? null : true, select_toggle ? select_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "select_tuple"},
+          "update": "modify(\"select_store\", select_toggle ? null : select_tuple, select_toggle ? null : true, select_toggle ? select_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/interactive_bin_extent.vg.json
+++ b/examples/compiled/interactive_bin_extent.vg.json
@@ -272,7 +272,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/interactive_brush.vg.json
+++ b/examples/compiled/interactive_brush.vg.json
@@ -262,7 +262,12 @@
     },
     {
       "name": "brush_modify",
-      "update": "modify(\"brush_store\", brush_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "brush_tuple"},
+          "update": "modify(\"brush_store\", brush_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/interactive_concat_layer.vg.json
+++ b/examples/compiled/interactive_concat_layer.vg.json
@@ -295,7 +295,12 @@
         },
         {
           "name": "pts_modify",
-          "update": "modify(\"pts_store\", pts_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "pts_tuple"},
+              "update": "modify(\"pts_store\", pts_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/interactive_dashboard_europe_pop.vg.json
+++ b/examples/compiled/interactive_dashboard_europe_pop.vg.json
@@ -526,7 +526,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -838,7 +843,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1227,7 +1237,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/interactive_index_chart.vg.json
+++ b/examples/compiled/interactive_index_chart.vg.json
@@ -130,7 +130,12 @@
     },
     {
       "name": "index_modify",
-      "update": "modify(\"index_store\", index_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "index_tuple"},
+          "update": "modify(\"index_store\", index_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/interactive_layered_crossfilter.vg.json
+++ b/examples/compiled/interactive_layered_crossfilter.vg.json
@@ -362,7 +362,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -726,7 +731,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1090,7 +1100,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/interactive_layered_crossfilter_discrete.vg.json
+++ b/examples/compiled/interactive_layered_crossfilter_discrete.vg.json
@@ -239,7 +239,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_toggle ? null : brush_tuple, brush_toggle ? null : true, brush_toggle ? brush_tuple : null)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_toggle ? null : brush_tuple, brush_toggle ? null : true, brush_toggle ? brush_tuple : null)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -397,7 +402,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_toggle ? null : brush_tuple, brush_toggle ? null : true, brush_toggle ? brush_tuple : null)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_toggle ? null : brush_tuple, brush_toggle ? null : true, brush_toggle ? brush_tuple : null)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -555,7 +565,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_toggle ? null : brush_tuple, brush_toggle ? null : true, brush_toggle ? brush_tuple : null)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_toggle ? null : brush_tuple, brush_toggle ? null : true, brush_toggle ? brush_tuple : null)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/interactive_legend.vg.json
+++ b/examples/compiled/interactive_legend.vg.json
@@ -107,7 +107,12 @@
     },
     {
       "name": "industry_modify",
-      "update": "modify(\"industry_store\", industry_toggle ? null : industry_tuple, industry_toggle ? null : true, industry_toggle ? industry_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "industry_tuple"},
+          "update": "modify(\"industry_store\", industry_toggle ? null : industry_tuple, industry_toggle ? null : true, industry_toggle ? industry_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/interactive_legend_dblclick.vg.json
+++ b/examples/compiled/interactive_legend_dblclick.vg.json
@@ -107,7 +107,12 @@
     },
     {
       "name": "industry_modify",
-      "update": "modify(\"industry_store\", industry_toggle ? null : industry_tuple, industry_toggle ? null : true, industry_toggle ? industry_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "industry_tuple"},
+          "update": "modify(\"industry_store\", industry_toggle ? null : industry_tuple, industry_toggle ? null : true, industry_toggle ? industry_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/interactive_multi_line_label.vg.json
+++ b/examples/compiled/interactive_multi_line_label.vg.json
@@ -85,7 +85,12 @@
     },
     {
       "name": "label_modify",
-      "update": "modify(\"label_store\", label_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "label_tuple"},
+          "update": "modify(\"label_store\", label_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/interactive_multi_line_tooltip.vg.json
+++ b/examples/compiled/interactive_multi_line_tooltip.vg.json
@@ -60,7 +60,12 @@
     },
     {
       "name": "hover_modify",
-      "update": "modify(\"hover_store\", hover_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "hover_tuple"},
+          "update": "modify(\"hover_store\", hover_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/interactive_overview_detail.vg.json
+++ b/examples/compiled/interactive_overview_detail.vg.json
@@ -276,7 +276,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/interactive_paintbrush.vg.json
+++ b/examples/compiled/interactive_paintbrush.vg.json
@@ -65,7 +65,12 @@
     },
     {
       "name": "paintbrush_modify",
-      "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "paintbrush_tuple"},
+          "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/interactive_paintbrush_color.vg.json
+++ b/examples/compiled/interactive_paintbrush_color.vg.json
@@ -61,7 +61,12 @@
     },
     {
       "name": "paintbrush_modify",
-      "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "paintbrush_tuple"},
+          "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/interactive_paintbrush_color_nearest.vg.json
+++ b/examples/compiled/interactive_paintbrush_color_nearest.vg.json
@@ -65,7 +65,12 @@
     },
     {
       "name": "paintbrush_modify",
-      "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "paintbrush_tuple"},
+          "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/interactive_paintbrush_interval.vg.json
+++ b/examples/compiled/interactive_paintbrush_interval.vg.json
@@ -253,7 +253,12 @@
     },
     {
       "name": "paintbrush_modify",
-      "update": "modify(\"paintbrush_store\", paintbrush_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "paintbrush_tuple"},
+          "update": "modify(\"paintbrush_store\", paintbrush_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/interactive_paintbrush_simple_all.vg.json
+++ b/examples/compiled/interactive_paintbrush_simple_all.vg.json
@@ -60,7 +60,12 @@
     },
     {
       "name": "paintbrush_modify",
-      "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "paintbrush_tuple"},
+          "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/interactive_paintbrush_simple_none.vg.json
+++ b/examples/compiled/interactive_paintbrush_simple_none.vg.json
@@ -60,7 +60,12 @@
     },
     {
       "name": "paintbrush_modify",
-      "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "paintbrush_tuple"},
+          "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/interactive_panzoom_splom.vg.json
+++ b/examples/compiled/interactive_panzoom_splom.vg.json
@@ -229,7 +229,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -417,7 +422,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -584,7 +594,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -774,7 +789,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -941,7 +961,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1129,7 +1154,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1296,7 +1326,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1486,7 +1521,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1676,7 +1716,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/interactive_panzoom_vconcat_shared.vg.json
+++ b/examples/compiled/interactive_panzoom_vconcat_shared.vg.json
@@ -162,7 +162,12 @@
         },
         {
           "name": "region_modify",
-          "update": "modify(\"region_store\", region_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "region_tuple"},
+              "update": "modify(\"region_store\", region_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/interactive_query_widgets.vg.json
+++ b/examples/compiled/interactive_query_widgets.vg.json
@@ -88,7 +88,12 @@
     },
     {
       "name": "CylYr_modify",
-      "update": "modify(\"CylYr_store\", CylYr_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "CylYr_tuple"},
+          "update": "modify(\"CylYr_store\", CylYr_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/interactive_seattle_weather.vg.json
+++ b/examples/compiled/interactive_seattle_weather.vg.json
@@ -247,7 +247,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -457,7 +462,12 @@
         },
         {
           "name": "click_modify",
-          "update": "modify(\"click_store\", click_toggle ? null : click_tuple, click_toggle ? null : true, click_toggle ? click_tuple : null)"
+          "on": [
+            {
+              "events": {"signal": "click_tuple"},
+              "update": "modify(\"click_store\", click_toggle ? null : click_tuple, click_toggle ? null : true, click_toggle ? click_tuple : null)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/interactive_splom.vg.json
+++ b/examples/compiled/interactive_splom.vg.json
@@ -365,7 +365,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon\"})"
+            }
+          ]
         },
         {
           "name": "grid_Miles_per_Gallon",
@@ -496,7 +501,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -860,7 +870,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Acceleration\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Acceleration\"})"
+            }
+          ]
         },
         {
           "name": "grid_Acceleration",
@@ -989,7 +1004,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1286,7 +1306,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Horsepower\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Horsepower\"})"
+            }
+          ]
         },
         {
           "name": "grid_Horsepower",
@@ -1394,7 +1419,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1757,7 +1787,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon\"})"
+            }
+          ]
         },
         {
           "name": "grid_Miles_per_Gallon",
@@ -1888,7 +1923,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -2185,7 +2225,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Acceleration\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Acceleration\"})"
+            }
+          ]
         },
         {
           "name": "grid_Acceleration",
@@ -2293,7 +2338,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -2654,7 +2704,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Horsepower\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Horsepower\"})"
+            }
+          ]
         },
         {
           "name": "grid_Horsepower",
@@ -2783,7 +2838,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -3080,7 +3140,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon\"})"
+            }
+          ]
         },
         {
           "name": "grid_Miles_per_Gallon",
@@ -3188,7 +3253,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -3551,7 +3621,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration\"})"
+            }
+          ]
         },
         {
           "name": "grid_Acceleration",
@@ -3682,7 +3757,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -4048,7 +4128,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower\"})"
+            }
+          ]
         },
         {
           "name": "grid_Horsepower",
@@ -4179,7 +4264,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/interactive_stocks_nearest_index.vg.json
+++ b/examples/compiled/interactive_stocks_nearest_index.vg.json
@@ -72,7 +72,12 @@
     },
     {
       "name": "index_modify",
-      "update": "modify(\"index_store\", index_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "index_tuple"},
+          "update": "modify(\"index_store\", index_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/isotype_grid.vg.json
+++ b/examples/compiled/isotype_grid.vg.json
@@ -346,7 +346,12 @@
     },
     {
       "name": "highlight_modify",
-      "update": "modify(\"highlight_store\", highlight_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "highlight_tuple"},
+          "update": "modify(\"highlight_store\", highlight_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_bind_cylyr.vg.json
+++ b/examples/compiled/selection_bind_cylyr.vg.json
@@ -55,7 +55,12 @@
     },
     {
       "name": "CylYr_modify",
-      "update": "modify(\"CylYr_store\", CylYr_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "CylYr_tuple"},
+          "update": "modify(\"CylYr_store\", CylYr_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_bind_origin.vg.json
+++ b/examples/compiled/selection_bind_origin.vg.json
@@ -38,7 +38,15 @@
       "update": "org_Origin !== null ? {fields: org_tuple_fields, values: [org_Origin]} : null"
     },
     {"name": "org_tuple_fields", "value": [{"type": "E", "field": "Origin"}]},
-    {"name": "org_modify", "update": "modify(\"org_store\", org_tuple, true)"}
+    {
+      "name": "org_modify",
+      "on": [
+        {
+          "events": {"signal": "org_tuple"},
+          "update": "modify(\"org_store\", org_tuple, true)"
+        }
+      ]
+    }
   ],
   "marks": [
     {

--- a/examples/compiled/selection_brush_timeunit.vg.json
+++ b/examples/compiled/selection_brush_timeunit.vg.json
@@ -242,7 +242,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/selection_clear_brush.vg.json
+++ b/examples/compiled/selection_clear_brush.vg.json
@@ -255,7 +255,12 @@
     },
     {
       "name": "brush_modify",
-      "update": "modify(\"brush_store\", brush_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "brush_tuple"},
+          "update": "modify(\"brush_store\", brush_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_composition_and.vg.json
+++ b/examples/compiled/selection_composition_and.vg.json
@@ -257,7 +257,12 @@
     },
     {
       "name": "alex_modify",
-      "update": "modify(\"alex_store\", alex_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "alex_tuple"},
+          "update": "modify(\"alex_store\", alex_tuple, true)"
+        }
+      ]
     },
     {
       "name": "morgan_x",
@@ -475,7 +480,12 @@
     },
     {
       "name": "morgan_modify",
-      "update": "modify(\"morgan_store\", morgan_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "morgan_tuple"},
+          "update": "modify(\"morgan_store\", morgan_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_composition_or.vg.json
+++ b/examples/compiled/selection_composition_or.vg.json
@@ -257,7 +257,12 @@
     },
     {
       "name": "alex_modify",
-      "update": "modify(\"alex_store\", alex_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "alex_tuple"},
+          "update": "modify(\"alex_store\", alex_tuple, true)"
+        }
+      ]
     },
     {
       "name": "morgan_x",
@@ -475,7 +480,12 @@
     },
     {
       "name": "morgan_modify",
-      "update": "modify(\"morgan_store\", morgan_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "morgan_tuple"},
+          "update": "modify(\"morgan_store\", morgan_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_concat.vg.json
+++ b/examples/compiled/selection_concat.vg.json
@@ -283,7 +283,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -552,7 +557,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/selection_filter.vg.json
+++ b/examples/compiled/selection_filter.vg.json
@@ -280,7 +280,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/selection_filter_composition.vg.json
+++ b/examples/compiled/selection_filter_composition.vg.json
@@ -280,7 +280,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/selection_heatmap.vg.json
+++ b/examples/compiled/selection_heatmap.vg.json
@@ -67,7 +67,12 @@
     },
     {
       "name": "highlight_modify",
-      "update": "modify(\"highlight_store\", highlight_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "highlight_tuple"},
+          "update": "modify(\"highlight_store\", highlight_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_insert.vg.json
+++ b/examples/compiled/selection_insert.vg.json
@@ -49,7 +49,12 @@
     },
     {
       "name": "paintbrush_modify",
-      "update": "modify(\"paintbrush_store\", paintbrush_tuple, null)"
+      "on": [
+        {
+          "events": {"signal": "paintbrush_tuple"},
+          "update": "modify(\"paintbrush_store\", paintbrush_tuple, null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_interval_mark_style.vg.json
+++ b/examples/compiled/selection_interval_mark_style.vg.json
@@ -257,7 +257,12 @@
     },
     {
       "name": "alex_modify",
-      "update": "modify(\"alex_store\", alex_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "alex_tuple"},
+          "update": "modify(\"alex_store\", alex_tuple, true)"
+        }
+      ]
     },
     {
       "name": "morgan_x",
@@ -475,7 +480,12 @@
     },
     {
       "name": "morgan_modify",
-      "update": "modify(\"morgan_store\", morgan_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "morgan_tuple"},
+          "update": "modify(\"morgan_store\", morgan_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_layer_bar_month.vg.json
+++ b/examples/compiled/selection_layer_bar_month.vg.json
@@ -216,7 +216,12 @@
     },
     {
       "name": "brush_modify",
-      "update": "modify(\"brush_store\", brush_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "brush_tuple"},
+          "update": "modify(\"brush_store\", brush_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_multi_condition.vg.json
+++ b/examples/compiled/selection_multi_condition.vg.json
@@ -253,7 +253,12 @@
     },
     {
       "name": "brush_modify",
-      "update": "modify(\"brush_store\", brush_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "brush_tuple"},
+          "update": "modify(\"brush_store\", brush_tuple, true)"
+        }
+      ]
     },
     {
       "name": "hoverbrush_tuple",
@@ -287,7 +292,12 @@
     },
     {
       "name": "hoverbrush_modify",
-      "update": "modify(\"hoverbrush_store\", hoverbrush_toggle ? null : hoverbrush_tuple, hoverbrush_toggle ? null : true, hoverbrush_toggle ? hoverbrush_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "hoverbrush_tuple"},
+          "update": "modify(\"hoverbrush_store\", hoverbrush_toggle ? null : hoverbrush_tuple, hoverbrush_toggle ? null : true, hoverbrush_toggle ? hoverbrush_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_project_binned_interval.vg.json
+++ b/examples/compiled/selection_project_binned_interval.vg.json
@@ -240,7 +240,12 @@
     },
     {
       "name": "brush_modify",
-      "update": "modify(\"brush_store\", brush_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "brush_tuple"},
+          "update": "modify(\"brush_store\", brush_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_project_interval.vg.json
+++ b/examples/compiled/selection_project_interval.vg.json
@@ -239,7 +239,15 @@
         }
       ]
     },
-    {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
+    {
+      "name": "pts_modify",
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_tuple, true)"
+        }
+      ]
+    }
   ],
   "marks": [
     {

--- a/examples/compiled/selection_project_interval_x.vg.json
+++ b/examples/compiled/selection_project_interval_x.vg.json
@@ -182,7 +182,15 @@
         }
       ]
     },
-    {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
+    {
+      "name": "pts_modify",
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_tuple, true)"
+        }
+      ]
+    }
   ],
   "marks": [
     {

--- a/examples/compiled/selection_project_interval_x_y.vg.json
+++ b/examples/compiled/selection_project_interval_x_y.vg.json
@@ -239,7 +239,15 @@
         }
       ]
     },
-    {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
+    {
+      "name": "pts_modify",
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_tuple, true)"
+        }
+      ]
+    }
   ],
   "marks": [
     {

--- a/examples/compiled/selection_project_interval_y.vg.json
+++ b/examples/compiled/selection_project_interval_y.vg.json
@@ -182,7 +182,15 @@
         }
       ]
     },
-    {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
+    {
+      "name": "pts_modify",
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_tuple, true)"
+        }
+      ]
+    }
   ],
   "marks": [
     {

--- a/examples/compiled/selection_project_multi.vg.json
+++ b/examples/compiled/selection_project_multi.vg.json
@@ -57,7 +57,12 @@
     },
     {
       "name": "pts_modify",
-      "update": "modify(\"pts_store\", pts_toggle ? null : pts_tuple, pts_toggle ? null : true, pts_toggle ? pts_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_toggle ? null : pts_tuple, pts_toggle ? null : true, pts_toggle ? pts_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_project_multi_cylinders.vg.json
+++ b/examples/compiled/selection_project_multi_cylinders.vg.json
@@ -59,7 +59,12 @@
     },
     {
       "name": "pts_modify",
-      "update": "modify(\"pts_store\", pts_toggle ? null : pts_tuple, pts_toggle ? null : true, pts_toggle ? pts_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_toggle ? null : pts_tuple, pts_toggle ? null : true, pts_toggle ? pts_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_project_multi_cylinders_origin.vg.json
+++ b/examples/compiled/selection_project_multi_cylinders_origin.vg.json
@@ -62,7 +62,12 @@
     },
     {
       "name": "pts_modify",
-      "update": "modify(\"pts_store\", pts_toggle ? null : pts_tuple, pts_toggle ? null : true, pts_toggle ? pts_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_toggle ? null : pts_tuple, pts_toggle ? null : true, pts_toggle ? pts_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_project_multi_origin.vg.json
+++ b/examples/compiled/selection_project_multi_origin.vg.json
@@ -56,7 +56,12 @@
     },
     {
       "name": "pts_modify",
-      "update": "modify(\"pts_store\", pts_toggle ? null : pts_tuple, pts_toggle ? null : true, pts_toggle ? pts_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_toggle ? null : pts_tuple, pts_toggle ? null : true, pts_toggle ? pts_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_project_single.vg.json
+++ b/examples/compiled/selection_project_single.vg.json
@@ -41,7 +41,15 @@
       ]
     },
     {"name": "pts_tuple_fields", "value": [{"type": "E", "field": "_vgsid_"}]},
-    {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
+    {
+      "name": "pts_modify",
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_tuple, true)"
+        }
+      ]
+    }
   ],
   "marks": [
     {

--- a/examples/compiled/selection_project_single_cylinders.vg.json
+++ b/examples/compiled/selection_project_single_cylinders.vg.json
@@ -43,7 +43,15 @@
       "name": "pts_tuple_fields",
       "value": [{"type": "E", "field": "Cylinders"}]
     },
-    {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
+    {
+      "name": "pts_modify",
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_tuple, true)"
+        }
+      ]
+    }
   ],
   "marks": [
     {

--- a/examples/compiled/selection_project_single_cylinders_origin.vg.json
+++ b/examples/compiled/selection_project_single_cylinders_origin.vg.json
@@ -46,7 +46,15 @@
         {"type": "E", "field": "Origin"}
       ]
     },
-    {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
+    {
+      "name": "pts_modify",
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_tuple, true)"
+        }
+      ]
+    }
   ],
   "marks": [
     {

--- a/examples/compiled/selection_project_single_origin.vg.json
+++ b/examples/compiled/selection_project_single_origin.vg.json
@@ -40,7 +40,15 @@
       ]
     },
     {"name": "pts_tuple_fields", "value": [{"type": "E", "field": "Origin"}]},
-    {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
+    {
+      "name": "pts_modify",
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_tuple, true)"
+        }
+      ]
+    }
   ],
   "marks": [
     {

--- a/examples/compiled/selection_resolution_global.vg.json
+++ b/examples/compiled/selection_resolution_global.vg.json
@@ -319,7 +319,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -721,7 +726,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1058,7 +1068,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1459,7 +1474,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1796,7 +1816,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -2195,7 +2220,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -2532,7 +2562,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -2933,7 +2968,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [
@@ -3337,7 +3377,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/selection_resolution_intersect.vg.json
+++ b/examples/compiled/selection_resolution_intersect.vg.json
@@ -319,7 +319,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon\"})"
+            }
+          ]
         }
       ],
       "marks": [
@@ -673,7 +678,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Acceleration\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Acceleration\"})"
+            }
+          ]
         }
       ],
       "marks": [
@@ -962,7 +972,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Horsepower\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Horsepower\"})"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1315,7 +1330,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon\"})"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1604,7 +1624,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Acceleration\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Acceleration\"})"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1955,7 +1980,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Horsepower\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Horsepower\"})"
+            }
+          ]
         }
       ],
       "marks": [
@@ -2244,7 +2274,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon\"})"
+            }
+          ]
         }
       ],
       "marks": [
@@ -2597,7 +2632,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration\"})"
+            }
+          ]
         }
       ],
       "marks": [
@@ -2953,7 +2993,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower\"})"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/selection_resolution_union.vg.json
+++ b/examples/compiled/selection_resolution_union.vg.json
@@ -319,7 +319,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Miles_per_Gallon\"})"
+            }
+          ]
         }
       ],
       "marks": [
@@ -673,7 +678,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Acceleration\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Acceleration\"})"
+            }
+          ]
         }
       ],
       "marks": [
@@ -962,7 +972,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Horsepower\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Horsepower__repeat_column_Horsepower\"})"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1315,7 +1330,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Miles_per_Gallon\"})"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1604,7 +1624,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Acceleration\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Acceleration\"})"
+            }
+          ]
         }
       ],
       "marks": [
@@ -1955,7 +1980,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Horsepower\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Acceleration__repeat_column_Horsepower\"})"
+            }
+          ]
         }
       ],
       "marks": [
@@ -2244,7 +2274,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Miles_per_Gallon\"})"
+            }
+          ]
         }
       ],
       "marks": [
@@ -2597,7 +2632,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Acceleration\"})"
+            }
+          ]
         }
       ],
       "marks": [
@@ -2953,7 +2993,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower\"})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child__repeat_row_Miles_per_Gallon__repeat_column_Horsepower\"})"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/selection_toggle_altKey.vg.json
+++ b/examples/compiled/selection_toggle_altKey.vg.json
@@ -60,7 +60,12 @@
     },
     {
       "name": "paintbrush_modify",
-      "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "paintbrush_tuple"},
+          "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_toggle_altKey_shiftKey.vg.json
+++ b/examples/compiled/selection_toggle_altKey_shiftKey.vg.json
@@ -60,7 +60,12 @@
     },
     {
       "name": "paintbrush_modify",
-      "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "paintbrush_tuple"},
+          "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_toggle_shiftKey.vg.json
+++ b/examples/compiled/selection_toggle_shiftKey.vg.json
@@ -60,7 +60,12 @@
     },
     {
       "name": "paintbrush_modify",
-      "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "paintbrush_tuple"},
+          "update": "modify(\"paintbrush_store\", paintbrush_toggle ? null : paintbrush_tuple, paintbrush_toggle ? null : true, paintbrush_toggle ? paintbrush_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_translate_brush_drag.vg.json
+++ b/examples/compiled/selection_translate_brush_drag.vg.json
@@ -246,7 +246,12 @@
     },
     {
       "name": "brush_modify",
-      "update": "modify(\"brush_store\", brush_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "brush_tuple"},
+          "update": "modify(\"brush_store\", brush_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_translate_brush_shift-drag.vg.json
+++ b/examples/compiled/selection_translate_brush_shift-drag.vg.json
@@ -252,7 +252,12 @@
     },
     {
       "name": "brush_modify",
-      "update": "modify(\"brush_store\", brush_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "brush_tuple"},
+          "update": "modify(\"brush_store\", brush_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_translate_scatterplot_drag.vg.json
+++ b/examples/compiled/selection_translate_scatterplot_drag.vg.json
@@ -123,7 +123,12 @@
     },
     {
       "name": "grid_modify",
-      "update": "modify(\"grid_store\", grid_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "grid_tuple"},
+          "update": "modify(\"grid_store\", grid_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_translate_scatterplot_shift-drag.vg.json
+++ b/examples/compiled/selection_translate_scatterplot_shift-drag.vg.json
@@ -133,7 +133,12 @@
     },
     {
       "name": "grid_modify",
-      "update": "modify(\"grid_store\", grid_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "grid_tuple"},
+          "update": "modify(\"grid_store\", grid_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_type_interval.vg.json
+++ b/examples/compiled/selection_type_interval.vg.json
@@ -239,7 +239,15 @@
         }
       ]
     },
-    {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
+    {
+      "name": "pts_modify",
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_tuple, true)"
+        }
+      ]
+    }
   ],
   "marks": [
     {

--- a/examples/compiled/selection_type_interval_invert.vg.json
+++ b/examples/compiled/selection_type_interval_invert.vg.json
@@ -239,7 +239,15 @@
         }
       ]
     },
-    {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
+    {
+      "name": "pts_modify",
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_tuple, true)"
+        }
+      ]
+    }
   ],
   "marks": [
     {

--- a/examples/compiled/selection_type_multi.vg.json
+++ b/examples/compiled/selection_type_multi.vg.json
@@ -66,7 +66,12 @@
     },
     {
       "name": "pts_modify",
-      "update": "modify(\"pts_store\", pts_toggle ? null : pts_tuple, pts_toggle ? null : true, pts_toggle ? pts_tuple : null)"
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_toggle ? null : pts_tuple, pts_toggle ? null : true, pts_toggle ? pts_tuple : null)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_type_single.vg.json
+++ b/examples/compiled/selection_type_single.vg.json
@@ -50,7 +50,15 @@
       ]
     },
     {"name": "pts_tuple_fields", "value": [{"type": "E", "field": "_vgsid_"}]},
-    {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
+    {
+      "name": "pts_modify",
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_tuple, true)"
+        }
+      ]
+    }
   ],
   "marks": [
     {

--- a/examples/compiled/selection_type_single_dblclick.vg.json
+++ b/examples/compiled/selection_type_single_dblclick.vg.json
@@ -50,7 +50,15 @@
       ]
     },
     {"name": "pts_tuple_fields", "value": [{"type": "E", "field": "_vgsid_"}]},
-    {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
+    {
+      "name": "pts_modify",
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_tuple, true)"
+        }
+      ]
+    }
   ],
   "marks": [
     {

--- a/examples/compiled/selection_type_single_mouseover.vg.json
+++ b/examples/compiled/selection_type_single_mouseover.vg.json
@@ -50,7 +50,15 @@
       ]
     },
     {"name": "pts_tuple_fields", "value": [{"type": "E", "field": "_vgsid_"}]},
-    {"name": "pts_modify", "update": "modify(\"pts_store\", pts_tuple, true)"}
+    {
+      "name": "pts_modify",
+      "on": [
+        {
+          "events": {"signal": "pts_tuple"},
+          "update": "modify(\"pts_store\", pts_tuple, true)"
+        }
+      ]
+    }
   ],
   "marks": [
     {

--- a/examples/compiled/selection_zoom_brush_shift-wheel.vg.json
+++ b/examples/compiled/selection_zoom_brush_shift-wheel.vg.json
@@ -248,7 +248,12 @@
     },
     {
       "name": "brush_modify",
-      "update": "modify(\"brush_store\", brush_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "brush_tuple"},
+          "update": "modify(\"brush_store\", brush_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_zoom_brush_wheel.vg.json
+++ b/examples/compiled/selection_zoom_brush_wheel.vg.json
@@ -246,7 +246,12 @@
     },
     {
       "name": "brush_modify",
-      "update": "modify(\"brush_store\", brush_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "brush_tuple"},
+          "update": "modify(\"brush_store\", brush_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_zoom_scatterplot_shift-wheel.vg.json
+++ b/examples/compiled/selection_zoom_scatterplot_shift-wheel.vg.json
@@ -137,7 +137,12 @@
     },
     {
       "name": "grid_modify",
-      "update": "modify(\"grid_store\", grid_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "grid_tuple"},
+          "update": "modify(\"grid_store\", grid_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/selection_zoom_scatterplot_wheel.vg.json
+++ b/examples/compiled/selection_zoom_scatterplot_wheel.vg.json
@@ -123,7 +123,12 @@
     },
     {
       "name": "grid_modify",
-      "update": "modify(\"grid_store\", grid_tuple, true)"
+      "on": [
+        {
+          "events": {"signal": "grid_tuple"},
+          "update": "modify(\"grid_store\", grid_tuple, true)"
+        }
+      ]
     }
   ],
   "marks": [

--- a/examples/compiled/trellis_selections.vg.json
+++ b/examples/compiled/trellis_selections.vg.json
@@ -309,7 +309,12 @@
         },
         {
           "name": "brush_modify",
-          "update": "modify(\"brush_store\", brush_tuple, {unit: \"child\" + '__facet_column_' + (facet[\"Series\"])})"
+          "on": [
+            {
+              "events": {"signal": "brush_tuple"},
+              "update": "modify(\"brush_store\", brush_tuple, {unit: \"child\" + '__facet_column_' + (facet[\"Series\"])})"
+            }
+          ]
         },
         {
           "name": "grid_X",
@@ -423,7 +428,12 @@
         },
         {
           "name": "grid_modify",
-          "update": "modify(\"grid_store\", grid_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "grid_tuple"},
+              "update": "modify(\"grid_store\", grid_tuple, true)"
+            }
+          ]
         },
         {
           "name": "xenc_tuple",
@@ -432,7 +442,12 @@
         {"name": "xenc_tuple_fields", "value": [{"type": "E", "field": "X"}]},
         {
           "name": "xenc_modify",
-          "update": "modify(\"xenc_store\", xenc_tuple, true)"
+          "on": [
+            {
+              "events": {"signal": "xenc_tuple"},
+              "update": "modify(\"xenc_store\", xenc_tuple, true)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/examples/compiled/vconcat_flatten.vg.json
+++ b/examples/compiled/vconcat_flatten.vg.json
@@ -134,7 +134,12 @@
         },
         {
           "name": "pts_modify",
-          "update": "modify(\"pts_store\", pts_toggle ? null : pts_tuple, pts_toggle ? null : true, pts_toggle ? pts_tuple : null)"
+          "on": [
+            {
+              "events": {"signal": "pts_tuple"},
+              "update": "modify(\"pts_store\", pts_toggle ? null : pts_tuple, pts_toggle ? null : true, pts_toggle ? pts_tuple : null)"
+            }
+          ]
         }
       ],
       "marks": [

--- a/src/compile/selection/assemble.ts
+++ b/src/compile/selection/assemble.ts
@@ -1,7 +1,7 @@
 import {Signal, SignalRef} from 'vega';
 import {selector as parseSelector} from 'vega-event-selector';
 import {identity, isArray, stringValue} from 'vega-util';
-import {forEachSelection, MODIFY, STORE, unitName, VL_SELECTION_RESOLVE} from '.';
+import {forEachSelection, MODIFY, STORE, unitName, VL_SELECTION_RESOLVE, TUPLE} from '.';
 import {dateTimeExpr, isDateTime} from '../../datetime';
 import {SelectionInit, SelectionInitInterval, SelectionExtent} from '../../selection';
 import {keys, varName} from '../../util';
@@ -45,7 +45,12 @@ export function assembleUnitSelectionSignals(model: UnitModel, signals: Signal[]
 
     signals.push({
       name: name + MODIFY,
-      update: `modify(${stringValue(selCmpt.name + STORE)}, ${modifyExpr})`
+      on: [
+        {
+          events: {signal: selCmpt.name + TUPLE},
+          update: `modify(${stringValue(selCmpt.name + STORE)}, ${modifyExpr})`
+        }
+      ]
     });
   });
 

--- a/test/compile/selection/interval.test.ts
+++ b/test/compile/selection/interval.test.ts
@@ -477,15 +477,30 @@ describe('Interval Selections', () => {
       expect.arrayContaining([
         {
           name: 'one_modify',
-          update: `modify("one_store", ${oneExpr})`
+          on: [
+            {
+              events: {signal: 'one_tuple'},
+              update: `modify("one_store", ${oneExpr})`
+            }
+          ]
         },
         {
           name: 'two_modify',
-          update: `modify("two_store", ${twoExpr})`
+          on: [
+            {
+              events: {signal: 'two_tuple'},
+              update: `modify("two_store", ${twoExpr})`
+            }
+          ]
         },
         {
           name: 'thr_ee_modify',
-          update: `modify("thr_ee_store", ${threeExpr})`
+          on: [
+            {
+              events: {signal: 'thr_ee_tuple'},
+              update: `modify("thr_ee_store", ${threeExpr})`
+            }
+          ]
         }
       ])
     );

--- a/test/compile/selection/single.test.ts
+++ b/test/compile/selection/single.test.ts
@@ -141,11 +141,21 @@ describe('Single Selection', () => {
       expect.arrayContaining([
         {
           name: 'one_modify',
-          update: `modify("one_store", ${oneExpr})`
+          on: [
+            {
+              events: {signal: 'one_tuple'},
+              update: `modify("one_store", ${oneExpr})`
+            }
+          ]
         },
         {
           name: 'two_modify',
-          update: `modify("two_store", ${twoExpr})`
+          on: [
+            {
+              events: {signal: 'two_tuple'},
+              update: `modify("two_store", ${twoExpr})`
+            }
+          ]
         }
       ])
     );

--- a/test/compile/selection/toggle.test.ts
+++ b/test/compile/selection/toggle.test.ts
@@ -86,11 +86,21 @@ describe('Toggle Selection Transform', () => {
       expect.arrayContaining([
         {
           name: 'one_modify',
-          update: `modify("one_store", ${oneExpr})`
+          on: [
+            {
+              events: {signal: 'one_tuple'},
+              update: `modify("one_store", ${oneExpr})`
+            }
+          ]
         },
         {
           name: 'two_modify',
-          update: `modify("two_store", ${twoExpr})`
+          on: [
+            {
+              events: {signal: 'two_tuple'},
+              update: `modify("two_store", ${twoExpr})`
+            }
+          ]
         }
       ])
     );


### PR DESCRIPTION
In #4943, we extracted selection initialization to the store (rather than the signals). However, as a result, the order of dataflow execution differs between unit views (i.e., when selection signals are at the top-level) and multi-views (i.e., when selection signals are nested within groups). In the former case, signals execute _before_ the selection's store is populated with values; in the latter, signals execute _after_ the store is populated. As a result, in multi-views, the store would get populated and then wiped out by the `modify` signal (#5551). 

In this PR, we only have the `modify` signal fire when the corresponding `tuple` signal changes. As a result, the `modify` signal does not fire on the first pulse of the dataflow, and the selection store is maintained from its initial specification. Fixes #5551. 