### PR TITLE
docs: annual temperature example

### DIFF
--- a/examples/specs/annual-temperature.vl.json
+++ b/examples/specs/annual-temperature.vl.json
@@ -1,0 +1,81 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+  "padding": 5,
+  "config": {
+    "view": {"stroke": "transparent"},
+    "headerRow": {
+      "titlePadding": -5,
+      "labelAlign": "left",
+      "labelPadding": 0,
+      "labelAngle": 0,
+      "labelExpr": "datum.value === 0 ? 'Midnight' : datum.value === 12 ? 'Noon' : datum.value < 12 ? datum.value + ':00 am' : (datum.value - 12) + ':00 pm'"
+    }
+  },
+  "title": {
+    "fontSize": 14,
+    "text": "Seattle Annual Temperatures",
+    "anchor": "start",
+    "offset": 4
+  },
+  "data": {
+    "name": "temperature",
+    "url": "data/seattle-temps.csv",
+    "format": {"type": "csv", "parse": {"temp": "number", "date": "date"}}
+  },
+  "transform": [
+    {"calculate": "hours(datum.date)", "as": "hour"},
+    {
+      "calculate": "datetime(year(datum.date), month(datum.date), date(datum.date))",
+      "as": "date"
+    }
+  ],
+  "width": 800,
+  "height": 25,
+  "mark": "area",
+  "encoding": {
+    "x": {
+      "field": "date",
+      "type": "temporal",
+      "axis": {"title": "Month", "grid": false, "domain": false, "format": "%b"}
+    },
+    "y": {
+      "field": "temp",
+      "type": "quantitative",
+      "title": null,
+      "axis": null,
+      "scale": {"zero": false, "range": [25, 1]}
+    },
+    "row": {
+      "spacing": -1,
+      "title": "Hour",
+      "field": "hour",
+      "type": "nominal",
+      "sort": [
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Hi,
I am new to vega-lite and I thought I could contribute at the same time that I learn how to use it. I have been trying to implement the Vega Lite version of [this example from Vega](https://vega.github.io/vega/examples/annual-temperature/). There are a few things that I cannot get right:

- [ ] It seems that the vega example has less spacing from row to row
- [ ] I am not sure how to use the y2 axis here
- [ ] In vega-lite it seems that specifying the `height` of a spec when using the row channel will set the height of the row, but in the vega example it specifies the facet height as (`rangeStep` signal) 25 and the whole height as 24*25 (`height` signal)

Open in Vega Editor:[Annual temperature](https://vega.github.io/editor/#/url/vega-lite/N4KABGBEAkDODGALApgWwIaQFxUQFzwAdYsB6UgN2QHN0A6agSz0QFcAjOxge1IRQyUa6ALQAbZskoAWOgCtY3AHaQANOCiF0AE22Ml1bGACs6iJHjKAZo0M5QEcxUbIA7keCRYeAE7cA1shGkL7oSrBaPshKeJAAvmaOkCg6yD4AStzu9hqOUHjMYsgACjp6BkYiprlJYujsyGIAghLUKjiQRVaxiXmd9Y2luvp2YAAMvbUDzQZFRhM15nUNYgCiAB6EPsHa6HisqHQU6GKsyGAAvFfjYAD8YADkALKM2kq2+A9gOLv7h8enc5XC5gACMACY7o8AHLcZRfH57A5HE5nMAAHjBkPuv2RALRAGpHlgxmMwOhUAiwAAKXH-VHnERYgCUYCJDxJZMIlMgNTiGgSGhChSCOT6VmUeAAyowAF6isHSSYhZDrWIdKXIPZ4IpgJpKJSsE5gAAqaEIaSRUVgahqkDCSG42w63nQPh6du4VissGQ6rA0gFiUgv0wYqSSgpCpVqAtPitQWVrB8Yh2e3QfC1BCKIjw5tgdHgsAotvFTow-s8eAAnhbgkWS6pNG7fR4Y4RgobUA1tk2Q3to78gnF+RBBeZQuEJT5UEYANo1TzwE7wVh1PPBRDcZOwWlIw5D5lqKDoG0dLfJ+KTBx5KDLsSr9eDgcFVDIanVrU+Pd-OiHpuoJKiA-si-5gEOIEHgOzJHpM5inmmG58hoAC6wauK8LBGAAHKSwYoB8-rgtU5gYD4-jBG6WqllA0SWOUow3uY6weIsUA2I02iIYmbEhLW0Z5rGTonDRfToOsjBnmAVYisETxAcekDUD4rxGFYJy+n22jcBg+hqRpyB9tOFbBAApOw8R8sq1asbe7EuGIXEdIJHZwfk-HBAAjkaMTMHsjBUKJSQFDqCqGmIYhufaElSeFkW8QgJwKp48p+PpYiaVA8YGAqc7EU2oIoaOjjjkkfjZNJCVaPAIyVKCUUhXMHQABLbr2vEcY5m5tUFE4eR0Sg6foIlRYo7rzmxEAAGxuRAADss1gNhi0AJyLaCCx2RAoL1ZNWLrQAzOtSp7aCJFbaCM2nQtp3Lada17eCm1beCu1bWA4Lgot4JHXtz12W9L2Lb970ne9xhsShyFjiAcRAA)

Part of issue #1486