### PR TITLE
fix: remove unnecessary division between Data/SelectionLookupTransform + docs SelectionLookup

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -2036,12 +2036,6 @@
           ],
           "type": "string"
         },
-        "labels": {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
         "name": {
           "type": "string"
         },

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -2036,6 +2036,12 @@
           ],
           "type": "string"
         },
+        "labels": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
         "name": {
           "type": "string"
         },
@@ -9816,6 +9822,7 @@
           "description": "Key in data to lookup."
         },
         "selection": {
+          "description": "Selection name to look up.",
           "type": "string"
         }
       },

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -4347,42 +4347,6 @@
         }
       ]
     },
-    "DataLookupTransform": {
-      "additionalProperties": false,
-      "properties": {
-        "as": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/FieldName"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/FieldName"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "The output fields on which to store the looked up data values.\n\nFor data lookups, this property may be left blank if `from.fields`\nhas been specified (those field names will be used); if `from.fields`\nhas not been specified, `as` must be a string.\n\nFor selection lookups, this property is optional: if unspecified,\nlooked up values will be stored under a property named for the selection;\nand if specified, it must correspond to `from.fields`."
-        },
-        "default": {
-          "description": "The default value to use if lookup fails.\n\n__Default value:__ `null`",
-          "type": "string"
-        },
-        "from": {
-          "$ref": "#/definitions/LookupData",
-          "description": "Secondary data reference."
-        },
-        "lookup": {
-          "description": "Key in primary data source.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "from",
-        "lookup"
-      ],
-      "type": "object"
-    },
     "DataSource": {
       "anyOf": [
         {
@@ -9862,14 +9826,47 @@
       "type": "object"
     },
     "LookupTransform": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/DataLookupTransform"
+      "additionalProperties": false,
+      "properties": {
+        "as": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/FieldName"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/FieldName"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "The output fields on which to store the looked up data values.\n\nFor data lookups, this property may be left blank if `from.fields`\nhas been specified (those field names will be used); if `from.fields`\nhas not been specified, `as` must be a string.\n\nFor selection lookups, this property is optional: if unspecified,\nlooked up values will be stored under a property named for the selection;\nand if specified, it must correspond to `from.fields`."
         },
-        {
-          "$ref": "#/definitions/SelectionLookupTransform"
+        "default": {
+          "description": "The default value to use if lookup fails.\n\n__Default value:__ `null`",
+          "type": "string"
+        },
+        "from": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/LookupData"
+            },
+            {
+              "$ref": "#/definitions/LookupSelection"
+            }
+          ],
+          "description": "Data source or selection for secondary data reference."
+        },
+        "lookup": {
+          "description": "Key in primary data source.",
+          "type": "string"
         }
-      ]
+      },
+      "required": [
+        "lookup",
+        "from"
+      ],
+      "type": "object"
     },
     "Mark": {
       "description": "All types of primitive marks.",
@@ -13194,42 +13191,6 @@
     },
     "SelectionInitMapping": {
       "$ref": "#/definitions/Dict<SelectionInit>"
-    },
-    "SelectionLookupTransform": {
-      "additionalProperties": false,
-      "properties": {
-        "as": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/FieldName"
-            },
-            {
-              "items": {
-                "$ref": "#/definitions/FieldName"
-              },
-              "type": "array"
-            }
-          ],
-          "description": "The output fields on which to store the looked up data values.\n\nFor data lookups, this property may be left blank if `from.fields`\nhas been specified (those field names will be used); if `from.fields`\nhas not been specified, `as` must be a string.\n\nFor selection lookups, this property is optional: if unspecified,\nlooked up values will be stored under a property named for the selection;\nand if specified, it must correspond to `from.fields`."
-        },
-        "default": {
-          "description": "The default value to use if lookup fails.\n\n__Default value:__ `null`",
-          "type": "string"
-        },
-        "from": {
-          "$ref": "#/definitions/LookupSelection",
-          "description": "The selection to use as the secondary data reference."
-        },
-        "lookup": {
-          "description": "Key in primary data source.",
-          "type": "string"
-        }
-      },
-      "required": [
-        "from",
-        "lookup"
-      ],
-      "type": "object"
     },
     "SelectionPredicate": {
       "additionalProperties": false,

--- a/site/_includes/docs_toc.md
+++ b/site/_includes/docs_toc.md
@@ -72,8 +72,6 @@
         - [Example]({{site.baseurl}}/docs/loess.html#example)
     - [Lookup]({{site.baseurl}}/docs/lookup.html)
         - [Lookup Transform]({{site.baseurl}}/docs/lookup.html#lookup-transform)
-        - [Lookup Data]({{site.baseurl}}/docs/lookup.html#lookup-data)
-        - [Example]({{site.baseurl}}/docs/lookup.html#example)
     - [Pivot]({{site.baseurl}}/docs/pivot.html)
         - [Pivot Transform Definition]({{site.baseurl}}/docs/pivot.html#pivot-transform-definition)
         - [Usage]({{site.baseurl}}/docs/pivot.html#usage)

--- a/site/docs/transform/lookup.md
+++ b/site/docs/transform/lookup.md
@@ -25,14 +25,24 @@ For each data object in the main data source, the transform tries to find a matc
 
 {% include table.html props="lookup,from,as,default" source="LookupTransform" %}
 
-## Lookup Data
+### Lookup Data
 
-The secondary data reference (set with `from`) is an object that specifies how the lookup key should be matched to a second data source and what fields should be added.
+The secondary data reference (set with `from`) can be object that specifies how the lookup key should be matched to a second data source and what fields should be added.
 
 {% include table.html props="data,key,fields" source="LookupData" %}
 
-## Example
+#### Example
 
 This example uses `lookup` to add the properties `age` and `height` to the main data source. The `person` field in the main data source is matched to the `name` field in the secondary data source.
 
 <span class="vl-example" data-name="lookup"></span>
+
+### Lookup Selection
+
+The secondary data reference (set with `from`) canalso be a selection name reference.
+
+{% include table.html props="selection" source="LookupSelection" %}
+
+#### Example: Interactive Index Chart
+
+<span class="vl-example" data-name="interactive_index_chart"></span>

--- a/src/compile/data/lookup.ts
+++ b/src/compile/data/lookup.ts
@@ -1,8 +1,8 @@
-import {isString, array} from 'vega-util';
-import * as log from '../../log';
-import {LookupTransform, isDataLookup, isSelectionLookup} from '../../transform';
-import {duplicate, hash, varName} from '../../util';
 import {LookupTransform as VgLookupTransform} from 'vega';
+import {array, isString} from 'vega-util';
+import * as log from '../../log';
+import {isLookupData, isLookupSelection, LookupTransform} from '../../transform';
+import {duplicate, hash, varName} from '../../util';
 import {Model} from '../model';
 import {DataFlowNode, OutputNode} from './dataflow';
 import {findSource} from './parse';
@@ -19,21 +19,22 @@ export class LookupNode extends DataFlowNode {
 
   public static make(parent: DataFlowNode, model: Model, transform: LookupTransform, counter: number) {
     const sources = model.component.data.sources;
+    const {from} = transform;
     let fromOutputNode = null;
 
-    if (isDataLookup(transform)) {
-      let fromSource = findSource(transform.from.data, sources);
+    if (isLookupData(from)) {
+      let fromSource = findSource(from.data, sources);
 
       if (!fromSource) {
-        fromSource = new SourceNode(transform.from.data);
+        fromSource = new SourceNode(from.data);
         sources.push(fromSource);
       }
 
       const fromOutputName = model.getName(`lookup_${counter}`);
       fromOutputNode = new OutputNode(fromSource, fromOutputName, 'lookup', model.component.data.outputNodeRefCounts);
       model.component.data.outputNodes[fromOutputName] = fromOutputNode;
-    } else if (isSelectionLookup(transform)) {
-      const selName = transform.from.selection;
+    } else if (isLookupSelection(from)) {
+      const selName = from.selection;
       transform.as = transform.as ?? selName;
       fromOutputNode = model.getSelectionComponent(varName(selName), selName).materialized;
       if (!fromOutputNode) {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -326,7 +326,7 @@ export interface LookupSelection extends LookupBase {
   selection: string;
 }
 
-export interface BaseLookupTransform {
+export interface LookupTransform {
   /**
    * Key in primary data source.
    */
@@ -351,23 +351,24 @@ export interface BaseLookupTransform {
    * __Default value:__ `null`
    */
   default?: string;
-}
 
-export interface DataLookupTransform extends BaseLookupTransform {
   /**
-   * Secondary data reference.
+   * Data source or selection for secondary data reference.
    */
-  from: LookupData;
+  from: LookupData | LookupSelection;
 }
 
-export interface SelectionLookupTransform extends BaseLookupTransform {
-  /**
-   * The selection to use as the secondary data reference.
-   */
-  from: LookupSelection;
+export function isLookup(t: Transform): t is LookupTransform {
+  return t['lookup'] !== undefined;
 }
 
-export type LookupTransform = DataLookupTransform | SelectionLookupTransform;
+export function isLookupData(from: LookupData | LookupSelection): from is LookupData {
+  return from['data'] !== undefined;
+}
+
+export function isLookupSelection(from: LookupData | LookupSelection): from is LookupData {
+  return from['selection'] !== undefined;
+}
 
 export interface FoldTransform {
   /**
@@ -604,18 +605,6 @@ export interface LoessTransform {
 
 export function isLoess(t: Transform): t is LoessTransform {
   return t['loess'] !== undefined;
-}
-
-export function isLookup(t: Transform): t is LookupTransform {
-  return t['lookup'] !== undefined;
-}
-
-export function isDataLookup(t: Transform): t is DataLookupTransform {
-  return t['lookup'] !== undefined && t['from']['selection'] === undefined;
-}
-
-export function isSelectionLookup(t: Transform): t is SelectionLookupTransform {
-  return t['lookup'] !== undefined && t['from']['selection'] !== undefined;
 }
 
 export function isSample(t: Transform): t is SampleTransform {

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -323,6 +323,9 @@ export interface LookupData extends LookupBase {
 }
 
 export interface LookupSelection extends LookupBase {
+  /**
+   * Selection name to look up.
+   */
   selection: string;
 }
 


### PR DESCRIPTION
This fix has a few benefits:

- make it possible to reference the object in the docs
- simplify output schema
- simplify output Altair classes (only one LookupTransform class)

Part of https://github.com/vega/vega-lite/issues/5634

cc: @arvind 