### PR TITLE
chore: remove now unnecessary timeunit functions

### DIFF
--- a/src/timeunit.ts
+++ b/src/timeunit.ts
@@ -256,60 +256,6 @@ export function isTimeUnit(t: string): t is TimeUnit {
   return !!TIMEUNIT_INDEX[t];
 }
 
-type DateMethodName = keyof Date;
-
-const SET_DATE_METHOD: Record<LocalSingleTimeUnit, DateMethodName> = {
-  year: 'setFullYear',
-  month: 'setMonth',
-  date: 'setDate',
-  hours: 'setHours',
-  minutes: 'setMinutes',
-  seconds: 'setSeconds',
-  milliseconds: 'setMilliseconds',
-  // Day and quarter have their own special cases
-  quarter: null,
-  day: null
-};
-
-/**
- * Converts a date to only have the measurements relevant to the specified unit
- * i.e. ('yearmonth', '2000-12-04 07:58:14') -> '2000-12-01 00:00:00'
- * Note: the base date is Jan 01 1900 00:00:00
- */
-export function convert(unit: TimeUnit, date: Date): Date {
-  const isUTC = isUTCTimeUnit(unit);
-  const result: Date = isUTC
-    ? // start with uniform date
-      new Date(Date.UTC(1972, 0, 1, 0, 0, 0, 0)) // 1972 is the first leap year after 1970, the start of unix time
-    : new Date(1972, 0, 1, 0, 0, 0, 0);
-  for (const timeUnitPart of TIMEUNIT_PARTS) {
-    if (containsTimeUnit(unit, timeUnitPart)) {
-      switch (timeUnitPart) {
-        case TimeUnit.DAY:
-          throw new Error("Cannot convert to TimeUnits containing 'day'");
-        case TimeUnit.QUARTER: {
-          const {getDateMethod, setDateMethod} = dateMethods('month', isUTC);
-          // indicate quarter by setting month to be the first of the quarter i.e. may (4) -> april (3)
-          result[setDateMethod](Math.floor(date[getDateMethod]() / 3) * 3);
-          break;
-        }
-        default: {
-          const {getDateMethod, setDateMethod} = dateMethods(timeUnitPart, isUTC);
-          result[setDateMethod](date[getDateMethod]());
-        }
-      }
-    }
-  }
-  return result;
-}
-
-function dateMethods(singleUnit: SingleTimeUnit, isUtc: boolean) {
-  const rawSetDateMethod = SET_DATE_METHOD[singleUnit];
-  const setDateMethod = isUtc ? 'setUTC' + rawSetDateMethod.substr(3) : rawSetDateMethod;
-  const getDateMethod = 'get' + (isUtc ? 'UTC' : '') + rawSetDateMethod.substr(3);
-  return {setDateMethod, getDateMethod};
-}
-
 export function getTimeUnitParts(timeUnit: TimeUnit) {
   return TIMEUNIT_PARTS.reduce((parts, part) => {
     if (containsTimeUnit(timeUnit, part)) {

--- a/test/timeunit.test.ts
+++ b/test/timeunit.test.ts
@@ -1,4 +1,4 @@
-import {containsTimeUnit, convert, fieldExpr, formatExpression, TimeUnit} from '../src/timeunit';
+import {containsTimeUnit, fieldExpr, formatExpression, TimeUnit} from '../src/timeunit';
 
 describe('timeUnit', () => {
   describe('containsTimeUnit', () => {
@@ -66,94 +66,6 @@ describe('timeUnit', () => {
       expect(fieldExpr(TimeUnit.UTCQUARTER, 'x')).toBe('datetime(0, (utcquarter(datum["x"])-1)*3, 1, 0, 0, 0, 0)');
 
       expect(fieldExpr(TimeUnit.UTCMILLISECONDS, 'x')).toBe('datetime(0, 0, 1, 0, 0, 0, utcmilliseconds(datum["x"]))');
-    });
-  });
-
-  describe('convert', () => {
-    it('should throw an error for the DAY timeunit', () => {
-      expect(() => {
-        convert(TimeUnit.DAY, new Date(2000, 11, 2, 23, 59, 59, 999));
-      }).toThrowError("Cannot convert to TimeUnits containing 'day'");
-    });
-
-    it('should return expected result for YEARQUARTER', () => {
-      const date: Date = convert(TimeUnit.YEARQUARTER, new Date(2000, 11, 2, 23, 59, 59, 999));
-      expect(date.getTime()).toBe(new Date(2000, 9, 1, 0, 0, 0, 0).getTime());
-    });
-
-    it('should return expected result for UTCYEARQUARTER', () => {
-      const date: Date = convert(TimeUnit.UTCYEARQUARTER, new Date(Date.UTC(2000, 11, 2, 23, 59, 59, 999)));
-      expect(date.getTime()).toBe(new Date(Date.UTC(2000, 9, 1, 0, 0, 0, 0)).getTime());
-    });
-
-    it('should return expected result for YEARQUARTERMONTH', () => {
-      const date: Date = convert(TimeUnit.YEARQUARTERMONTH, new Date(2000, 11, 2, 23, 59, 59, 999));
-      expect(date.getTime()).toBe(new Date(2000, 11, 1, 0, 0, 0, 0).getTime());
-    });
-
-    it('should return expected result for YEARMONTH', () => {
-      const date: Date = convert(TimeUnit.YEARMONTH, new Date(2000, 11, 2, 23, 59, 59, 999));
-      expect(date.getTime()).toBe(new Date(2000, 11, 1, 0, 0, 0, 0).getTime());
-    });
-
-    it('should return expected result for UTCYEARMONTH', () => {
-      const date: Date = convert(TimeUnit.UTCYEARMONTH, new Date(Date.UTC(2000, 11, 2, 23, 59, 59, 999)));
-      expect(date.getTime()).toBe(new Date(Date.UTC(2000, 11, 1, 0, 0, 0, 0)).getTime());
-    });
-
-    it('should return expected result for UTCYEARMONTH', () => {
-      const date: Date = convert(TimeUnit.UTCYEAR, new Date(Date.UTC(2000, 11, 2, 23, 59, 59, 999)));
-      expect(date.getTime()).toBe(new Date(Date.UTC(2000, 0, 1, 0, 0, 0, 0)).getTime());
-    });
-
-    it('should return expected result for YEARMONTHDATE', () => {
-      const date: Date = convert(TimeUnit.YEARMONTHDATE, new Date(2000, 11, 2, 23, 59, 59, 999));
-      expect(date.getTime()).toBe(new Date(2000, 11, 2, 0, 0, 0, 0).getTime());
-    });
-
-    it('should return expected result for YEARMONTHDATEHOURS', () => {
-      const date: Date = convert(TimeUnit.YEARMONTHDATEHOURS, new Date(2000, 11, 2, 23, 59, 59, 999));
-      expect(date.getTime()).toBe(new Date(2000, 11, 2, 23, 0, 0, 0).getTime());
-    });
-
-    it('should return expected result for YEARMONTHDATEHOURSMINUTES', () => {
-      const date: Date = convert(TimeUnit.YEARMONTHDATEHOURSMINUTES, new Date(2000, 11, 2, 23, 59, 59, 999));
-      expect(date.getTime()).toBe(new Date(2000, 11, 2, 23, 59, 0, 0).getTime());
-    });
-
-    it('should return expected result for YEARMONTHDATEHOURSMINUTESSECONDS', () => {
-      const date: Date = convert(TimeUnit.YEARMONTHDATEHOURSMINUTESSECONDS, new Date(2000, 11, 2, 23, 59, 59, 999));
-      expect(date.getTime()).toBe(new Date(2000, 11, 2, 23, 59, 59, 0).getTime());
-    });
-
-    it('should return expected result for QUARTERMONTH', () => {
-      const date: Date = convert(TimeUnit.QUARTERMONTH, new Date(2000, 11, 2, 23, 59, 59, 999));
-      expect(date.getTime()).toBe(new Date(1972, 11, 1, 0, 0, 0, 0).getTime());
-    });
-
-    it('should return expected result for HOURSMINUTES', () => {
-      const date: Date = convert(TimeUnit.HOURSMINUTES, new Date(2000, 11, 2, 23, 59, 59, 999));
-      expect(date.getTime()).toBe(new Date(1972, 0, 1, 23, 59, 0, 0).getTime());
-    });
-
-    it('should return expected result for HOURSMINUTESSECONDS', () => {
-      const date: Date = convert(TimeUnit.HOURSMINUTESSECONDS, new Date(2000, 11, 2, 23, 59, 59, 999));
-      expect(date.getTime()).toBe(new Date(1972, 0, 1, 23, 59, 59, 0).getTime());
-    });
-
-    it('should return expected result for MINUTESSECONDS', () => {
-      const date: Date = convert(TimeUnit.MINUTESSECONDS, new Date(2000, 11, 2, 23, 59, 59, 999));
-      expect(date.getTime()).toBe(new Date(1972, 0, 1, 0, 59, 59, 0).getTime());
-    });
-
-    it('should return expected result for SECONDSMILLISECONDS', () => {
-      const date: Date = convert(TimeUnit.SECONDSMILLISECONDS, new Date(2000, 11, 2, 23, 59, 59, 999));
-      expect(date.getTime()).toBe(new Date(1972, 0, 1, 0, 0, 59, 999).getTime());
-    });
-
-    it('should return expected result for MONTHDATE', () => {
-      const date: Date = convert(TimeUnit.MONTHDATE, new Date(2000, 11, 2, 23, 59, 59, 999));
-      expect(date.getTime()).toBe(new Date(1972, 11, 2, 0, 0, 0, 0).getTime());
     });
   });
 


### PR DESCRIPTION
There are a couple functions that are now unnecessary after the move to Vega time format.