### PR TITLE
docs: fix link to gradient information

### DIFF
--- a/site/docs/mark/area.md
+++ b/site/docs/mark/area.md
@@ -61,7 +61,7 @@ By setting the `line` and `point` properties of the mark definition to `true` or
 
 <span class="vl-example" data-name="area_overlay"></span>
 
-Instead of using a single color as the fill color of the area, we can set it to a [gradient](/docs/types.html#gradient). In this example, we are also customizing the overlay.
+Instead of using a single color as the fill color of the area, we can set it to a [gradient](types.html#gradient). In this example, we are also customizing the overlay.
 
 <span class="vl-example" data-name="area_gradient"></span>
 


### PR DESCRIPTION
I found that the link to more [gradient](https://vega.github.io/vega-lite/docs/types.html#gradient) information on the [area mark](https://vega.github.io/vega-lite/docs/area.html#area-chart-with-overlaying-lines-and-point-markers) page was broken. I think this will fix things. 
