### PR TITLE
docs: add missing `index` property for expression in the axis docs

### DIFF
--- a/site/docs/encoding/axis.md
+++ b/site/docs/encoding/axis.md
@@ -116,6 +116,7 @@ Note that each axis tick, grid line, and label instance is backed by a data obje
 
 - `label` - the string label
 - `value` - the data value
+- `index` - _fractional_ tick index (`0` for the first tick and `1` for the last tick)
 
 For example, we can adjust the grid dash in a line chart based on whether a particular grid line falls on a year boundary:
 


### PR DESCRIPTION
Let's see if https://github.com/vega/vega/pull/2314 gets any edits before merging.