### PR TITLE
fix!: make layered unit specs not accept `width` and `height`

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -7251,23 +7251,6 @@
           "$ref": "#/definitions/Encoding",
           "description": "A key-value mapping between encoding channels and definition of fields."
         },
-        "height": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "enum": [
-                "container"
-              ],
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/Step"
-            }
-          ],
-          "description": "The height of a visualization.\n\n- For a plot with a continuous y-field, height should be a number.\n- For a plot with either a discrete y-field or no y-field, height can be either a number indicating a fixed height or an object in the form of `{step: number}` defining the height per discrete step. (No y-field is equivalent to having one discrete step.)\n- To enable responsive sizing on height, it should be set to `\"container\"`.\n\n__Default value:__ Based on `config.view.continuousHeight` for a plot with a continuous y-field and `config.view.discreteHeight` otherwise.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view and the `\"container\"` option cannot be used.\n\n__See also:__ [`height`](https://vega.github.io/vega-lite/docs/size.html) documentation."
-        },
         "mark": {
           "$ref": "#/definitions/AnyMark",
           "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
@@ -7304,27 +7287,6 @@
             "$ref": "#/definitions/Transform"
           },
           "type": "array"
-        },
-        "view": {
-          "$ref": "#/definitions/ViewBackground",
-          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
-        },
-        "width": {
-          "anyOf": [
-            {
-              "type": "number"
-            },
-            {
-              "enum": [
-                "container"
-              ],
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/Step"
-            }
-          ],
-          "description": "The width of a visualization.\n\n- For a plot with a continuous x-field, width should be a number.\n- For a plot with either a discrete x-field or no x-field, width can be either a number indicating a fixed width or an object in the form of `{step: number}` defining the width per discrete step. (No x-field is equivalent to having one discrete step.)\n- To enable responsive sizing on width, it should be set to `\"container\"`.\n\n__Default value:__\nBased on `config.view.continuousWidth` for a plot with a continuous x-field and `config.view.discreteWidth` otherwise.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view and the `\"container\"` option cannot be used.\n\n__See also:__ [`width`](https://vega.github.io/vega-lite/docs/size.html) documentation."
         }
       },
       "required": [
@@ -15592,7 +15554,7 @@
               "$ref": "#/definitions/LayerSpec"
             },
             {
-              "$ref": "#/definitions/FacetedUnitSpec"
+              "$ref": "#/definitions/UnitSpecWithFrame"
             }
           ],
           "description": "A specification of the view that gets faceted."
@@ -15963,6 +15925,109 @@
     "UnitSpec": {
       "$ref": "#/definitions/GenericUnitSpec%3CEncoding%2CAnyMark%3E",
       "description": "A unit specification, which can contain either [primitive marks or composite marks](https://vega.github.io/vega-lite/docs/mark.html#types)."
+    },
+    "UnitSpecWithFrame": {
+      "additionalProperties": false,
+      "properties": {
+        "data": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Data"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "An object describing the data source. Set to `null` to ignore the parent's data source. If no data is set, it is derived from the parent."
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "encoding": {
+          "$ref": "#/definitions/Encoding",
+          "description": "A key-value mapping between encoding channels and definition of fields."
+        },
+        "height": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "enum": [
+                "container"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/Step"
+            }
+          ],
+          "description": "The height of a visualization.\n\n- For a plot with a continuous y-field, height should be a number.\n- For a plot with either a discrete y-field or no y-field, height can be either a number indicating a fixed height or an object in the form of `{step: number}` defining the height per discrete step. (No y-field is equivalent to having one discrete step.)\n- To enable responsive sizing on height, it should be set to `\"container\"`.\n\n__Default value:__ Based on `config.view.continuousHeight` for a plot with a continuous y-field and `config.view.discreteHeight` otherwise.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the height of a single view and the `\"container\"` option cannot be used.\n\n__See also:__ [`height`](https://vega.github.io/vega-lite/docs/size.html) documentation."
+        },
+        "mark": {
+          "$ref": "#/definitions/AnyMark",
+          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "projection": {
+          "$ref": "#/definitions/Projection",
+          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
+        },
+        "selection": {
+          "additionalProperties": {
+            "$ref": "#/definitions/SelectionDef"
+          },
+          "description": "A key-value mapping between selection names and definitions.",
+          "type": "object"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Text"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "view": {
+          "$ref": "#/definitions/ViewBackground",
+          "description": "An object defining the view background's fill and stroke.\n\n__Default value:__ none (transparent)"
+        },
+        "width": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "enum": [
+                "container"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/Step"
+            }
+          ],
+          "description": "The width of a visualization.\n\n- For a plot with a continuous x-field, width should be a number.\n- For a plot with either a discrete x-field or no x-field, width can be either a number indicating a fixed width or an object in the form of `{step: number}` defining the width per discrete step. (No x-field is equivalent to having one discrete step.)\n- To enable responsive sizing on width, it should be set to `\"container\"`.\n\n__Default value:__\nBased on `config.view.continuousWidth` for a plot with a continuous x-field and `config.view.discreteWidth` otherwise.\n\n__Note:__ For plots with [`row` and `column` channels](https://vega.github.io/vega-lite/docs/encoding.html#facet), this represents the width of a single view and the `\"container\"` option cannot be used.\n\n__See also:__ [`width`](https://vega.github.io/vega-lite/docs/size.html) documentation."
+        }
+      },
+      "required": [
+        "mark"
+      ],
+      "type": "object"
     },
     "UrlData": {
       "additionalProperties": false,

--- a/examples/specs/normalized/trellis_barley_layer_median_normalized.vl.json
+++ b/examples/specs/normalized/trellis_barley_layer_median_normalized.vl.json
@@ -11,9 +11,9 @@
     }
   },
   "spec": {
+    "height": {"step": 12},
     "layer": [
       {
-        "height": {"step": 12},
         "mark": "point",
         "encoding": {
           "x": {

--- a/examples/specs/trellis_barley_layer_median.vl.json
+++ b/examples/specs/trellis_barley_layer_median.vl.json
@@ -11,6 +11,7 @@
     }
   },
   "spec": {
+    "height": {"step": 12},
     "encoding": {
       "x": {
         "aggregate": "median",
@@ -21,7 +22,6 @@
     },
     "layer": [
       {
-        "height": {"step": 12},
         "mark": "point",
         "encoding": {
           "y": {

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -22,6 +22,7 @@ import {Projection} from '../projection';
 import {Domain, Scale} from '../scale';
 import {SelectionDef} from '../selection';
 import {LayoutSizeMixins, NormalizedUnitSpec} from '../spec';
+import {isFrameMixins} from '../spec/base';
 import {stack, StackProperties} from '../stack';
 import {Dict} from '../util';
 import {VgData, VgLayout} from '../vega.schema';
@@ -74,7 +75,16 @@ export class UnitModel extends ModelWithField {
     repeater: RepeaterValue,
     config: Config
   ) {
-    super(spec, 'unit', parent, parentGivenName, config, repeater, undefined, spec.view);
+    super(
+      spec,
+      'unit',
+      parent,
+      parentGivenName,
+      config,
+      repeater,
+      undefined,
+      isFrameMixins(spec) ? spec.view : undefined
+    );
 
     const mark = isMarkDef(spec.mark) ? spec.mark.type : spec.mark;
 
@@ -87,11 +97,13 @@ export class UnitModel extends ModelWithField {
 
     this.size = initLayoutSize({
       encoding,
-      size: {
-        ...parentGivenSize,
-        ...(spec.width ? {width: spec.width} : {}),
-        ...(spec.height ? {height: spec.height} : {})
-      }
+      size: isFrameMixins(spec)
+        ? {
+            ...parentGivenSize,
+            ...(spec.width ? {width: spec.width} : {}),
+            ...(spec.height ? {height: spec.height} : {})
+          }
+        : parentGivenSize
     });
 
     // calculate stack properties

--- a/src/spec/base.ts
+++ b/src/spec/base.ts
@@ -1,5 +1,6 @@
 import {Color, Cursor, Text} from 'vega';
 import {isArray, isNumber, isObject} from 'vega-util';
+import {NormalizedSpec} from '.';
 import {Config} from '../config';
 import {Data} from '../data';
 import {Resolve} from '../resolve';
@@ -9,7 +10,6 @@ import {Flag, keys} from '../util';
 import {BaseMarkConfig, LayoutAlign, RowCol} from '../vega.schema';
 import {isConcatSpec} from './concat';
 import {isFacetMapping, isFacetSpec} from './facet';
-import {NormalizedSpec} from '.';
 import {isRepeatSpec} from './repeat';
 
 export {TopLevel} from './toplevel';
@@ -99,7 +99,11 @@ export interface LayoutSizeMixins {
   height?: number | 'container' | Step;
 }
 
-export interface LayerUnitMixins extends LayoutSizeMixins {
+export function isFrameMixins(o: any): o is FrameMixins {
+  return o['view'] || o['width'] || o['height'];
+}
+
+export interface FrameMixins extends LayoutSizeMixins {
   /**
    * An object defining the view background's fill and stroke.
    *

--- a/src/spec/index.ts
+++ b/src/spec/index.ts
@@ -11,7 +11,7 @@ import {GenericFacetSpec} from './facet';
 import {GenericLayerSpec, LayerSpec, NormalizedLayerSpec} from './layer';
 import {GenericRepeatSpec} from './repeat';
 import {TopLevel} from './toplevel';
-import {FacetedUnitSpec, GenericUnitSpec, NormalizedUnitSpec, TopLevelUnitSpec} from './unit';
+import {FacetedUnitSpec, GenericUnitSpec, NormalizedUnitSpec, TopLevelUnitSpec, UnitSpecWithFrame} from './unit';
 
 export {BaseSpec, LayoutSizeMixins} from './base';
 export {
@@ -45,7 +45,7 @@ export type GenericSpec<U extends GenericUnitSpec<any, any>, L extends GenericLa
  */
 export type NormalizedSpec = GenericSpec<NormalizedUnitSpec, NormalizedLayerSpec>;
 
-export type TopLevelFacetSpec = TopLevel<GenericFacetSpec<FacetedUnitSpec, LayerSpec>> & DataMixins;
+export type TopLevelFacetSpec = TopLevel<GenericFacetSpec<UnitSpecWithFrame, LayerSpec>> & DataMixins;
 
 /**
  * A Vega-Lite top-level specification.

--- a/src/spec/layer.ts
+++ b/src/spec/layer.ts
@@ -1,15 +1,12 @@
 import {CompositeEncoding} from '../compositemark';
 import {Projection} from '../projection';
-import {BaseSpec, LayerUnitMixins, ResolveMixins} from './base';
+import {BaseSpec, FrameMixins, ResolveMixins} from './base';
 import {GenericUnitSpec, NormalizedUnitSpec, UnitSpec} from './unit';
 
 /**
  * Base interface for a layer specification.
  */
-export interface GenericLayerSpec<U extends GenericUnitSpec<any, any>>
-  extends BaseSpec,
-    LayerUnitMixins,
-    ResolveMixins {
+export interface GenericLayerSpec<U extends GenericUnitSpec<any, any>> extends BaseSpec, FrameMixins, ResolveMixins {
   /**
    * Layer or single view specifications to be layered.
    *

--- a/src/spec/unit.ts
+++ b/src/spec/unit.ts
@@ -4,13 +4,13 @@ import {Encoding} from '../encoding';
 import {AnyMark, Mark, MarkDef} from '../mark';
 import {Projection} from '../projection';
 import {SelectionDef} from '../selection';
-import {BaseSpec, BoundsMixins, DataMixins, LayerUnitMixins, ResolveMixins} from './base';
+import {BaseSpec, BoundsMixins, DataMixins, FrameMixins, ResolveMixins} from './base';
 import {TopLevel} from './toplevel';
 
 /**
  * Base interface for a unit (single-view) specification.
  */
-export interface GenericUnitSpec<E extends Encoding<any>, M> extends BaseSpec, LayerUnitMixins {
+export interface GenericUnitSpec<E extends Encoding<any>, M> extends BaseSpec {
   /**
    * A string describing the mark type (one of `"bar"`, `"circle"`, `"square"`, `"tick"`, `"line"`,
    * `"area"`, `"point"`, `"rule"`, `"geoshape"`, and `"text"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def).
@@ -44,10 +44,15 @@ export type NormalizedUnitSpec = GenericUnitSpec<Encoding<Field>, Mark | MarkDef
  */
 export type UnitSpec = GenericUnitSpec<CompositeEncoding, AnyMark>;
 
+export type UnitSpecWithFrame = GenericUnitSpec<CompositeEncoding, AnyMark> & FrameMixins;
+
 /**
  * Unit spec that can have a composite mark and row or column channels (shorthand for a facet spec).
  */
-export type FacetedUnitSpec = GenericUnitSpec<FacetedCompositeEncoding, AnyMark> & ResolveMixins & BoundsMixins;
+export type FacetedUnitSpec = GenericUnitSpec<FacetedCompositeEncoding, AnyMark> &
+  ResolveMixins &
+  BoundsMixins &
+  FrameMixins;
 
 export type TopLevelUnitSpec = TopLevel<FacetedUnitSpec> & DataMixins;
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -17,6 +17,9 @@ import {
   TopLevel,
   TopLevelSpec
 } from '../src/spec';
+import {FrameMixins} from '../src/spec/base';
+
+export type TopLevelNormalizedUnitSpecForTest = TopLevel<NormalizedUnitSpec> & FrameMixins;
 
 export function parseModel(inputSpec: TopLevelSpec): Model {
   const config = initConfig(inputSpec.config);
@@ -30,30 +33,30 @@ export function parseModelWithScale(inputSpec: TopLevelSpec): Model {
   return model;
 }
 
-export function parseUnitModel(spec: TopLevel<NormalizedUnitSpec>) {
+export function parseUnitModel(spec: TopLevelNormalizedUnitSpecForTest) {
   return new UnitModel(spec, null, '', undefined, undefined, initConfig(spec.config));
 }
 
-export function parseUnitModelWithScale(spec: TopLevel<NormalizedUnitSpec>) {
+export function parseUnitModelWithScale(spec: TopLevelNormalizedUnitSpecForTest) {
   const model = parseUnitModel(spec);
   model.parseScale();
   return model;
 }
 
-export function parseUnitModelWithScaleAndSelection(spec: TopLevel<NormalizedUnitSpec>) {
+export function parseUnitModelWithScaleAndSelection(spec: TopLevelNormalizedUnitSpecForTest) {
   const model = parseUnitModel(spec);
   model.parseScale();
   model.parseSelections();
   return model;
 }
 
-export function parseUnitModelWithScaleExceptRange(spec: TopLevel<NormalizedUnitSpec>) {
+export function parseUnitModelWithScaleExceptRange(spec: TopLevelNormalizedUnitSpecForTest) {
   const model = parseUnitModel(spec);
   parseScales(model, {ignoreRange: true});
   return model;
 }
 
-export function parseUnitModelWithScaleAndLayoutSize(spec: TopLevel<NormalizedUnitSpec>) {
+export function parseUnitModelWithScaleAndLayoutSize(spec: TopLevelNormalizedUnitSpecForTest) {
   const model = parseUnitModelWithScale(spec);
   model.parseLayoutSize();
   return model;


### PR DESCRIPTION
(since it's a part of a common frame)

fix #5793 