### PR TITLE
fix: make cornerRadius work for stacked bars with timeUnit

### DIFF
--- a/examples/compiled/stacked_bar_count_corner_radius_config.vg.json
+++ b/examples/compiled/stacked_bar_count_corner_radius_config.vg.json
@@ -48,7 +48,7 @@
         "facet": {
           "data": "source_0",
           "name": "stack_group_main",
-          "groupby": ["month_date"],
+          "groupby": ["month_date", "month_date_end"],
           "aggregate": {
             "fields": [
               "__count_start",

--- a/examples/compiled/stacked_bar_count_corner_radius_mark.vg.json
+++ b/examples/compiled/stacked_bar_count_corner_radius_mark.vg.json
@@ -48,7 +48,7 @@
         "facet": {
           "data": "source_0",
           "name": "stack_group_main",
-          "groupby": ["month_date"],
+          "groupby": ["month_date", "month_date_end"],
           "aggregate": {
             "fields": [
               "__count_start",

--- a/examples/compiled/stacked_bar_count_corner_radius_mark_x.vg.json
+++ b/examples/compiled/stacked_bar_count_corner_radius_mark_x.vg.json
@@ -48,7 +48,7 @@
         "facet": {
           "data": "source_0",
           "name": "stack_group_main",
-          "groupby": ["month_date"],
+          "groupby": ["month_date", "month_date_end"],
           "aggregate": {
             "fields": [
               "__count_start",

--- a/examples/compiled/stacked_bar_count_corner_radius_stroke.vg.json
+++ b/examples/compiled/stacked_bar_count_corner_radius_stroke.vg.json
@@ -48,7 +48,7 @@
         "facet": {
           "data": "source_0",
           "name": "stack_group_main",
-          "groupby": ["month_date"],
+          "groupby": ["month_date", "month_date_end"],
           "aggregate": {
             "fields": [
               "__count_start",

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -174,8 +174,8 @@ function getStackGroups(model: UnitModel) {
       }
     }
 
+    // For bin and time unit, we have to add bin/timeunit -end channels.
     const groupByField = model.fieldDef(model.stack.groupbyChannel);
-    // For bin we have to add bin channels.
     const groupby: string[] = vgField(groupByField) ? [vgField(groupByField)] : [];
 
     if (groupByField?.bin || groupByField?.timeUnit) {

--- a/src/compile/mark/mark.ts
+++ b/src/compile/mark/mark.ts
@@ -174,12 +174,12 @@ function getStackGroups(model: UnitModel) {
       }
     }
 
+    const groupByField = model.fieldDef(model.stack.groupbyChannel);
     // For bin we have to add bin channels.
-    const groupby: string[] = model.vgField(model.stack.groupbyChannel)
-      ? [model.vgField(model.stack.groupbyChannel)]
-      : [];
-    if (model.fieldDef(model.stack.groupbyChannel)?.bin) {
-      groupby.push(model.vgField(model.stack.groupbyChannel, {binSuffix: 'end'}));
+    const groupby: string[] = vgField(groupByField) ? [vgField(groupByField)] : [];
+
+    if (groupByField?.bin || groupByField?.timeUnit) {
+      groupby.push(vgField(groupByField, {binSuffix: 'end'}));
     }
 
     const strokeProperties = [


### PR DESCRIPTION
fix #5800


![image](https://user-images.githubusercontent.com/111269/73143935-7609b680-4054-11ea-922b-7fa8e0bef713.png)
