### PR TITLE
refactor: make channel type more specific

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -9,7 +9,14 @@ import {Mark} from './mark';
 import {EncodingFacetMapping, EncodingFacetMapping as ExtendedFacetMapping} from './spec/facet';
 import {Flag, keys} from './util';
 
-export type Channel = keyof Encoding<any> | keyof ExtendedFacetMapping<any>;
+/**
+ * Channels of normalized encodings.
+ */
+export type Channel = keyof Encoding<any>;
+/**
+ * Channel with facet channels.
+ */
+export type ExtendedChannel = Channel | keyof ExtendedFacetMapping<any>;
 
 // Facet
 export const ROW: 'row' = 'row';
@@ -343,7 +350,7 @@ const {geoshape: _g, ...ALL_MARKS_EXCEPT_GEOSHAPE} = ALL_MARKS;
  * @param channel
  * @return A dictionary mapping mark types to 'always', 'binned', or undefined
  */
-function getSupportedMark(channel: Channel): SupportedMark {
+function getSupportedMark(channel: ExtendedChannel): SupportedMark {
   switch (channel) {
     case COLOR:
     case FILL:
@@ -410,7 +417,7 @@ function getSupportedMark(channel: Channel): SupportedMark {
   }
 }
 
-export function rangeType(channel: Channel): RangeType {
+export function rangeType(channel: ExtendedChannel): RangeType {
   switch (channel) {
     case X:
     case Y:

--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -15,7 +15,6 @@ import {getMarkConfig} from './compile/common';
 import {CompositeAggregate} from './compositemark';
 import {Config} from './config';
 import {DateTime, dateTimeExpr, isDateTime} from './datetime';
-import {Encoding} from './encoding';
 import {FormatMixins, Guide, TitleMixins} from './guide';
 import {ImputeParams} from './impute';
 import {Legend} from './legend';
@@ -277,7 +276,7 @@ export interface TypeMixins<T extends Type> {
  */
 export type TypedFieldDef<
   F extends Field,
-  T extends Type = Type,
+  T extends Type = StandardType,
   B extends Bin = boolean | BinParams | 'binned' | null // This is equivalent to Bin but we use the full form so the docs has detailed types
 > = FieldDefBase<F, B> & TitleMixins & TypeMixins<T>;
 
@@ -474,9 +473,36 @@ export type ChannelDef<
   V extends ValueOrGradientOrText = ValueOrGradientOrText
 > = ChannelDefWithCondition<FD, V>;
 
-export type Foo = Encoding<any>[Channel];
+// export type Foo = Encoding<any>[Channel];
 
-export type Bar = Exclude<Foo, ChannelDef<any>>;
+// let c: ChannelDef<any> = {
+//   value: 'foo',
+//   type: 'ordinal'
+// };
+
+// let d: Foo = {
+//   value: 'foo',
+//   type: 'ordinal'
+// };
+
+// const f: FieldDef<any> = {
+//   field: 'foo',
+//   type: 'ordinal'
+// };
+
+// const v: ValueDef<any> = {
+//   value: 'foo'
+// };
+
+// d = c;
+// d = f;
+// d = v;
+
+// c = d;
+// c = f;
+// c = v;
+
+// console.log(c, d, f, v);
 
 export function isConditionalDef<F extends Field, V extends ValueOrGradientOrText>(
   channelDef: ChannelDef<FieldDef<F>, V>

--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -3,11 +3,19 @@ import {isArray, isBoolean, isNumber, isString} from 'vega-util';
 import {Aggregate, isAggregateOp, isArgmaxDef, isArgminDef, isCountingAggregateOp} from './aggregate';
 import {Axis} from './axis';
 import {autoMaxBins, Bin, BinParams, binToString, isBinned, isBinning} from './bin';
-import {Channel, isScaleChannel, isSecondaryRangeChannel, POSITION_SCALE_CHANNELS, rangeType} from './channel';
+import {
+  Channel,
+  ExtendedChannel,
+  isScaleChannel,
+  isSecondaryRangeChannel,
+  POSITION_SCALE_CHANNELS,
+  rangeType
+} from './channel';
 import {getMarkConfig} from './compile/common';
 import {CompositeAggregate} from './compositemark';
 import {Config} from './config';
 import {DateTime, dateTimeExpr, isDateTime} from './datetime';
+import {Encoding} from './encoding';
 import {FormatMixins, Guide, TitleMixins} from './guide';
 import {ImputeParams} from './impute';
 import {Legend} from './legend';
@@ -466,6 +474,10 @@ export type ChannelDef<
   V extends ValueOrGradientOrText = ValueOrGradientOrText
 > = ChannelDefWithCondition<FD, V>;
 
+export type Foo = Encoding<any>[Channel];
+
+export type Bar = Exclude<Foo, ChannelDef<any>>;
+
 export function isConditionalDef<F extends Field, V extends ValueOrGradientOrText>(
   channelDef: ChannelDef<FieldDef<F>, V>
 ): channelDef is ChannelDefWithCondition<FieldDef<F>, V> {
@@ -908,7 +920,7 @@ export function normalizeBin(bin: BinParams | boolean | 'binned', channel?: Chan
 const COMPATIBLE = {compatible: true};
 export function channelCompatibility(
   fieldDef: TypedFieldDef<Field>,
-  channel: Channel
+  channel: ExtendedChannel
 ): {compatible: boolean; warning?: string} {
   const type = fieldDef.type;
 

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -2,7 +2,15 @@ import {AggregateOp} from 'vega';
 import {isArray} from 'vega-util';
 import {isArgmaxDef, isArgminDef} from './aggregate';
 import {isBinned, isBinning} from './bin';
-import {Channel, CHANNELS, isChannel, isNonPositionScaleChannel, isSecondaryRangeChannel, supportMark} from './channel';
+import {
+  Channel,
+  ExtendedChannel,
+  isChannel,
+  isNonPositionScaleChannel,
+  isSecondaryRangeChannel,
+  supportMark,
+  UNIT_CHANNELS
+} from './channel';
 import {
   binRequiresRange,
   ChannelDef,
@@ -230,7 +238,7 @@ export interface Encoding<F extends Field> {
 
 export interface EncodingWithFacet<F extends Field> extends Encoding<F>, EncodingFacetMapping<F> {}
 
-export function channelHasField<F extends Field>(encoding: EncodingWithFacet<F>, channel: Channel): boolean {
+export function channelHasField<F extends Field>(encoding: EncodingWithFacet<F>, channel: ExtendedChannel): boolean {
   const channelDef = encoding && encoding[channel];
   if (channelDef) {
     if (isArray(channelDef)) {
@@ -243,7 +251,7 @@ export function channelHasField<F extends Field>(encoding: EncodingWithFacet<F>,
 }
 
 export function isAggregate(encoding: EncodingWithFacet<Field>) {
-  return some(CHANNELS, channel => {
+  return some(UNIT_CHANNELS, channel => {
     if (channelHasField(encoding, channel)) {
       const channelDef = encoding[channel];
       if (isArray(channelDef)) {


### PR DESCRIPTION
Basically, the idea is to have `Channel` be the type for `Encoding` (normalized) rather than `ExtendedEncoding`.

fixes #5173