### PR TITLE
docs: fix {:#repeat-ref} anchor in field.md

### DIFF
--- a/site/docs/encoding/field.md
+++ b/site/docs/encoding/field.md
@@ -35,7 +35,7 @@ Valid JavaScript object access paths using either dot (e.g., `foo.bar`) or brack
 
 Further note that in JSON, you have to escape backslashes. Hence, a single backslash (`\`) is escaped as `\\\\` in JSON. You also need to escape quotes (`\"`) and use special escape characters for newlines (`\n`), carriage returns (`\r`), and tabs (`\t`).
 
-{:#repeat-ref} **2) An object defining iterated values from the `repeat` operator**
+**2) An object defining iterated values from the `repeat` operator**
 
 For example, we can set `field` of `x` channel to `{"repeat": "column"}` to create a histogram of different fields.
 

--- a/site/docs/encoding/field.md
+++ b/site/docs/encoding/field.md
@@ -35,6 +35,8 @@ Valid JavaScript object access paths using either dot (e.g., `foo.bar`) or brack
 
 Further note that in JSON, you have to escape backslashes. Hence, a single backslash (`\`) is escaped as `\\\\` in JSON. You also need to escape quotes (`\"`) and use special escape characters for newlines (`\n`), carriage returns (`\r`), and tabs (`\t`).
 
+{:#repeat-ref}
+
 **2) An object defining iterated values from the `repeat` operator**
 
 For example, we can set `field` of `x` channel to `{"repeat": "column"}` to create a histogram of different fields.


### PR DESCRIPTION
This `repeat-ref` keyword  is [showing up in the docs](https://vega.github.io/vega-lite/docs/field.html):
![image](https://user-images.githubusercontent.com/10337788/73244367-13c2ca00-41aa-11ea-92b2-9d38f59d5541.png)

As the number is in the code anyway, I thought it is safe to remove it but it is referenced in [vega-lite/site/_data/link.yml#L299-L300](https://github.com/keckelt/vega-lite/blob/e0c6eac22954d91dfe0061f73e927cd0a6d9e498/site/_data/link.yml#L299-L300) and I'm not really sure what that does.


I can remove the anchor there as well or change the code here so that the anchor works again (with a little help 😉  )
