### PR TITLE
fix: bring back width/height/view for unit specs inside layers (as deprecated)

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -7943,72 +7943,6 @@
       ],
       "description": "Any specification in Vega-Lite."
     },
-    "GenericUnitSpec<Encoding,AnyMark>": {
-      "additionalProperties": false,
-      "description": "Base interface for a unit (single-view) specification.",
-      "properties": {
-        "data": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Data"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "description": "An object describing the data source. Set to `null` to ignore the parent's data source. If no data is set, it is derived from the parent."
-        },
-        "description": {
-          "description": "Description of this mark for commenting purpose.",
-          "type": "string"
-        },
-        "encoding": {
-          "$ref": "#/definitions/Encoding",
-          "description": "A key-value mapping between encoding channels and definition of fields."
-        },
-        "mark": {
-          "$ref": "#/definitions/AnyMark",
-          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
-        },
-        "name": {
-          "description": "Name of the visualization for later reference.",
-          "type": "string"
-        },
-        "projection": {
-          "$ref": "#/definitions/Projection",
-          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
-        },
-        "selection": {
-          "additionalProperties": {
-            "$ref": "#/definitions/SelectionDef"
-          },
-          "description": "A key-value mapping between selection names and definitions.",
-          "type": "object"
-        },
-        "title": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/Text"
-            },
-            {
-              "$ref": "#/definitions/TitleParams"
-            }
-          ],
-          "description": "Title for the plot."
-        },
-        "transform": {
-          "description": "An array of data transformations such as filter and new field calculation.",
-          "items": {
-            "$ref": "#/definitions/Transform"
-          },
-          "type": "array"
-        }
-      },
-      "required": [
-        "mark"
-      ],
-      "type": "object"
-    },
     "VConcatSpec": {
       "additionalProperties": false,
       "description": "Base interface for a vertical concatenation specification.",
@@ -16716,8 +16650,108 @@
       "type": "object"
     },
     "UnitSpec": {
-      "$ref": "#/definitions/GenericUnitSpec<Encoding,AnyMark>",
-      "description": "A unit specification, which can contain either [primitive marks or composite marks](https://vega.github.io/vega-lite/docs/mark.html#types)."
+      "additionalProperties": false,
+      "description": "A unit specification, which can contain either [primitive marks or composite marks](https://vega.github.io/vega-lite/docs/mark.html#types).",
+      "properties": {
+        "data": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Data"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "An object describing the data source. Set to `null` to ignore the parent's data source. If no data is set, it is derived from the parent."
+        },
+        "description": {
+          "description": "Description of this mark for commenting purpose.",
+          "type": "string"
+        },
+        "encoding": {
+          "$ref": "#/definitions/Encoding",
+          "description": "A key-value mapping between encoding channels and definition of fields."
+        },
+        "height": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "enum": [
+                "container"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/Step"
+            }
+          ],
+          "deprecated": "Please avoid using width in a unit spec that's a part of a layer spec."
+        },
+        "mark": {
+          "$ref": "#/definitions/AnyMark",
+          "description": "A string describing the mark type (one of `\"bar\"`, `\"circle\"`, `\"square\"`, `\"tick\"`, `\"line\"`,\n`\"area\"`, `\"point\"`, `\"rule\"`, `\"geoshape\"`, and `\"text\"`) or a [mark definition object](https://vega.github.io/vega-lite/docs/mark.html#mark-def)."
+        },
+        "name": {
+          "description": "Name of the visualization for later reference.",
+          "type": "string"
+        },
+        "projection": {
+          "$ref": "#/definitions/Projection",
+          "description": "An object defining properties of geographic projection, which will be applied to `shape` path for `\"geoshape\"` marks\nand to `latitude` and `\"longitude\"` channels for other marks."
+        },
+        "selection": {
+          "additionalProperties": {
+            "$ref": "#/definitions/SelectionDef"
+          },
+          "description": "A key-value mapping between selection names and definitions.",
+          "type": "object"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Text"
+            },
+            {
+              "$ref": "#/definitions/TitleParams"
+            }
+          ],
+          "description": "Title for the plot."
+        },
+        "transform": {
+          "description": "An array of data transformations such as filter and new field calculation.",
+          "items": {
+            "$ref": "#/definitions/Transform"
+          },
+          "type": "array"
+        },
+        "view": {
+          "$ref": "#/definitions/ViewBackground",
+          "deprecated": "Please avoid using width in a unit spec that's a part of a layer spec."
+        },
+        "width": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "enum": [
+                "container"
+              ],
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/Step"
+            }
+          ],
+          "deprecated": "Please avoid using width in a unit spec that's a part of a layer spec."
+        }
+      },
+      "required": [
+        "mark"
+      ],
+      "type": "object"
     },
     "UnitSpecWithFrame": {
       "additionalProperties": false,

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -16687,7 +16687,7 @@
               "$ref": "#/definitions/Step"
             }
           ],
-          "deprecated": "Please avoid using width in a unit spec that's a part of a layer spec."
+          "description": "__Deprecated:__ Please avoid using width in a unit spec that's a part of a layer spec."
         },
         "mark": {
           "$ref": "#/definitions/AnyMark",
@@ -16728,7 +16728,7 @@
         },
         "view": {
           "$ref": "#/definitions/ViewBackground",
-          "deprecated": "Please avoid using width in a unit spec that's a part of a layer spec."
+          "description": "__Deprecated:__ Please avoid using width in a unit spec that's a part of a layer spec."
         },
         "width": {
           "anyOf": [
@@ -16745,7 +16745,7 @@
               "$ref": "#/definitions/Step"
             }
           ],
-          "deprecated": "Please avoid using width in a unit spec that's a part of a layer spec."
+          "description": "__Deprecated:__ Please avoid using width in a unit spec that's a part of a layer spec."
         }
       },
       "required": [
@@ -17550,8 +17550,7 @@
           "type": "number"
         },
         "height": {
-          "deprecated": "Since Vega-Lite 4.0. Please use continuousHeight and discreteHeight instead.",
-          "description": "Default height",
+          "description": "Default height\n\n__Deprecated:__ Since Vega-Lite 4.0. Please use continuousHeight and discreteHeight instead.",
           "type": "number"
         },
         "opacity": {
@@ -17610,8 +17609,7 @@
           "type": "number"
         },
         "width": {
-          "deprecated": "Since Vega-Lite 4.0. Please use continuousWidth and discreteWidth instead.",
-          "description": "Default width",
+          "description": "Default width\n\n__Deprecated:__ Since Vega-Lite 4.0. Please use continuousWidth and discreteWidth instead.",
           "type": "number"
         }
       },

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "predeploy:site": "yarn presite",
     "deploy:site": "gh-pages -d site",
     "data": "rsync -r node_modules/vega-datasets/data/* site/data",
-    "schema": "mkdir -p build && ts-json-schema-generator -f tsconfig.json -p src/index.ts -t TopLevelSpec --validationKeywords deprecated --no-type-check --no-ref-encode > build/vega-lite-schema.json && yarn renameschema && cp build/vega-lite-schema.json site/_data/",
+    "schema": "mkdir -p build && ts-json-schema-generator -f tsconfig.json -p src/index.ts -t TopLevelSpec --no-type-check --no-ref-encode > build/vega-lite-schema.json && yarn renameschema && cp build/vega-lite-schema.json site/_data/",
     "renameschema": "scripts/rename-schema.sh",
     "presite": "yarn data && yarn schema && yarn build:site && yarn build:versions && scripts/create-example-pages.sh",
     "site": "pushd site && bundle exec jekyll serve -I -l && popd",

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -42,7 +42,7 @@ The rest of this page outlines different types of config properties:
 
 A Vega-Lite `config` object can have the following top-level properties:
 
-{% include table.html props="autosize,background,countTitle,fieldTitle,padding" source="Config" %}
+{% include table.html props="autosize,background,countTitle,fieldTitle,font,padding" source="Config" %}
 
 {:#format}
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,14 +27,14 @@ export interface ViewConfig extends BaseViewBackground {
   /**
    * Default width
    *
-   * @deprecated Since Vega-Lite 4.0. Please use continuousWidth and discreteWidth instead.
+   * __Deprecated:__ Since Vega-Lite 4.0. Please use continuousWidth and discreteWidth instead.
    */
   width?: number;
 
   /**
    * Default height
    *
-   * @deprecated Since Vega-Lite 4.0. Please use continuousHeight and discreteHeight instead.
+   * __Deprecated:__ Since Vega-Lite 4.0. Please use continuousHeight and discreteHeight instead.
    */
   height?: number;
 

--- a/src/spec/base.ts
+++ b/src/spec/base.ts
@@ -113,6 +113,23 @@ export interface FrameMixins extends LayoutSizeMixins {
   view?: ViewBackground;
 }
 
+export type DeprecatedFrameMixins = {
+  /**
+   * @deprecated Please avoid using width in a unit spec that's a part of a layer spec.
+   */
+  width?: FrameMixins['width'];
+
+  /**
+   * @deprecated Please avoid using width in a unit spec that's a part of a layer spec.
+   */
+  height?: FrameMixins['height'];
+
+  /**
+   * @deprecated Please avoid using width in a unit spec that's a part of a layer spec.
+   */
+  view?: FrameMixins['view'];
+};
+
 export interface ResolveMixins {
   /**
    * Scale, axis, and legend resolutions for view composition specifications.

--- a/src/spec/base.ts
+++ b/src/spec/base.ts
@@ -115,17 +115,17 @@ export interface FrameMixins extends LayoutSizeMixins {
 
 export type DeprecatedFrameMixins = {
   /**
-   * @deprecated Please avoid using width in a unit spec that's a part of a layer spec.
+   * __Deprecated:__ Please avoid using width in a unit spec that's a part of a layer spec.
    */
   width?: FrameMixins['width'];
 
   /**
-   * @deprecated Please avoid using width in a unit spec that's a part of a layer spec.
+   * __Deprecated:__ Please avoid using width in a unit spec that's a part of a layer spec.
    */
   height?: FrameMixins['height'];
 
   /**
-   * @deprecated Please avoid using width in a unit spec that's a part of a layer spec.
+   * __Deprecated:__ Please avoid using width in a unit spec that's a part of a layer spec.
    */
   view?: FrameMixins['view'];
 };

--- a/src/spec/unit.ts
+++ b/src/spec/unit.ts
@@ -4,7 +4,7 @@ import {Encoding} from '../encoding';
 import {AnyMark, Mark, MarkDef} from '../mark';
 import {Projection} from '../projection';
 import {SelectionDef} from '../selection';
-import {BaseSpec, BoundsMixins, DataMixins, FrameMixins, ResolveMixins} from './base';
+import {BaseSpec, BoundsMixins, DataMixins, DeprecatedFrameMixins, FrameMixins, ResolveMixins} from './base';
 import {TopLevel} from './toplevel';
 
 /**
@@ -42,7 +42,7 @@ export type NormalizedUnitSpec = GenericUnitSpec<Encoding<Field>, Mark | MarkDef
 /**
  * A unit specification, which can contain either [primitive marks or composite marks](https://vega.github.io/vega-lite/docs/mark.html#types).
  */
-export type UnitSpec = GenericUnitSpec<CompositeEncoding, AnyMark>;
+export type UnitSpec = GenericUnitSpec<CompositeEncoding, AnyMark> & DeprecatedFrameMixins;
 
 export type UnitSpecWithFrame = GenericUnitSpec<CompositeEncoding, AnyMark> & FrameMixins;
 


### PR DESCRIPTION
Fix https://github.com/vega/vega-lite/issues/5854

