### PR TITLE
docs: add Seattle annual temperature area trellis example

### DIFF
--- a/examples/specs/trellis_area_seattle.vl.json
+++ b/examples/specs/trellis_area_seattle.vl.json
@@ -1,0 +1,92 @@
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
+  "description": "Derived from https://vega.github.io/vega/examples/annual-temperature/",
+  "width": 800,
+  "height": 25,
+  "data": {
+    "url": "data/seattle-temps.csv"
+  },
+  "mark": "area",
+  "title": "Seattle Annual Temperatures",
+  "encoding": {
+    "x": {
+      "field": "date",
+      "type": "temporal",
+      "title": "Month",
+      "axis": {
+        "grid": false,
+        "labelExpr": "timeFormat(datum.value, '%b')"
+      }
+    },
+    "y": {
+      "field": "temp",
+      "type": "quantitative",
+      "scale": {
+        "domain": [
+          37.5,
+          75.9
+        ],
+        "padding": 0,
+        "zero": false,
+        "nice": false
+      },
+      "axis": {
+        "grid": false,
+        "title": null,
+        "labels": false,
+        "ticks": false
+      }
+    },
+    "row": {
+      "field": "date",
+      "timeUnit": "hours",
+      "type": "nominal",
+      "spacing": 1,
+      "sort": [
+        6,
+        7,
+        8,
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+        17,
+        18,
+        19,
+        20,
+        21,
+        22,
+        23,
+        0,
+        1,
+        2,
+        3,
+        4,
+        5
+      ],
+      "axis": {
+        "title": "Hour",
+        "labels": false
+      },
+      "header": {
+        "title": null,
+        "labelAngle": 0,
+        "labelPadding": -40,
+        "labelExpr": "hours(datum.value) == 0 ? 'Midnight ' : hours(datum.value) == 12 ? 'Noon   ' : timeFormat(datum.value, '%I:%M %p')"
+      }
+    }
+  },
+  "config": {
+    "view": {
+      "stroke": null
+    },
+    "axis": {
+      "grid": false,
+      "domain": false
+    }
+  }
+}

--- a/examples/specs/trellis_area_seattle.vl.json
+++ b/examples/specs/trellis_area_seattle.vl.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
-  "description": "Derived from https://vega.github.io/vega/examples/annual-temperature/",
+  "description": "Average temperatures in Seattle, broken down by hour. Derived from [Seattle Annual Temperate](https://vega.github.io/vega/examples/annual-temperature/) example from the Vega example gallery.",
   "width": 800,
   "height": 25,
   "data": {

--- a/examples/specs/trellis_area_seattle.vl.json
+++ b/examples/specs/trellis_area_seattle.vl.json
@@ -18,8 +18,9 @@
     },
     "headerRow": {
       "labelAngle": 0,
-      "labelPadding": -40,
+      "labelPadding": 2,
       "titlePadding": -5,
+      "labelAlign": "left",
       "labelExpr": "hours(datum.value) == 0 ? 'Midnight' : hours(datum.value) == 12 ? 'Noon' : timeFormat(datum.value, '%I:%M %p')"
     }
   },

--- a/examples/specs/trellis_area_seattle.vl.json
+++ b/examples/specs/trellis_area_seattle.vl.json
@@ -3,55 +3,23 @@
   "description": "Average temperatures in Seattle, broken down by hour. Derived from [Seattle Annual Temperate](https://vega.github.io/vega/examples/annual-temperature/) example from the Vega example gallery.",
   "width": 800,
   "height": 25,
-  "data": {
-    "url": "data/seattle-temps.csv"
-  },
-  "mark": "area",
   "title": "Seattle Annual Temperatures",
-  "config": {
-    "view": {
-      "stroke": null
-    },
-    "axis": {
-      "grid": false,
-      "domain": false
-    },
-    "headerRow": {
-      "labelAngle": 0,
-      "labelPadding": 2,
-      "titlePadding": -5,
-      "labelAlign": "left",
-      "labelExpr": "hours(datum.value) == 0 ? 'Midnight' : hours(datum.value) == 12 ? 'Noon' : timeFormat(datum.value, '%I:%M %p')"
-    }
-  },
+  "data": {"url": "data/seattle-temps.csv"},
+  "mark": "area",
   "encoding": {
     "x": {
       "field": "date",
       "type": "temporal",
       "title": "Month",
-      "axis": {
-        "grid": false,
-        "labelExpr": "timeFormat(datum.value, '%b')"
-      }
+      "axis": {"labelExpr": "timeFormat(datum.value, '%b')"}
     },
     "y": {
       "field": "temp",
       "type": "quantitative",
       "scale": {
-        "domain": [
-          37.5,
-          75.9
-        ],
-        "padding": 0,
-        "zero": false,
-        "nice": false
+        "zero": false
       },
-      "axis": {
-        "grid": false,
-        "title": null,
-        "labels": false,
-        "ticks": false
-      }
+      "axis": {"title": null, "labels": false, "ticks": false}
     },
     "row": {
       "field": "date",
@@ -84,7 +52,18 @@
         3,
         4,
         5
-      ]
+      ],
+      "header": {
+        "labelAngle": 0,
+        "labelPadding": 2,
+        "titlePadding": -4,
+        "labelAlign": "left",
+        "labelExpr": "hours(datum.value) == 0 ? 'Midnight' : hours(datum.value) == 12 ? 'Noon' : timeFormat(datum.value, '%I:%M %p')"
+      }
     }
+  },
+  "config": {
+    "view": {"stroke": null},
+    "axis": {"grid": false, "domain": false}
   }
 }

--- a/examples/specs/trellis_area_seattle.vl.json
+++ b/examples/specs/trellis_area_seattle.vl.json
@@ -8,6 +8,21 @@
   },
   "mark": "area",
   "title": "Seattle Annual Temperatures",
+  "config": {
+    "view": {
+      "stroke": null
+    },
+    "axis": {
+      "grid": false,
+      "domain": false
+    },
+    "headerRow": {
+      "labelAngle": 0,
+      "labelPadding": -40,
+      "titlePadding": -5,
+      "labelExpr": "hours(datum.value) == 0 ? 'Midnight' : hours(datum.value) == 12 ? 'Noon' : timeFormat(datum.value, '%I:%M %p')"
+    }
+  },
   "encoding": {
     "x": {
       "field": "date",
@@ -42,6 +57,7 @@
       "timeUnit": "hours",
       "type": "nominal",
       "spacing": 1,
+      "title": "Hour",
       "sort": [
         6,
         7,
@@ -67,26 +83,7 @@
         3,
         4,
         5
-      ],
-      "axis": {
-        "title": "Hour",
-        "labels": false
-      },
-      "header": {
-        "title": null,
-        "labelAngle": 0,
-        "labelPadding": -40,
-        "labelExpr": "hours(datum.value) == 0 ? 'Midnight ' : hours(datum.value) == 12 ? 'Noon   ' : timeFormat(datum.value, '%I:%M %p')"
-      }
-    }
-  },
-  "config": {
-    "view": {
-      "stroke": null
-    },
-    "axis": {
-      "grid": false,
-      "domain": false
+      ]
     }
   }
 }

--- a/site/_data/examples.json
+++ b/site/_data/examples.json
@@ -90,7 +90,6 @@
         "name": "histogram_log",
         "title": "Log-scaled Histogram"
       },
-
       {
         "name": "area_density",
         "title": "Density Plot"
@@ -577,6 +576,10 @@
       {
         "name": "trellis_area",
         "title": "Trellis Area"
+      },
+      {
+        "name": "trellis_area_seattle",
+        "title": "Trellis Area Plot Showing Annual Temperatures in Seattle"
       },
       {
         "name": "area_density_facet",


### PR DESCRIPTION
## Context

This PR adds a Vega-Lite spec reproducing the [Seattle Annual Temperature example](https://vega.github.io/vega/examples/annual-temperature/) from the Vega example gallery. This work is part of the list of examples included in issue #1486 .

This PR largely overlaps with PR #5582 with some additional improvements to more closely match the Vega example, including `"zero": false` and `"nice": false` settings on Y axis scale, as well as taking advantage of encoding-level `timeUnits` to avoid explicit transformations. In addition, it includes changes to add the example to the `examples.json` file so that it will show up in the gallery of examples.

## Screenshots and Demo

Open in Vega Editor: [Annual Temperature](https://vega.github.io/editor/#/url/vega-lite/N4KABGBEAkDODGALApgWwIaQFxUQFzwAdYsB6UgN2QHN0A6agSz0QFcAjOxge1IRQyUa6ALQAbZskoAWOgCtY3AHaQANOCgATZAgBOjQnh4qckAIJVd6asjB40hZFbytdOsIyVgAysnQExZFUwdl1uAGtkL01uAHcvdgBPMERuVzowABEnRipNMAAzMNQwAG1ffzxAsDMlJVZ0MTAAFQcnf2QAXQAKfCIScipaBmY2Th4hWlJkAA90VEJA2FJ0OoaxEXsF9pc3UgBKMFn5xdsi7hKWWwA1YSO5heraMUDdRLo1DUhYxk0WbDAAA4AAzA9QQSAoRjUfAAgBMAFZwVp-JgcKAIBDXGIAZBNKi+H4AshNg5YHR4LAKJANABfZGQDC6cK49BuTAMoxVZC4irEmprRotNrOVw6T4Q+DKArQgEYzGQCiMZCxOUaTFQWB4MKRAH1F7qsD0w2QdAzRiwNUaiHUfSaAEFRqwIKGiExDCeB1O5CG40ayF+bS6ABKcSt1sgYnQ7GQYlq1ECALBrqgUZjYgACuhNJpPNR4cj-VzAlmc3mASIkSnI9HY2YJNQTKnkAU8BKI2nYwBRGaEXS41KuWDdfEuVB0CiNVjIQ4AXlnYGBYAA-GAAOQAWV+Smh+DXYBwg90w9HrHHk7E07nC4AjHCV+uAHLcZT7nBGVDIABi3F0GDwI7+GeE5TkE64AKQAJJYOBG5gOBhBrvsNIarSdIMlEUq5ko+boiaMzhv6MqxvapijjyhYKngiSOLiWyEL+jTtkWzCJqYG7KP8lEQmaFqERGtq-F6YjOtxCqdmIPZ9nRjCfj+f7+IBY4gZeYFruB7BISh1poahlGQIk-EQsRYikVA9HMVRNE8qYACODRKFy-i5BR1YII0NlgPK1paBc6CejgpQphqADMADsdBVj5GphQidAAJzBWAnRiRChDZthuGLqlUAAF5ONwwmiUlkA7vAnmOiJPo+X6Ea8ZaeHRVAglmZVxVNZAxaefqYg5TW6YNYU3p9UY8DhINbXVTpvr6WEqqNRGJlmXiHSWRCH7IAAqjubamEelpiZ11m4koFyeExh2wOl8DljgN6HV1uIABJpP2l2-rtZRJQAbDlYU5YCOXxTlN7Jk1N73Uld4gyFIPSCDUXRTev1Q-9UOA1DwNJXCYPRXCkNNXCcI5XCsNJbjPkE3jOVk018NJQiKadL6dIgGhQA)

---

![Screen Shot 2020-02-13 at 1 29 38 PM](https://user-images.githubusercontent.com/766944/74479949-e8f09b00-4e64-11ea-9ec2-b47da8297256.png)

> Additional entry in the example gallery

---

![Screen Shot 2020-02-13 at 1 29 18 PM](https://user-images.githubusercontent.com/766944/74479960-ef7f1280-4e64-11ea-9b6e-7ed1c1bfe80c.png)

> The detailed example view
