### PR TITLE
perf: faster `version.sh`

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -3,7 +3,7 @@
 set -eu
 
 if [[ $1 == "vega-lite" ]]; then
-  npm list vega-lite | head -n 1 | sed 's/.*@//' | awk '{print $1}'
+  node -p "require('./package.json').version"
 else
-  npm list $1 | tail -n 2 | head -n 1 | sed 's/.*@//' | awk '{print $1}'
+  node -p "require('./node_modules/$1/package.json').version"
 fi


### PR DESCRIPTION
## Context

This PR addresses PR #3649 - an annoyingly slow `version.sh` script.

**Note:** This solution does *not* use `jq`, as the originating issue suggested.

## Background

The source of this slowness is actually the `npm list` command built-in to NPM, which is used by the script to extract the installed versions of various packages.

Unfortunately, the `npm list` command uses a package called `readPackageTree` to recursively walk the file tree in `node_modules`, inflate the various lockfile/shrinkwrap files possibly available, and produce a tree of package versions. Unfortunately, it does this *regardless* of any filters or depth parameters, which are applied *after* the tree is constructed. This means that performance of the command degrades as the number and depth of dependencies increases. At the time of creating this PR `npm list` returns over 3k lines of dependencies.

## Solution

Since `version.sh` is designed to fetch only a single version per call, it can avoid loading the entire package tree and instead jump straight to the `package.json` file of the project in question and report the version number by simply `require`ing the `package.json` in question and referencing the `.version` parameter.

## Results

A comparison of a few operations. These are single runs using `time <command>`, not real benchmarks, on a 2018 Macbook Pro with SSD:

| Old/New | Scenario | Result (s) |
|----------|---------|-----------|
| Old | `version.sh` | 2.99 s |
| New | `version.sh` | 0.02 s |
| Old | `update-version.sh` | 11.5 s |
| New | `update-version.sh` | 0.22 s |

Notably, this particularly impacts `update-version.sh`, which invokes the `version.sh` script several time. This presents a significant amount of repeated work to re-parse the entire dependency tree on each invocation. 
