### PR TITLE
feat(experimental): support signal ref for most of header properties

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -7892,12 +7892,16 @@
         },
         "labelFont": {
           "description": "The font of the header label.",
-          "type": "string"
+          "type": [
+            "string"
+          ]
         },
         "labelFontSize": {
           "description": "The font size of the header label, in pixels.",
           "minimum": 0,
-          "type": "number"
+          "type": [
+            "number"
+          ]
         },
         "labelFontStyle": {
           "$ref": "#/definitions/FontStyle",
@@ -7905,7 +7909,9 @@
         },
         "labelLimit": {
           "description": "The maximum length of the header label in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
-          "type": "number"
+          "type": [
+            "number"
+          ]
         },
         "labelOrient": {
           "$ref": "#/definitions/Orient",
@@ -7913,7 +7919,9 @@
         },
         "labelPadding": {
           "description": "The padding, in pixel, between facet header's label and the plot.\n\n__Default value:__ `10`",
-          "type": "number"
+          "type": [
+            "number"
+          ]
         },
         "labels": {
           "description": "A boolean flag indicating if labels should be included as part of the header.\n\n__Default value:__ `true`.",
@@ -7954,12 +7962,16 @@
         },
         "titleFont": {
           "description": "Font of the header title. (e.g., `\"Helvetica Neue\"`).",
-          "type": "string"
+          "type": [
+            "string"
+          ]
         },
         "titleFontSize": {
           "description": "Font size of the header title.",
           "minimum": 0,
-          "type": "number"
+          "type": [
+            "number"
+          ]
         },
         "titleFontStyle": {
           "$ref": "#/definitions/FontStyle",
@@ -7971,11 +7983,15 @@
         },
         "titleLimit": {
           "description": "The maximum length of the header title in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
-          "type": "number"
+          "type": [
+            "number"
+          ]
         },
         "titleLineHeight": {
           "description": "Line height in pixels for multi-line title text.",
-          "type": "number"
+          "type": [
+            "number"
+          ]
         },
         "titleOrient": {
           "$ref": "#/definitions/Orient",
@@ -7983,7 +7999,9 @@
         },
         "titlePadding": {
           "description": "The padding, in pixel, between facet header's title and the label.\n\n__Default value:__ `10`",
-          "type": "number"
+          "type": [
+            "number"
+          ]
         }
       },
       "type": "object"
@@ -8027,12 +8045,16 @@
         },
         "labelFont": {
           "description": "The font of the header label.",
-          "type": "string"
+          "type": [
+            "string"
+          ]
         },
         "labelFontSize": {
           "description": "The font size of the header label, in pixels.",
           "minimum": 0,
-          "type": "number"
+          "type": [
+            "number"
+          ]
         },
         "labelFontStyle": {
           "$ref": "#/definitions/FontStyle",
@@ -8040,7 +8062,9 @@
         },
         "labelLimit": {
           "description": "The maximum length of the header label in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
-          "type": "number"
+          "type": [
+            "number"
+          ]
         },
         "labelOrient": {
           "$ref": "#/definitions/Orient",
@@ -8048,7 +8072,9 @@
         },
         "labelPadding": {
           "description": "The padding, in pixel, between facet header's label and the plot.\n\n__Default value:__ `10`",
-          "type": "number"
+          "type": [
+            "number"
+          ]
         },
         "labels": {
           "description": "A boolean flag indicating if labels should be included as part of the header.\n\n__Default value:__ `true`.",
@@ -8082,12 +8108,16 @@
         },
         "titleFont": {
           "description": "Font of the header title. (e.g., `\"Helvetica Neue\"`).",
-          "type": "string"
+          "type": [
+            "string"
+          ]
         },
         "titleFontSize": {
           "description": "Font size of the header title.",
           "minimum": 0,
-          "type": "number"
+          "type": [
+            "number"
+          ]
         },
         "titleFontStyle": {
           "$ref": "#/definitions/FontStyle",
@@ -8099,11 +8129,15 @@
         },
         "titleLimit": {
           "description": "The maximum length of the header title in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.\n\n__Default value:__ `0`, indicating no limit",
-          "type": "number"
+          "type": [
+            "number"
+          ]
         },
         "titleLineHeight": {
           "description": "Line height in pixels for multi-line title text.",
-          "type": "number"
+          "type": [
+            "number"
+          ]
         },
         "titleOrient": {
           "$ref": "#/definitions/Orient",
@@ -8111,7 +8145,9 @@
         },
         "titlePadding": {
           "description": "The padding, in pixel, between facet header's title and the label.\n\n__Default value:__ `10`",
-          "type": "number"
+          "type": [
+            "number"
+          ]
         }
       },
       "type": "object"

--- a/src/header.ts
+++ b/src/header.ts
@@ -1,4 +1,14 @@
-import {Align, Color, FontStyle, FontWeight, Orient, TextBaseline, TitleAnchor, TitleConfig} from 'vega-typings';
+import {
+  Align,
+  Color,
+  FontStyle,
+  FontWeight,
+  Orient,
+  SignalRef,
+  TextBaseline,
+  TitleAnchor,
+  TitleConfig
+} from 'vega-typings';
 import {FormatMixins, Guide, VlOnlyGuideConfig} from './guide';
 import {keys} from './util';
 
@@ -40,12 +50,12 @@ export interface CoreHeader extends FormatMixins {
   /**
    * The anchor position for placing the title. One of `"start"`, `"middle"`, or `"end"`. For example, with an orientation of top these anchor positions map to a left-, center-, or right-aligned title.
    */
-  titleAnchor?: TitleAnchor;
+  titleAnchor?: TitleAnchor; // We don't allow signal for titleAnchor since there is a dependent logic
 
   /**
    * Horizontal text alignment (to the anchor) of header titles.
    */
-  titleAlign?: Align;
+  titleAlign?: Align | SignalRef;
 
   /**
    * The rotation angle of the header title.
@@ -55,54 +65,54 @@ export interface CoreHeader extends FormatMixins {
    * @minimum -360
    * @maximum 360
    */
-  titleAngle?: number;
+  titleAngle?: number; // We don't allow signal for titleAngle since there is a dependent logic
 
   /**
    * Vertical text baseline for the header title. One of `"top"`, `"bottom"`, `"middle"`.
    *
    * __Default value:__ `"middle"`
    */
-  titleBaseline?: TextBaseline;
+  titleBaseline?: TextBaseline | SignalRef;
 
   /**
    * Color of the header title, can be in hex color code or regular color name.
    */
-  titleColor?: Color;
+  titleColor?: Color | SignalRef;
 
   /**
    * Font of the header title. (e.g., `"Helvetica Neue"`).
    */
-  titleFont?: string;
+  titleFont?: string | SignalRef;
 
   /**
    * Font size of the header title.
    *
    * @minimum 0
    */
-  titleFontSize?: number;
+  titleFontSize?: number | SignalRef;
 
   /**
    * The font style of the header title.
    */
-  titleFontStyle?: FontStyle;
+  titleFontStyle?: FontStyle | SignalRef;
 
   /**
    * Font weight of the header title.
    * This can be either a string (e.g `"bold"`, `"normal"`) or a number (`100`, `200`, `300`, ..., `900` where `"normal"` = `400` and `"bold"` = `700`).
    */
-  titleFontWeight?: FontWeight;
+  titleFontWeight?: FontWeight | SignalRef;
 
   /**
    * The maximum length of the header title in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.
    *
    * __Default value:__ `0`, indicating no limit
    */
-  titleLimit?: number;
+  titleLimit?: number | SignalRef;
 
   /**
    * Line height in pixels for multi-line title text.
    */
-  titleLineHeight?: number;
+  titleLineHeight?: number | SignalRef;
 
   /**
    * The orientation of the header title. One of `"top"`, `"bottom"`, `"left"` or `"right"`.
@@ -114,7 +124,7 @@ export interface CoreHeader extends FormatMixins {
    *
    * __Default value:__ `10`
    */
-  titlePadding?: number;
+  titlePadding?: number | SignalRef;
 
   // ---------- Label ----------
 
@@ -128,7 +138,7 @@ export interface CoreHeader extends FormatMixins {
   /**
    * Horizontal text alignment of header labels. One of `"left"`, `"center"`, or `"right"`.
    */
-  labelAlign?: Align;
+  labelAlign?: Align | SignalRef;
 
   /**
    * The anchor position for placing the labels. One of `"start"`, `"middle"`, or `"end"`. For example, with a label orientation of top these anchor positions map to a left-, center-, or right-aligned label.
@@ -150,48 +160,48 @@ export interface CoreHeader extends FormatMixins {
    * @minimum -360
    * @maximum 360
    */
-  labelAngle?: number;
+  labelAngle?: number; // no signal ref since there is a dependent logic
 
   /**
    * The color of the header label, can be in hex color code or regular color name.
    */
-  labelColor?: Color;
+  labelColor?: Color | SignalRef;
 
   /**
    * The font of the header label.
    */
-  labelFont?: string;
+  labelFont?: string | SignalRef;
 
   /**
    * The font size of the header label, in pixels.
    *
    * @minimum 0
    */
-  labelFontSize?: number;
+  labelFontSize?: number | SignalRef;
 
   /**
    * The font style of the header label.
    */
-  labelFontStyle?: FontStyle;
+  labelFontStyle?: FontStyle | SignalRef;
 
   /**
    * The maximum length of the header label in pixels. The text value will be automatically truncated if the rendered size exceeds the limit.
    *
    * __Default value:__ `0`, indicating no limit
    */
-  labelLimit?: number;
+  labelLimit?: number | SignalRef;
 
   /**
    * The orientation of the header label. One of `"top"`, `"bottom"`, `"left"` or `"right"`.
    */
-  labelOrient?: Orient;
+  labelOrient?: Orient; // no signal ref since there is a dependent logic
 
   /**
    * The padding, in pixel, between facet header's label and the plot.
    *
    * __Default value:__ `10`
    */
-  labelPadding?: number;
+  labelPadding?: number | SignalRef;
 }
 
 export interface HeaderConfig extends CoreHeader, VlOnlyGuideConfig {}


### PR DESCRIPTION
This is not particularly important, but it's super easy so I'd rather not leave it as a technical debt.

Note that since we manually map header groups, we mostly get these for free. :) 