### PR TITLE
fix: change default sort op to min

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -5219,7 +5219,7 @@
         },
         "op": {
           "$ref": "#/definitions/NonArgAggregateOp",
-          "description": "An [aggregate operation](https://vega.github.io/vega-lite/docs/aggregate.html#ops) to perform on the field prior to sorting (e.g., `\"count\"`, `\"mean\"` and `\"median\"`).\nAn aggregation is required when there are multiple values of the sort field for each encoded data field.\nThe input data objects will be aggregated, grouped by the encoded data field.\n\nFor a full list of operations, please see the documentation for [aggregate](https://vega.github.io/vega-lite/docs/aggregate.html#ops).\n\n__Default value:__ `\"sum\"` for stacked plots. Otherwise, `\"mean\"`."
+          "description": "An [aggregate operation](https://vega.github.io/vega-lite/docs/aggregate.html#ops) to perform on the field prior to sorting (e.g., `\"count\"`, `\"mean\"` and `\"median\"`).\nAn aggregation is required when there are multiple values of the sort field for each encoded data field.\nThe input data objects will be aggregated, grouped by the encoded data field.\n\nFor a full list of operations, please see the documentation for [aggregate](https://vega.github.io/vega-lite/docs/aggregate.html#ops).\n\n__Default value:__ `\"sum\"` for stacked plots. Otherwise, `\"min\"`."
         },
         "order": {
           "anyOf": [

--- a/examples/compiled/interactive_dashboard_europe_pop.vg.json
+++ b/examples/compiled/interactive_dashboard_europe_pop.vg.json
@@ -1438,7 +1438,7 @@
         "data": "source_0",
         "field": "Country",
         "sort": {
-          "op": "mean",
+          "op": "min",
           "field": "Population_ages_15_64_of_total",
           "order": "descending"
         }
@@ -1465,7 +1465,7 @@
         "data": "source_0",
         "field": "Country",
         "sort": {
-          "op": "mean",
+          "op": "min",
           "field": "Population_ages_65_and_above_of_total",
           "order": "descending"
         }

--- a/src/sort.ts
+++ b/src/sort.ts
@@ -26,7 +26,7 @@ export interface SortFields {
   order?: SortOrder[];
 }
 
-export const DEFAULT_SORT_OP = 'mean';
+export const DEFAULT_SORT_OP = 'min';
 
 /**
  * A sort definition for sorting a discrete scale in an encoding field definition.
@@ -46,7 +46,7 @@ export interface EncodingSortField<F> {
    *
    * For a full list of operations, please see the documentation for [aggregate](https://vega.github.io/vega-lite/docs/aggregate.html#ops).
    *
-   * __Default value:__ `"sum"` for stacked plots. Otherwise, `"mean"`.
+   * __Default value:__ `"sum"` for stacked plots. Otherwise, `"min"`.
    */
   op?: NonArgAggregateOp;
 

--- a/test/compile/data/facet.test.ts
+++ b/test/compile/data/facet.test.ts
@@ -210,7 +210,7 @@ describe('compile/data/facet', () => {
             type: 'aggregate',
             groupby: ['c'],
             fields: ['a'],
-            ops: ['mean'],
+            ops: ['min'],
             as: ['a']
           }
         ]

--- a/test/compile/scale/domain.test.ts
+++ b/test/compile/scale/domain.test.ts
@@ -405,7 +405,7 @@ describe('compile/scale', () => {
               sort: sortDef
             },
             y: {
-              aggregate: 'mean',
+              aggregate: 'min',
               field: 'precipitation',
               type: 'quantitative'
             }
@@ -417,7 +417,7 @@ describe('compile/scale', () => {
           {
             data: 'raw',
             field: 'month_date',
-            sort: {...sortDef, op: 'mean'}
+            sort: {...sortDef, op: 'min'}
           }
         ]);
       });


### PR DESCRIPTION
fixes #5951

Reverts https://github.com/vega/vega-lite/issues/5951

We already use min for other cases such as 

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v4.json",
  "description": "A simple bar chart with embedded data.",
  "data": {
    "values": [
      {"a": "A", "b": 28}, {"a": "B", "b": 55}, {"a": "C", "b": 43},
      {"a": "D", "b": 91}, {"a": "E", "b": 81}, {"a": "F", "b": 53},
      {"a": "G", "b": 19}, {"a": "H", "b": 87}, {"a": "I", "b": 52}
    ]
  },
  "mark": "bar",
  "encoding": {
    "x": {"field": "a", "type": "ordinal", "sort": "descending"},
    "y": {"field": "b", "type": "quantitative"}
  }
}
```