### PR TITLE
fix: make cornerRadiusEnd apply to all cornerRadius for ranged bars

### DIFF
--- a/src/compile/mark/init.ts
+++ b/src/compile/mark/init.ts
@@ -49,7 +49,11 @@ export function normalizeMarkDef(
         config
       );
     if (cornerRadiusEnd !== undefined) {
-      const newProps = BAR_CORNER_RADIUS_END_INDEX[markDef.orient];
+      const newProps =
+        (markDef.orient === 'horizontal' && encoding.x2) || (markDef.orient === 'vertical' && encoding.y2)
+          ? ['cornerRadius']
+          : BAR_CORNER_RADIUS_END_INDEX[markDef.orient];
+
       for (const newProp of newProps) {
         markDef[newProp] = cornerRadiusEnd;
       }

--- a/test/compile/mark/init.test.ts
+++ b/test/compile/mark/init.test.ts
@@ -1,8 +1,48 @@
+import {normalizeMarkDef} from '../../../src/compile/mark/init';
+import {defaultConfig} from '../../../src/config';
 import {CIRCLE, POINT, PRIMITIVE_MARKS, SQUARE, TICK} from '../../../src/mark';
 import {without} from '../../../src/util';
 import {parseUnitModelWithScaleAndLayoutSize} from '../../util';
 
 describe('compile/mark/init', () => {
+  describe('normalizeMarkDef', () => {
+    it('applies cornerRadiusEnd to all cornerRadius for ranged bars', () => {
+      expect(
+        normalizeMarkDef(
+          {type: 'bar', cornerRadiusEnd: 5},
+          {x: {field: 'x', type: 'quantitative'}, x2: {field: 'x2'}},
+          defaultConfig,
+          {graticule: false}
+        )
+      ).toMatchObject({cornerRadius: 5});
+
+      expect(
+        normalizeMarkDef(
+          {type: 'bar', cornerRadiusEnd: 5},
+          {y: {field: 'x', type: 'quantitative'}, y2: {field: 'x2'}},
+          defaultConfig,
+          {graticule: false}
+        )
+      ).toMatchObject({cornerRadius: 5});
+    });
+
+    it('applies cornerRadiusEnd to top cornerRadius for vertical bars', () => {
+      expect(
+        normalizeMarkDef({type: 'bar', cornerRadiusEnd: 5}, {y: {field: 'x', type: 'quantitative'}}, defaultConfig, {
+          graticule: false
+        })
+      ).toMatchObject({cornerRadiusTopLeft: 5, cornerRadiusTopRight: 5});
+    });
+
+    it('applies cornerRadiusEnd to top cornerRadius for vertical bars', () => {
+      expect(
+        normalizeMarkDef({type: 'bar', cornerRadiusEnd: 5}, {x: {field: 'x', type: 'quantitative'}}, defaultConfig, {
+          graticule: false
+        })
+      ).toMatchObject({cornerRadiusBottomRight: 5, cornerRadiusTopRight: 5});
+    });
+  });
+
   describe('defaultOpacity', () => {
     it('should return 0.7 by default for unaggregated point, tick, circle, and square', () => {
       for (const mark of [POINT, TICK, CIRCLE, SQUARE]) {


### PR DESCRIPTION
fix https://github.com/vega/vega-lite/issues/5942

![image](https://user-images.githubusercontent.com/111269/75124191-6cc73600-5662-11ea-8ac0-d8455c872e2c.png)

