### PR TITLE
refactor: correctly name methods called in init

### DIFF
--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -832,7 +832,7 @@ export function getTypedFieldDef<F extends Field>(channelDef: ChannelDef<TypedFi
 /**
  * Convert type to full, lowercase type, or augment the fieldDef with a default type if missing.
  */
-export function normalize(channelDef: ChannelDef, channel: Channel): ChannelDef<any> {
+export function initChannelDef(channelDef: ChannelDef, channel: Channel): ChannelDef<any> {
   if (isString(channelDef) || isNumber(channelDef) || isBoolean(channelDef)) {
     const primitiveType = isString(channelDef) ? 'string' : isNumber(channelDef) ? 'number' : 'boolean';
     log.warn(log.message.primitiveChannelDef(channel, primitiveType, channelDef));
@@ -841,17 +841,17 @@ export function normalize(channelDef: ChannelDef, channel: Channel): ChannelDef<
 
   // If a fieldDef contains a field, we need type.
   if (isFieldDef(channelDef)) {
-    return normalizeFieldDef(channelDef, channel);
+    return initFieldDef(channelDef, channel);
   } else if (hasConditionalFieldDef(channelDef)) {
     return {
       ...channelDef,
       // Need to cast as normalizeFieldDef normally return FieldDef, but here we know that it is definitely Condition<FieldDef>
-      condition: normalizeFieldDef(channelDef.condition, channel) as Conditional<TypedFieldDef<string>>
+      condition: initFieldDef(channelDef.condition, channel) as Conditional<TypedFieldDef<string>>
     };
   }
   return channelDef;
 }
-export function normalizeFieldDef(fd: FieldDef<string>, channel: Channel) {
+export function initFieldDef(fd: FieldDef<string>, channel: Channel) {
   const {aggregate, timeUnit, bin, field} = fd;
   const fieldDef = {...fd};
 

--- a/src/compile/facet.ts
+++ b/src/compile/facet.ts
@@ -2,7 +2,7 @@ import {AggregateOp, LayoutAlign, NewSignal} from 'vega';
 import {isArray} from 'vega-util';
 import {isBinning} from '../bin';
 import {Channel, COLUMN, FacetChannel, FACET_CHANNELS, ROW, ScaleChannel} from '../channel';
-import {FieldRefOption, normalize, TypedFieldDef, vgField} from '../channeldef';
+import {FieldRefOption, initChannelDef, TypedFieldDef, vgField} from '../channeldef';
 import {Config} from '../config';
 import {reduce} from '../encoding';
 import * as log from '../log';
@@ -61,7 +61,7 @@ export class FacetModel extends ModelWithField {
   private initFacet(facet: FacetFieldDef<string> | FacetMapping<string>): EncodingFacetMapping<string> {
     // clone to prevent side effect to the original spec
     if (!isFacetMapping(facet)) {
-      return {facet: normalize(facet, 'facet')};
+      return {facet: initChannelDef(facet, 'facet')};
     }
 
     return reduce(
@@ -79,7 +79,7 @@ export class FacetModel extends ModelWithField {
         }
 
         // Convert type to full, lowercase type, or augment the fieldDef with a default type if missing.
-        normalizedFacet[channel] = normalize(fieldDef, channel);
+        normalizedFacet[channel] = initChannelDef(fieldDef, channel);
         return normalizedFacet;
       },
       {}

--- a/src/compile/mark/init.ts
+++ b/src/compile/mark/init.ts
@@ -25,7 +25,7 @@ import {QUANTITATIVE, TEMPORAL} from '../../type';
 import {contains, getFirstDefined} from '../../util';
 import {getMarkConfig} from '../common';
 
-export function normalizeMarkDef(
+export function initMarkdef(
   mark: Mark | MarkDef,
   encoding: Encoding<string>,
   config: Config,

--- a/src/compile/unit.ts
+++ b/src/compile/unit.ts
@@ -15,7 +15,7 @@ import {getTypedFieldDef, hasConditionalFieldDef, isFieldDef, TypedFieldDef} fro
 import {Config} from '../config';
 import {isGraticuleGenerator} from '../data';
 import * as vlEncoding from '../encoding';
-import {Encoding, normalizeEncoding} from '../encoding';
+import {Encoding, initEncoding} from '../encoding';
 import {Legend} from '../legend';
 import {GEOSHAPE, isMarkDef, Mark, MarkDef} from '../mark';
 import {Projection} from '../projection';
@@ -34,7 +34,7 @@ import {assembleLayoutSignals} from './layoutsize/assemble';
 import {initLayoutSize} from './layoutsize/init';
 import {parseUnitLayoutSize} from './layoutsize/parse';
 import {LegendIndex} from './legend/component';
-import {normalizeMarkDef} from './mark/init';
+import {initMarkdef} from './mark/init';
 import {parseMarkGroups} from './mark/mark';
 import {isLayerModel, Model, ModelWithField} from './model';
 import {RepeaterValue, replaceRepeaterInEncoding} from './repeater';
@@ -90,10 +90,10 @@ export class UnitModel extends ModelWithField {
 
     const encodingWithRepeaterReplaced = replaceRepeaterInEncoding(spec.encoding ?? {}, repeater);
 
-    this.markDef = normalizeMarkDef(spec.mark, encodingWithRepeaterReplaced, config, {
+    this.markDef = initMarkdef(spec.mark, encodingWithRepeaterReplaced, config, {
       graticule: spec.data && isGraticuleGenerator(spec.data)
     });
-    const encoding = (this.encoding = normalizeEncoding(encodingWithRepeaterReplaced, this.markDef));
+    const encoding = (this.encoding = initEncoding(encodingWithRepeaterReplaced, this.markDef));
 
     this.size = initLayoutSize({
       encoding,

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -15,13 +15,13 @@ import {
   getGuide,
   getTypedFieldDef,
   hasConditionalFieldDef,
+  initChannelDef,
+  initFieldDef,
   isConditionalDef,
   isFieldDef,
   isTypedFieldDef,
   isValueDef,
   LatLongFieldDef,
-  normalize,
-  normalizeFieldDef,
   NumericArrayFieldDefWithCondition,
   NumericArrayValueDefWithCondition,
   NumericFieldDefWithCondition,
@@ -401,7 +401,7 @@ export function markChannelCompatible(encoding: Encoding<string>, channel: Chann
   return true;
 }
 
-export function normalizeEncoding(encoding: Encoding<string>, markDef: MarkDef): Encoding<string> {
+export function initEncoding(encoding: Encoding<string>, markDef: MarkDef): Encoding<string> {
   const mark = markDef.type;
 
   return keys(encoding).reduce((normalizedEncoding: Encoding<string>, channel: Channel | string) => {
@@ -446,7 +446,7 @@ export function normalizeEncoding(encoding: Encoding<string>, markDef: MarkDef):
             if (!isFieldDef(fieldDef)) {
               log.warn(log.message.emptyFieldDef(fieldDef, channel));
             } else {
-              defs.push(normalizeFieldDef(fieldDef, channel));
+              defs.push(initFieldDef(fieldDef, channel));
             }
             return defs;
           },
@@ -466,7 +466,7 @@ export function normalizeEncoding(encoding: Encoding<string>, markDef: MarkDef):
         log.warn(log.message.emptyFieldDef(channelDef, channel));
         return normalizedEncoding;
       }
-      normalizedEncoding[channel] = normalize(channelDef as ChannelDef, channel);
+      normalizedEncoding[channel] = initChannelDef(channelDef as ChannelDef, channel);
     }
     return normalizedEncoding;
   }, {});

--- a/test/channeldef.test.ts
+++ b/test/channeldef.test.ts
@@ -5,7 +5,7 @@ import {
   defaultTitle,
   defaultType,
   functionalTitleFormatter,
-  normalize,
+  initChannelDef,
   TypedFieldDef,
   vgField
 } from '../src/channeldef';
@@ -54,23 +54,23 @@ describe('fieldDef', () => {
     });
   });
 
-  describe('normalize()', () => {
+  describe('initChannelDef()', () => {
     it(
       'should convert primitive type to value def',
       log.wrap(localLogger => {
-        expect(normalize(5 as any, 'x')).toEqual({value: 5});
+        expect(initChannelDef(5 as any, 'x')).toEqual({value: 5});
         expect(localLogger.warns.length).toEqual(1);
       })
     );
 
     it('should return fieldDef with full type name.', () => {
       const fieldDef: TypedFieldDef<string> = {field: 'a', type: 'q' as any};
-      expect(normalize(fieldDef, 'x')).toEqual({field: 'a', type: 'quantitative'});
+      expect(initChannelDef(fieldDef, 'x')).toEqual({field: 'a', type: 'quantitative'});
     });
 
-    it('should normalize non-string field to string', () => {
+    it('should standardize non-string field to string', () => {
       const fieldDef: TypedFieldDef<string> = {field: 1 as any, type: 'q' as any};
-      expect(normalize(fieldDef, 'x')).toEqual({field: '1', type: 'quantitative'});
+      expect(initChannelDef(fieldDef, 'x')).toEqual({field: '1', type: 'quantitative'});
     });
 
     it(
@@ -81,7 +81,7 @@ describe('fieldDef', () => {
           field: 'a',
           type: 'temporal'
         };
-        expect(normalize(fieldDef, 'x')).toEqual({
+        expect(initChannelDef(fieldDef, 'x')).toEqual({
           timeUnit: {
             unit: 'yearmonthdate'
           },
@@ -97,7 +97,7 @@ describe('fieldDef', () => {
       log.wrap(localLogger => {
         for (const aggregate of COUNTING_OPS) {
           const fieldDef: TypedFieldDef<string> = {aggregate, field: 'a', type: 'nominal'};
-          expect(normalize(fieldDef, 'x')).toEqual({aggregate, field: 'a', type: 'quantitative'});
+          expect(initChannelDef(fieldDef, 'x')).toEqual({aggregate, field: 'a', type: 'quantitative'});
         }
         expect(localLogger.warns.length).toEqual(4);
       })
@@ -107,7 +107,7 @@ describe('fieldDef', () => {
       'should return fieldDef with default type and throw warning if type is missing.',
       log.wrap(localLogger => {
         const fieldDef = {field: 'a'};
-        expect(normalize(fieldDef, 'x')).toEqual({field: 'a', type: 'quantitative'});
+        expect(initChannelDef(fieldDef, 'x')).toEqual({field: 'a', type: 'quantitative'});
         expect(localLogger.warns[0]).toEqual(log.message.missingFieldType('x', 'quantitative'));
       })
     );
@@ -116,7 +116,7 @@ describe('fieldDef', () => {
       'should drop invalid aggregate ops and throw warning.',
       log.wrap(localLogger => {
         const fieldDef: TypedFieldDef<string> = {aggregate: 'boxplot', field: 'a', type: 'quantitative'};
-        expect(normalize(fieldDef, 'x')).toEqual({field: 'a', type: 'quantitative'});
+        expect(initChannelDef(fieldDef, 'x')).toEqual({field: 'a', type: 'quantitative'});
         expect(localLogger.warns[0]).toEqual(log.message.invalidAggregate('boxplot'));
       })
     );

--- a/test/compile/mark/init.test.ts
+++ b/test/compile/mark/init.test.ts
@@ -1,14 +1,14 @@
-import {normalizeMarkDef} from '../../../src/compile/mark/init';
+import {initMarkdef} from '../../../src/compile/mark/init';
 import {defaultConfig} from '../../../src/config';
 import {CIRCLE, POINT, PRIMITIVE_MARKS, SQUARE, TICK} from '../../../src/mark';
 import {without} from '../../../src/util';
 import {parseUnitModelWithScaleAndLayoutSize} from '../../util';
 
 describe('compile/mark/init', () => {
-  describe('normalizeMarkDef', () => {
+  describe('initMarkDef', () => {
     it('applies cornerRadiusEnd to all cornerRadius for ranged bars', () => {
       expect(
-        normalizeMarkDef(
+        initMarkdef(
           {type: 'bar', cornerRadiusEnd: 5},
           {x: {field: 'x', type: 'quantitative'}, x2: {field: 'x2'}},
           defaultConfig,
@@ -17,7 +17,7 @@ describe('compile/mark/init', () => {
       ).toMatchObject({cornerRadius: 5});
 
       expect(
-        normalizeMarkDef(
+        initMarkdef(
           {type: 'bar', cornerRadiusEnd: 5},
           {y: {field: 'x', type: 'quantitative'}, y2: {field: 'x2'}},
           defaultConfig,
@@ -28,7 +28,7 @@ describe('compile/mark/init', () => {
 
     it('applies cornerRadiusEnd to top cornerRadius for vertical bars', () => {
       expect(
-        normalizeMarkDef({type: 'bar', cornerRadiusEnd: 5}, {y: {field: 'x', type: 'quantitative'}}, defaultConfig, {
+        initMarkdef({type: 'bar', cornerRadiusEnd: 5}, {y: {field: 'x', type: 'quantitative'}}, defaultConfig, {
           graticule: false
         })
       ).toMatchObject({cornerRadiusTopLeft: 5, cornerRadiusTopRight: 5});
@@ -36,7 +36,7 @@ describe('compile/mark/init', () => {
 
     it('applies cornerRadiusEnd to top cornerRadius for vertical bars', () => {
       expect(
-        normalizeMarkDef({type: 'bar', cornerRadiusEnd: 5}, {x: {field: 'x', type: 'quantitative'}}, defaultConfig, {
+        initMarkdef({type: 'bar', cornerRadiusEnd: 5}, {x: {field: 'x', type: 'quantitative'}}, defaultConfig, {
           graticule: false
         })
       ).toMatchObject({cornerRadiusBottomRight: 5, cornerRadiusTopRight: 5});

--- a/test/encoding.test.ts
+++ b/test/encoding.test.ts
@@ -16,8 +16,8 @@ import {
   Encoding,
   extractTransformsFromEncoding,
   fieldDefs,
+  initEncoding,
   markChannelCompatible,
-  normalizeEncoding,
   pathGroupingFields
 } from '../src/encoding';
 import * as log from '../src/log';
@@ -25,11 +25,11 @@ import {CIRCLE, Mark, POINT, SQUARE, TICK} from '../src/mark';
 import {internalField} from '../src/util';
 
 describe('encoding', () => {
-  describe('normalizeEncoding', () => {
+  describe('initEncoding', () => {
     it(
       'should drop color channel if fill is specified and filled = true',
       log.wrap(logger => {
-        const encoding = normalizeEncoding(
+        const encoding = initEncoding(
           {
             color: {field: 'a', type: 'quantitative'},
             fill: {field: 'b', type: 'quantitative'}
@@ -47,7 +47,7 @@ describe('encoding', () => {
     it(
       'should drop color channel if stroke is specified and filled is false',
       log.wrap(logger => {
-        const encoding = normalizeEncoding(
+        const encoding = initEncoding(
           {
             color: {field: 'a', type: 'quantitative'},
             stroke: {field: 'b', type: 'quantitative'}
@@ -65,7 +65,7 @@ describe('encoding', () => {
 
   describe('extractTransformsFromEncoding', () => {
     function normalizeEncodingWithMark(encoding: Encoding<string>, mark: Mark) {
-      return normalizeEncoding(encoding, {type: mark});
+      return initEncoding(encoding, {type: mark});
     }
 
     it('should indlude axis in extracted encoding', () => {


### PR DESCRIPTION
We shouldn't call these normalizeXXX since we call them in init.

Some of the logic, perhaps could be moved to normalize at some point (but not in this PR). 
Until we perform such refactors, it's at least better to name based on when they are called. 

Merge https://github.com/vega/vega-lite/pull/5968 first