### PR TITLE
fix: vl2vg STDIN error in Windows (#4727)

### DIFF
--- a/bin/vl2vg
+++ b/bin/vl2vg
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // Compile a Vega-Lite spec to Vega
 
+//@ts-check
 'use strict';
 
 const helpText = `Compile a Vega-Lite spec to Vega.
@@ -10,7 +11,7 @@ Usage: vl2vg [vega_lite_json_file] [output_vega_json_file]
   If output_vega_json_file is not provided, writes to stdout.`;
 
 // import required libraries
-const {createWriteStream, readFile} = require('fs');
+const {createReadStream, createWriteStream} = require('fs');
 const vegaLite = require('../build/vega-lite');
 const compactStringify = require('json-stringify-pretty-compact');
 
@@ -26,19 +27,23 @@ args
 
 const argv = args.help().version().argv;
 
-// input file
-const specFile = argv._[0] || '/dev/stdin';
+function read(file) {
+  return new Promise((resolve, reject) => {
+    const input = file ? createReadStream(file) : process.stdin;
+    let text = '';
+
+    input.setEncoding('utf8');
+    input.on('error', err => reject(err));
+    input.on('data', chunk => (text += chunk));
+    input.on('end', () => resolve(text));
+  });
+}
 
 // load spec, compile vg spec
-readFile(specFile, 'utf8', function(err, text) {
-  if (err) {
-    throw err;
-  }
-  const spec = JSON.parse(text);
-  compile(spec);
-});
+read(argv._[0]).then(text => compile(JSON.parse(text)));
 
 function compile(vlSpec) {
+  // @ts-ignore
   const vgSpec = vegaLite.compile(vlSpec).spec;
 
   const file = argv._[1] || null;


### PR DESCRIPTION
Fixes #4727

The fix is very similar to the commit which solved a similar issue in Vega (https://github.com/vega/vega/issues/1276).
I have only tested in Windows and not in other operating systems.
Feel free to modify (e.g. remove "//@ts-check" and "// @ts-ignore" or remove only "// @ts-ignore" and fix the typescript check problem).

- [X] Make the pull requests (PRs) atomic. (Fix one issue at a time.) Multiple relevant issues that must be fixed together? Make atomic commits so we can easily review each issue.
- [X] Provide a concise title so we can easily copy it to the release note.
  - Use imperative mood and present tense.
  - Mention relevant issues. (e.g., `Fixes #1` / `Fixes part of #1`)
- [ ] Lint and test (Run `yarn test`)
  Did not work (even initially). Error message:
```
$ yarn test
yarn run v1.22.0
$ jest test/ && yarn lint && yarn schema && jest examples/ && yarn test:runtime
jest-haste-map: Haste module naming collision: vega-lite
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>\build\package.json
    * <rootDir>\package.json

Determining test suites to run...
DevTools listening on ws://127.0.0.1:52961/devtools/browser/44b248ca-c2f6-43b9-9228-cf488ba83d2f
C:\Users\Winfried\Documents\workspace_vscode\vega-lite\node_modules\.bin\http-server:2
basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
          ^^^^^^^

SyntaxError: missing ) after argument list
    at Module._compile (internal/modules/cjs/loader.js:891:18)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:991:10)
    at Module.load (internal/modules/cjs/loader.js:811:32)
    at Function.Module._load (internal/modules/cjs/loader.js:723:14)
    at Function.Module.runMain (internal/modules/cjs/loader.js:1043:10)
    at internal/main/run_main_module.js:17:11
error Command failed with exit code 1.
``` 
- [X] Rebase onto the latest `master` branch.
- [X] Review your changes before sending the PR (to ensure code quality).
- For new features:
  - [ ] Add new unit tests.
  - [ ] Update the documentation under `site/docs/` + add examples.
