### PR TITLE
refactor: remove concat type from concat model

### DIFF
--- a/examples/compiled/concat_bar_scales_discretize_2_cols.vg.json
+++ b/examples/compiled/concat_bar_scales_discretize_2_cols.vg.json
@@ -69,7 +69,7 @@
       "update": "bandspace(domain('concat_2_y').length, 1, 0.5) * concat_2_y_step"
     }
   ],
-  "layout": {"padding": 20, "bounds": "full", "align": "each", "columns": 2},
+  "layout": {"padding": 20, "columns": 2, "bounds": "full", "align": "each"},
   "marks": [
     {
       "type": "group",

--- a/examples/compiled/concat_weather.vg.json
+++ b/examples/compiled/concat_weather.vg.json
@@ -94,7 +94,7 @@
     {"name": "concat_2_width", "value": 200},
     {"name": "concat_2_height", "value": 200}
   ],
-  "layout": {"padding": 20, "bounds": "full", "align": "each", "columns": 2},
+  "layout": {"padding": 20, "columns": 2, "bounds": "full", "align": "each"},
   "marks": [
     {
       "type": "group",

--- a/src/compile/concat.ts
+++ b/src/compile/concat.ts
@@ -12,8 +12,6 @@ import {RepeaterValue} from './repeater';
 export class ConcatModel extends BaseConcatModel {
   public readonly children: Model[];
 
-  public readonly concatType: 'vconcat' | 'hconcat' | 'concat';
-
   constructor(
     spec: NormalizedConcatSpec,
     parent: Model,
@@ -26,8 +24,6 @@ export class ConcatModel extends BaseConcatModel {
     if (spec.resolve?.axis?.x === 'shared' || spec.resolve?.axis?.y === 'shared') {
       log.warn(log.message.CONCAT_CANNOT_SHARE_AXIS);
     }
-
-    this.concatType = isVConcatSpec(spec) ? 'vconcat' : isHConcatSpec(spec) ? 'hconcat' : 'concat';
 
     this.children = this.getChildren(spec).map((child, i) => {
       return buildModel(child, this, this.getName('concat_' + i), undefined, repeater, config);
@@ -52,8 +48,9 @@ export class ConcatModel extends BaseConcatModel {
   }
 
   protected assembleDefaultLayout(): VgLayout {
+    const columns = this.layout.columns;
     return {
-      ...(this.concatType === 'vconcat' ? {columns: 1} : {}),
+      ...(columns != null ? {columns: columns} : {}),
       bounds: 'full',
       // Use align each so it can work with multiple plots with different size
       align: 'each'

--- a/src/compile/layoutsize/parse.ts
+++ b/src/compile/layoutsize/parse.ts
@@ -19,14 +19,24 @@ export function parseLayerLayoutSize(model: Model) {
 
 export const parseRepeatLayoutSize = parseLayerLayoutSize;
 
+function sizeTypeToMerge(columns: number | undefined) {
+  switch (columns) {
+    case 1:
+      return 'width';
+    case undefined:
+      return 'height';
+    default:
+      return undefined;
+  }
+}
+
 export function parseConcatLayoutSize(model: ConcatModel) {
   parseChildrenLayoutSize(model);
   const layoutSizeCmpt = model.component.layoutSize;
 
-  const columns = model.layout.columns;
-  const sizeTypeToMerge = columns === 1 ? 'width' : columns === undefined ? 'height' : undefined;
-  if (sizeTypeToMerge) {
-    layoutSizeCmpt.setWithExplicit(sizeTypeToMerge, parseNonUnitLayoutSizeForChannel(model, sizeTypeToMerge));
+  const sizeType = sizeTypeToMerge(model.layout.columns);
+  if (sizeType) {
+    layoutSizeCmpt.setWithExplicit(sizeType, parseNonUnitLayoutSizeForChannel(model, sizeType));
   }
 }
 

--- a/src/compile/layoutsize/parse.ts
+++ b/src/compile/layoutsize/parse.ts
@@ -19,16 +19,12 @@ export function parseLayerLayoutSize(model: Model) {
 
 export const parseRepeatLayoutSize = parseLayerLayoutSize;
 
-const SIZE_TYPE_TO_MERGE = {
-  vconcat: 'width',
-  hconcat: 'height'
-};
-
 export function parseConcatLayoutSize(model: ConcatModel) {
   parseChildrenLayoutSize(model);
   const layoutSizeCmpt = model.component.layoutSize;
 
-  const sizeTypeToMerge = SIZE_TYPE_TO_MERGE[model.concatType];
+  const columns = model.layout.columns;
+  const sizeTypeToMerge = columns === 1 ? 'width' : columns === undefined ? 'height' : undefined;
   if (sizeTypeToMerge) {
     layoutSizeCmpt.setWithExplicit(sizeTypeToMerge, parseNonUnitLayoutSizeForChannel(model, sizeTypeToMerge));
   }

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -23,7 +23,7 @@ import {forEach, reduce} from '../encoding';
 import * as log from '../log';
 import {Resolve} from '../resolve';
 import {hasDiscreteDomain} from '../scale';
-import {isFacetSpec, isLayerSpec, isUnitSpec} from '../spec';
+import {isFacetSpec} from '../spec';
 import {
   extractCompositionLayout,
   GenericCompositionLayoutWithColumns,
@@ -209,7 +209,7 @@ export abstract class Model {
 
     this.description = spec.description;
     this.transforms = normalizeTransform(spec.transform ?? []);
-    this.layout = isUnitSpec(spec) || isLayerSpec(spec) ? {} : extractCompositionLayout(spec, type, config);
+    this.layout = type === 'layer' || type === 'unit' ? {} : extractCompositionLayout(spec, type, config);
 
     this.component = {
       data: {

--- a/src/spec/base.ts
+++ b/src/spec/base.ts
@@ -1,7 +1,6 @@
 import {Color, Cursor, SignalRef, Text} from 'vega';
 import {isArray, isNumber, isObject} from 'vega-util';
 import {NormalizedSpec} from '.';
-import {Config} from '../config';
 import {Data} from '../data';
 import {MarkConfig} from '../mark';
 import {Resolve} from '../resolve';
@@ -9,7 +8,7 @@ import {TitleParams} from '../title';
 import {Transform} from '../transform';
 import {Flag, keys} from '../util';
 import {LayoutAlign, RowCol} from '../vega.schema';
-import {isConcatSpec} from './concat';
+import {isConcatSpec, isVConcatSpec} from './concat';
 import {isFacetMapping, isFacetSpec} from './facet';
 import {isRepeatSpec} from './repeat';
 
@@ -292,8 +291,8 @@ export type SpecType = 'unit' | 'facet' | 'layer' | 'concat' | 'repeat';
 
 export function extractCompositionLayout(
   spec: NormalizedSpec,
-  specType: SpecType,
-  config: Config
+  specType: keyof CompositionConfigMixins,
+  config: CompositionConfigMixins
 ): GenericCompositionLayoutWithColumns {
   const compositionConfig = config[specType];
   const layout: GenericCompositionLayoutWithColumns = {};
@@ -312,6 +311,10 @@ export function extractCompositionLayout(
     ) {
       layout.columns = columns;
     }
+  }
+
+  if (isVConcatSpec(spec)) {
+    layout.columns = 1;
   }
 
   // Then copy properties from the spec

--- a/test/compile/concat.test.ts
+++ b/test/compile/concat.test.ts
@@ -27,7 +27,6 @@ describe('ConcatModel', () => {
       });
 
       expect(model.layout).toMatchObject({columns: 1, spacing: DEFAULT_SPACING});
-      expect(model.concatType).toBe('concat');
     });
   });
 
@@ -52,7 +51,7 @@ describe('ConcatModel', () => {
       });
 
       expect(model.children).toHaveLength(2);
-      expect(model.concatType).toBe('vconcat');
+      expect(model.layout.columns).toBe(1);
     });
 
     it('should instantiate all children in hconcat', () => {
@@ -75,7 +74,7 @@ describe('ConcatModel', () => {
       });
 
       expect(model.children).toHaveLength(2);
-      expect(model.concatType).toBe('hconcat');
+      expect(model.layout.columns).toBe(undefined);
     });
 
     it('should create correct layout for vconcat', () => {
@@ -114,7 +113,7 @@ describe('ConcatModel', () => {
         ]
       });
 
-      expect(model.concatType).toBe('hconcat');
+      expect(model.layout.columns).toBe(undefined);
 
       expect(model.assembleLayout()).toEqual({
         padding: DEFAULT_SPACING,


### PR DESCRIPTION
Fixes https://github.com/vega/vega-lite/issues/6023

We now consistently treat a concat spec with 1 column as a vconcat. 