### PR TITLE
fix: escape paths in dimension fields

### DIFF
--- a/src/compile/data/aggregate.ts
+++ b/src/compile/data/aggregate.ts
@@ -209,7 +209,7 @@ export class AggregateNode extends DataFlowNode {
 
     const result: VgAggregateTransform = {
       type: 'aggregate',
-      groupby: [...this.dimensions],
+      groupby: [...this.dimensions].map(replacePathInField),
       ops,
       fields,
       as

--- a/test/compile/data/aggregate.test.ts
+++ b/test/compile/data/aggregate.test.ts
@@ -289,4 +289,17 @@ describe('compile/data/aggregate', () => {
       expect(agg1.producedFields()).toEqual(new Set(['a_mean', 'b_mean']));
     });
   });
+
+  describe('assemble', () => {
+    it('should escape nested accesses', () => {
+      const agg = new AggregateNode(null, new Set(['foo.bar']), {'foo.baz': {mean: new Set(['foo_baz_mean'])}});
+      expect(agg.assemble()).toEqual({
+        as: ['foo_baz_mean'],
+        fields: ['foo\\.baz'],
+        groupby: ['foo\\.bar'],
+        ops: ['mean'],
+        type: 'aggregate'
+      });
+    });
+  });
 });

--- a/test/compile/data/aggregate.test.ts
+++ b/test/compile/data/aggregate.test.ts
@@ -290,7 +290,7 @@ describe('compile/data/aggregate', () => {
     });
   });
 
-  describe('assemble', () => {
+  describe('assemble()', () => {
     it('should escape nested accesses', () => {
       const agg = new AggregateNode(null, new Set(['foo.bar']), {'foo.baz': {mean: new Set(['foo_baz_mean'])}});
       expect(agg.assemble()).toEqual({


### PR DESCRIPTION
Fixes https://github.com/vega/vega-lite/issues/6066