### PR TITLE
feat: support axis config based on both orientation and type (e.g., `config.axisXTemporal`)	

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -896,7 +896,7 @@
               "type": "array"
             }
           ],
-          "description": "A string or array of strings indicating the name of custom styles to apply to the axis. A style is a named collection of axis property defined within the [style configuration](https://vega.github.io/vega-lite/docs/mark.html#style-config). If style is an array, later styles will override earlier styles. Any [axis properties](https://vega.github.io/vega-lite/docs/encoding.html#mark-prop) explicitly defined within the `encoding` will override a style default.\n\n__Default value:__ (none)\n__Note:__ Any specified style will augment the default style. For example, an x-axis mark with `\"style\": \"foo\"` will use `config.axisX` and `config.style.foo` (the specified style `\"foo\"` has higher precedence)."
+          "description": "A string or array of strings indicating the name of custom styles to apply to the axis. A style is a named collection of axis property defined within the [style configuration](https://vega.github.io/vega-lite/docs/mark.html#style-config). If style is an array, later styles will override earlier styles.\n\n__Default value:__ (none)\n__Note:__ Any specified style will augment the default style. For example, an x-axis mark with `\"style\": \"foo\"` will use `config.axisX` and `config.style.foo` (the specified style `\"foo\"` has higher precedence)."
         },
         "tickBand": {
           "description": "For band scales, indicates if ticks and grid lines should be placed at the center of a band (default) or at the band extents to indicate intervals.",
@@ -1417,6 +1417,20 @@
         "orient": {
           "$ref": "#/definitions/AxisOrient",
           "description": "The orientation of the axis. One of `\"top\"`, `\"bottom\"`, `\"left\"` or `\"right\"`. The orientation can be used to further specialize the axis type (e.g., a y-axis oriented towards the right edge of the chart).\n\n__Default value:__ `\"bottom\"` for x-axes and `\"left\"` for y-axes."
+        },
+        "style": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ],
+          "description": "A string or array of strings indicating the name of custom styles to apply to the axis. A style is a named collection of axis property defined within the [style configuration](https://vega.github.io/vega-lite/docs/mark.html#style-config). If style is an array, later styles will override earlier styles.\n\n__Default value:__ (none)\n__Note:__ Any specified style will augment the default style. For example, an x-axis mark with `\"style\": \"foo\"` will use `config.axisX` and `config.style.foo` (the specified style `\"foo\"` has higher precedence)."
         },
         "tickBand": {
           "description": "For band scales, indicates if ticks and grid lines should be placed at the center of a band (default) or at the band extents to indicate intervals.",

--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -4623,9 +4623,49 @@
           "$ref": "#/definitions/AxisConfig",
           "description": "X-axis specific config."
         },
+        "axisXBand": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Config for x-axes with \"band\" scales."
+        },
+        "axisXDiscrete": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Config for x-axes with \"point\" or \"band\" scales."
+        },
+        "axisXPoint": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Config for x-axes with \"point\" scales."
+        },
+        "axisXQuantitative": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Config for x-quantitative axes."
+        },
+        "axisXTemporal": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Config for x-temporal axes."
+        },
         "axisY": {
           "$ref": "#/definitions/AxisConfig",
           "description": "Y-axis specific config."
+        },
+        "axisYBand": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Config for y-axes with \"band\" scales."
+        },
+        "axisYDiscrete": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Config for y-axes with \"point\" or \"band\" scales."
+        },
+        "axisYPoint": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Config for y-axes with \"point\" scales."
+        },
+        "axisYQuantitative": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Config for y-quantitative axes."
+        },
+        "axisYTemporal": {
+          "$ref": "#/definitions/AxisConfig",
+          "description": "Config for y-temporal axes."
         },
         "background": {
           "$ref": "#/definitions/Color",

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -62,7 +62,7 @@ Axis configurations define default settings for axes. Properties defined under t
 
 Additional property blocks can target more specific axis types based on the orientation (`"axisX"`, `"axisY"`, `"axisLeft"`, `"axisTop"`, etc.), band scale type (`"axisBand"`), or scale's data type (`"axisQuantitative"` and `"axisTemporal"`). For example, properties defined under the `"axisBand"` property will only apply to axes visualizing `"band"` scales. If multiple axis config blocks apply to a single axis, type-based options take precedence over orientation-based options, which in turn take precedence over general options.
 
-{% include table.html props="axis,axisX,axisY,axisLeft,axisRight,axisTop,axisBottom,axisBand,axisQuantitative,axisTemporal" source="Config" %}
+{% include table.html props="axis,axisX,axisY,axisLeft,axisRight,axisTop,axisBottom,axisBand,axisPoint,axisDiscrete,axisQuantitative,axisTemporal" source="Config" %}
 
 {:#header-config}
 

--- a/site/docs/config.md
+++ b/site/docs/config.md
@@ -58,11 +58,11 @@ These two config properties define the default number and time formats for text 
 
 ### Axis Configurations
 
-Axis configurations define default settings for axes. Properties defined under the main `"axis"` object are applied to _all_ axes.
+Axis configurations define default settings for axes. Properties defined under the main `"axis"` object are applied to _all_ axes. Additional property blocks can target more specific axis types based on the orientation (`"axisX"`, `"axisY"`, `"axisLeft"`, `"axisTop"`, etc.), band scale type (`"axisBand"`), scale's data type (`"axisDiscrete"`, `"axisQuantitative"`, and `"axisTemporal"`), or both orientation and scale/data type (e.g., `"axisXTemporal"`). For example, properties defined under the `"axisBand"` property will only apply to axes visualizing `"band"` scales. If multiple axis config blocks apply to a single axis, type-based options take precedence over orientation-based options, which in turn take precedence over general options.
 
-Additional property blocks can target more specific axis types based on the orientation (`"axisX"`, `"axisY"`, `"axisLeft"`, `"axisTop"`, etc.), band scale type (`"axisBand"`), or scale's data type (`"axisQuantitative"` and `"axisTemporal"`). For example, properties defined under the `"axisBand"` property will only apply to axes visualizing `"band"` scales. If multiple axis config blocks apply to a single axis, type-based options take precedence over orientation-based options, which in turn take precedence over general options.
+See more details in the [axis documentation](axis.html#config).
 
-{% include table.html props="axis,axisX,axisY,axisLeft,axisRight,axisTop,axisBottom,axisBand,axisPoint,axisDiscrete,axisQuantitative,axisTemporal" source="Config" %}
+{% include table.html props="axis,axisX,axisY,axisLeft,axisRight,axisTop,axisBottom,axisBand,axisPoint,axisDiscrete,axisQuantitative,axisTemporal,axisXBand,axisXPoint,axisXDiscrete,axisXQuantitative,axisXTemporal,axisYBand,axisYPoint,axisYDiscrete,axisYQuantitative,axisYTemporal" source="Config" %}
 
 {:#header-config}
 

--- a/site/docs/encoding/axis.md
+++ b/site/docs/encoding/axis.md
@@ -154,7 +154,7 @@ We can also conditionally hide some labels and ticks in the following Lasagna pl
 
 Axis configuration defines default settings for axes. Properties defined under the `"axis"` property in the top-level [`config`](config.html) object are applied to _all_ axes.
 
-Additional property blocks can target more specific axis types based on the orientation (`"axisX"`, `"axisY"`, `"axisLeft"`, `"axisTop"`, etc.), band scale type (`"axisBand"`), or scale's data type (`"axisQuantitative"` and `"axisTemporal"`). For example, properties defined under the `"axisBand"` property will only apply to axes visualizing `"band"` scales.
+Additional property blocks can target more specific axis types based on the orientation (`"axisX"`, `"axisY"`, `"axisLeft"`, `"axisTop"`, etc.), band scale type (`"axisBand"`), scale's data type (`"axisDiscrete"`, `"axisQuantitative"`, and `"axisTemporal"`), or both orientation and scale/data type (e.g., `"axisXTemporal"`). For example, properties defined under the `"axisBand"` property will only apply to axes visualizing `"band"` scales.
 
 An axis configuration supports all [axis properties](#properties) except `position`, `orient`, `format`, `values`, and `zindex`.
 
@@ -167,9 +167,11 @@ An axis configuration supports all [axis properties](#properties) except `positi
 - In summary, here is the precedence level order for each axis property (from the highest to the lowest):
   - Axis properties (`axis.*`)
   - Axis style (`config.axis[axis.style].*`)
+  - Orientation and type based axis config (e.g., `config.axisXBand.*`)
   - Type-based axis config (e.g., `config.axisBand.*`)
   - Orientation-based axis config (`config.axisX/Y.*`)
   - General axis config (`config.axis.*`)
+  - Style of orientation and type based axis config (e.g., `config.style[config.axisXBand.style].*`)
   - Style of type-based axis config (e.g., `config.style[config.axisBand.style].*`)
   - Style of orientation-based axis config (e.g., `config.style[config.axisX.style].*`)
   - Style general axis config (`config.style[config.axis.style].*`)

--- a/site/docs/encoding/axis.md
+++ b/site/docs/encoding/axis.md
@@ -154,9 +154,25 @@ We can also conditionally hide some labels and ticks in the following Lasagna pl
 
 Axis configuration defines default settings for axes. Properties defined under the `"axis"` property in the top-level [`config`](config.html) object are applied to _all_ axes.
 
-Additional property blocks can target more specific axis types based on the orientation (`"axisX"`, `"axisY"`, `"axisLeft"`, `"axisTop"`, etc.), band scale type (`"axisBand"`), or scale's data type (`"axisQuantitative"` and `"axisTemporal"`). For example, properties defined under the `"axisBand"` property will only apply to axes visualizing `"band"` scales. If multiple axis config blocks apply to a single axis, type-based options take precedence over orientation-based options, which in turn take precedence over general options.
+Additional property blocks can target more specific axis types based on the orientation (`"axisX"`, `"axisY"`, `"axisLeft"`, `"axisTop"`, etc.), band scale type (`"axisBand"`), or scale's data type (`"axisQuantitative"` and `"axisTemporal"`). For example, properties defined under the `"axisBand"` property will only apply to axes visualizing `"band"` scales.
 
 An axis configuration supports all [axis properties](#properties) except `position`, `orient`, `format`, `values`, and `zindex`.
+
+**Note:**
+
+- If multiple axis config blocks apply to a single axis, type-based options take precedence over orientation-based options, which in turn take precedence over general options.
+
+- If an axis config has a style property, the style will have lower precedence than any of the axis config properties.
+
+- In summary, here is the precedence level order for each axis property (from the highest to the lowest):
+  - Axis properties (`axis.*`)
+  - Axis style (`config.axis[axis.style].*`)
+  - Type-based axis config (e.g., `config.axisBand.*`)
+  - Orientation-based axis config (`config.axisX/Y.*`)
+  - General axis config (`config.axis.*`)
+  - Style of type-based axis config (e.g., `config.style[config.axisBand.style].*`)
+  - Style of orientation-based axis config (e.g., `config.style[config.axisX.style].*`)
+  - Style general axis config (`config.style[config.axis.style].*`)
 
 **See also:** [Axis Labels Properties](#labels) and [`guide-label` style config](mark.html#style-config) (common styles for by axis, [legend](legend.html), and [header](facet.html#header) labels).
 

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -570,4 +570,54 @@ export interface AxisConfigMixins {
    * Config for temporal axes.
    */
   axisTemporal?: AxisConfig;
+
+  /**
+   * Config for x-axes with "band" scales.
+   */
+  axisXBand?: AxisConfig;
+
+  /**
+   * Config for x-axes with "point" scales.
+   */
+  axisXPoint?: AxisConfig;
+
+  /**
+   * Config for x-axes with "point" or "band" scales.
+   */
+  axisXDiscrete?: AxisConfig;
+
+  /**
+   * Config for x-quantitative axes.
+   */
+  axisXQuantitative?: AxisConfig;
+
+  /**
+   * Config for x-temporal axes.
+   */
+  axisXTemporal?: AxisConfig;
+
+  /**
+   * Config for y-axes with "band" scales.
+   */
+  axisYBand?: AxisConfig;
+
+  /**
+   * Config for y-axes with "point" scales.
+   */
+  axisYPoint?: AxisConfig;
+
+  /**
+   * Config for y-axes with "point" or "band" scales.
+   */
+  axisYDiscrete?: AxisConfig;
+
+  /**
+   * Config for y-quantitative axes.
+   */
+  axisYQuantitative?: AxisConfig;
+
+  /**
+   * Config for y-temporal axes.
+   */
+  axisYTemporal?: AxisConfig;
 }

--- a/src/axis.ts
+++ b/src/axis.ts
@@ -236,11 +236,11 @@ export interface AxisPropsWithConditionAndSignal {
 
 export type AxisConfig = VlOnlyGuideConfig &
   AxisConfigBaseWithConditionalAndSignal &
-  Pick<Axis, 'labelExpr' | 'labelOffset' | 'tickCount'>;
+  Pick<Axis, 'labelExpr' | 'labelOffset' | 'tickCount' | 'style'>;
 
 export interface Axis extends AxisConfigBaseWithConditionalAndSignal, Guide {
   /**
-   * A string or array of strings indicating the name of custom styles to apply to the axis. A style is a named collection of axis property defined within the [style configuration](https://vega.github.io/vega-lite/docs/mark.html#style-config). If style is an array, later styles will override earlier styles. Any [axis properties](https://vega.github.io/vega-lite/docs/encoding.html#mark-prop) explicitly defined within the `encoding` will override a style default.
+   * A string or array of strings indicating the name of custom styles to apply to the axis. A style is a named collection of axis property defined within the [style configuration](https://vega.github.io/vega-lite/docs/mark.html#style-config). If style is an array, later styles will override earlier styles.
    *
    * __Default value:__ (none)
    * __Note:__ Any specified style will augment the default style. For example, an x-axis mark with `"style": "foo"` will use `config.axisX` and `config.style.foo` (the specified style `"foo"` has higher precedence).

--- a/src/compile/axis/config.ts
+++ b/src/compile/axis/config.ts
@@ -12,7 +12,7 @@ export function getAxisConfig(
   scaleType: ScaleType,
   style: string | string[]
 ) {
-  const styleConfig = getStyleConfig(property, style, config.style);
+  let styleConfig = getStyleConfig(property, style, config.style);
 
   if (styleConfig !== undefined) {
     return {
@@ -36,12 +36,27 @@ export function getAxisConfig(
     'axis'
   ];
 
+  // apply properties in config Types first
+
   for (const configType of configTypes) {
     if (config[configType]?.[property] !== undefined) {
       return {
         configFrom: configType,
         configValue: config[configType][property]
       };
+    }
+  }
+
+  // then apply style in config types
+  for (const configType of configTypes) {
+    if (config[configType]?.style) {
+      styleConfig = getStyleConfig(property, config[configType]?.style, config.style);
+      if (styleConfig !== undefined) {
+        return {
+          configFrom: 'axis-config-style',
+          configValue: styleConfig
+        };
+      }
     }
   }
 

--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -1,4 +1,5 @@
 import {AxisEncode as VgAxisEncode, AxisOrient, SignalRef, Text} from 'vega';
+import {toSet} from 'vega-util';
 import {Axis, AXIS_PARTS, isAxisProperty, isConditionalAxisValue} from '../../axis';
 import {isBinned} from '../../bin';
 import {PositionScaleChannel, POSITION_SCALE_CHANNELS, X, Y} from '../../channel';
@@ -217,6 +218,13 @@ function isExplicit<T extends string | number | boolean | object>(
   return value === axis[property];
 }
 
+const TYPE_SUFFIX = ['Band', 'Point', 'Discrete', 'Quantitative', 'Temporal'];
+
+const ORIENTATION_TYPE_AXIS_CONFIG_INDEX = toSet([
+  ...TYPE_SUFFIX.map(t => `axisX${t}`),
+  ...TYPE_SUFFIX.map(t => `axisY${t}`)
+]);
+
 function parseAxis(channel: PositionScaleChannel, model: UnitModel): AxisComponent {
   const axis = model.axis(channel);
 
@@ -251,7 +259,10 @@ function parseAxis(channel: PositionScaleChannel, model: UnitModel): AxisCompone
       isConditionalAxisValue<any>(configValue) || // need to set "any" as TS isn't smart enough to figure the generic parameter type yet
       isSignalRef(configValue) ||
       // 3. StyleAxis
-      contains(['axisQuantitative', 'axisTemporal', 'style', 'axis-config-style'], configFrom)
+      contains(['style', 'axis-config-style'], configFrom) ||
+      // 4. Vega-Lite only config
+      contains(['axisQuantitative', 'axisTemporal'], configFrom) ||
+      configFrom in ORIENTATION_TYPE_AXIS_CONFIG_INDEX // axisXTemporal, ...
     ) {
       // If a config is specified and is conditional, copy conditional value from axis config
       axisComponent.set(property, configValue, false);

--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -251,7 +251,7 @@ function parseAxis(channel: PositionScaleChannel, model: UnitModel): AxisCompone
       isConditionalAxisValue<any>(configValue) || // need to set "any" as TS isn't smart enough to figure the generic parameter type yet
       isSignalRef(configValue) ||
       // 3. StyleAxis
-      contains(['axisQuantitative', 'axisTemporal', 'style'], configFrom)
+      contains(['axisQuantitative', 'axisTemporal', 'style', 'axis-config-style'], configFrom)
     ) {
       // If a config is specified and is conditional, copy conditional value from axis config
       axisComponent.set(property, configValue, false);

--- a/test/compile/axis/parse.test.ts
+++ b/test/compile/axis/parse.test.ts
@@ -191,7 +191,8 @@ describe('Axis', () => {
 
       const axisComponent = parseUnitAxes(model);
       expect(axisComponent['x'].length).toEqual(1);
-      expect(axisComponent['x'][0].implicit.labelColor).toEqual(undefined); // blue would get applied with Vega's logic
+      expect(axisComponent['x'][0].implicit.labelColor).toEqual(undefined); 
+      // Vega-Lite doesn't have to output "blue" here since Vega will apply config.axisX.labelColor and renders blue label color anyway.
     });
 
     it('should produce axis component with grid=false', () => {

--- a/test/compile/axis/parse.test.ts
+++ b/test/compile/axis/parse.test.ts
@@ -152,6 +152,25 @@ describe('Axis', () => {
       expect(axisComponent['x'][0].implicit.labelColor).toEqual('red');
     });
 
+    it('should include axis property in orientation and type based axis config style', () => {
+      const model = parseUnitModelWithScale({
+        mark: 'point',
+        encoding: {
+          x: {
+            field: 'a',
+            type: 'quantitative'
+          }
+        },
+        config: {
+          axisXQuantitative: {labelColor: 'red'}
+        }
+      });
+
+      const axisComponent = parseUnitAxes(model);
+      expect(axisComponent['x'].length).toEqual(1);
+      expect(axisComponent['x'][0].implicit.labelColor).toEqual('red');
+    });
+
     it('should include axis property in axis config over axis config style', () => {
       const model = parseUnitModelWithScale({
         mark: 'point',

--- a/test/compile/axis/parse.test.ts
+++ b/test/compile/axis/parse.test.ts
@@ -130,6 +130,51 @@ describe('Axis', () => {
       expect(axisComponent['x'][0].implicit.labelColor).toEqual('red');
     });
 
+    it('should include axis property in axis config style', () => {
+      const model = parseUnitModelWithScale({
+        mark: 'point',
+        encoding: {
+          x: {
+            field: 'a',
+            type: 'quantitative'
+          }
+        },
+        config: {
+          axis: {style: 'foo'},
+          style: {
+            foo: {labelColor: 'red'}
+          }
+        }
+      });
+
+      const axisComponent = parseUnitAxes(model);
+      expect(axisComponent['x'].length).toEqual(1);
+      expect(axisComponent['x'][0].implicit.labelColor).toEqual('red');
+    });
+
+    it('should include axis property in axis config over axis config style', () => {
+      const model = parseUnitModelWithScale({
+        mark: 'point',
+        encoding: {
+          x: {
+            field: 'a',
+            type: 'quantitative'
+          }
+        },
+        config: {
+          axis: {style: 'foo'},
+          axisX: {labelColor: 'blue'},
+          style: {
+            foo: {labelColor: 'red'}
+          }
+        }
+      });
+
+      const axisComponent = parseUnitAxes(model);
+      expect(axisComponent['x'].length).toEqual(1);
+      expect(axisComponent['x'][0].implicit.labelColor).toEqual(undefined); // blue would get applied with Vega's logic
+    });
+
     it('should produce axis component with grid=false', () => {
       const model = parseUnitModelWithScale({
         mark: 'point',

--- a/test/compile/axis/parse.test.ts
+++ b/test/compile/axis/parse.test.ts
@@ -191,7 +191,7 @@ describe('Axis', () => {
 
       const axisComponent = parseUnitAxes(model);
       expect(axisComponent['x'].length).toEqual(1);
-      expect(axisComponent['x'][0].implicit.labelColor).toEqual(undefined); 
+      expect(axisComponent['x'][0].implicit.labelColor).toEqual(undefined);
       // Vega-Lite doesn't have to output "blue" here since Vega will apply config.axisX.labelColor and renders blue label color anyway.
     });
 


### PR DESCRIPTION
Merge https://github.com/vega/vega-lite/pull/6082 first 