### PR TITLE
feat: support header `orient` as a shortcut for setting both labelOrient and titleOrient

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -8077,6 +8077,10 @@
           "description": "A boolean flag indicating if labels should be included as part of the header.\n\n__Default value:__ `true`.",
           "type": "boolean"
         },
+        "orient": {
+          "$ref": "#/definitions/Orient",
+          "description": "Shortcut for setting both labelOrient and titleOrient."
+        },
         "title": {
           "anyOf": [
             {
@@ -8214,6 +8218,10 @@
         "labels": {
           "description": "A boolean flag indicating if labels should be included as part of the header.\n\n__Default value:__ `true`.",
           "type": "boolean"
+        },
+        "orient": {
+          "$ref": "#/definitions/Orient",
+          "description": "Shortcut for setting both labelOrient and titleOrient."
         },
         "title": {
           "description": "Set to null to disable title for the axis, legend, or header.",

--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -928,6 +928,21 @@ export function initFieldDef(fd: FieldDef<string>, channel: Channel) {
     }
   }
 
+  if (isFacetFieldDef(fieldDef)) {
+    const {header} = fieldDef;
+    const {orient, ...rest} = header;
+    if (orient) {
+      return {
+        ...fieldDef,
+        header: {
+          ...rest,
+          labelOrient: header.labelOrient || orient,
+          titleOrient: header.titleOrient || orient
+        }
+      };
+    }
+  }
+
   return fieldDef;
 }
 

--- a/src/header.ts
+++ b/src/header.ts
@@ -192,6 +192,11 @@ export interface CoreHeader extends FormatMixins {
    * __Default value:__ `10`
    */
   labelPadding?: number | SignalRef;
+
+  /**
+   * Shortcut for setting both labelOrient and titleOrient.
+   */
+  orient?: Orient; // no signal ref since there is a dependent logic
 }
 
 export interface HeaderConfig extends CoreHeader, VlOnlyGuideConfig {}

--- a/test/channeldef.test.ts
+++ b/test/channeldef.test.ts
@@ -10,6 +10,7 @@ import {
   vgField
 } from '../src/channeldef';
 import * as log from '../src/log';
+import {FacetFieldDef} from '../src/spec/facet';
 import {TimeUnit} from '../src/timeunit';
 import {QUANTITATIVE, TEMPORAL} from '../src/type';
 
@@ -71,6 +72,15 @@ describe('fieldDef', () => {
     it('should standardize non-string field to string', () => {
       const fieldDef: TypedFieldDef<string> = {field: 1 as any, type: 'q' as any};
       expect(initChannelDef(fieldDef, 'x')).toEqual({field: '1', type: 'quantitative'});
+    });
+
+    it('converts header orient to labelOrient and titleOrient', () => {
+      const fieldDef: FacetFieldDef<string> = {field: 1 as any, type: 'quantitative', header: {orient: 'bottom'}};
+      expect(initChannelDef(fieldDef, 'row')).toEqual({
+        field: '1',
+        type: 'quantitative',
+        header: {labelOrient: 'bottom', titleOrient: 'bottom'}
+      });
     });
 
     it(


### PR DESCRIPTION
fix #4637

This would help with discoverability. Basically both axis and legend do have `orient`, so it would be consistent for header to have it too.