### PR TITLE
feat: support "width" / "height" in the range array

### DIFF
--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -111,11 +111,7 @@ export function parseRangeForChannel(channel: ScaleChannel, model: UnitModel): E
                   if (v === 'width' || v === 'height') {
                     // get signal for width/height
 
-                    // Note that, just like default range logic below, these range signals are temporary
-                    // as they can be merged and renamed.
-                    // (We do not have the right size signal here since parseLayoutSize() happens after parseScale().)
-                    // We will later replace these temporary names with
-                    // the final name in assembleScaleRange()
+                    // Just like default range logic below, we use SignalRefWrapper to account for potential merges and renames.
 
                     const sizeSignal = model.getName(v);
                     const getSignalName = model.getSignalName.bind(model);
@@ -189,11 +185,7 @@ function defaultRange(channel: ScaleChannel, model: UnitModel): VgRange {
       }
 
       // If step is null, use zero to width or height.
-      // Note that these range signals are temporary
-      // as they can be merged and renamed.
-      // (We do not have the right size signal here since parseLayoutSize() happens after parseScale().)
-      // We will later replace these temporary names with
-      // the final name in assembleScaleRange()
+      // Note that we use SignalRefWrapper to account for potential merges and renames.
 
       const sizeType = getSizeType(channel);
       const sizeSignal = model.getName(sizeType);

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -105,7 +105,27 @@ export function parseRangeForChannel(channel: ScaleChannel, model: UnitModel): E
       } else {
         switch (property) {
           case 'range':
-            return makeExplicit(specifiedScale[property]);
+            if (isArray(specifiedScale.range) && (channel === 'x' || channel === 'y')) {
+              return makeExplicit(
+                specifiedScale.range.map(v => {
+                  if (v === 'width' || v === 'height') {
+                    // get signal for width/height
+
+                    // Note that, just like default range logic below, these range signals are temporary
+                    // as they can be merged and renamed.
+                    // (We do not have the right size signal here since parseLayoutSize() happens after parseScale().)
+                    // We will later replace these temporary names with
+                    // the final name in assembleScaleRange()
+
+                    const sizeSignal = model.getName(v);
+                    const getSignalName = model.getSignalName.bind(model);
+                    return SignalRefWrapper.fromName(getSignalName, sizeSignal);
+                  }
+                  return v;
+                })
+              );
+            }
+            return makeExplicit(specifiedScale.range);
           case 'scheme':
             return makeExplicit(parseScheme(specifiedScale[property]));
         }

--- a/test/compile/scale/range.test.ts
+++ b/test/compile/scale/range.test.ts
@@ -67,6 +67,20 @@ describe('compile/scale', () => {
         }
       });
 
+      it('should return signal for width and height strings in range', () => {
+        const model = parseUnitModelWithScaleExceptRange({
+          mark: 'point',
+          encoding: {
+            x: {field: 'x', type: 'nominal', scale: {range: [40, 'width']}},
+            y: {field: 'y', type: 'nominal', scale: {range: ['height', 40]}}
+          }
+        });
+
+        expect(parseRangeForChannel('x', model)).toEqual(makeExplicit([40, {signal: 'width'}]));
+
+        expect(parseRangeForChannel('y', model)).toEqual(makeExplicit([{signal: 'height'}, 40]));
+      });
+
       it('should return config.view.discreteWidth for x/y-band/point scales by default.', () => {
         for (const scaleType of [ScaleType.BAND, ScaleType.POINT]) {
           const model = parseUnitModelWithScaleExceptRange({


### PR DESCRIPTION
fix #5501

This could be important for making a layer not using the whole width height.

Even if we have signals, users don't always know the width/height signal names in multi-view settings without looking at vega, so this will still be useful.
