### PR TITLE
fix: rule orientation for binned data (e.g., error bar for binned data)

### DIFF
--- a/src/compile/mark/init.ts
+++ b/src/compile/mark/init.ts
@@ -149,7 +149,7 @@ function orient(mark: Mark, encoding: Encoding<string>, specifiedOrient: Orienta
     // falls through
     case RULE:
       // return undefined for line segment rule and bar with both axis ranged
-      // we have to ignore that case that the data are already binned though
+      // we have to ignore the case that the data are already binned
       if (x2 && !(isFieldDef(x) && isBinned(x.bin)) && y2 && !(isFieldDef(y) && isBinned(y.bin))) {
         return undefined;
       }

--- a/src/compile/mark/init.ts
+++ b/src/compile/mark/init.ts
@@ -149,7 +149,8 @@ function orient(mark: Mark, encoding: Encoding<string>, specifiedOrient: Orienta
     // falls through
     case RULE:
       // return undefined for line segment rule and bar with both axis ranged
-      if (x2 && y2) {
+      // we have to ignore that case that the data are already binned though
+      if (x2 && !(isFieldDef(x) && isBinned(x.bin)) && y2 && !(isFieldDef(y) && isBinned(y.bin))) {
         return undefined;
       }
 


### PR DESCRIPTION
fix #5489

![image](https://user-images.githubusercontent.com/111269/76707317-5897b700-66ab-11ea-97a9-dba9cae6db4a.png)

