### PR TITLE
chore: add timer (in ms) to build-example script, so we can benchmark

### DIFF
--- a/scripts/build-example.sh
+++ b/scripts/build-example.sh
@@ -4,10 +4,13 @@ set -eo pipefail
 
 dir=${dir-"examples/compiled"}
 
+# mac osx doesn't have ms time, need to use python -- https://apple.stackexchange.com/a/314573
+start=`python -c 'from time import time; print int(round(time() * 1000))'`
+end=`python -c 'from time import time; print int(round(time() * 1000))'`
+timertime=$((end-start))
+
 for name in "$@"
 do
-  echo "Compiling $name" # to $dir (nopatch=$nopatch, forcesvg=$forcesvg)"
-
   # compile normalized example if $skipnormalize is not set
   if [ ! -n "$skipnormalize" ]; then
     #build full vl example
@@ -16,12 +19,21 @@ do
 
   # compile Vega example
   rm -f examples/compiled/$name.vg.json
+
+  start=`python -c 'from time import time; print int(round(time() * 1000))'`
+
   bin/vl2vg -p examples/specs/$name.vl.json > examples/compiled/$name.vg.json
+
+  end=`python -c 'from time import time; print int(round(time() * 1000))'`
+  runtime=$((end-start-timertime)) # minus 100 because python takes about 100ms to run the time
+
+  echo "Compiling $name (~$runtime ms)" # to $dir (nopatch=$nopatch, forcesvg=$forcesvg)"
 
   # compile SVG if one of the following condition is true
   # 1) Vega spec has changed
   # 2) The SVG file does not exist (new example would not have vg file diff)
   # or 3) the forcesvg environment variable is true
+
   if (! git diff $nopatch --exit-code $dir/$name.vg.json || [ ! -f $dir/$name.svg ] || $forcesvg)
   then
     rm -f examples/compiled/$name.svg

--- a/scripts/build-example.sh
+++ b/scripts/build-example.sh
@@ -4,9 +4,9 @@ set -eo pipefail
 
 dir=${dir-"examples/compiled"}
 
-# mac osx doesn't have ms time, need to use python -- https://apple.stackexchange.com/a/314573
-start=`python -c 'from time import time; print int(round(time() * 1000))'`
-end=`python -c 'from time import time; print int(round(time() * 1000))'`
+# mac osx doesn't have ms time, need to use perl -- https://apple.stackexchange.com/a/314573
+start=`perl -MTime::HiRes=time -e 'printf "%d\n", time*1000'`
+end=`perl -MTime::HiRes=time -e 'printf "%d\n", time*1000'`
 timertime=$((end-start))
 
 for name in "$@"
@@ -20,12 +20,12 @@ do
   # compile Vega example
   rm -f examples/compiled/$name.vg.json
 
-  start=`python -c 'from time import time; print int(round(time() * 1000))'`
+  start=`perl -MTime::HiRes=time -e 'printf "%d\n", time*1000'`
 
   bin/vl2vg -p examples/specs/$name.vl.json > examples/compiled/$name.vg.json
 
-  end=`python -c 'from time import time; print int(round(time() * 1000))'`
-  runtime=$((end-start-timertime)) # minus 100 because python takes about 100ms to run the time
+  end=`perl -MTime::HiRes=time -e 'printf "%d\n", time*1000'`
+  runtime=$((end-start-timertime)) # minus 100 because perl takes about 20ms to run the time
 
   echo "Compiling $name (~$runtime ms)" # to $dir (nopatch=$nopatch, forcesvg=$forcesvg)"
 


### PR DESCRIPTION
The console will now output

```
Compiling bar (~160 ms)
```

instead of 

```
Compiling bar
```


Note that `build:example` is much faster than building each example in the parallel version (`build:examples`)