### PR TITLE
perf: avoid redundant axisConfigType calculation

### DIFF
--- a/src/compile/axis/config.ts
+++ b/src/compile/axis/config.ts
@@ -1,16 +1,11 @@
 import {Axis} from '../../axis';
-import {PositionScaleChannel} from '../../channel';
 import {Config} from '../../config';
-import {isQuantitative, ScaleType} from '../../scale';
-import {titlecase} from '../../util';
 import {getStyleConfig} from '../common';
 
 export function getAxisConfig(
   property: keyof Axis,
   config: Config,
-  channel: PositionScaleChannel,
-  orient: string,
-  scaleType: ScaleType,
+  axisConfigTypes: string[],
   style: string | string[]
 ) {
   let styleConfig = getStyleConfig(property, style, config.style);
@@ -22,31 +17,9 @@ export function getAxisConfig(
     };
   }
 
-  const typeBasedConfigs = [
-    ...(scaleType === 'band' ? ['axisBand', 'axisDiscrete'] : []),
-    ...(scaleType === 'point' ? ['axisPoint', 'axisDiscrete'] : []),
-    ...(isQuantitative(scaleType) ? ['axisQuantitative'] : []),
-    ...(scaleType === 'time' || scaleType === 'utc' ? ['axisTemporal'] : [])
-  ];
-
-  const channelBasedConfig = channel === 'x' ? 'axisX' : 'axisY';
-
-  // configTypes to loop, starting from higher precedence
-  const axisConfigs = [
-    ...typeBasedConfigs.map(c => channelBasedConfig + c.substr(4)),
-
-    ...typeBasedConfigs,
-    // X/Y
-    channelBasedConfig,
-
-    // axisTop, axisBottom, ...
-    ...(orient ? ['axis' + titlecase(orient)] : []),
-    'axis'
-  ];
-
   // apply properties in config Types first
 
-  for (const configType of axisConfigs) {
+  for (const configType of axisConfigTypes) {
     if (config[configType]?.[property] !== undefined) {
       return {
         configFrom: configType,
@@ -56,7 +29,7 @@ export function getAxisConfig(
   }
 
   // then apply style in config types
-  for (const configType of axisConfigs) {
+  for (const configType of axisConfigTypes) {
     if (config[configType]?.style) {
       styleConfig = getStyleConfig(property, config[configType]?.style, config.style);
       if (styleConfig !== undefined) {

--- a/src/compile/axis/properties.ts
+++ b/src/compile/axis/properties.ts
@@ -4,7 +4,6 @@ import {Axis} from '../../axis';
 import {isBinning} from '../../bin';
 import {PositionScaleChannel, X, Y} from '../../channel';
 import {DatumDef, isDiscrete, isFieldDef, TypedFieldDef, valueArray} from '../../channeldef';
-import * as log from '../../log';
 import {Mark} from '../../mark';
 import {hasDiscreteDomain, ScaleType} from '../../scale';
 import {normalizeTimeUnit} from '../../timeunit';
@@ -36,21 +35,15 @@ export function labelAngle(
   model: UnitModel,
   specifiedAxis: Axis,
   channel: PositionScaleChannel,
-  fieldOrDatumDef: TypedFieldDef<string> | DatumDef
+  fieldOrDatumDef: TypedFieldDef<string> | DatumDef,
+  axisConfigTypes: string[]
 ) {
   // try axis value
   if (specifiedAxis?.labelAngle !== undefined) {
     return normalizeAngle(specifiedAxis?.labelAngle);
   } else {
     // try axis config value
-    const {configValue: angle} = getAxisConfig(
-      'labelAngle',
-      model.config,
-      channel,
-      orient(channel),
-      model.getScaleComponent(channel).get('type'),
-      specifiedAxis?.style
-    );
+    const {configValue: angle} = getAxisConfig('labelAngle', model.config, axisConfigTypes, specifiedAxis?.style);
     if (angle !== undefined) {
       return normalizeAngle(angle);
     } else {
@@ -137,8 +130,6 @@ export function orient(channel: PositionScaleChannel) {
     case Y:
       return 'left';
   }
-  /* istanbul ignore next: This should never happen. */
-  throw new Error(log.message.INVALID_CHANNEL_FOR_AXIS);
 }
 
 export function defaultTickCount({

--- a/test/compile/axis/properties.test.ts
+++ b/test/compile/axis/properties.test.ts
@@ -193,23 +193,27 @@ describe('compile/axis', () => {
     });
 
     it('should return the correct labelAngle from the axis definition', () => {
-      expect(240).toEqual(labelAngle(axisModel, axisModel.axis('y'), 'y', axisModel.typedFieldDef('y')));
+      expect(240).toEqual(labelAngle(axisModel, axisModel.axis('y'), 'y', axisModel.typedFieldDef('y'), []));
     });
 
     it('should return the correct labelAngle from the axis config definition', () => {
-      expect(140).toEqual(labelAngle(configModel, configModel.axis('y'), 'y', configModel.typedFieldDef('y')));
+      expect(140).toEqual(
+        labelAngle(configModel, configModel.axis('y'), 'y', configModel.typedFieldDef('y'), ['axis'])
+      );
     });
 
     it('should return the correct default labelAngle when not specified', () => {
-      expect(270).toEqual(labelAngle(defaultModel, defaultModel.axis('x'), 'x', defaultModel.typedFieldDef('x')));
+      expect(270).toEqual(labelAngle(defaultModel, defaultModel.axis('x'), 'x', defaultModel.typedFieldDef('x'), []));
     });
 
     it('should return the labelAngle declared in the axis when both the axis and axis config have labelAngle', () => {
-      expect(240).toEqual(labelAngle(bothModel, bothModel.axis('y'), 'y', bothModel.typedFieldDef('y')));
+      expect(240).toEqual(labelAngle(bothModel, bothModel.axis('y'), 'y', bothModel.typedFieldDef('y'), []));
     });
 
     it('should return undefined when there is no default and no specified labelAngle', () => {
-      expect(undefined).toEqual(labelAngle(neitherModel, neitherModel.axis('y'), 'y', neitherModel.typedFieldDef('y')));
+      expect(undefined).toEqual(
+        labelAngle(neitherModel, neitherModel.axis('y'), 'y', neitherModel.typedFieldDef('y'), [])
+      );
     });
   });
 


### PR DESCRIPTION
This may reduce ~5% of compile time on my computer from a set of quick runs. 