### PR TITLE
docs: add missing properties for title parameter object

### DIFF
--- a/site/docs/view/title.md
+++ b/site/docs/view/title.md
@@ -17,7 +17,7 @@ For example, the following bar chart is titled "A Simple Bar Chart".
 
 A `title` parameter object can contain the following properties:
 
-{% include table.html props="text,anchor,angle,baseline,color,font,fontSize,fontStyle,fontWeight,frame,limit,offset,orient,style,zindex" source="TitleParams" %}
+{% include table.html props="text,align,anchor,angle,baseline,color,dx,dy,font,fontSize,fontStyle,fontWeight,frame,limit,lineHeight,offset,orient,style,subtitle,subtitleColor,subtitleFont,subtitleFontSize,subtitleFontStyle,subtitleFontWeight,subtitleLineHeight,subtitlePadding,zindex" source="TitleParams" %}
 
 For example, we can customize the `anchor` of the title of a bar chart.
 


### PR DESCRIPTION
Added the following props to view/title.html spec page: align, dx, dy, lineHeight, and subtitle props

Fixes #6220