### PR TITLE
[WIP] Don't log warning when encodingOverridden

### DIFF
--- a/src/normalize/core.ts
+++ b/src/normalize/core.ts
@@ -336,7 +336,7 @@ function mergeEncoding(opt: {parentEncoding: Encoding<any>; encoding: Encoding<a
     }, []);
 
     if (overriden.length > 0) {
-      log.warn(log.message.encodingOverridden(overriden));
+      log.info(log.message.encodingOverridden(overriden));
     }
   }
 

--- a/src/normalize/core.ts
+++ b/src/normalize/core.ts
@@ -328,15 +328,15 @@ export class CoreNormalizer extends SpecMapper<NormalizerParams, FacetedUnitSpec
 function mergeEncoding(opt: {parentEncoding: Encoding<any>; encoding: Encoding<any>}): Encoding<any> {
   const {parentEncoding, encoding} = opt;
   if (parentEncoding && encoding) {
-    const overriden = keys(parentEncoding).reduce((o, key) => {
+    const overridden = keys(parentEncoding).reduce((o, key) => {
       if (encoding[key]) {
         o.push(key);
       }
       return o;
     }, []);
 
-    if (overriden.length > 0) {
-      log.info(log.message.encodingOverridden(overriden));
+    if (overridden.length > 0) {
+      log.info(log.message.encodingOverridden(overridden));
     }
   }
 


### PR DESCRIPTION
The ability to override a channel is a nice feature of hierarchical layers. E.g., this spec defines a default fill color for all the sub-layers, which is overridden by the one that is a text layer:

```json
{
  "$schema": "https://vega.github.io/schema/vega-lite/v4.9.0.json",
  "data": { "values": [1] },
  "encoding": { 
    "stroke": { "value": "red" }
  },
  "layer": [
    {
      "mark": "point",
      "encoding": {
        "x": { "value": 0 }
      }
    },
    {
      "mark": "point",
      "encoding": {
      }
    },
    {
      "mark": "point",
      "encoding": {
        "x": { "value": "width" }
      }
    },
    {
      "mark": { "type": "text", "dy": 20 },
      "encoding": {
        "text": { "value": "XYZ" },
        "stroke": { "value": "black" }
      }
    }
  ]
}
```

As of VL 4.9, this spec raises the console warning:

```console
[Warning] Layer's shared stroke channel is overriden.
```

This makes it seem like the user is doing something wrong, when if fact they may just be taking advantage of this feature.
