### PR TITLE
fix: correct precedence for axis config style

### DIFF
--- a/src/compile/axis/config.ts
+++ b/src/compile/axis/config.ts
@@ -41,7 +41,7 @@ export function getAxisConfigs(channel: PositionScaleChannel, scaleType: ScaleTy
   return {
     vlOnlyAxisConfig: getAxisConfigFromConfigTypes(vlOnlyConfigTypes, config),
     vgAxisConfig: getAxisConfigFromConfigTypes(vgConfigTypes, config),
-    axisConfigStyle: getAxisConfigStyle([...vlOnlyConfigTypes, ...vgConfigTypes], config)
+    axisConfigStyle: getAxisConfigStyle([...vgConfigTypes, ...vlOnlyConfigTypes], config)
   };
 }
 


### PR DESCRIPTION
In https://github.com/vega/vega-lite/pull/6278, I used Object.assign to merge the configs instead of looping through them for each property.

However, this means that the array order has to go from the lowest precedence to the highest precedence. 