### PR TITLE
fix: arc marks shouldn't output `theta`

### DIFF
--- a/src/compile/mark/arc.ts
+++ b/src/compile/mark/arc.ts
@@ -11,7 +11,8 @@ export const arc: MarkCompiler = {
         baseline: 'ignore',
         color: 'include',
         size: 'ignore',
-        orient: 'ignore'
+        orient: 'ignore',
+        theta: 'ignore'
       }),
       ...encode.pointPosition('x', model, {defaultPos: 'mid'}),
       ...encode.pointPosition('y', model, {defaultPos: 'mid'}),

--- a/src/compile/mark/area.ts
+++ b/src/compile/mark/area.ts
@@ -11,7 +11,8 @@ export const area: MarkCompiler = {
         baseline: 'ignore',
         color: 'include',
         orient: 'include',
-        size: 'ignore'
+        size: 'ignore',
+        theta: 'ignore'
       }),
       ...encode.pointOrRangePosition('x', model, {
         defaultPos: 'zeroOrMin',

--- a/src/compile/mark/bar.ts
+++ b/src/compile/mark/bar.ts
@@ -11,7 +11,8 @@ export const bar: MarkCompiler = {
         baseline: 'ignore',
         color: 'include',
         orient: 'ignore',
-        size: 'ignore'
+        size: 'ignore',
+        theta: 'ignore'
       }),
       ...encode.rectPosition(model, 'x', 'bar'),
       ...encode.rectPosition(model, 'y', 'bar')

--- a/src/compile/mark/encode/base.ts
+++ b/src/compile/mark/encode/base.ts
@@ -21,7 +21,7 @@ export {rectPosition} from './position-rect';
 export {text} from './text';
 export {tooltip} from './tooltip';
 
-export type Ignore = Record<'color' | 'size' | 'orient' | 'align' | 'baseline', 'ignore' | 'include'>;
+export type Ignore = Record<'color' | 'size' | 'orient' | 'align' | 'baseline' | 'theta', 'ignore' | 'include'>;
 
 export function baseEncodeEntry(model: UnitModel, ignore: Ignore) {
   const {fill = undefined, stroke = undefined} = ignore.color === 'include' ? color(model) : {};

--- a/src/compile/mark/geoshape.ts
+++ b/src/compile/mark/geoshape.ts
@@ -15,7 +15,8 @@ export const geoshape: MarkCompiler = {
         baseline: 'ignore',
         color: 'include',
         size: 'ignore',
-        orient: 'ignore'
+        orient: 'ignore',
+        theta: 'ignore'
       })
     };
   },

--- a/src/compile/mark/image.ts
+++ b/src/compile/mark/image.ts
@@ -11,7 +11,8 @@ export const image: MarkCompiler = {
         baseline: 'ignore',
         color: 'ignore',
         orient: 'ignore',
-        size: 'ignore'
+        size: 'ignore',
+        theta: 'ignore'
       }),
       ...encode.rectPosition(model, 'x', 'image'),
       ...encode.rectPosition(model, 'y', 'image'),

--- a/src/compile/mark/line.ts
+++ b/src/compile/mark/line.ts
@@ -11,7 +11,8 @@ export const line: MarkCompiler = {
         baseline: 'ignore',
         color: 'include',
         size: 'ignore',
-        orient: 'ignore'
+        orient: 'ignore',
+        theta: 'ignore'
       }),
       ...encode.pointPosition('x', model, {defaultPos: 'mid'}),
       ...encode.pointPosition('y', model, {defaultPos: 'mid'}),
@@ -32,7 +33,8 @@ export const trail: MarkCompiler = {
         baseline: 'ignore',
         color: 'include',
         size: 'include',
-        orient: 'ignore'
+        orient: 'ignore',
+        theta: 'ignore'
       }),
       ...encode.pointPosition('x', model, {defaultPos: 'mid'}),
       ...encode.pointPosition('y', model, {defaultPos: 'mid'}),

--- a/src/compile/mark/point.ts
+++ b/src/compile/mark/point.ts
@@ -13,7 +13,8 @@ function encodeEntry(model: UnitModel, fixedShape?: 'circle' | 'square') {
       baseline: 'ignore',
       color: 'include',
       size: 'include',
-      orient: 'ignore'
+      orient: 'ignore',
+      theta: 'ignore'
     }),
     ...encode.pointPosition('x', model, {defaultPos: 'mid'}),
     ...encode.pointPosition('y', model, {defaultPos: 'mid'}),

--- a/src/compile/mark/rect.ts
+++ b/src/compile/mark/rect.ts
@@ -11,7 +11,8 @@ export const rect: MarkCompiler = {
         baseline: 'ignore',
         color: 'include',
         orient: 'ignore',
-        size: 'ignore'
+        size: 'ignore',
+        theta: 'ignore'
       }),
       ...encode.rectPosition(model, 'x', 'rect'),
       ...encode.rectPosition(model, 'y', 'rect')

--- a/src/compile/mark/rule.ts
+++ b/src/compile/mark/rule.ts
@@ -19,7 +19,8 @@ export const rule: MarkCompiler = {
         baseline: 'ignore',
         color: 'include',
         orient: 'ignore',
-        size: 'ignore'
+        size: 'ignore',
+        theta: 'ignore'
       }),
       ...encode.pointOrRangePosition('x', model, {
         defaultPos: orient === 'horizontal' ? 'zeroOrMax' : 'mid',

--- a/src/compile/mark/text.ts
+++ b/src/compile/mark/text.ts
@@ -18,7 +18,8 @@ export const text: MarkCompiler = {
         baseline: 'include',
         color: 'include',
         size: 'ignore',
-        orient: 'ignore'
+        orient: 'ignore',
+        theta: 'include'
       }),
       ...encode.pointPosition('x', model, {defaultPos: 'mid'}),
       ...encode.pointPosition('y', model, {defaultPos: 'mid'}),

--- a/src/compile/mark/tick.ts
+++ b/src/compile/mark/tick.ts
@@ -23,7 +23,8 @@ export const tick: MarkCompiler = {
         baseline: 'ignore',
         color: 'include',
         orient: 'ignore',
-        size: 'ignore'
+        size: 'ignore',
+        theta: 'ignore'
       }),
 
       ...encode.pointPosition('x', model, {defaultPos: 'mid', vgChannel: 'xc'}),

--- a/test/compile/mark/arc.test.ts
+++ b/test/compile/mark/arc.test.ts
@@ -2,6 +2,26 @@ import {arc} from '../../../src/compile/mark/arc';
 import {parseUnitModelWithScaleAndLayoutSize} from '../../util';
 
 describe('Mark: Arc', () => {
+  describe('with theta in mark def', () => {
+    // This is a simplified example for stacked text.
+    // In reality this will be used as stacked's overlayed marker
+    const model = parseUnitModelWithScaleAndLayoutSize({
+      mark: {
+        type: 'arc',
+        theta: 1.57,
+        theta2: 3.14
+      }
+    });
+
+    const props = arc.encodeEntry(model);
+
+    it('applies theta to startAngle and endAngle and not theta', () => {
+      expect(props.startAngle).toEqual({value: 1.57});
+      expect(props.endAngle).toEqual({value: 3.14});
+      expect(props.theta).toBeUndefined();
+    });
+  });
+
   describe('for pie', () => {
     // This is a simplified example for stacked text.
     // In reality this will be used as stacked's overlayed marker


### PR DESCRIPTION
Fix #6291