### PR TITLE
fix: hide startAngle/endAngle from mark def as they aren't necessary

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -12518,10 +12518,6 @@
           "description": "The ellipsis string for text truncated in response to the limit parameter.\n\n__Default value:__ `\"…\"`",
           "type": "string"
         },
-        "endAngle": {
-          "description": "The start angle in radians for arc marks.",
-          "type": "number"
-        },
         "fill": {
           "anyOf": [
             {
@@ -12682,10 +12678,6 @@
         "size": {
           "description": "Default size for marks.\n- For `point`/`circle`/`square`, this represents the pixel area of the marks. Note that this value sets the area of the symbol; the side lengths will increase with the square root of this value.\n- For `bar`, this represents the band size of the bar, in pixels.\n- For `text`, this represents the font size, in pixels.\n\n__Default value:__\n- `30` for point, circle, square marks; width/height's `step`\n- `2` for bar marks with discrete dimensions;\n- `5` for bar marks with continuous dimensions;\n- `11` for text marks.",
           "minimum": 0,
-          "type": "number"
-        },
-        "startAngle": {
-          "description": "The start angle in radians for arc marks.",
           "type": "number"
         },
         "stroke": {

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -558,12 +558,27 @@ export interface MarkDefMixins {
 // Point/Line OverlayMixins are only for area, line, and trail but we don't want to declare multiple types of MarkDef
 export interface MarkDef<M extends string | Mark = Mark>
   extends GenericMarkDef<M>,
-    MarkConfig,
-    AreaConfig,
-    BarConfig, // always extends RectConfig
-    LineConfig,
-    TickConfig,
-    MarkDefMixins {}
+    Omit<
+      MarkConfig &
+        AreaConfig &
+        BarConfig & // always extends RectConfig
+        LineConfig &
+        TickConfig,
+      'startAngle' | 'endAngle'
+    >,
+    MarkDefMixins {
+  // Omit startAngle/endAngle since we use theta/theta2 from Vega-Lite schema to avoid confusion
+  // We still support start/endAngle  only in config, just in case people use Vega config with Vega-Lite.
+
+  /**
+   * @hidden
+   */
+  startAngle?: number | SignalRef;
+  /**
+   * @hidden
+   */
+  endAngle?: number | SignalRef;
+}
 
 const DEFAULT_RECT_BAND_SIZE = 5;
 


### PR DESCRIPTION
We shouldn't include them as it's introducing multiple ways to do the same thing.

Plus, startAngle and endAngle doesn't really mean anything. 
(It's just like x and x2, in that neither of them is strictly start nor end.) 

I'd argue that this isn't a breaking change since I intentionally didn't document them in https://vega.github.io/vega-lite/docs/arc.html