### PR TITLE
fix: don't include fill/strokeOpacity legends (unsupported by Vega)

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -5482,19 +5482,19 @@
         },
         "hours": {
           "description": "Integer value representing the hour of a day from 0-23.",
-          "maximum": 23,
+          "maximum": 24,
           "minimum": 0,
           "type": "number"
         },
         "milliseconds": {
           "description": "Integer value representing the millisecond segment of time.",
-          "maximum": 999,
+          "maximum": 1000,
           "minimum": 0,
           "type": "number"
         },
         "minutes": {
           "description": "Integer value representing the minute segment of time from 0-59.",
-          "maximum": 59,
+          "maximum": 60,
           "minimum": 0,
           "type": "number"
         },
@@ -5517,7 +5517,7 @@
         },
         "seconds": {
           "description": "Integer value representing the second segment (0-59) of a time value",
-          "maximum": 59,
+          "maximum": 60,
           "minimum": 0,
           "type": "number"
         },

--- a/src/compile/legend/parse.ts
+++ b/src/compile/legend/parse.ts
@@ -1,5 +1,5 @@
 import {Legend as VgLegend, LegendEncode, SignalRef} from 'vega';
-import {COLOR, FILLOPACITY, NonPositionScaleChannel, SHAPE, STROKEOPACITY} from '../../channel';
+import {COLOR, NonPositionScaleChannel, SHAPE} from '../../channel';
 import {
   DatumDef,
   FieldDef,
@@ -40,7 +40,7 @@ function parseUnitLegend(model: UnitModel): LegendComponentIndex {
 
   const legendComponent: LegendComponentIndex = {};
 
-  for (const channel of [COLOR, ...LEGEND_SCALE_CHANNELS, FILLOPACITY, STROKEOPACITY]) {
+  for (const channel of [COLOR, ...LEGEND_SCALE_CHANNELS]) {
     const def = getFieldOrDatumDef(encoding[channel]) as MarkPropFieldDef<string> | MarkPropDatumDef<string>;
 
     if (!def || !model.getScaleComponent(channel)) {

--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -68,7 +68,7 @@ export interface DateTime {
   /**
    * Integer value representing the hour of a day from 0-23.
    * @minimum 0
-   * @maximum 23
+   * @maximum 24
    * @TJS-type integer
    */
   hours?: number;
@@ -76,7 +76,7 @@ export interface DateTime {
   /**
    * Integer value representing the minute segment of time from 0-59.
    * @minimum 0
-   * @maximum 59
+   * @maximum 60
    * @TJS-type integer
    */
   minutes?: number;
@@ -84,7 +84,7 @@ export interface DateTime {
   /**
    * Integer value representing the second segment (0-59) of a time value
    * @minimum 0
-   * @maximum 59
+   * @maximum 60
    * @TJS-type integer
    */
   seconds?: number;
@@ -92,7 +92,7 @@ export interface DateTime {
   /**
    * Integer value representing the millisecond segment of time.
    * @minimum 0
-   * @maximum 999
+   * @maximum 1000
    * @TJS-type integer
    */
   milliseconds?: number;

--- a/test/transformextract.test.ts
+++ b/test/transformextract.test.ts
@@ -55,6 +55,7 @@ describe('extractTransforms()', () => {
     'interactive_layered_crossfilter_discrete.vl.json',
     'interactive_layered_crossfilter.vl.json',
     'interactive_line_hover.vl.json',
+    'interactive_multi_line_label.vl.json',
     'interactive_seattle_weather.vl.json',
     'joinaggregate_mean_difference.vl.json',
     'layer_bar_dual_axis_minmax.vl.json',


### PR DESCRIPTION
merge https://github.com/vega/vega-lite/pull/6302 first 