### PR TITLE
refactor: consolidate labelAlign logic for x and y

### DIFF
--- a/src/compile/axis/properties.ts
+++ b/src/compile/axis/properties.ts
@@ -188,25 +188,28 @@ export function defaultLabelBaseline(angle: number, axisOrient: AxisOrient, chan
   return undefined;
 }
 
+function _defaultLabelAlign(angle: number, axisOrient: AxisOrient, startAngle: 0 | 90, mainOrient: 'bottom' | 'left') {
+  // TODO: generate signal based on a similar formula if orient is a signal
+  if ((angle + startAngle) % 180 === 0) {
+    return 'center';
+  } else if ((startAngle < angle && angle < 180 + startAngle) === (axisOrient === mainOrient)) {
+    return 'left';
+  }
+  return 'right';
+}
+
 export function defaultLabelAlign(angle: number, axisOrient: AxisOrient, channel?: 'x' | 'y'): Align {
   channel = channel || (axisOrient === 'top' || axisOrient === 'bottom' ? 'x' : 'y');
 
-  // TODO: generate signal based on a similar formula if orient is a signal
-
   if (angle !== undefined) {
     if (channel === 'x') {
-      return angle % 180 === 0 ? 'center' : angle < 180 === (axisOrient === 'top') ? 'right' : 'left';
+      return _defaultLabelAlign(angle, axisOrient, 0, 'bottom');
     } else {
-      return (angle + 90) % 180 === 0
-        ? 'center'
-        : (90 < angle && angle < 270) === (axisOrient === 'left')
-        ? 'left'
-        : 'right';
+      return _defaultLabelAlign(angle, axisOrient, 90, 'left');
     }
   }
   return undefined;
 }
-
 export function defaultLabelFlush(type: Type, channel: PositionScaleChannel) {
   if (channel === 'x' && contains(['quantitative', 'temporal'], type)) {
     return true;


### PR DESCRIPTION
so it's easier to write cases for signals


Re do of https://github.com/vega/vega-lite/pull/6309


The misleading check marks is really disrupting our flows:

![image](https://user-images.githubusercontent.com/111269/78912891-085b0d00-7a3d-11ea-86c1-6e7a1e9566d8.png)

