### PR TITLE
fix: support timestamp / month name in scale domain for single time unit

### DIFF
--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -1239,10 +1239,13 @@ export function valueExpr(
     expr = dateTimeToExpr(v);
   } else if (isString(v) || isNumber(v)) {
     if (unit || type === 'temporal') {
+      expr = `datetime(${JSON.stringify(v)})`;
+
       if (isLocalSingleTimeUnit(unit)) {
-        expr = dateTimeToExpr({[unit]: v});
-      } else {
-        expr = `datetime(${JSON.stringify(v)})`;
+        // for single timeUnit, we will use dateTimeToExpr to convert number/string to match the timeUnit
+        if ((isNumber(v) && v < 10000) || (isString(v) && isNaN(Date.parse(v)))) {
+          expr = dateTimeToExpr({[unit]: v});
+        }
       }
     }
   }

--- a/test/compile/scale/domain.test.ts
+++ b/test/compile/scale/domain.test.ts
@@ -558,6 +558,46 @@ describe('compile/scale', () => {
         ]);
       });
 
+      it('should return the right custom domain with single time unit', () => {
+        const model = parseUnitModel({
+          mark: 'point',
+          encoding: {
+            y: {
+              timeUnit: 'year',
+              field: 'date',
+              type: 'temporal',
+              scale: {domain: [1970, {year: 1980}]}
+            }
+          }
+        });
+        const _domain = testParseDomainForChannel(model, 'y');
+
+        expect(_domain).toEqual([
+          {signal: '{data: datetime(1970, 0, 1, 0, 0, 0, 0)}'},
+          {signal: '{data: datetime(1980, 0, 1, 0, 0, 0, 0)}'}
+        ]);
+      });
+
+      it('should return the right custom domain with month', () => {
+        const model = parseUnitModel({
+          mark: 'point',
+          encoding: {
+            y: {
+              timeUnit: 'month',
+              field: 'date',
+              type: 'temporal',
+              scale: {domain: [2134512352, 'February']}
+            }
+          }
+        });
+        const _domain = testParseDomainForChannel(model, 'y');
+
+        expect(_domain).toEqual([
+          {signal: '{data: datetime(2134512352)}'},
+          {signal: '{data: datetime(2012, 1, 1, 0, 0, 0, 0)}'}
+        ]);
+      });
+
       it('should return the right custom domain with DateTime object and signal', () => {
         const model = parseUnitModel({
           mark: 'point',


### PR DESCRIPTION
fix #6298