### PR TITLE
fix: mark's offset properties should support signals

### DIFF
--- a/src/compile/mark/encode/valueref.ts
+++ b/src/compile/mark/encode/valueref.ts
@@ -208,7 +208,7 @@ export interface MidPointParams {
   scaleName: string;
   scale: ScaleComponent;
   stack?: StackProperties;
-  offset?: number;
+  offset?: number | SignalRef;
   defaultRef: VgValueRef | (() => VgValueRef);
 
   /**

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -515,42 +515,42 @@ export interface MarkDefMixins {
   /**
    * Offset for x-position.
    */
-  xOffset?: number;
+  xOffset?: number | SignalRef;
 
   /**
    * Offset for y-position.
    */
-  yOffset?: number;
+  yOffset?: number | SignalRef;
 
   /**
    * Offset for x2-position.
    */
-  x2Offset?: number;
+  x2Offset?: number | SignalRef;
 
   /**
    * Offset for y2-position.
    */
-  y2Offset?: number;
+  y2Offset?: number | SignalRef;
 
   /**
    * Offset for theta.
    */
-  thetaOffset?: number;
+  thetaOffset?: number | SignalRef;
 
   /**
    * Offset for theta2.
    */
-  theta2Offset?: number;
+  theta2Offset?: number | SignalRef;
 
   /**
    * Offset for radius.
    */
-  radiusOffset?: number;
+  radiusOffset?: number | SignalRef;
 
   /**
    * Offset for radius2.
    */
-  radius2Offset?: number;
+  radius2Offset?: number | SignalRef;
 }
 
 // Point/Line OverlayMixins are only for area, line, and trail but we don't want to declare multiple types of MarkDef


### PR DESCRIPTION
Fix #6207 