### PR TITLE
fix:  apply offset to both range positions when position2 is unspecified

### DIFF
--- a/src/compile/mark/encode/position-range.ts
+++ b/src/compile/mark/encode/position-range.ts
@@ -79,7 +79,10 @@ function pointPosition2OrSize(
   const scaleName = model.scaleName(baseChannel);
   const scale = model.getScaleComponent(baseChannel);
 
-  const offset = getOffset(channel, model.markDef);
+  const offset =
+    channel in encoding || channel in markDef
+      ? getOffset(channel, model.markDef)
+      : getOffset(baseChannel, model.markDef);
 
   if (!channelDef && (channel === 'x2' || channel === 'y2') && (encoding.latitude || encoding.longitude)) {
     // use geopoint output if there are lat2/long2 and there is no point position2 overriding lat2/long2.

--- a/test/compile/mark/arc.test.ts
+++ b/test/compile/mark/arc.test.ts
@@ -41,6 +41,25 @@ describe('Mark: Arc', () => {
     });
   });
 
+  describe('for pie with thetaOffset', () => {
+    // This is a simplified example for stacked text.
+    // In reality this will be used as stacked's overlayed marker
+    const model = parseUnitModelWithScaleAndLayoutSize({
+      mark: {type: 'arc', thetaOffset: 5},
+      encoding: {
+        theta: {field: 'field', type: 'quantitative'},
+        color: {field: 'id', type: 'nominal'}
+      }
+    });
+
+    const props = arc.encodeEntry(model);
+
+    it('applies thetaOffset to both startAngle and endAngle', () => {
+      expect(props.startAngle).toEqual({scale: 'theta', field: 'field_end', offset: 5});
+      expect(props.endAngle).toEqual({scale: 'theta', field: 'field_start', offset: 5});
+    });
+  });
+
   describe('for radial histogram', () => {
     // This is a simplified example for stacked text.
     // In reality this will be used as stacked's overlayed marker

--- a/test/compile/mark/arc.test.ts
+++ b/test/compile/mark/arc.test.ts
@@ -43,7 +43,7 @@ describe('Mark: Arc', () => {
 
   describe('for pie with thetaOffset', () => {
     // This is a simplified example for stacked text.
-    // In reality this will be used as stacked's overlayed marker
+    // In reality this will be used as stacked's overlayed marks.
     const model = parseUnitModelWithScaleAndLayoutSize({
       mark: {type: 'arc', thetaOffset: 5},
       encoding: {


### PR DESCRIPTION
fix #6320


