### PR TITLE
docs: fix multiple anchors for same heading

### DIFF
--- a/site/docs/encoding.md
+++ b/site/docs/encoding.md
@@ -244,7 +244,9 @@ Here are the list of mark property channels:
 
 {% include table.html props="angle,color,fill,stroke,opacity,fillOpacity,strokeOpacity,shape,size,strokeDash,strokeWidth" source="Encoding" %}
 
-{:#mark-prop-field-def} {:#mark-prop-datum-def}
+<a id="mark-prop-datum-def"></a>
+
+{:#mark-prop-field-def}
 
 ### Mark Property Field Definition and Datum Definition
 

--- a/site/docs/encoding/scale.md
+++ b/site/docs/encoding/scale.md
@@ -273,7 +273,7 @@ By default, Vega-Lite automatically creates ordinal scales for `color` and `shap
 
 The [`range`](#range) of an ordinal scale can be an array of desired output values, which are directly mapped to elements in the [`domain`](#domain). Both `domain` and `range` array can be re-ordered to specify the order and mapping between the domain and the output range. For ordinal color scales, a custom [`scheme`](#scheme) can be set as well.
 
-<a name="point"></a><!-- point and band are in the same section -->
+<a id="point"></a><!-- point and band are in the same section -->
 
 {:#band}
 
@@ -301,7 +301,6 @@ For example, the following bar chart has uses a band scale for its x-position.
 
 <div class="vl-example" data-name="bar"></div>
 
-<a name="padding"/>
 {:#range-step}
 
 To customize the step size of band scales for x/y-fields, we can set the step property of the view's `width`/`height`.


### PR DESCRIPTION
There are a couple links in the docs for [encoding](https://vega.github.io/vega-lite/docs/encoding.html) that are broken right now, namely [`position-datum-def`](https://vega.github.io/vega-lite/docs/encoding.html#mark-prop-datum-def) and [`position-field-def`](https://vega.github.io/vega-lite/docs/encoding.html#mark-prop-field-def). The cause is jekyll not handling multiple anchors for one heading, and the fix is to define one of the anchors using HTML like in `encoding/scale.md`.

In the process of making this change, I learned that the [`name` attribute is deprecated for `a` elements](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#name), so I replaced it with the `id` attribute as recommended.

I also found an anchor for `padding` which is no longer needed since [padding has its own heading in that page](https://vega.github.io/vega-lite/docs/scale.html#padding).
