### PR TITLE
refactor: improve time unit code

### DIFF
--- a/src/datetime.ts
+++ b/src/datetime.ts
@@ -238,7 +238,7 @@ function dateTimeParts(d: DateTime | DateTimeExpr, normalize: boolean) {
   if (d.year !== undefined) {
     parts.push(d.year);
   } else {
-    // Just like Vega's timeunit transform, set default year to 2012, so domain converstion will be compatible with Vega
+    // Just like Vega's timeunit transform, set default year to 2012, so domain conversion will be compatible with Vega
     // Note: 2012 is a leap year (and so the date February 29 is respected) that begins on a Sunday (and so days of the week will order properly at the beginning of the year).
     parts.push(2012);
   }

--- a/src/timeunit.ts
+++ b/src/timeunit.ts
@@ -190,12 +190,15 @@ export const VEGALITE_TIMEFORMAT: TimeFormatConfig = {
 };
 
 export function getTimeUnitParts(timeUnit: TimeUnit) {
-  return TIMEUNIT_PARTS.reduce((parts, part) => {
+  const parts: LocalSingleTimeUnit[] = [];
+
+  for (const part of TIMEUNIT_PARTS) {
     if (containsTimeUnit(timeUnit, part)) {
-      return [...parts, part];
+      parts.push(part);
     }
-    return parts;
-  }, []);
+  }
+
+  return parts;
 }
 
 /** Returns true if fullTimeUnit contains the timeUnit, false otherwise. */
@@ -207,7 +210,7 @@ export function containsTimeUnit(fullTimeUnit: TimeUnit, timeUnit: TimeUnit) {
 }
 
 /**
- * Returns Vega expresssion for a given timeUnit and fieldRef
+ * Returns Vega expression for a given timeUnit and fieldRef
  */
 export function fieldExpr(fullTimeUnit: TimeUnit, field: string, {end}: {end: boolean} = {end: false}): string {
   const fieldRef = accessPathWithDatum(field);
@@ -225,19 +228,20 @@ export function fieldExpr(fullTimeUnit: TimeUnit, field: string, {end}: {end: bo
 
   let lastTimeUnit: TimeUnit;
 
-  const d = TIMEUNIT_PARTS.reduce((dateExpr: DateTimeExpr, tu: TimeUnit) => {
-    if (containsTimeUnit(fullTimeUnit, tu)) {
-      dateExpr[tu] = func(tu);
-      lastTimeUnit = tu;
-    }
-    return dateExpr;
-  }, {} as Record<SingleTimeUnit, string>);
+  const dateExpr: DateTimeExpr = {};
 
-  if (end) {
-    d[lastTimeUnit] += '+1';
+  for (const part of TIMEUNIT_PARTS) {
+    if (containsTimeUnit(fullTimeUnit, part)) {
+      dateExpr[part] = func(part);
+      lastTimeUnit = part;
+    }
   }
 
-  return dateTimeExprToExpr(d);
+  if (end) {
+    dateExpr[lastTimeUnit] += '+1';
+  }
+
+  return dateTimeExprToExpr(dateExpr);
 }
 
 export function getTimeUnitSpecifierExpression(timeUnit: TimeUnit) {


### PR DESCRIPTION
* use loop instead of reduce for better readability
* remove need for `Record<SingleTimeUnit, string>`
* fix typos