### PR TITLE
refactor: simplify Value types

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -4038,7 +4038,7 @@
             "datum": {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/Value"
+                  "$ref": "#/definitions/PrimitiveValue"
                 },
                 {
                   "$ref": "#/definitions/DateTime"
@@ -4195,7 +4195,7 @@
             "datum": {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/Value"
+                  "$ref": "#/definitions/PrimitiveValue"
                 },
                 {
                   "$ref": "#/definitions/DateTime"
@@ -4743,7 +4743,7 @@
             "datum": {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/Value"
+                  "$ref": "#/definitions/PrimitiveValue"
                 },
                 {
                   "$ref": "#/definitions/DateTime"
@@ -4900,7 +4900,7 @@
             "datum": {
               "anyOf": [
                 {
-                  "$ref": "#/definitions/Value"
+                  "$ref": "#/definitions/PrimitiveValue"
                 },
                 {
                   "$ref": "#/definitions/DateTime"
@@ -5640,7 +5640,7 @@
         "datum": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Value"
+              "$ref": "#/definitions/PrimitiveValue"
             },
             {
               "$ref": "#/definitions/DateTime"
@@ -7620,7 +7620,7 @@
         "datum": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Value"
+              "$ref": "#/definitions/PrimitiveValue"
             },
             {
               "$ref": "#/definitions/DateTime"
@@ -7655,7 +7655,7 @@
         "datum": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Value"
+              "$ref": "#/definitions/PrimitiveValue"
             },
             {
               "$ref": "#/definitions/DateTime"
@@ -7690,7 +7690,7 @@
         "datum": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Value"
+              "$ref": "#/definitions/PrimitiveValue"
             },
             {
               "$ref": "#/definitions/DateTime"
@@ -7725,7 +7725,7 @@
         "datum": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Value"
+              "$ref": "#/definitions/PrimitiveValue"
             },
             {
               "$ref": "#/definitions/DateTime"
@@ -14071,7 +14071,7 @@
         "datum": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Value"
+              "$ref": "#/definitions/PrimitiveValue"
             },
             {
               "$ref": "#/definitions/DateTime"
@@ -14137,7 +14137,7 @@
         "datum": {
           "anyOf": [
             {
-              "$ref": "#/definitions/Value"
+              "$ref": "#/definitions/PrimitiveValue"
             },
             {
               "$ref": "#/definitions/DateTime"
@@ -14430,6 +14430,14 @@
         {
           "type": "string"
         }
+      ]
+    },
+    "PrimitiveValue": {
+      "type": [
+        "number",
+        "string",
+        "boolean",
+        "null"
       ]
     },
     "Projection": {
@@ -16091,7 +16099,7 @@
     "SelectionInit": {
       "anyOf": [
         {
-          "$ref": "#/definitions/Value"
+          "$ref": "#/definitions/PrimitiveValue"
         },
         {
           "$ref": "#/definitions/DateTime"
@@ -19352,28 +19360,6 @@
         "utcmilliseconds"
       ],
       "type": "string"
-    },
-    "Value": {
-      "anyOf": [
-        {
-          "type": "number"
-        },
-        {
-          "type": "string"
-        },
-        {
-          "type": "boolean"
-        },
-        {
-          "items": {
-            "type": "number"
-          },
-          "type": "array"
-        },
-        {
-          "type": "null"
-        }
-      ]
     },
     "YValueDef": {
       "additionalProperties": false,

--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -73,17 +73,14 @@ import {getFullName, QUANTITATIVE, StandardType, Type} from './type';
 import {contains, flatAccessWithDatum, getFirstDefined, internalField, replacePathInField, titlecase} from './util';
 import {isSignalRef} from './vega.schema';
 
-export type Value = number | string | boolean | number[] | null;
-export {Gradient};
+export type PrimitiveValue = number | string | boolean | null;
 
-export type ValueOrGradient = Value | Gradient;
-
-export type ValueOrGradientOrText = Value | Gradient | Text;
+export type Value = PrimitiveValue | number[] | Gradient | Text;
 
 /**
  * Definition object for a constant value (primitive value or gradient definition) of an encoding channel.
  */
-export interface ValueDef<V extends ValueOrGradient | Value[] = Value> {
+export interface ValueDef<V extends Value = Value> {
   /**
    * A constant value in visual domain (e.g., `"red"` / `"#0099ff"` / [gradient definition](https://vega.github.io/vega-lite/docs/types.html#gradient) for color, values between `0` to `1` for opacity).
    */
@@ -101,10 +98,9 @@ export interface ValueDef<V extends ValueOrGradient | Value[] = Value> {
 /**
  * @minProperties 1
  */
-export type ValueDefWithCondition<
-  F extends FieldDef<any> | DatumDef<any>,
-  V extends ValueOrGradientOrText = Value
-> = Partial<ValueDef<V>> & {
+export type ValueDefWithCondition<F extends FieldDef<any> | DatumDef<any>, V extends Value = Value> = Partial<
+  ValueDef<V>
+> & {
   /**
    * A field definition or one or more value definition(s) with a selection predicate.
    */
@@ -114,20 +110,16 @@ export type ValueDefWithCondition<
 /**
  * @hidden
  */
-export type SignalRefWithCondition<
-  F extends FieldDef<any> | DatumDef,
-  V extends ValueOrGradientOrText = Value
-> = SignalRef & {
+export type SignalRefWithCondition<F extends FieldDef<any> | DatumDef, V extends Value = Value> = SignalRef & {
   /**
    * A field definition or one or more value definition(s) with a selection predicate.
    */
   condition?: Conditional<F> | ValueOrSignalCondition<V>;
 };
 
-export type ValueOrSignalDefWithCondition<
-  F extends FieldDef<any> | DatumDef<any>,
-  V extends ValueOrGradientOrText = Value
-> = ValueDefWithCondition<F, V> | SignalRefWithCondition<F, V>;
+export type ValueOrSignalDefWithCondition<F extends FieldDef<any> | DatumDef<any>, V extends Value = Value> =
+  | ValueDefWithCondition<F, V>
+  | SignalRefWithCondition<F, V>;
 
 export type StringValueOrSignalDefWithCondition<
   F extends Field,
@@ -176,13 +168,13 @@ export function isConditionalSelection<T>(c: Conditional<T>): c is ConditionalSe
   return c['selection'];
 }
 
-export type ValueOrSignalCondition<V extends ValueOrGradientOrText = Value> =
+export type ValueOrSignalCondition<V extends Value = Value> =
   | Conditional<ValueDef<V>>
   | Conditional<ValueDef<V>>[]
   | Conditional<SignalRef>
   | Conditional<SignalRef>[];
 
-export interface ConditionValueDefMixins<V extends ValueOrGradientOrText = Value> {
+export interface ConditionValueDefMixins<V extends Value = Value> {
   /**
    * One or more value definition(s) with [a selection or a test predicate](https://vega.github.io/vega-lite/docs/condition.html).
    *
@@ -201,10 +193,8 @@ export interface ConditionValueDefMixins<V extends ValueOrGradientOrText = Value
  * }
  */
 
-export type FieldOrDatumDefWithCondition<
-  F extends FieldDef<any, any> | DatumDef<any>,
-  V extends ValueOrGradientOrText = Value
-> = F & ConditionValueDefMixins<V>;
+export type FieldOrDatumDefWithCondition<F extends FieldDef<any, any> | DatumDef<any>, V extends Value = Value> = F &
+  ConditionValueDefMixins<V>;
 
 export type ColorGradientFieldDefWithCondition<F extends Field> = FieldOrDatumDefWithCondition<
   MarkPropFieldDef<F, StandardType>,
@@ -407,7 +397,7 @@ export interface ScaleMixins {
 
 export interface DatumDef<
   F extends Field = string,
-  V extends Value | DateTime | SignalRef = Value | DateTime | SignalRef
+  V extends PrimitiveValue | DateTime | SignalRef = PrimitiveValue | DateTime | SignalRef
 > extends Partial<TypeMixins<Type>>, BandMixins {
   /**
    * A constant value in data domain.

--- a/src/compile/legend/encode.ts
+++ b/src/compile/legend/encode.ts
@@ -1,27 +1,26 @@
-import {ColorValueRef, EncodeEntry, LegendEncode, LegendType, SignalRef, SymbolEncodeEntry} from 'vega';
+import {ColorValueRef, EncodeEntry, Gradient, LegendEncode, LegendType, SignalRef, SymbolEncodeEntry} from 'vega';
 import {array, isArray, stringValue} from 'vega-util';
 import {COLOR, OPACITY, ScaleChannel} from '../../channel';
 import {
   Conditional,
   DatumDef,
-  Gradient,
   hasConditionalValueDef,
   isFieldDef,
+  isFieldOrDatumDefWithCustomTimeFormat,
   isValueDef,
   TypedFieldDef,
   Value,
-  ValueDef,
-  isFieldOrDatumDefWithCustomTimeFormat
+  ValueDef
 } from '../../channeldef';
 import {Encoding} from '../../encoding';
 import {FILL_STROKE_CONFIG} from '../../mark';
 import {getFirstDefined, keys, varName} from '../../util';
 import {applyMarkConfig, signalOrValueRef} from '../common';
+import {formatCustomType} from '../format';
 import * as mixins from '../mark/encode';
 import {STORE} from '../selection';
 import {UnitModel} from '../unit';
 import {LegendComponent} from './component';
-import {formatCustomType} from '../format';
 
 export interface LegendEncodeParams {
   fieldOrDatumDef: TypedFieldDef<string> | DatumDef;

--- a/src/compile/mark/encode/nonposition.ts
+++ b/src/compile/mark/encode/nonposition.ts
@@ -1,6 +1,6 @@
 import {SignalRef} from 'vega';
 import {NonPositionScaleChannel} from '../../../channel';
-import {ValueOrGradient} from '../../../channeldef';
+import {Value} from '../../../channeldef';
 import {VgEncodeChannel, VgEncodeEntry, VgValueRef} from '../../../vega.schema';
 import {getMarkPropOrConfig, signalOrValueRef} from '../../common';
 import {UnitModel} from '../../unit';
@@ -14,7 +14,7 @@ export function nonPosition(
   channel: NonPositionScaleChannel,
   model: UnitModel,
   opt: {
-    defaultValue?: ValueOrGradient | SignalRef;
+    defaultValue?: Value | SignalRef;
     vgChannel?: VgEncodeChannel;
     defaultRef?: VgValueRef;
   } = {}

--- a/src/compile/mark/encode/valueref.ts
+++ b/src/compile/mark/encode/valueref.ts
@@ -23,7 +23,7 @@ import {
   SecondaryChannelDef,
   SecondaryFieldDef,
   TypedFieldDef,
-  ValueOrGradientOrText,
+  Value,
   vgField
 } from '../../../channeldef';
 import {Config} from '../../../config';
@@ -332,7 +332,7 @@ export function midPoint({
 /**
  * Convert special "width" and "height" values in Vega-Lite into Vega value ref.
  */
-export function widthHeightValueOrSignalRef(channel: Channel, value: ValueOrGradientOrText | SignalRef) {
+export function widthHeightValueOrSignalRef(channel: Channel, value: Value | SignalRef) {
   if (contains(['x', 'x2'], channel) && value === 'width') {
     return {field: {group: 'width'}};
   } else if (contains(['y', 'y2'], channel) && value === 'height') {

--- a/src/mark.ts
+++ b/src/mark.ts
@@ -1,6 +1,5 @@
-import {Align, Color, MarkConfig as VgMarkConfig, Orientation, SignalRef, TextBaseline} from 'vega';
+import {Align, Color, Gradient, MarkConfig as VgMarkConfig, Orientation, SignalRef, TextBaseline} from 'vega';
 import {toSet} from 'vega-util';
-import {Gradient} from './channeldef';
 import {CompositeMark, CompositeMarkDef} from './compositemark';
 import {contains, Flag, keys} from './util';
 

--- a/src/selection.ts
+++ b/src/selection.ts
@@ -1,7 +1,7 @@
 import {Binding, Color, Cursor, Stream, Vector2} from 'vega';
 import {isObject} from 'vega-util';
 import {SingleDefUnitChannel} from './channel';
-import {FieldName, Value} from './channeldef';
+import {FieldName, PrimitiveValue} from './channeldef';
 import {DateTime} from './datetime';
 import {Dict} from './util';
 
@@ -9,7 +9,7 @@ export const SELECTION_ID = '_vgsid_';
 export type SelectionType = 'single' | 'multi' | 'interval';
 export type SelectionResolution = 'global' | 'union' | 'intersect';
 
-export type SelectionInit = Value | DateTime;
+export type SelectionInit = PrimitiveValue | DateTime;
 export type SelectionInitInterval = Vector2<boolean> | Vector2<number> | Vector2<string> | Vector2<DateTime>;
 
 export type SelectionInitMapping = Dict<SelectionInit>;

--- a/src/vega.schema.ts
+++ b/src/vega.schema.ts
@@ -41,7 +41,7 @@ import {
   UnionSortField as VgUnionSortField
 } from 'vega';
 import {isArray} from 'vega-util';
-import {ValueOrGradientOrText} from './channeldef';
+import {Value} from './channeldef';
 import {SortOrder} from './sort';
 import {Flag, keys} from './util';
 
@@ -89,7 +89,7 @@ export function isSignalRef(o: any): o is SignalRef {
 
 // TODO: add type of value (Make it VgValueRef<V extends ValueOrGradient> {value?:V ...})
 export interface VgValueRef {
-  value?: ValueOrGradientOrText | number[];
+  value?: Value | number[];
   field?:
     | string
     | {


### PR DESCRIPTION
`Value` should represent all possible values of `ValueDef`

(`ValueOrGradientOrText` sounds very funny)

