### PR TITLE
fix: revise `encoding.color = {signal:...}` to be `{value: {signal:...}}`

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -2874,8 +2874,8 @@
     "ColorGradientFieldDefWithCondition": {
       "$ref": "#/definitions/FieldOrDatumDefWithCondition<MarkPropFieldDef,(Gradient|string|null)>"
     },
-    "ColorGradientValueDefWithConditionAlias": {
-      "$ref": "#/definitions/ValueDefWithConditionAlias<MarkPropFieldOrDatumDef,(Gradient|string|null)>"
+    "ColorGradientValueDefWithCondition": {
+      "$ref": "#/definitions/ValueDefWithCondition<MarkPropFieldOrDatumDef,(Gradient|string|null)>"
     },
     "ColorName": {
       "enum": [
@@ -3061,7 +3061,7 @@
               "$ref": "#/definitions/NumericDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/NumericValueDefWithConditionAlias"
+              "$ref": "#/definitions/NumericValueDefWithCondition"
             }
           ],
           "description": "Rotation angle of point and text marks."
@@ -3075,7 +3075,7 @@
               "$ref": "#/definitions/ColorGradientDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/ColorGradientValueDefWithConditionAlias"
+              "$ref": "#/definitions/ColorGradientValueDefWithCondition"
             }
           ],
           "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels. The `fill` or `stroke` encodings have higher precedence than `color`, thus may override the `color` encoding if conflicting encodings are specified.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
@@ -3103,7 +3103,7 @@
               "$ref": "#/definitions/ColorGradientDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/ColorGradientValueDefWithConditionAlias"
+              "$ref": "#/definitions/ColorGradientValueDefWithCondition"
             }
           ],
           "description": "Fill color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `color` property.\n\n_Note:_ The `fill` encoding has higher precedence than `color`, thus may override the `color` encoding if conflicting encodings are specified."
@@ -3117,7 +3117,7 @@
               "$ref": "#/definitions/NumericDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/NumericValueDefWithConditionAlias"
+              "$ref": "#/definitions/NumericValueDefWithCondition"
             }
           ],
           "description": "Fill opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `fillOpacity` property."
@@ -3128,7 +3128,7 @@
               "$ref": "#/definitions/StringFieldDefWithCondition"
             },
             {
-              "$ref": "#/definitions/StringValueDefWithConditionAlias"
+              "$ref": "#/definitions/StringValueDefWithCondition"
             }
           ],
           "description": "A URL to load upon mouse click."
@@ -3146,7 +3146,7 @@
               "$ref": "#/definitions/DatumDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "Latitude position of geographically projected marks."
@@ -3160,7 +3160,7 @@
               "$ref": "#/definitions/DatumDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "Latitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
@@ -3174,7 +3174,7 @@
               "$ref": "#/definitions/DatumDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "Longitude position of geographically projected marks."
@@ -3188,7 +3188,7 @@
               "$ref": "#/definitions/DatumDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "Longitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
@@ -3202,7 +3202,7 @@
               "$ref": "#/definitions/NumericDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/NumericValueDefWithConditionAlias"
+              "$ref": "#/definitions/NumericValueDefWithCondition"
             }
           ],
           "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `opacity` property."
@@ -3219,7 +3219,7 @@
               "type": "array"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "Order of the marks.\n- For stacked marks, this `order` channel encodes [stack order](https://vega.github.io/vega-lite/docs/stack.html#order).\n- For line and trail marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/connected_scatterplot.html). Setting `order` to `{\"value\": null}` makes the line marks use the original order in the data sources.\n- Otherwise, this `order` channel encodes layer order of the marks.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
@@ -3233,7 +3233,7 @@
               "$ref": "#/definitions/PolarDatumDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "The outer radius in pixels of arc marks."
@@ -3247,7 +3247,7 @@
               "$ref": "#/definitions/DatumDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "The inner radius in pixels of arc marks."
@@ -3261,7 +3261,7 @@
               "$ref": "#/definitions/StringDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/ShapeValueDefWithConditionAlias"
+              "$ref": "#/definitions/ShapeValueDefWithCondition"
             }
           ],
           "description": "Shape of the mark.\n\n1. For `point` marks the supported values include:\n   - plotting shapes: `\"circle\"`, `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, `\"triangle-down\"`, `\"triangle-right\"`, or `\"triangle-left\"`.\n   - the line symbol `\"stroke\"`\n   - centered directional shapes `\"arrow\"`, `\"wedge\"`, or `\"triangle\"`\n   - a custom [SVG path string](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths) (For correct sizing, custom shape paths should be defined within a square bounding box with coordinates ranging from -1 to 1 along both the x and y dimensions.)\n\n2. For `geoshape` marks it should be a field definition of the geojson data\n\n__Default value:__ If undefined, the default shape depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape` property. (`\"circle\"` if unset.)"
@@ -3275,7 +3275,7 @@
               "$ref": "#/definitions/NumericDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/NumericValueDefWithConditionAlias"
+              "$ref": "#/definitions/NumericValueDefWithCondition"
             }
           ],
           "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
@@ -3289,7 +3289,7 @@
               "$ref": "#/definitions/ColorGradientDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/ColorGradientValueDefWithConditionAlias"
+              "$ref": "#/definitions/ColorGradientValueDefWithCondition"
             }
           ],
           "description": "Stroke color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `color` property.\n\n_Note:_ The `stroke` encoding has higher precedence than `color`, thus may override the `color` encoding if conflicting encodings are specified."
@@ -3303,7 +3303,7 @@
               "$ref": "#/definitions/NumericArrayDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/NumericArrayValueDefWithConditionAlias"
+              "$ref": "#/definitions/NumericArrayValueDefWithCondition"
             }
           ],
           "description": "Stroke dash of the marks.\n\n__Default value:__ `[1,0]` (No dash)."
@@ -3317,7 +3317,7 @@
               "$ref": "#/definitions/NumericDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/NumericValueDefWithConditionAlias"
+              "$ref": "#/definitions/NumericValueDefWithCondition"
             }
           ],
           "description": "Stroke opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `strokeOpacity` property."
@@ -3331,7 +3331,7 @@
               "$ref": "#/definitions/NumericDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/NumericValueDefWithConditionAlias"
+              "$ref": "#/definitions/NumericValueDefWithCondition"
             }
           ],
           "description": "Stroke width of the marks.\n\n__Default value:__ If undefined, the default stroke width depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `strokeWidth` property."
@@ -3342,7 +3342,7 @@
               "$ref": "#/definitions/TextFieldDefWithCondition"
             },
             {
-              "$ref": "#/definitions/TextValueDefWithConditionAlias"
+              "$ref": "#/definitions/TextValueDefWithCondition"
             }
           ],
           "description": "Text of the `text` mark."
@@ -3356,7 +3356,7 @@
               "$ref": "#/definitions/PolarDatumDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "- For arc marks, the arc length in radians if theta2 is not specified, otherwise the start arc angle. (A value of 0 indicates up or “north”, increasing values proceed clockwise.)\n\n- For text marks, polar coordinate angle in radians."
@@ -3370,7 +3370,7 @@
               "$ref": "#/definitions/DatumDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "The end angle of arc marks in radians. A value of 0 indicates up or “north”, increasing values proceed clockwise."
@@ -3381,7 +3381,7 @@
               "$ref": "#/definitions/StringFieldDefWithCondition"
             },
             {
-              "$ref": "#/definitions/StringValueDefWithConditionAlias"
+              "$ref": "#/definitions/StringValueDefWithCondition"
             },
             {
               "items": {
@@ -3401,7 +3401,7 @@
               "$ref": "#/definitions/StringFieldDefWithCondition"
             },
             {
-              "$ref": "#/definitions/StringValueDefWithConditionAlias"
+              "$ref": "#/definitions/StringValueDefWithCondition"
             }
           ],
           "description": "The URL of an image mark."
@@ -3440,7 +3440,7 @@
               "$ref": "#/definitions/SecondaryFieldDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/ValueDef<number>"
             }
           ],
           "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
@@ -3451,7 +3451,7 @@
               "$ref": "#/definitions/SecondaryFieldDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/ValueDef<number>"
             }
           ],
           "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
@@ -3490,7 +3490,7 @@
               "$ref": "#/definitions/SecondaryFieldDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/ValueDef<number>"
             }
           ],
           "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
@@ -3501,7 +3501,7 @@
               "$ref": "#/definitions/SecondaryFieldDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/ValueDef<number>"
             }
           ],
           "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
@@ -3589,13 +3589,13 @@
         }
       ]
     },
-    "ConditionalStringValueDef": {
+    "ConditionalValueDef<(string|null)>": {
       "anyOf": [
         {
-          "$ref": "#/definitions/ConditionalPredicate<StringValueDef>"
+          "$ref": "#/definitions/ConditionalPredicate<ValueDef<(string|null)>>"
         },
         {
-          "$ref": "#/definitions/ConditionalSelection<StringValueDef>"
+          "$ref": "#/definitions/ConditionalSelection<ValueDef<(string|null)>>"
         }
       ]
     },
@@ -3609,13 +3609,13 @@
         }
       ]
     },
-    "ConditionalNumberValueDef": {
+    "ConditionalValueDef<number>": {
       "anyOf": [
         {
-          "$ref": "#/definitions/ConditionalPredicate<NumberValueDef>"
+          "$ref": "#/definitions/ConditionalPredicate<ValueDef<number>>"
         },
         {
-          "$ref": "#/definitions/ConditionalSelection<NumberValueDef>"
+          "$ref": "#/definitions/ConditionalSelection<ValueDef<number>>"
         }
       ]
     },
@@ -3903,11 +3903,11 @@
         "condition": {
           "anyOf": [
             {
-              "$ref": "#/definitions/ConditionalPredicate<StringValueDef>"
+              "$ref": "#/definitions/ConditionalPredicate<ValueDef<(string|null)>>"
             },
             {
               "items": {
-                "$ref": "#/definitions/ConditionalPredicate<StringValueDef>"
+                "$ref": "#/definitions/ConditionalPredicate<ValueDef<(string|null)>>"
               },
               "type": "array"
             }
@@ -4539,7 +4539,7 @@
       ],
       "type": "object"
     },
-    "ConditionalPredicate<StringValueDef>": {
+    "ConditionalPredicate<ValueDef<(string|null)>>": {
       "additionalProperties": false,
       "properties": {
         "test": {
@@ -4578,7 +4578,7 @@
       ],
       "type": "object"
     },
-    "ConditionalPredicate<NumberValueDef>": {
+    "ConditionalPredicate<ValueDef<number>>": {
       "additionalProperties": false,
       "properties": {
         "test": {
@@ -5070,7 +5070,7 @@
       ],
       "type": "object"
     },
-    "ConditionalSelection<StringValueDef>": {
+    "ConditionalSelection<ValueDef<(string|null)>>": {
       "additionalProperties": false,
       "properties": {
         "selection": {
@@ -5109,7 +5109,7 @@
       ],
       "type": "object"
     },
-    "ConditionalSelection<NumberValueDef>": {
+    "ConditionalSelection<ValueDef<number>>": {
       "additionalProperties": false,
       "properties": {
         "selection": {
@@ -6725,7 +6725,7 @@
               "$ref": "#/definitions/NumericDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/NumericValueDefWithConditionAlias"
+              "$ref": "#/definitions/NumericValueDefWithCondition"
             }
           ],
           "description": "Rotation angle of point and text marks."
@@ -6739,7 +6739,7 @@
               "$ref": "#/definitions/ColorGradientDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/ColorGradientValueDefWithConditionAlias"
+              "$ref": "#/definitions/ColorGradientValueDefWithCondition"
             }
           ],
           "description": "Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.\nBy default, `color` represents fill color for `\"area\"`, `\"bar\"`, `\"tick\"`,\n`\"text\"`, `\"trail\"`, `\"circle\"`, and `\"square\"` / stroke color for `\"line\"` and `\"point\"`.\n\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `color` property.\n\n_Note:_\n1) For fine-grained control over both fill and stroke colors of the marks, please use the `fill` and `stroke` channels. The `fill` or `stroke` encodings have higher precedence than `color`, thus may override the `color` encoding if conflicting encodings are specified.\n2) See the scale documentation for more information about customizing [color scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme)."
@@ -6775,7 +6775,7 @@
               "$ref": "#/definitions/ColorGradientDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/ColorGradientValueDefWithConditionAlias"
+              "$ref": "#/definitions/ColorGradientValueDefWithCondition"
             }
           ],
           "description": "Fill color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `color` property.\n\n_Note:_ The `fill` encoding has higher precedence than `color`, thus may override the `color` encoding if conflicting encodings are specified."
@@ -6789,7 +6789,7 @@
               "$ref": "#/definitions/NumericDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/NumericValueDefWithConditionAlias"
+              "$ref": "#/definitions/NumericValueDefWithCondition"
             }
           ],
           "description": "Fill opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `fillOpacity` property."
@@ -6800,7 +6800,7 @@
               "$ref": "#/definitions/StringFieldDefWithCondition"
             },
             {
-              "$ref": "#/definitions/StringValueDefWithConditionAlias"
+              "$ref": "#/definitions/StringValueDefWithCondition"
             }
           ],
           "description": "A URL to load upon mouse click."
@@ -6818,7 +6818,7 @@
               "$ref": "#/definitions/DatumDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "Latitude position of geographically projected marks."
@@ -6832,7 +6832,7 @@
               "$ref": "#/definitions/DatumDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "Latitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
@@ -6846,7 +6846,7 @@
               "$ref": "#/definitions/DatumDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "Longitude position of geographically projected marks."
@@ -6860,7 +6860,7 @@
               "$ref": "#/definitions/DatumDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "Longitude-2 position for geographically projected ranged `\"area\"`, `\"bar\"`, `\"rect\"`, and  `\"rule\"`."
@@ -6874,7 +6874,7 @@
               "$ref": "#/definitions/NumericDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/NumericValueDefWithConditionAlias"
+              "$ref": "#/definitions/NumericValueDefWithCondition"
             }
           ],
           "description": "Opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `opacity` property."
@@ -6891,7 +6891,7 @@
               "type": "array"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "Order of the marks.\n- For stacked marks, this `order` channel encodes [stack order](https://vega.github.io/vega-lite/docs/stack.html#order).\n- For line and trail marks, this `order` channel encodes order of data points in the lines. This can be useful for creating [a connected scatterplot](https://vega.github.io/vega-lite/examples/connected_scatterplot.html). Setting `order` to `{\"value\": null}` makes the line marks use the original order in the data sources.\n- Otherwise, this `order` channel encodes layer order of the marks.\n\n__Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping."
@@ -6905,7 +6905,7 @@
               "$ref": "#/definitions/PolarDatumDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "The outer radius in pixels of arc marks."
@@ -6919,7 +6919,7 @@
               "$ref": "#/definitions/DatumDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "The inner radius in pixels of arc marks."
@@ -6937,7 +6937,7 @@
               "$ref": "#/definitions/StringDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/ShapeValueDefWithConditionAlias"
+              "$ref": "#/definitions/ShapeValueDefWithCondition"
             }
           ],
           "description": "Shape of the mark.\n\n1. For `point` marks the supported values include:\n   - plotting shapes: `\"circle\"`, `\"square\"`, `\"cross\"`, `\"diamond\"`, `\"triangle-up\"`, `\"triangle-down\"`, `\"triangle-right\"`, or `\"triangle-left\"`.\n   - the line symbol `\"stroke\"`\n   - centered directional shapes `\"arrow\"`, `\"wedge\"`, or `\"triangle\"`\n   - a custom [SVG path string](https://developer.mozilla.org/en-US/docs/Web/SVG/Tutorial/Paths) (For correct sizing, custom shape paths should be defined within a square bounding box with coordinates ranging from -1 to 1 along both the x and y dimensions.)\n\n2. For `geoshape` marks it should be a field definition of the geojson data\n\n__Default value:__ If undefined, the default shape depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape` property. (`\"circle\"` if unset.)"
@@ -6951,7 +6951,7 @@
               "$ref": "#/definitions/NumericDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/NumericValueDefWithConditionAlias"
+              "$ref": "#/definitions/NumericValueDefWithCondition"
             }
           ],
           "description": "Size of the mark.\n- For `\"point\"`, `\"square\"` and `\"circle\"`, – the symbol size, or pixel area of the mark.\n- For `\"bar\"` and `\"tick\"` – the bar and tick's size.\n- For `\"text\"` – the text's font size.\n- Size is unsupported for `\"line\"`, `\"area\"`, and `\"rect\"`. (Use `\"trail\"` instead of line with varying size)"
@@ -6965,7 +6965,7 @@
               "$ref": "#/definitions/ColorGradientDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/ColorGradientValueDefWithConditionAlias"
+              "$ref": "#/definitions/ColorGradientValueDefWithCondition"
             }
           ],
           "description": "Stroke color of the marks.\n__Default value:__ If undefined, the default color depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `color` property.\n\n_Note:_ The `stroke` encoding has higher precedence than `color`, thus may override the `color` encoding if conflicting encodings are specified."
@@ -6979,7 +6979,7 @@
               "$ref": "#/definitions/NumericArrayDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/NumericArrayValueDefWithConditionAlias"
+              "$ref": "#/definitions/NumericArrayValueDefWithCondition"
             }
           ],
           "description": "Stroke dash of the marks.\n\n__Default value:__ `[1,0]` (No dash)."
@@ -6993,7 +6993,7 @@
               "$ref": "#/definitions/NumericDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/NumericValueDefWithConditionAlias"
+              "$ref": "#/definitions/NumericValueDefWithCondition"
             }
           ],
           "description": "Stroke opacity of the marks.\n\n__Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `strokeOpacity` property."
@@ -7007,7 +7007,7 @@
               "$ref": "#/definitions/NumericDatumDefWithCondition"
             },
             {
-              "$ref": "#/definitions/NumericValueDefWithConditionAlias"
+              "$ref": "#/definitions/NumericValueDefWithCondition"
             }
           ],
           "description": "Stroke width of the marks.\n\n__Default value:__ If undefined, the default stroke width depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `strokeWidth` property."
@@ -7018,7 +7018,7 @@
               "$ref": "#/definitions/TextFieldDefWithCondition"
             },
             {
-              "$ref": "#/definitions/TextValueDefWithConditionAlias"
+              "$ref": "#/definitions/TextValueDefWithCondition"
             }
           ],
           "description": "Text of the `text` mark."
@@ -7032,7 +7032,7 @@
               "$ref": "#/definitions/PolarDatumDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "- For arc marks, the arc length in radians if theta2 is not specified, otherwise the start arc angle. (A value of 0 indicates up or “north”, increasing values proceed clockwise.)\n\n- For text marks, polar coordinate angle in radians."
@@ -7046,7 +7046,7 @@
               "$ref": "#/definitions/DatumDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/NumericValueDef"
             }
           ],
           "description": "The end angle of arc marks in radians. A value of 0 indicates up or “north”, increasing values proceed clockwise."
@@ -7057,7 +7057,7 @@
               "$ref": "#/definitions/StringFieldDefWithCondition"
             },
             {
-              "$ref": "#/definitions/StringValueDefWithConditionAlias"
+              "$ref": "#/definitions/StringValueDefWithCondition"
             },
             {
               "items": {
@@ -7077,7 +7077,7 @@
               "$ref": "#/definitions/StringFieldDefWithCondition"
             },
             {
-              "$ref": "#/definitions/StringValueDefWithConditionAlias"
+              "$ref": "#/definitions/StringValueDefWithCondition"
             }
           ],
           "description": "The URL of an image mark."
@@ -7116,7 +7116,7 @@
               "$ref": "#/definitions/SecondaryFieldDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/ValueDef<number>"
             }
           ],
           "description": "Error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
@@ -7127,7 +7127,7 @@
               "$ref": "#/definitions/SecondaryFieldDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/ValueDef<number>"
             }
           ],
           "description": "Secondary error value of x coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
@@ -7166,7 +7166,7 @@
               "$ref": "#/definitions/SecondaryFieldDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/ValueDef<number>"
             }
           ],
           "description": "Error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
@@ -7177,7 +7177,7 @@
               "$ref": "#/definitions/SecondaryFieldDef"
             },
             {
-              "$ref": "#/definitions/NumberValueDef"
+              "$ref": "#/definitions/ValueDef<number>"
             }
           ],
           "description": "Secondary error value of y coordinates for error specified `\"errorbar\"` and `\"errorband\"`."
@@ -7614,7 +7614,17 @@
           "type": "number"
         },
         "condition": {
-          "$ref": "#/definitions/ValueOrSignalCondition<(Gradient|string|null)>",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalValueDef<(Gradient|string|null)>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef<(Gradient|string|null)>"
+              },
+              "type": "array"
+            }
+          ],
           "description": "One or more value definition(s) with [a selection or a test predicate](https://vega.github.io/vega-lite/docs/condition.html).\n\n__Note:__ A field definition's `condition` property can only contain [conditional value definitions](https://vega.github.io/vega-lite/docs/condition.html#value)\nsince Vega-Lite only allows at most one encoded field per encoding channel."
         },
         "datum": {
@@ -7649,7 +7659,17 @@
           "type": "number"
         },
         "condition": {
-          "$ref": "#/definitions/ValueOrSignalCondition<number>",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalValueDef<number>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef<number>"
+              },
+              "type": "array"
+            }
+          ],
           "description": "One or more value definition(s) with [a selection or a test predicate](https://vega.github.io/vega-lite/docs/condition.html).\n\n__Note:__ A field definition's `condition` property can only contain [conditional value definitions](https://vega.github.io/vega-lite/docs/condition.html#value)\nsince Vega-Lite only allows at most one encoded field per encoding channel."
         },
         "datum": {
@@ -7684,7 +7704,17 @@
           "type": "number"
         },
         "condition": {
-          "$ref": "#/definitions/ValueOrSignalCondition<number[]>",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalValueDef<number[]>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef<number[]>"
+              },
+              "type": "array"
+            }
+          ],
           "description": "One or more value definition(s) with [a selection or a test predicate](https://vega.github.io/vega-lite/docs/condition.html).\n\n__Note:__ A field definition's `condition` property can only contain [conditional value definitions](https://vega.github.io/vega-lite/docs/condition.html#value)\nsince Vega-Lite only allows at most one encoded field per encoding channel."
         },
         "datum": {
@@ -7719,7 +7749,17 @@
           "type": "number"
         },
         "condition": {
-          "$ref": "#/definitions/ValueOrSignalCondition<string>",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalValueDef<string>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef<string>"
+              },
+              "type": "array"
+            }
+          ],
           "description": "One or more value definition(s) with [a selection or a test predicate](https://vega.github.io/vega-lite/docs/condition.html).\n\n__Note:__ A field definition's `condition` property can only contain [conditional value definitions](https://vega.github.io/vega-lite/docs/condition.html#value)\nsince Vega-Lite only allows at most one encoded field per encoding channel."
         },
         "datum": {
@@ -7772,7 +7812,17 @@
           "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "condition": {
-          "$ref": "#/definitions/ValueOrSignalCondition<(Gradient|string|null)>",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalValueDef<(Gradient|string|null)>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef<(Gradient|string|null)>"
+              },
+              "type": "array"
+            }
+          ],
           "description": "One or more value definition(s) with [a selection or a test predicate](https://vega.github.io/vega-lite/docs/condition.html).\n\n__Note:__ A field definition's `condition` property can only contain [conditional value definitions](https://vega.github.io/vega-lite/docs/condition.html#value)\nsince Vega-Lite only allows at most one encoded field per encoding channel."
         },
         "field": {
@@ -7866,7 +7916,17 @@
           "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "condition": {
-          "$ref": "#/definitions/ValueOrSignalCondition<number>",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalValueDef<number>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef<number>"
+              },
+              "type": "array"
+            }
+          ],
           "description": "One or more value definition(s) with [a selection or a test predicate](https://vega.github.io/vega-lite/docs/condition.html).\n\n__Note:__ A field definition's `condition` property can only contain [conditional value definitions](https://vega.github.io/vega-lite/docs/condition.html#value)\nsince Vega-Lite only allows at most one encoded field per encoding channel."
         },
         "field": {
@@ -7960,7 +8020,17 @@
           "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "condition": {
-          "$ref": "#/definitions/ValueOrSignalCondition<number[]>",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalValueDef<number[]>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef<number[]>"
+              },
+              "type": "array"
+            }
+          ],
           "description": "One or more value definition(s) with [a selection or a test predicate](https://vega.github.io/vega-lite/docs/condition.html).\n\n__Note:__ A field definition's `condition` property can only contain [conditional value definitions](https://vega.github.io/vega-lite/docs/condition.html#value)\nsince Vega-Lite only allows at most one encoded field per encoding channel."
         },
         "field": {
@@ -8054,7 +8124,17 @@
           "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "condition": {
-          "$ref": "#/definitions/ValueOrSignalCondition<(string|null)>",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalValueDef<(string|null)>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef<(string|null)>"
+              },
+              "type": "array"
+            }
+          ],
           "description": "One or more value definition(s) with [a selection or a test predicate](https://vega.github.io/vega-lite/docs/condition.html).\n\n__Note:__ A field definition's `condition` property can only contain [conditional value definitions](https://vega.github.io/vega-lite/docs/condition.html#value)\nsince Vega-Lite only allows at most one encoded field per encoding channel."
         },
         "field": {
@@ -8154,7 +8234,17 @@
           "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "condition": {
-          "$ref": "#/definitions/ValueOrSignalCondition<Text>",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalValueDef<Text>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef<Text>"
+              },
+              "type": "array"
+            }
+          ],
           "description": "One or more value definition(s) with [a selection or a test predicate](https://vega.github.io/vega-lite/docs/condition.html).\n\n__Note:__ A field definition's `condition` property can only contain [conditional value definitions](https://vega.github.io/vega-lite/docs/condition.html#value)\nsince Vega-Lite only allows at most one encoded field per encoding channel."
         },
         "field": {
@@ -8247,7 +8337,17 @@
           "description": "A flag for binning a `quantitative` field, [an object defining binning parameters](https://vega.github.io/vega-lite/docs/bin.html#params), or indicating that the data for `x` or `y` channel are binned before they are imported into Vega-Lite (`\"binned\"`).\n\n- If `true`, default [binning parameters](https://vega.github.io/vega-lite/docs/bin.html) will be applied.\n\n- If `\"binned\"`, this indicates that the data for the `x` (or `y`) channel are already binned. You can map the bin-start field to `x` (or `y`) and the bin-end field to `x2` (or `y2`). The scale and axis will be formatted similar to binning in Vega-Lite.  To adjust the axis ticks based on the bin step, you can also set the axis's [`tickMinStep`](https://vega.github.io/vega-lite/docs/axis.html#ticks) property.\n\n__Default value:__ `false`\n\n__See also:__ [`bin`](https://vega.github.io/vega-lite/docs/bin.html) documentation."
         },
         "condition": {
-          "$ref": "#/definitions/ValueOrSignalCondition<string>",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ConditionalValueDef<string>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef<string>"
+              },
+              "type": "array"
+            }
+          ],
           "description": "One or more value definition(s) with [a selection or a test predicate](https://vega.github.io/vega-lite/docs/condition.html).\n\n__Note:__ A field definition's `condition` property can only contain [conditional value definitions](https://vega.github.io/vega-lite/docs/condition.html#value)\nsince Vega-Lite only allows at most one encoded field per encoding channel."
         },
         "field": {
@@ -13417,8 +13517,8 @@
     "NumericArrayFieldDefWithCondition": {
       "$ref": "#/definitions/FieldOrDatumDefWithCondition<MarkPropFieldDef,number[]>"
     },
-    "NumericArrayValueDefWithConditionAlias": {
-      "$ref": "#/definitions/ValueDefWithConditionAlias<MarkPropFieldOrDatumDef,number[]>"
+    "NumericArrayValueDefWithCondition": {
+      "$ref": "#/definitions/ValueDefWithCondition<MarkPropFieldOrDatumDef,number[]>"
     },
     "NumericDatumDefWithCondition": {
       "$ref": "#/definitions/FieldOrDatumDefWithCondition<DatumDef,number>"
@@ -13426,8 +13526,11 @@
     "NumericFieldDefWithCondition": {
       "$ref": "#/definitions/FieldOrDatumDefWithCondition<MarkPropFieldDef,number>"
     },
-    "NumericValueDefWithConditionAlias": {
-      "$ref": "#/definitions/ValueDefWithConditionAlias<MarkPropFieldOrDatumDef,number>"
+    "NumericValueDef": {
+      "$ref": "#/definitions/ValueDef<number>"
+    },
+    "NumericValueDefWithCondition": {
+      "$ref": "#/definitions/ValueDefWithCondition<MarkPropFieldOrDatumDef,number>"
     },
     "OrderFieldDef": {
       "additionalProperties": false,
@@ -16311,8 +16414,8 @@
     "ShapeFieldDefWithCondition": {
       "$ref": "#/definitions/FieldOrDatumDefWithCondition<MarkPropFieldDef<TypeForShape>,(string|null)>"
     },
-    "ShapeValueDefWithConditionAlias": {
-      "$ref": "#/definitions/StringValueDefWithConditionAlias<TypeForShape>"
+    "ShapeValueDefWithCondition": {
+      "$ref": "#/definitions/StringValueDefWithCondition<TypeForShape>"
     },
     "SingleDefUnitChannel": {
       "enum": [
@@ -16891,11 +16994,11 @@
     "StringFieldDefWithCondition": {
       "$ref": "#/definitions/FieldOrDatumDefWithCondition<StringFieldDef,string>"
     },
-    "StringValueDefWithConditionAlias<TypeForShape>": {
-      "$ref": "#/definitions/ValueDefWithConditionAlias<MarkPropFieldOrDatumDef<TypeForShape>,(string|null)>"
+    "StringValueDefWithCondition<TypeForShape>": {
+      "$ref": "#/definitions/ValueDefWithCondition<MarkPropFieldOrDatumDef<TypeForShape>,(string|null)>"
     },
-    "StringValueDefWithConditionAlias": {
-      "$ref": "#/definitions/ValueDefWithConditionAlias<MarkPropFieldOrDatumDef,(string|null)>"
+    "StringValueDefWithCondition": {
+      "$ref": "#/definitions/ValueDefWithCondition<MarkPropFieldOrDatumDef,(string|null)>"
     },
     "StrokeCap": {
       "enum": [
@@ -17055,8 +17158,8 @@
     "TextFieldDefWithCondition": {
       "$ref": "#/definitions/FieldOrDatumDefWithCondition<StringFieldDef,Text>"
     },
-    "TextValueDefWithConditionAlias": {
-      "$ref": "#/definitions/ValueDefWithConditionAlias<StringFieldDef,Text>"
+    "TextValueDefWithCondition": {
+      "$ref": "#/definitions/ValueDefWithCondition<StringFieldDef,Text>"
     },
     "TickConfig": {
       "additionalProperties": false,
@@ -19361,7 +19464,7 @@
       ],
       "type": "string"
     },
-    "YValueDef": {
+    "ValueDef<(number|\"height\")>": {
       "additionalProperties": false,
       "description": "Definition object for a constant value (primitive value or gradient definition) of an encoding channel.",
       "properties": {
@@ -19385,7 +19488,7 @@
       ],
       "type": "object"
     },
-    "XValueDef": {
+    "ValueDef<(number|\"width\")>": {
       "additionalProperties": false,
       "description": "Definition object for a constant value (primitive value or gradient definition) of an encoding channel.",
       "properties": {
@@ -19409,7 +19512,7 @@
       ],
       "type": "object"
     },
-    "NumberValueDef": {
+    "ValueDef<number>": {
       "additionalProperties": false,
       "description": "Definition object for a constant value (primitive value or gradient definition) of an encoding channel.",
       "properties": {
@@ -19433,7 +19536,13 @@
               "$ref": "#/definitions/ConditionalMarkPropFieldOrDatumDef"
             },
             {
-              "$ref": "#/definitions/ValueOrSignalCondition<(Gradient|string|null)>"
+              "$ref": "#/definitions/ConditionalValueDef<(Gradient|string|null)>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef<(Gradient|string|null)>"
+              },
+              "type": "array"
             }
           ],
           "description": "A field definition or one or more value definition(s) with a selection predicate."
@@ -19465,7 +19574,13 @@
               "$ref": "#/definitions/ConditionalMarkPropFieldOrDatumDef"
             },
             {
-              "$ref": "#/definitions/ValueOrSignalCondition<(string|null)>"
+              "$ref": "#/definitions/ConditionalValueDef<(string|null)>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef<(string|null)>"
+              },
+              "type": "array"
             }
           ],
           "description": "A field definition or one or more value definition(s) with a selection predicate."
@@ -19490,7 +19605,13 @@
               "$ref": "#/definitions/ConditionalMarkPropFieldOrDatumDef"
             },
             {
-              "$ref": "#/definitions/ValueOrSignalCondition<number>"
+              "$ref": "#/definitions/ConditionalValueDef<number>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef<number>"
+              },
+              "type": "array"
             }
           ],
           "description": "A field definition or one or more value definition(s) with a selection predicate."
@@ -19512,7 +19633,13 @@
               "$ref": "#/definitions/ConditionalMarkPropFieldOrDatumDef"
             },
             {
-              "$ref": "#/definitions/ValueOrSignalCondition<number[]>"
+              "$ref": "#/definitions/ConditionalValueDef<number[]>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef<number[]>"
+              },
+              "type": "array"
             }
           ],
           "description": "A field definition or one or more value definition(s) with a selection predicate."
@@ -19537,7 +19664,13 @@
               "$ref": "#/definitions/ConditionalMarkPropFieldOrDatumDef<TypeForShape>"
             },
             {
-              "$ref": "#/definitions/ValueOrSignalCondition<(string|null)>"
+              "$ref": "#/definitions/ConditionalValueDef<(string|null)>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef<(string|null)>"
+              },
+              "type": "array"
             }
           ],
           "description": "A field definition or one or more value definition(s) with a selection predicate."
@@ -19562,7 +19695,13 @@
               "$ref": "#/definitions/ConditionalStringFieldDef"
             },
             {
-              "$ref": "#/definitions/ValueOrSignalCondition<Text>"
+              "$ref": "#/definitions/ConditionalValueDef<Text>"
+            },
+            {
+              "items": {
+                "$ref": "#/definitions/ConditionalValueDef<Text>"
+              },
+              "type": "array"
             }
           ],
           "description": "A field definition or one or more value definition(s) with a selection predicate."
@@ -19573,102 +19712,6 @@
         }
       },
       "type": "object"
-    },
-    "ValueOrSignalCondition<(Gradient|string|null)>": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ConditionalValueDef<(Gradient|string|null)>"
-        },
-        {
-          "items": {
-            "$ref": "#/definitions/ConditionalValueDef<(Gradient|string|null)>"
-          },
-          "type": "array"
-        }
-      ]
-    },
-    "ValueOrSignalCondition<(string|null)>": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ConditionalStringValueDef"
-        },
-        {
-          "items": {
-            "$ref": "#/definitions/ConditionalStringValueDef"
-          },
-          "type": "array"
-        }
-      ]
-    },
-    "ValueOrSignalCondition<Text>": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ConditionalValueDef<Text>"
-        },
-        {
-          "items": {
-            "$ref": "#/definitions/ConditionalValueDef<Text>"
-          },
-          "type": "array"
-        }
-      ]
-    },
-    "ValueOrSignalCondition<number>": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ConditionalNumberValueDef"
-        },
-        {
-          "items": {
-            "$ref": "#/definitions/ConditionalNumberValueDef"
-          },
-          "type": "array"
-        }
-      ]
-    },
-    "ValueOrSignalCondition<number[]>": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ConditionalValueDef<number[]>"
-        },
-        {
-          "items": {
-            "$ref": "#/definitions/ConditionalValueDef<number[]>"
-          },
-          "type": "array"
-        }
-      ]
-    },
-    "ValueOrSignalCondition<string>": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ConditionalValueDef<string>"
-        },
-        {
-          "items": {
-            "$ref": "#/definitions/ConditionalValueDef<string>"
-          },
-          "type": "array"
-        }
-      ]
-    },
-    "ValueDefWithConditionAlias<MarkPropFieldOrDatumDef,(Gradient|string|null)>": {
-      "$ref": "#/definitions/ValueDefWithCondition<MarkPropFieldOrDatumDef,(Gradient|string|null)>"
-    },
-    "ValueDefWithConditionAlias<MarkPropFieldOrDatumDef,(string|null)>": {
-      "$ref": "#/definitions/ValueDefWithCondition<MarkPropFieldOrDatumDef,(string|null)>"
-    },
-    "ValueDefWithConditionAlias<MarkPropFieldOrDatumDef,number>": {
-      "$ref": "#/definitions/ValueDefWithCondition<MarkPropFieldOrDatumDef,number>"
-    },
-    "ValueDefWithConditionAlias<MarkPropFieldOrDatumDef,number[]>": {
-      "$ref": "#/definitions/ValueDefWithCondition<MarkPropFieldOrDatumDef,number[]>"
-    },
-    "ValueDefWithConditionAlias<MarkPropFieldOrDatumDef<TypeForShape>,(string|null)>": {
-      "$ref": "#/definitions/ValueDefWithCondition<MarkPropFieldOrDatumDef<TypeForShape>,(string|null)>"
-    },
-    "ValueDefWithConditionAlias<StringFieldDef,Text>": {
-      "$ref": "#/definitions/ValueDefWithCondition<StringFieldDef,Text>"
     },
     "Vector2<DateTime>": {
       "items": [
@@ -20095,6 +20138,12 @@
         "window"
       ],
       "type": "object"
+    },
+    "XValueDef": {
+      "$ref": "#/definitions/ValueDef<(number|\"width\")>"
+    },
+    "YValueDef": {
+      "$ref": "#/definitions/ValueDef<(number|\"height\")>"
     }
   }
 }

--- a/scripts/rename-schema.sh
+++ b/scripts/rename-schema.sh
@@ -10,13 +10,7 @@ perl -pi -e s,'CompositeEncoding','Encoding',g build/vega-lite-schema.json
 perl -pi -e s,'Generic(.*)<FacetedUnitSpec\,LayerSpec\,?.*\,FieldName>','\1',g build/vega-lite-schema.json
 perl -pi -e s,'Generic(.*)<FacetedUnitSpec\,LayerSpec\,?.*\,Field>','Normalized\1',g build/vega-lite-schema.json
 
-perl -pi -e s,'ValueDef(.*)\<\(number\|\\\"width\\\"\)\>','XValueDef\1',g build/vega-lite-schema.json
-perl -pi -e s,'ValueDef(.*)\<\(number\|\\\"height\\\"\)\>','YValueDef\1',g build/vega-lite-schema.json
-perl -pi -e s,'ValueDef(.*)<\(string\|null\)>','StringValueDef\1',g build/vega-lite-schema.json
 perl -pi -e s,'ValueDef(.*)<Value>','ValueDef\1',g build/vega-lite-schema.json
-perl -pi -e s,'ValueDef(.*)<number>','NumberValueDef\1',g build/vega-lite-schema.json
-perl -pi -e s,'ValueOrSignalDefWithCondition','ValueDefWithConditionAlias',g build/vega-lite-schema.json
-
 perl -pi -e s,'Conditional<(.*)>','Conditional\1',g build/vega-lite-schema.json
 
 perl -pi -e s,'FieldDefWithCondition<FieldDefWithoutScale>','FieldDefWithConditionWithoutScale',g build/vega-lite-schema.json

--- a/site/_data/link.yml
+++ b/site/_data/link.yml
@@ -201,9 +201,6 @@ AllSortString:
 NumericFieldDefWithCondition:
   name: MarkPropFieldDef
   link: 'encoding.html#mark-prop-field-def'
-NumericValueDefWithConditionAlias:
-  name: MarkPropValueDef
-  link: 'encoding.html#mark-prop-value-def'
 NumericDatumDefWithCondition:
   name: MarkPropDatumDef
   link: 'encoding.html#mark-prop-datum-def'
@@ -211,9 +208,6 @@ NumericDatumDefWithCondition:
 NumericArrayFieldDefWithCondition:
   name: MarkPropFieldDef
   link: 'encoding.html#mark-prop-field-def'
-NumericArrayValueDefWithConditionAlias:
-  name: MarkPropValueDef
-  link: 'encoding.html#mark-prop-value-def'
 NumericArrayDatumDefWithCondition:
   name: MarkPropDatumDef
   link: 'encoding.html#mark-prop-datum-def'
@@ -221,9 +215,6 @@ NumericArrayDatumDefWithCondition:
 StringFieldDefWithCondition:
   name: MarkPropFieldDef
   link: 'encoding.html#mark-prop-field-def'
-StringValueDefWithConditionAlias:
-  name: ValueDef
-  link: 'encoding.html#mark-prop-value-def'
 StringDatumDefWithCondition:
   name: MarkPropDatumDef
   link: 'encoding.html#mark-prop-datum-def'
@@ -231,9 +222,6 @@ StringDatumDefWithCondition:
 ShapeFieldDefWithCondition:
   name: MarkPropFieldDef
   link: 'encoding.html#mark-prop-field-def'
-ShapeValueDefWithConditionAlias:
-  name: MarkPropValueDef
-  link: 'encoding.html#mark-prop-value-def'
 ShapeDatumDefWithCondition:
   name: MarkPropDatumDef
   link: 'encoding.html#mark-prop-datum-def'
@@ -241,9 +229,6 @@ ShapeDatumDefWithCondition:
 ColorGradientFieldDefWithCondition:
   name: MarkPropFieldDef
   link: 'encoding.html#mark-prop-field-def'
-ColorGradientValueDefWithConditionAlias:
-  name: MarkPropValueDef
-  link: 'encoding.html#mark-prop-value-def'
 ColorGradientDatumDefWithCondition:
   name: MarkPropDatumDef
   link: 'encoding.html#mark-prop-datum-def'
@@ -251,9 +236,6 @@ ColorGradientDatumDefWithCondition:
 TextFieldDefWithCondition:
   name: TextFieldDef
   link: 'encoding.html#text-field-def'
-TextValueDefWithConditionAlias:
-  name: TextValueDef
-  link: 'encoding.html#text-value-def'
 
 FieldDefWithCondition:
   link: 'encoding.html#href-field-def'
@@ -309,16 +291,13 @@ PolarDatumDef:
 ValueDef:
   link: 'encoding.html#value-def'
 
-NumberValueDef:
-  name: MarkPropValueDef
+NumericValueDef:
+  name: ValueDef
   link: 'encoding.html#value-def'
 XValueDef:
   name: ValueDef
   link: 'encoding.html#value-def'
 YValueDef:
-  name: ValueDef
-  link: 'encoding.html#value-def'
-StringValueDef:
   name: ValueDef
   link: 'encoding.html#value-def'
 

--- a/site/docs/encoding.md
+++ b/site/docs/encoding.md
@@ -329,8 +329,6 @@ The example below show how the href channel can be used to provide links to exte
 
 In addition to the constant `value`, [value definitions](#value-def) of the `href` channel can include the `condition` property to specify conditional logic.
 
-<!-- {% include table.html props="condition" source="StringValueDefWithCondition" %} -->
-
 {% include table.html props="condition" source="ValueDefWithCondition<MarkPropFieldDef,(string|null)>" %}
 
 {:#detail}

--- a/src/compile/mark/encode/conditional.ts
+++ b/src/compile/mark/encode/conditional.ts
@@ -1,3 +1,4 @@
+import {SignalRef} from 'vega';
 import {array} from 'vega-util';
 import {
   ChannelDef,
@@ -16,7 +17,7 @@ import {UnitModel} from '../../unit';
  * Return a mixin that includes a Vega production rule for a Vega-Lite conditional channel definition.
  * or a simple mixin if channel def has no condition.
  */
-export function wrapCondition<CD extends ChannelDef | GuideEncodingConditionalValueDef>(
+export function wrapCondition<CD extends ChannelDef | GuideEncodingConditionalValueDef | SignalRef>(
   model: UnitModel,
   channelDef: CD,
   vgChannel: string,

--- a/src/compile/mark/encode/text.ts
+++ b/src/compile/mark/encode/text.ts
@@ -1,7 +1,8 @@
 import {getFormatMixins, isTypedFieldDef, isValueDef} from '../../../channeldef';
 import {Config} from '../../../config';
 import {Encoding} from '../../../encoding';
-import {VgValueRef, isSignalRef} from '../../../vega.schema';
+import {VgValueRef} from '../../../vega.schema';
+import {signalOrValueRef} from '../../common';
 import {formatSignalRef} from '../../format';
 import {UnitModel} from '../../unit';
 import {wrapCondition} from './conditional';
@@ -19,14 +20,11 @@ export function textRef(
   // text
   if (channelDef) {
     if (isValueDef(channelDef)) {
-      return {value: channelDef.value};
+      return signalOrValueRef(channelDef.value);
     }
     if (isTypedFieldDef(channelDef)) {
       const {format, formatType} = getFormatMixins(channelDef);
       return formatSignalRef({fieldOrDatumDef: channelDef, format, formatType, expr, config});
-    }
-    if (isSignalRef(channelDef)) {
-      return channelDef;
     }
   }
   return undefined;

--- a/src/compile/mark/encode/valueref.ts
+++ b/src/compile/mark/encode/valueref.ts
@@ -306,8 +306,6 @@ export function midPoint({
       const offsetMixins = offset ? {offset} : {};
 
       return {...widthHeightValueOrSignalRef(channel, value), ...offsetMixins};
-    } else if (isSignalRef(channelDef)) {
-      return channelDef;
     }
 
     // If channelDef is neither field def or value def, it's a condition-only def.

--- a/src/compositemark/common.ts
+++ b/src/compositemark/common.ts
@@ -10,7 +10,7 @@ import {
   SecondaryFieldDef,
   StringFieldDef,
   StringFieldDefWithCondition,
-  StringValueOrSignalDefWithCondition
+  StringValueDefWithCondition
 } from '../channeldef';
 import {Encoding, fieldDefs} from '../encoding';
 import * as log from '../log';
@@ -51,7 +51,7 @@ export function filterTooltipWithAggregatedField<F extends Field>(
 ): {
   customTooltipWithoutAggregatedField?:
     | StringFieldDefWithCondition<F>
-    | StringValueOrSignalDefWithCondition<F>
+    | StringValueDefWithCondition<F>
     | StringFieldDef<F>[];
   filteredEncoding: Encoding<F>;
 } {
@@ -62,11 +62,11 @@ export function filterTooltipWithAggregatedField<F extends Field>(
 
   let customTooltipWithAggregatedField:
     | StringFieldDefWithCondition<F>
-    | StringValueOrSignalDefWithCondition<F>
+    | StringValueDefWithCondition<F>
     | StringFieldDef<F>[];
   let customTooltipWithoutAggregatedField:
     | StringFieldDefWithCondition<F>
-    | StringValueOrSignalDefWithCondition<F>
+    | StringValueDefWithCondition<F>
     | StringFieldDef<F>[];
 
   if (isArray(tooltip)) {

--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -1,4 +1,4 @@
-import {AggregateOp, SignalRef} from 'vega';
+import {AggregateOp} from 'vega';
 import {array, isArray} from 'vega-util';
 import {isArgmaxDef, isArgminDef} from './aggregate';
 import {isBinned, isBinning} from './bin';
@@ -46,7 +46,7 @@ import {
   ChannelDef,
   ColorGradientDatumDefWithCondition,
   ColorGradientFieldDefWithCondition,
-  ColorGradientValueOrSignalDefWithCondition,
+  ColorGradientValueDefWithCondition,
   DatumDef,
   Field,
   FieldDef,
@@ -64,10 +64,11 @@ import {
   LatLongFieldDef,
   NumericArrayDatumDefWithCondition,
   NumericArrayFieldDefWithCondition,
-  NumericArrayValueOrSignalDefWithCondition,
+  NumericArrayValueDefWithCondition,
   NumericDatumDefWithCondition,
   NumericFieldDefWithCondition,
-  NumericValueOrSignalDefWithCondition,
+  NumericValueDef,
+  NumericValueDefWithCondition,
   OrderFieldDef,
   PolarDatumDef,
   PolarFieldDef,
@@ -75,17 +76,18 @@ import {
   PositionFieldDef,
   SecondaryFieldDef,
   ShapeFieldDefWithCondition,
-  ShapeValueOrSignalDefWithCondition,
+  ShapeValueDefWithCondition,
   StringDatumDefWithCondition,
   StringFieldDef,
   StringFieldDefWithCondition,
-  StringValueOrSignalDefWithCondition,
+  StringValueDefWithCondition,
   TextFieldDefWithCondition,
-  TextValueOrSignalDefWithCondition,
+  TextValueDefWithCondition,
   title,
   TypedFieldDef,
-  ValueDef,
-  vgField
+  vgField,
+  XValueDef,
+  YValueDef
 } from './channeldef';
 import {Config} from './config';
 import * as log from './log';
@@ -102,14 +104,14 @@ export interface Encoding<F extends Field> {
    *
    * The `value` of this channel can be a number or a string `"width"` for the width of the plot.
    */
-  x?: PositionFieldDef<F> | PositionDatumDef<F> | ValueDef<number | 'width'> | SignalRef;
+  x?: PositionFieldDef<F> | PositionDatumDef<F> | XValueDef;
 
   /**
    * Y coordinates of the marks, or height of vertical `"bar"` and `"area"` without specified `y2` or `height`.
    *
    * The `value` of this channel can be a number or a string `"height"` for the height of the plot.
    */
-  y?: PositionFieldDef<F> | PositionDatumDef<F> | ValueDef<number | 'height'> | SignalRef;
+  y?: PositionFieldDef<F> | PositionDatumDef<F> | YValueDef;
 
   /**
    * X2 coordinates for ranged `"area"`, `"bar"`, `"rect"`, and  `"rule"`.
@@ -118,7 +120,7 @@ export interface Encoding<F extends Field> {
    */
   // TODO: Ham need to add default behavior
   // `x2` cannot have type as it should have the same type as `x`
-  x2?: SecondaryFieldDef<F> | DatumDef<F> | ValueDef<number | 'width'> | SignalRef;
+  x2?: SecondaryFieldDef<F> | DatumDef<F> | XValueDef;
 
   /**
    * Y2 coordinates for ranged `"area"`, `"bar"`, `"rect"`, and  `"rule"`.
@@ -127,52 +129,52 @@ export interface Encoding<F extends Field> {
    */
   // TODO: Ham need to add default behavior
   // `y2` cannot have type as it should have the same type as `y`
-  y2?: SecondaryFieldDef<F> | DatumDef<F> | ValueDef<number | 'height'> | SignalRef;
+  y2?: SecondaryFieldDef<F> | DatumDef<F> | YValueDef;
 
   /**
    * Longitude position of geographically projected marks.
    */
-  longitude?: LatLongFieldDef<F> | DatumDef<F> | ValueDef<number>;
+  longitude?: LatLongFieldDef<F> | DatumDef<F> | NumericValueDef;
 
   /**
    * Latitude position of geographically projected marks.
    */
-  latitude?: LatLongFieldDef<F> | DatumDef<F> | ValueDef<number>;
+  latitude?: LatLongFieldDef<F> | DatumDef<F> | NumericValueDef;
 
   /**
    * - For arc marks, the arc length in radians if theta2 is not specified, otherwise the start arc angle. (A value of 0 indicates up or “north”, increasing values proceed clockwise.)
    *
    * - For text marks, polar coordinate angle in radians.
    */
-  theta?: PolarFieldDef<F> | PolarDatumDef<F> | ValueDef<number> | SignalRef;
+  theta?: PolarFieldDef<F> | PolarDatumDef<F> | NumericValueDef;
 
   /**
    * The end angle of arc marks in radians. A value of 0 indicates up or “north”, increasing values proceed clockwise.
    */
-  theta2?: SecondaryFieldDef<F> | DatumDef<F> | ValueDef<number> | SignalRef;
+  theta2?: SecondaryFieldDef<F> | DatumDef<F> | NumericValueDef;
 
   /**
    * The outer radius in pixels of arc marks.
    */
 
-  radius?: PolarFieldDef<F> | PolarDatumDef<F> | ValueDef<number> | SignalRef;
+  radius?: PolarFieldDef<F> | PolarDatumDef<F> | NumericValueDef;
 
   /**
    * The inner radius in pixels of arc marks.
    */
-  radius2?: SecondaryFieldDef<F> | DatumDef<F> | ValueDef<number> | SignalRef;
+  radius2?: SecondaryFieldDef<F> | DatumDef<F> | NumericValueDef;
 
   /**
    * Longitude-2 position for geographically projected ranged `"area"`, `"bar"`, `"rect"`, and  `"rule"`.
    */
   // `longitude2` cannot have type as it should have the same type as `longitude`
-  longitude2?: SecondaryFieldDef<F> | DatumDef<F> | ValueDef<number>;
+  longitude2?: SecondaryFieldDef<F> | DatumDef<F> | NumericValueDef;
 
   /**
    * Latitude-2 position for geographically projected ranged `"area"`, `"bar"`, `"rect"`, and  `"rule"`.
    */
   // `latitude2` cannot have type as it should have the same type as `latitude`
-  latitude2?: SecondaryFieldDef<F> | DatumDef<F> | ValueDef<number>;
+  latitude2?: SecondaryFieldDef<F> | DatumDef<F> | NumericValueDef;
 
   /**
    * Color of the marks – either fill or stroke color based on  the `filled` property of mark definition.
@@ -188,7 +190,7 @@ export interface Encoding<F extends Field> {
   color?:
     | ColorGradientFieldDefWithCondition<F>
     | ColorGradientDatumDefWithCondition<F>
-    | ColorGradientValueOrSignalDefWithCondition<F>;
+    | ColorGradientValueDefWithCondition<F>;
 
   /**
    * Fill color of the marks.
@@ -199,7 +201,7 @@ export interface Encoding<F extends Field> {
   fill?:
     | ColorGradientFieldDefWithCondition<F>
     | ColorGradientDatumDefWithCondition<F>
-    | ColorGradientValueOrSignalDefWithCondition<F>;
+    | ColorGradientValueDefWithCondition<F>;
 
   /**
    * Stroke color of the marks.
@@ -211,44 +213,35 @@ export interface Encoding<F extends Field> {
   stroke?:
     | ColorGradientFieldDefWithCondition<F>
     | ColorGradientDatumDefWithCondition<F>
-    | ColorGradientValueOrSignalDefWithCondition<F>;
+    | ColorGradientValueDefWithCondition<F>;
 
   /**
    * Opacity of the marks.
    *
    * __Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `opacity` property.
    */
-  opacity?: NumericFieldDefWithCondition<F> | NumericDatumDefWithCondition<F> | NumericValueOrSignalDefWithCondition<F>;
+  opacity?: NumericFieldDefWithCondition<F> | NumericDatumDefWithCondition<F> | NumericValueDefWithCondition<F>;
 
   /**
    * Fill opacity of the marks.
    *
    * __Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `fillOpacity` property.
    */
-  fillOpacity?:
-    | NumericFieldDefWithCondition<F>
-    | NumericDatumDefWithCondition<F>
-    | NumericValueOrSignalDefWithCondition<F>;
+  fillOpacity?: NumericFieldDefWithCondition<F> | NumericDatumDefWithCondition<F> | NumericValueDefWithCondition<F>;
 
   /**
    * Stroke opacity of the marks.
    *
    * __Default value:__ If undefined, the default opacity depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `strokeOpacity` property.
    */
-  strokeOpacity?:
-    | NumericFieldDefWithCondition<F>
-    | NumericDatumDefWithCondition<F>
-    | NumericValueOrSignalDefWithCondition<F>;
+  strokeOpacity?: NumericFieldDefWithCondition<F> | NumericDatumDefWithCondition<F> | NumericValueDefWithCondition<F>;
 
   /**
    * Stroke width of the marks.
    *
    * __Default value:__ If undefined, the default stroke width depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#mark-config)'s `strokeWidth` property.
    */
-  strokeWidth?:
-    | NumericFieldDefWithCondition<F>
-    | NumericDatumDefWithCondition<F>
-    | NumericValueOrSignalDefWithCondition<F>;
+  strokeWidth?: NumericFieldDefWithCondition<F> | NumericDatumDefWithCondition<F> | NumericValueDefWithCondition<F>;
 
   /**
    * Stroke dash of the marks.
@@ -258,7 +251,7 @@ export interface Encoding<F extends Field> {
   strokeDash?:
     | NumericArrayFieldDefWithCondition<F>
     | NumericArrayDatumDefWithCondition<F>
-    | NumericArrayValueOrSignalDefWithCondition<F>;
+    | NumericArrayValueDefWithCondition<F>;
 
   /**
    * Size of the mark.
@@ -267,12 +260,12 @@ export interface Encoding<F extends Field> {
    * - For `"text"` – the text's font size.
    * - Size is unsupported for `"line"`, `"area"`, and `"rect"`. (Use `"trail"` instead of line with varying size)
    */
-  size?: NumericFieldDefWithCondition<F> | NumericDatumDefWithCondition<F> | NumericValueOrSignalDefWithCondition<F>;
+  size?: NumericFieldDefWithCondition<F> | NumericDatumDefWithCondition<F> | NumericValueDefWithCondition<F>;
 
   /**
    * Rotation angle of point and text marks.
    */
-  angle?: NumericFieldDefWithCondition<F> | NumericDatumDefWithCondition<F> | NumericValueOrSignalDefWithCondition<F>;
+  angle?: NumericFieldDefWithCondition<F> | NumericDatumDefWithCondition<F> | NumericValueDefWithCondition<F>;
 
   /**
    * Shape of the mark.
@@ -287,7 +280,7 @@ export interface Encoding<F extends Field> {
    *
    * __Default value:__ If undefined, the default shape depends on [mark config](https://vega.github.io/vega-lite/docs/config.html#point-config)'s `shape` property. (`"circle"` if unset.)
    */
-  shape?: ShapeFieldDefWithCondition<F> | StringDatumDefWithCondition<F> | ShapeValueOrSignalDefWithCondition<F>;
+  shape?: ShapeFieldDefWithCondition<F> | StringDatumDefWithCondition<F> | ShapeValueDefWithCondition<F>;
   /**
    * Additional levels of detail for grouping data in aggregate views and
    * in line, trail, and area marks without mapping data to a specific visual channel.
@@ -302,24 +295,24 @@ export interface Encoding<F extends Field> {
   /**
    * Text of the `text` mark.
    */
-  text?: TextFieldDefWithCondition<F> | TextValueOrSignalDefWithCondition<F>;
+  text?: TextFieldDefWithCondition<F> | TextValueDefWithCondition<F>;
 
   /**
    * The tooltip text to show upon mouse hover. Specifying `tooltip` encoding overrides [the `tooltip` property in the mark definition](https://vega.github.io/vega-lite/docs/mark.html#mark-def).
    *
    * See the [`tooltip`](https://vega.github.io/vega-lite/docs/tooltip.html) documentation for a detailed discussion about tooltip in Vega-Lite.
    */
-  tooltip?: StringFieldDefWithCondition<F> | StringValueOrSignalDefWithCondition<F> | StringFieldDef<F>[] | null;
+  tooltip?: StringFieldDefWithCondition<F> | StringValueDefWithCondition<F> | StringFieldDef<F>[] | null;
 
   /**
    * A URL to load upon mouse click.
    */
-  href?: StringFieldDefWithCondition<F> | StringValueOrSignalDefWithCondition<F>;
+  href?: StringFieldDefWithCondition<F> | StringValueDefWithCondition<F>;
 
   /**
    * The URL of an image mark.
    */
-  url?: StringFieldDefWithCondition<F> | StringValueOrSignalDefWithCondition<F>;
+  url?: StringFieldDefWithCondition<F> | StringValueDefWithCondition<F>;
 
   /**
    * Order of the marks.
@@ -329,7 +322,7 @@ export interface Encoding<F extends Field> {
    *
    * __Note__: In aggregate plots, `order` field should be `aggregate`d to avoid creating additional aggregation grouping.
    */
-  order?: OrderFieldDef<F> | OrderFieldDef<F>[] | ValueDef<number>;
+  order?: OrderFieldDef<F> | OrderFieldDef<F>[] | NumericValueDef;
 }
 
 export interface EncodingWithFacet<F extends Field> extends Encoding<F>, EncodingFacetMapping<F> {}

--- a/test/compile/mark/encode/text.test.ts
+++ b/test/compile/mark/encode/text.test.ts
@@ -7,13 +7,13 @@ describe('compile/mark/encode/text', () => {
       mark: 'text',
       encoding: {
         text: {
-          signal: '"Hello Vega"'
+          value: {signal: 'Hello'}
         }
       },
       data: {url: 'data/population.json'}
     });
 
     const textMixins = text(model);
-    expect(textMixins.text).toEqual({signal: '"Hello Vega"'});
+    expect(textMixins.text).toEqual({signal: 'Hello'});
   });
 });


### PR DESCRIPTION
fix #6433

Note that we'll still support conditional axis signal like this:

```
gridColor: {
  condition: {
    test: '<is major grid>',
    signal: 'majorGridColor' // this can also be `value: "#ddd"`
  },
  signal: 'gridColor'  // this can also be `value: "#eee"`
}
```

