### PR TITLE
fix: remove unnecessary time() in expr for predicates

### DIFF
--- a/src/predicate.ts
+++ b/src/predicate.ts
@@ -180,7 +180,7 @@ export function isFieldPredicate(
 }
 
 function predicateValueExpr(v: number | string | boolean | DateTime | SignalRef, timeUnit: TimeUnit) {
-  return valueExpr(v, {timeUnit, time: true});
+  return valueExpr(v, {timeUnit, wrapTime: true});
 }
 
 function predicateValuesExpr(vals: (number | string | boolean | DateTime)[], timeUnit: TimeUnit) {

--- a/test/predicate.test.ts
+++ b/test/predicate.test.ts
@@ -204,7 +204,7 @@ describe('filter', () => {
 
     it('should return a correct expression for a RangeFilter with signal range', () => {
       const expr = expression(null, {field: 'x', range: {signal: 'r'}});
-      expect(expr).toBe('inrange(datum["x"], [isDate(r[0]) ? time(r[0]) : r[0], isDate(r[1]) ? time(r[1]) : r[1]])');
+      expect(expr).toBe('inrange(datum["x"], [r[0], r[1]])');
     });
 
     it('should return a correct expression for a RangeFilter with no lower bound', () => {


### PR DESCRIPTION
fix #6436

