### PR TITLE
fix: don't output tooltip: {content:'encoding'} in the config

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -532,6 +532,10 @@ export function stripAndRedirectConfig(config: Config) {
     for (const prop of VL_ONLY_MARK_CONFIG_PROPERTIES) {
       delete config.mark[prop];
     }
+
+    if (config.mark.tooltip && isObject(config.mark.tooltip)) {
+      delete config.mark.tooltip;
+    }
   }
 
   for (const markType of MARK_STYLES) {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -98,7 +98,8 @@ describe('config', () => {
       ...defaultConfig,
       mark: {
         ...defaultConfig.mark,
-        opacity: 0.3
+        opacity: 0.3,
+        tooltip: {content: 'encoding'}
       },
       bar: {
         opacity: 0.5,
@@ -136,6 +137,10 @@ describe('config', () => {
     it('should remove VL only mark config but keep Vega mark config', () => {
       expect(output.mark.color).not.toBeDefined();
       expect(output.mark.opacity).toEqual(0.3);
+    });
+
+    it('should remove VL tooltip object', () => {
+      expect(output.mark.tooltip).toBeUndefined();
     });
 
     it('should remove conditional axis config', () => {


### PR DESCRIPTION
part of https://github.com/vega/vega-lite/issues/6404


