### PR TITLE
fix: unescape escaped fields in `as`

### DIFF
--- a/src/channeldef.ts
+++ b/src/channeldef.ts
@@ -71,7 +71,15 @@ import {
 } from './timeunit';
 import {AggregatedFieldDef, WindowFieldDef} from './transform';
 import {getFullName, QUANTITATIVE, StandardType, Type} from './type';
-import {contains, flatAccessWithDatum, getFirstDefined, internalField, replacePathInField, titlecase} from './util';
+import {
+  contains,
+  flatAccessWithDatum,
+  getFirstDefined,
+  internalField,
+  replacePathInField,
+  titlecase,
+  removePathFromField
+} from './util';
 import {isSignalRef} from './vega.schema';
 
 export type PrimitiveValue = number | string | boolean | null;
@@ -759,7 +767,7 @@ export function vgField(
   }
 
   if (opt.forAs) {
-    return field;
+    return removePathFromField(field);
   } else if (opt.expr) {
     // Expression to access flattened field. No need to escape dots.
     return flatAccessWithDatum(field, opt.expr) + argAccessor;

--- a/src/util.ts
+++ b/src/util.ts
@@ -287,10 +287,6 @@ export function titlecase(s: string) {
   return s.charAt(0).toUpperCase() + s.substr(1);
 }
 
-function escapePathAccess(string: string) {
-  return string.replace(/(\[|\]|\.|'|")/g, '\\$1');
-}
-
 /**
  * Converts a path to an access path with datum.
  * @param path The field name.
@@ -316,6 +312,10 @@ export function flatAccessWithDatum(path: string, datum: 'datum' | 'parent' | 'd
   return `${datum}[${stringValue(splitAccessPath(path).join('.'))}]`;
 }
 
+function escapePathAccess(string: string) {
+  return string.replace(/(\[|\]|\.|'|")/g, '\\$1');
+}
+
 /**
  * Replaces path accesses with access to non-nested field.
  * For example, `foo["bar"].baz` becomes `foo\\.bar\\.baz`.
@@ -325,7 +325,7 @@ export function replacePathInField(path: string) {
 }
 
 /**
- * Replace all ocurrences of a string with another string.
+ * Replace all occurrences of a string with another string.
  *
  * @param string the string to replace in
  * @param find the string to replace

--- a/test/compile/data/stack.test.ts
+++ b/test/compile/data/stack.test.ts
@@ -11,6 +11,7 @@ function parse(model: UnitModel) {
 function assemble(model: UnitModel) {
   return StackNode.makeFromEncoding(null, model).assemble();
 }
+
 describe('compile/data/stack', () => {
   describe('StackNode.makeFromEncoding', () => {
     it('should produce correct stack component for bar with color', () => {
@@ -35,6 +36,31 @@ describe('compile/data/stack', () => {
         offset: 'zero',
         impute: false,
         as: ['sum_a_start', 'sum_a_end']
+      });
+    });
+
+    it('should remove escaping from fields for as', () => {
+      const model = parseUnitModelWithScale({
+        mark: 'bar',
+        encoding: {
+          x: {aggregate: 'sum', field: 'a\\[foo\\]', type: 'quantitative'},
+          y: {field: 'b', type: 'nominal'},
+          color: {field: 'c', type: 'ordinal'}
+        }
+      });
+
+      expect(parse(model)).toEqual({
+        dimensionFieldDef: {field: 'b', type: 'nominal'},
+        facetby: [],
+        stackField: 'sum_a\\[foo\\]',
+        stackby: ['c'],
+        sort: {
+          field: ['c'],
+          order: ['ascending']
+        },
+        offset: 'zero',
+        impute: false,
+        as: ['sum_a[foo]_start', 'sum_a[foo]_end']
       });
     });
 
@@ -216,7 +242,7 @@ describe('compile/data/stack', () => {
           groupby: ['age'],
           field: 'people',
           offset: 'zero',
-          sort: {field: [] as string[], order: []},
+          sort: {field: [], order: []},
           as: ['v1', 'v2']
         }
       ]);
@@ -236,7 +262,7 @@ describe('compile/data/stack', () => {
           groupby: ['age', 'gender'],
           field: 'people',
           offset: 'normalize',
-          sort: {field: [] as string[], order: []},
+          sort: {field: [], order: []},
           as: ['val', 'val_end']
         }
       ]);
@@ -290,7 +316,7 @@ describe('compile/data/stack', () => {
   });
 
   describe('StackNode.producedFields', () => {
-    it('should give producedfields correctly', () => {
+    it('should give producedFields correctly', () => {
       const transform: Transform = {
         stack: 'people',
         groupby: ['age'],


### PR DESCRIPTION
fixes #6422, fixes #4123
