### PR TITLE
fix: correctly redirect align, baseline, dx, dy, and limit of config.title to config.style.group-subtitle

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -583,19 +583,24 @@ export function stripAndRedirectConfig(config: Config) {
  * For subtitle configs in config.title, keep them in config.title as header titles never have subtitles.
  */
 function redirectTitleConfig(config: Config) {
-  const {mark: m, subtitle} = extractTitleConfig(config.title);
+  const {titleMarkConfig, subtitleMarkConfig, subtitle} = extractTitleConfig(config.title);
 
-  const style: MarkConfig = {
-    ...config.style['group-title'],
-    ...m
-  };
-
-  // set config.style if it is not an empty object
-  if (keys(style).length > 0) {
-    config.style['group-title'] = style;
+  // set config.style if title/subtitleMarkConfig is not an empty object
+  if (keys(titleMarkConfig).length > 0) {
+    // TODO figure precedence
+    config.style['group-title'] = {
+      ...config.style['group-title'],
+      ...titleMarkConfig // config.title has higher precedence than config.style.group-title in Vega
+    };
+  }
+  if (keys(subtitleMarkConfig).length > 0) {
+    config.style['group-subtitle'] = {
+      ...config.style['group-subtitle'],
+      ...subtitleMarkConfig
+    };
   }
 
-  //
+  // subtitle part can stay in config.title since header titles do not use subtitle
   if (keys(subtitle).length > 0) {
     config.title = subtitle;
   } else {

--- a/src/config.ts
+++ b/src/config.ts
@@ -587,7 +587,6 @@ function redirectTitleConfig(config: Config) {
 
   // set config.style if title/subtitleMarkConfig is not an empty object
   if (keys(titleMarkConfig).length > 0) {
-    // TODO figure precedence
     config.style['group-title'] = {
       ...config.style['group-title'],
       ...titleMarkConfig // config.title has higher precedence than config.style.group-title in Vega

--- a/src/title.ts
+++ b/src/title.ts
@@ -1,6 +1,7 @@
 import {BaseTitle, Text, TextEncodeEntry, TitleAnchor} from 'vega';
 import {isArray, isString} from 'vega-util';
 import {MarkConfig} from './mark';
+import {pick} from './util';
 import {ExcludeMappedValueRef, ExcludeMappedValueRefButKeepSignal} from './vega.schema';
 
 export type BaseTitleNoValueRefs = ExcludeMappedValueRefButKeepSignal<Omit<BaseTitle, 'align' | 'baseline'>> &
@@ -60,7 +61,8 @@ export interface TitleParams extends TitleBase {
 export function extractTitleConfig(
   titleConfig: TitleConfig
 ): {
-  mark: MarkConfig;
+  titleMarkConfig: MarkConfig;
+  subtitleMarkConfig: MarkConfig;
   nonMark: BaseTitleNoValueRefs;
   subtitle: BaseTitleNoValueRefs;
 } {
@@ -70,6 +72,7 @@ export function extractTitleConfig(
     frame,
     offset,
     orient,
+
     // color needs to be redirect to fill
     color,
 
@@ -83,14 +86,15 @@ export function extractTitleConfig(
     subtitlePadding,
 
     // The rest are mark config.
-    ...titleMarkConfig
+    ...rest
   } = titleConfig;
 
-  const mark: MarkConfig = {
-    ...titleMarkConfig,
+  const titleMarkConfig: MarkConfig = {
+    ...rest,
     ...(color ? {fill: color} : {})
   };
 
+  // These are non-mark title config that need to be hardcoded
   const nonMark: BaseTitleNoValueRefs = {
     ...(anchor ? {anchor} : {}),
     ...(frame ? {frame} : {}),
@@ -98,6 +102,7 @@ export function extractTitleConfig(
     ...(orient ? {orient} : {})
   };
 
+  // subtitle part can stay in config.title since header titles do not use subtitle
   const subtitle: BaseTitleNoValueRefs = {
     ...(subtitleColor ? {subtitleColor} : {}),
     ...(subtitleFont ? {subtitleFont} : {}),
@@ -108,7 +113,9 @@ export function extractTitleConfig(
     ...(subtitlePadding ? {subtitlePadding} : {})
   };
 
-  return {mark, nonMark, subtitle};
+  const subtitleMarkConfig = pick(titleMarkConfig, ['align', 'baseline', 'dx', 'dy', 'limit']);
+
+  return {titleMarkConfig, subtitleMarkConfig, nonMark, subtitle};
 }
 
 export function isText(v: any): v is Text {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -116,7 +116,12 @@ describe('config', () => {
       },
       title: {
         color: 'red',
-        fontWeight: 'bold'
+        fontWeight: 'bold',
+        align: 'center',
+        baseline: 'middle',
+        dx: 5,
+        dy: 5,
+        limit: 5
       },
       boxplot: {
         rule: {
@@ -163,6 +168,10 @@ describe('config', () => {
       expect(output).not.toHaveProperty('title');
       expect(output.style['group-title'].fontWeight).toBe('bold');
       expect(output.style['group-title'].fill).toBe('red');
+    });
+
+    it('redirects align, baseline, dx, dy, and limit of config.title to config.style.group-subtitle', () => {
+      expect(output.style['group-subtitle']).toEqual({align: 'center', baseline: 'middle', dx: 5, dy: 5, limit: 5});
     });
 
     it('should remove empty config object', () => {


### PR DESCRIPTION
fix #6445
