### PR TITLE
fix: don't remove titles from accessibility tree when config.aria is false

### DIFF
--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -414,10 +414,6 @@ export abstract class Model {
         title.anchor = title.anchor ?? 'start';
       }
 
-      if (this.config.aria === false && title.aria === undefined) {
-        title.aria = false;
-      }
-
       return keys(title).length > 0 ? title : undefined;
     }
     return undefined;


### PR DESCRIPTION
I believe the previous behavior was incorrect as the docs never said that we would remove titles when `config.aria=false`. 