### PR TITLE
fix: don't pass undefined to custom formatting function when no format is provided

### DIFF
--- a/src/compile/format.ts
+++ b/src/compile/format.ts
@@ -24,7 +24,7 @@ export function isCustomFormatType(formatType: string) {
 }
 
 function customFormatExpr(formatType: string, field: string, format: string | object) {
-  return `${formatType}(${field}, ${JSON.stringify(format)})`;
+  return `${formatType}(${field}${format ? `, ${JSON.stringify(format)}` : ''})`;
 }
 
 export const BIN_RANGE_DELIMITER = ' \u2013 ';

--- a/test/compile/axis/encode.test.ts
+++ b/test/compile/axis/encode.test.ts
@@ -37,5 +37,17 @@ describe('compile/axis/encode', () => {
       const labels = encode.labels(model, 'x', {});
       expect(labels.text.signal).toEqual('customNumberFormat(datum.value, "abc")');
     });
+
+    it('applies custom format type without format', () => {
+      const model = parseUnitModelWithScale({
+        mark: 'point',
+        encoding: {
+          x: {field: 'a', type: 'quantitative', axis: {formatType: 'customNumberFormat'}}
+        },
+        config: {customFormatTypes: true}
+      });
+      const labels = encode.labels(model, 'x', {});
+      expect(labels.text.signal).toEqual('customNumberFormat(datum.value)');
+    });
   });
 });


### PR DESCRIPTION
fixes #6486
