### PR TITLE
fix: make size in errorbar also set the length of its ticks

### DIFF
--- a/src/compositemark/errorbar.ts
+++ b/src/compositemark/errorbar.ts
@@ -69,7 +69,10 @@ export interface ErrorExtraEncoding<F extends Field> {
   yError2?: SecondaryFieldDef<F> | ValueDef<number>;
 }
 
-export type ErrorEncoding<F extends Field> = Pick<Encoding<F>, PositionChannel | 'color' | 'detail' | 'opacity'> &
+export type ErrorEncoding<F extends Field> = Pick<
+  Encoding<F>,
+  PositionChannel | 'color' | 'detail' | 'opacity' | 'size'
+> &
   ErrorExtraEncoding<F>;
 
 export type ErrorBarPartsMixins = PartsMixins<ErrorBarPart>;
@@ -131,15 +134,20 @@ export function normalizeErrorBar(
     tooltipEncoding
   } = errorBarParams(spec, ERRORBAR, config);
 
+  const {size, ...encodingWithoutContinuousAxisAndSize} = encodingWithoutContinuousAxis;
   const makeErrorBarPart = makeCompositeAggregatePartFactory<ErrorBarPartsMixins>(
     markDef,
     continuousAxis,
     continuousAxisChannelDef,
-    encodingWithoutContinuousAxis,
+    encodingWithoutContinuousAxisAndSize,
     config.errorbar
   );
 
-  const tick: MarkDef = {type: 'tick', orient: ticksOrient};
+  const tick: MarkDef = {
+    type: 'tick',
+    orient: ticksOrient,
+    ...(size && 'value' in size ? {thickness: size.value} : {})
+  };
 
   const layer = [
     ...makeErrorBarPart({
@@ -164,7 +172,10 @@ export function normalizeErrorBar(
       },
       positionPrefix: 'lower',
       endPositionPrefix: 'upper',
-      extraEncoding: tooltipEncoding
+      extraEncoding: {
+        ...tooltipEncoding,
+        ...(size ? size : {})
+      }
     })
   ];
 

--- a/test/compositemark/errorbar.test.ts
+++ b/test/compositemark/errorbar.test.ts
@@ -2,7 +2,7 @@ import {AggregateOp} from 'vega';
 import {ErrorBarCenter, ErrorBarExtent} from '../../src/compositemark/errorbar';
 import {defaultConfig} from '../../src/config';
 import * as log from '../../src/log';
-import {isMarkDef} from '../../src/mark';
+import {isMarkDef, MarkDef} from '../../src/mark';
 import {normalize} from '../../src/normalize';
 import {isLayerSpec, isUnitSpec} from '../../src/spec';
 import {TopLevelUnitSpec} from '../../src/spec/unit';
@@ -539,6 +539,36 @@ describe('normalizeErrorBar with raw data input', () => {
       {field: 'center_people', title: 'Median of people', type: 'quantitative'},
       {field: 'age', type: 'ordinal'}
     ]);
+  });
+
+  it("should move size (value def) in tick's encoing channel to its mark definition as thickness", () => {
+    const thickness = 5;
+    const outputSpec = normalize(
+      {
+        data: {url: 'data/population.json'},
+        mark: {type: 'errorbar', ticks: true},
+        encoding: {
+          x: {field: 'age', type: 'ordinal'},
+          y: {field: 'people', type: 'quantitative'},
+          size: {value: thickness}
+        }
+      },
+      defaultConfig
+    );
+
+    expect(isLayerSpec(outputSpec)).toBeTruthy();
+    if (isLayerSpec(outputSpec)) {
+      outputSpec.layer.forEach(l => {
+        if (isUnitSpec(l) && (l.mark as MarkDef).type === 'tick') {
+          const {mark} = l;
+          if (isMarkDef(mark) && mark.type === 'tick') {
+            expect(mark.thickness).toBe(thickness);
+          }
+        }
+      });
+    } else {
+      expect(false).toBe(true);
+    }
   });
 });
 


### PR DESCRIPTION
Fix #6495

`size` in errorbar's `encoding` becomes `thickness` in mark definition of `ticks`.