### PR TITLE
feat: use view descriptions for accessibility

### DIFF
--- a/src/compile/axis/assemble.ts
+++ b/src/compile/axis/assemble.ts
@@ -5,7 +5,7 @@ import {POSITION_SCALE_CHANNELS} from '../../channel';
 import {defaultTitle, FieldDefBase} from '../../channeldef';
 import {Config} from '../../config';
 import {isText} from '../../title';
-import {getFirstDefined, keys} from '../../util';
+import {getFirstDefined, isEmpty} from '../../util';
 import {isSignalRef, VgEncodeChannel, VgValueRef} from '../../vega.schema';
 import {exprFromValueOrSignalRef} from '../common';
 import {Model} from '../model';
@@ -116,7 +116,7 @@ export function assembleAxis(
         ...(grid ? {grid} : {})
       };
 
-      if (keys(axis.encode).length === 0) {
+      if (isEmpty(axis.encode)) {
         delete axis.encode;
       }
     }
@@ -159,7 +159,7 @@ export function assembleAxis(
           delete axis.encode[part];
         }
       }
-      if (keys(axis.encode).length === 0) {
+      if (isEmpty(axis.encode)) {
         delete axis.encode;
       }
     }

--- a/src/compile/axis/parse.ts
+++ b/src/compile/axis/parse.ts
@@ -2,7 +2,7 @@ import {AxisEncode as VgAxisEncode, AxisOrient} from 'vega';
 import {Axis, AXIS_PARTS, isAxisProperty, isConditionalAxisValue} from '../../axis';
 import {PositionScaleChannel, POSITION_SCALE_CHANNELS} from '../../channel';
 import {getFieldOrDatumDef, PositionDatumDef, PositionFieldDef} from '../../channeldef';
-import {getFirstDefined, keys, normalizeAngle} from '../../util';
+import {getFirstDefined, isEmpty, keys, normalizeAngle} from '../../util';
 import {isSignalRef} from '../../vega.schema';
 import {mergeTitleComponent} from '../common';
 import {guideEncodeEntry} from '../guide';
@@ -307,14 +307,14 @@ function parseAxis(channel: PositionScaleChannel, model: UnitModel): AxisCompone
 
     const value = part === 'labels' ? encode.labels(model, channel, axisEncodingPart) : axisEncodingPart;
 
-    if (value !== undefined && keys(value).length > 0) {
+    if (value !== undefined && !isEmpty(value)) {
       e[part] = {update: value};
     }
     return e;
   }, {} as VgAxisEncode);
 
   // FIXME: By having encode as one property, we won't have fine grained encode merging.
-  if (keys(axisEncode).length > 0) {
+  if (!isEmpty(axisEncode)) {
     axisComponent.set('encode', axisEncode, !!axis.encoding || axis.labelAngle !== undefined);
   }
 

--- a/src/compile/data/bin.ts
+++ b/src/compile/data/bin.ts
@@ -5,7 +5,7 @@ import {Channel} from '../../channel';
 import {binRequiresRange, FieldName, isTypedFieldDef, normalizeBin, TypedFieldDef, vgField} from '../../channeldef';
 import {Config} from '../../config';
 import {BinTransform} from '../../transform';
-import {Dict, duplicate, hash, keys, replacePathInField, unique, vals, varName} from '../../util';
+import {Dict, duplicate, hash, isEmpty, keys, replacePathInField, unique, vals, varName} from '../../util';
 import {binFormatExpression} from '../format';
 import {isUnitModel, Model, ModelWithField} from '../model';
 import {parseSelectionBinExtent} from '../selection/parse';
@@ -120,7 +120,7 @@ export class BinNode extends DataFlowNode {
       return binComponentIndex;
     }, {} as Dict<BinComponent>);
 
-    if (keys(bins).length === 0) {
+    if (isEmpty(bins)) {
       return null;
     }
 

--- a/src/compile/data/optimizers.ts
+++ b/src/compile/data/optimizers.ts
@@ -1,12 +1,14 @@
 import {MAIN, Parse} from '../../data';
-import {Dict, fieldIntersection, hash, hasIntersection, keys, some} from '../../util';
+import {Dict, fieldIntersection, hash, hasIntersection, isEmpty, keys, some} from '../../util';
 import {Model} from '../model';
+import {requiresSelectionId} from '../selection';
 import {AggregateNode} from './aggregate';
 import {BinNode} from './bin';
 import {DataFlowNode, OutputNode} from './dataflow';
 import {FacetNode} from './facet';
 import {FilterNode} from './filter';
 import {ParseNode} from './formatparse';
+import {IdentifierNode} from './identifier';
 import {JoinAggregateTransformNode} from './joinaggregate';
 import {FACET_SCALE_PREFIX} from './optimize';
 import {BottomUpOptimizer, isDataSourceNode, TopDownOptimizer} from './optimizer';
@@ -14,8 +16,6 @@ import * as optimizers from './optimizers';
 import {StackNode} from './stack';
 import {TimeUnitNode} from './timeunit';
 import {WindowTransformNode} from './window';
-import {IdentifierNode} from './identifier';
-import {requiresSelectionId} from '../selection';
 
 export interface OptimizerFlags {
   /**
@@ -336,7 +336,7 @@ export class MergeParse extends BottomUpOptimizer {
         delete commonParse[field];
       }
 
-      if (keys(commonParse).length !== 0) {
+      if (!isEmpty(commonParse)) {
         this.setMutated();
         const mergedParseNode = new ParseNode(parent, commonParse);
         for (const childNode of originalChildren) {

--- a/src/compile/data/source.ts
+++ b/src/compile/data/source.ts
@@ -1,7 +1,15 @@
-import {Data, DataFormatType, isGenerator, isInlineData, isNamedData, isSphereGenerator, isUrlData} from '../../data';
-import {contains, keys, omit} from '../../util';
+import {
+  Data,
+  DataFormat,
+  DataFormatType,
+  isGenerator,
+  isInlineData,
+  isNamedData,
+  isSphereGenerator,
+  isUrlData
+} from '../../data';
+import {contains, isEmpty, omit} from '../../util';
 import {VgData} from '../../vega.schema';
-import {DataFormat} from '../../data';
 import {DataFlowNode} from './dataflow';
 
 export class SourceNode extends DataFlowNode {
@@ -52,7 +60,7 @@ export class SourceNode extends DataFlowNode {
       this._name = data.name;
     }
 
-    if (format && keys(format).length > 0) {
+    if (format && !isEmpty(format)) {
       this._data.format = format;
     }
   }

--- a/src/compile/data/timeunit.ts
+++ b/src/compile/data/timeunit.ts
@@ -3,7 +3,7 @@ import {getSecondaryRangeChannel} from '../../channel';
 import {hasBand, vgField} from '../../channeldef';
 import {getTimeUnitParts, normalizeTimeUnit} from '../../timeunit';
 import {TimeUnitTransform} from '../../transform';
-import {Dict, duplicate, hash, keys, replacePathInField, vals} from '../../util';
+import {Dict, duplicate, hash, isEmpty, replacePathInField, vals} from '../../util';
 import {isUnitModel, ModelWithField} from '../model';
 import {DataFlowNode} from './dataflow';
 
@@ -48,7 +48,7 @@ export class TimeUnitNode extends DataFlowNode {
       return timeUnitComponent;
     }, {} as Dict<TimeUnitComponent>);
 
-    if (keys(formula).length === 0) {
+    if (isEmpty(formula)) {
       return null;
     }
 

--- a/src/compile/header/assemble.ts
+++ b/src/compile/header/assemble.ts
@@ -16,7 +16,7 @@ import {
 } from '../../header';
 import {isSortField} from '../../sort';
 import {FacetFieldDef, isFacetMapping} from '../../spec/facet';
-import {contains, keys, normalizeAngle, replaceAll} from '../../util';
+import {contains, isEmpty, normalizeAngle, replaceAll} from '../../util';
 import {RowCol, VgComparator, VgMarkGroup, VgTitle} from '../../vega.schema';
 import {defaultLabelAlign, defaultLabelBaseline} from '../axis/properties';
 import {sortArrayIndexField} from '../data/calculate';
@@ -253,7 +253,7 @@ export function assembleLayoutTitleBand(
     }
   }
 
-  return keys(titleBand).length > 0 ? titleBand : undefined;
+  return isEmpty(titleBand) ? undefined : titleBand;
 }
 
 export function assembleHeaderProperties(

--- a/src/compile/legend/encode.ts
+++ b/src/compile/legend/encode.ts
@@ -13,7 +13,7 @@ import {
 } from '../../channeldef';
 import {Encoding} from '../../encoding';
 import {FILL_STROKE_CONFIG} from '../../mark';
-import {getFirstDefined, keys, varName} from '../../util';
+import {getFirstDefined, isEmpty, varName} from '../../util';
 import {applyMarkConfig, signalOrValueRef} from '../common';
 import {formatCustomType, isCustomFormatType} from '../format';
 import * as mixins from '../mark/encode';
@@ -122,7 +122,7 @@ export function symbols(
 
   out = {...out, ...symbolsSpec};
 
-  return keys(out).length > 0 ? out : undefined;
+  return isEmpty(out) ? undefined : out;
 }
 
 export function gradient(gradientSpec: any, {model, legendType}: LegendEncodeParams) {
@@ -139,7 +139,7 @@ export function gradient(gradientSpec: any, {model, legendType}: LegendEncodePar
   }
 
   out = {...out, ...gradientSpec};
-  return keys(out).length > 0 ? out : undefined;
+  return isEmpty(out) ? undefined : out;
 }
 
 export function labels(specifiedlabelsSpec: any, {fieldOrDatumDef, model, channel, legendCmpt}: LegendEncodeParams) {
@@ -167,7 +167,7 @@ export function labels(specifiedlabelsSpec: any, {fieldOrDatumDef, model, channe
     ...specifiedlabelsSpec
   };
 
-  return keys(labelsSpec).length > 0 ? labelsSpec : undefined;
+  return isEmpty(labelsSpec) ? undefined : labelsSpec;
 }
 
 export function entries(entriesSpec: any, {legendCmpt}: LegendEncodeParams) {

--- a/src/compile/legend/parse.ts
+++ b/src/compile/legend/parse.ts
@@ -4,7 +4,7 @@ import {DatumDef, FieldDef, getFieldOrDatumDef, isFieldDef, MarkPropDatumDef, Ma
 import {Legend, LEGEND_SCALE_CHANNELS} from '../../legend';
 import {normalizeTimeUnit} from '../../timeunit';
 import {GEOJSON} from '../../type';
-import {deleteNestedProperty, keys, varName} from '../../util';
+import {deleteNestedProperty, isEmpty, keys, varName} from '../../util';
 import {mergeTitleComponent} from '../common';
 import {guideEncodeEntry} from '../guide';
 import {isUnitModel, Model} from '../model';
@@ -148,7 +148,7 @@ export function parseLegendForChannel(model: UnitModel, channel: NonPositionScal
         ? legendEncodeRules[part](legendEncodingPart, legendEncodeParams) // apply rule
         : legendEncodingPart; // no rule -- just default values
 
-    if (value !== undefined && keys(value).length > 0) {
+    if (value !== undefined && !isEmpty(value)) {
       legendEncode[part] = {
         ...(selections?.length && isFieldDef(fieldOrDatumDef)
           ? {name: `${varName(fieldOrDatumDef.field)}_legend_${part}`}
@@ -159,7 +159,7 @@ export function parseLegendForChannel(model: UnitModel, channel: NonPositionScal
     }
   }
 
-  if (keys(legendEncode).length > 0) {
+  if (!isEmpty(legendEncode)) {
     legendCmpt.set('encode', legendEncode, !!legend?.encoding);
   }
 

--- a/src/compile/mark/encode/aria.ts
+++ b/src/compile/mark/encode/aria.ts
@@ -1,4 +1,4 @@
-import {entries, keys} from '../../../util';
+import {entries, isEmpty} from '../../../util';
 import {getMarkPropOrConfig, signalOrValueRef} from '../../common';
 import {VG_MARK_INDEX} from './../../../vega.schema';
 import {UnitModel} from './../../unit';
@@ -63,7 +63,7 @@ export function description(model: UnitModel) {
 
   const data = tooltipData(encoding, stack, config);
 
-  if (keys(data).length === 0) {
+  if (isEmpty(data)) {
     return undefined;
   }
 

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -34,7 +34,7 @@ import {
 import {NormalizedSpec} from '../spec/index';
 import {extractTitleConfig, isText, TitleParams} from '../title';
 import {normalizeTransform, Transform} from '../transform';
-import {contains, Dict, duplicate, keys, varName} from '../util';
+import {contains, Dict, duplicate, keys, varName, isEmpty} from '../util';
 import {isVgRangeStep, VgData, VgEncodeEntry, VgLayout, VgMarkGroup} from '../vega.schema';
 import {assembleAxes} from './axis/assemble';
 import {AxisComponentIndex} from './axis/component';
@@ -341,7 +341,7 @@ export abstract class Model {
       }
     }
 
-    return encodeEntry;
+    return isEmpty(encodeEntry) ? undefined : encodeEntry;
   }
 
   public assembleLayout(): VgLayout {
@@ -421,7 +421,7 @@ export abstract class Model {
         title.anchor = title.anchor ?? 'start';
       }
 
-      return keys(title).length > 0 ? title : undefined;
+      return isEmpty(title) ? undefined : title;
     }
     return undefined;
   }

--- a/src/compile/model.ts
+++ b/src/compile/model.ts
@@ -307,22 +307,29 @@ export abstract class Model {
     // Exclude "style"
     const {style: _, ...baseView} = view;
 
-    const e = {};
+    const e: VgEncodeEntry = {};
     for (const property of keys(baseView)) {
       const value = baseView[property];
       if (value !== undefined) {
         e[property] = signalOrValueRef(value);
       }
     }
+
     return e;
   }
 
   public assembleGroupEncodeEntry(isTopLevel: boolean): VgEncodeEntry {
-    let encodeEntry: VgEncodeEntry = undefined;
+    let encodeEntry: VgEncodeEntry = {};
     if (this.view) {
       encodeEntry = this.assembleEncodeFromView(this.view);
     }
+
     if (!isTopLevel) {
+      // Descriptions are already added to the top-level description so we only need to add them to the inner views.
+      if (this.description) {
+        encodeEntry['description'] = signalOrValueRef(this.description);
+      }
+
       // For top-level spec, we can set the global width and height signal to adjust the group size.
       // For other child specs, we have to manually set width and height in the encode entry.
       if (this.type === 'unit' || this.type === 'layer') {

--- a/src/compile/selection/transforms/project.ts
+++ b/src/compile/selection/transforms/project.ts
@@ -3,7 +3,7 @@ import {isSingleDefUnitChannel, ScaleChannel, SingleDefUnitChannel} from '../../
 import * as log from '../../../log';
 import {hasContinuousDomain} from '../../../scale';
 import {SelectionInit, SelectionInitInterval} from '../../../selection';
-import {Dict, hash, keys, replacePathInField, varName} from '../../../util';
+import {Dict, hash, keys, replacePathInField, varName, isEmpty} from '../../../util';
 import {TimeUnitComponent, TimeUnitNode} from '../../data/timeunit';
 import {TransformCompiler} from './transforms';
 
@@ -165,7 +165,7 @@ const project: TransformCompiler = {
       }
     }
 
-    if (keys(timeUnits).length > 0) {
+    if (!isEmpty(timeUnits)) {
       proj.timeUnit = new TimeUnitNode(null, timeUnits);
     }
   },

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,7 +21,7 @@ import {defaultConfig as defaultSelectionConfig, SelectionConfig} from './select
 import {BaseViewBackground, CompositionConfigMixins, DEFAULT_SPACING, isStep} from './spec/base';
 import {TopLevelProperties} from './spec/toplevel';
 import {extractTitleConfig, TitleConfig} from './title';
-import {duplicate, getFirstDefined, keys} from './util';
+import {duplicate, getFirstDefined, isEmpty} from './util';
 
 export interface ViewConfig extends BaseViewBackground {
   /**
@@ -574,12 +574,12 @@ export function stripAndRedirectConfig(config: Config) {
 
   // Remove empty config objects.
   for (const prop in config) {
-    if (isObject(config[prop]) && keys(config[prop]).length === 0) {
+    if (isObject(config[prop]) && isEmpty(config[prop])) {
       delete config[prop];
     }
   }
 
-  return keys(config).length > 0 ? config : undefined;
+  return isEmpty(config) ? undefined : config;
 }
 
 /**
@@ -593,13 +593,13 @@ function redirectTitleConfig(config: Config) {
   const {titleMarkConfig, subtitleMarkConfig, subtitle} = extractTitleConfig(config.title);
 
   // set config.style if title/subtitleMarkConfig is not an empty object
-  if (keys(titleMarkConfig).length > 0) {
+  if (!isEmpty(titleMarkConfig)) {
     config.style['group-title'] = {
       ...config.style['group-title'],
       ...titleMarkConfig // config.title has higher precedence than config.style.group-title in Vega
     };
   }
-  if (keys(subtitleMarkConfig).length > 0) {
+  if (!isEmpty(subtitleMarkConfig)) {
     config.style['group-subtitle'] = {
       ...config.style['group-subtitle'],
       ...subtitleMarkConfig
@@ -607,7 +607,7 @@ function redirectTitleConfig(config: Config) {
   }
 
   // subtitle part can stay in config.title since header titles do not use subtitle
-  if (keys(subtitle).length > 0) {
+  if (!isEmpty(subtitle)) {
     config.title = subtitle;
   } else {
     delete config.title;
@@ -632,7 +632,7 @@ function redirectConfigToStyleConfig(
   };
 
   // set config.style if it is not an empty object
-  if (keys(style).length > 0) {
+  if (!isEmpty(style)) {
     config.style[toProp ?? prop] = style;
   }
 

--- a/src/normalize/core.ts
+++ b/src/normalize/core.ts
@@ -23,7 +23,7 @@ import {NormalizedLayerSpec} from '../spec/layer';
 import {SpecMapper} from '../spec/map';
 import {isLayerRepeatSpec, LayerRepeatSpec, NonLayerRepeatSpec, RepeatSpec} from '../spec/repeat';
 import {isUnitSpec, NormalizedUnitSpec} from '../spec/unit';
-import {keys, omit, varName} from '../util';
+import {keys, omit, varName, isEmpty} from '../util';
 import {NonFacetUnitNormalizer, NormalizerParams} from './base';
 import {PathOverlayNormalizer} from './pathoverlay';
 import {RangeStepNormalizer} from './rangestep';
@@ -344,7 +344,7 @@ function mergeEncoding(opt: {parentEncoding: Encoding<any>; encoding: Encoding<a
     ...(parentEncoding ?? {}),
     ...(encoding ?? {})
   };
-  return keys(merged).length > 0 ? merged : undefined;
+  return isEmpty(merged) ? undefined : merged;
 }
 
 function mergeProjection(opt: {parentProjection: Projection; projection: Projection}) {

--- a/src/normalize/rangestep.ts
+++ b/src/normalize/rangestep.ts
@@ -5,7 +5,7 @@ import * as log from '../log';
 import {Scale} from '../scale';
 import {GenericSpec} from '../spec';
 import {GenericUnitSpec, isUnitSpec, NormalizedUnitSpec} from '../spec/unit';
-import {keys} from '../util';
+import {isEmpty} from '../util';
 import {NonFacetUnitNormalizer} from './base';
 
 type UnitSpecWithRangeStep = GenericUnitSpec<Encoding<string>, any>; // this is not accurate, but it's not worth making it accurate
@@ -47,7 +47,7 @@ export class RangeStepNormalizer implements NonFacetUnitNormalizer<UnitSpecWithR
             ...encoding,
             [channel]: {
               ...defWithoutScale,
-              ...(keys(scaleWithoutRangeStep).length > 0 ? {scale: scaleWithoutRangeStep} : {})
+              ...(isEmpty(scaleWithoutRangeStep) ? {} : {scale: scaleWithoutRangeStep})
             }
           };
         }

--- a/src/util.ts
+++ b/src/util.ts
@@ -124,7 +124,7 @@ export function mergeDeep<T>(dest: T, ...src: readonly DeepPartial<T>[]): T {
 }
 
 function deepMerge_(dest: any, src: any) {
-  for (const property of Object.keys(src)) {
+  for (const property of keys(src)) {
     writeConfig(dest, property, src[property], true);
   }
 }
@@ -211,6 +211,10 @@ export function fieldIntersection(a: ReadonlySet<string>, b: ReadonlySet<string>
   return hasIntersection(prefixGenerator(a), prefixGenerator(b));
 }
 
+export function isEmpty(obj: object) {
+  return keys(obj).length === 0;
+}
+
 // This is a stricter version of Object.keys but with better types. See https://github.com/Microsoft/TypeScript/pull/12253#issuecomment-263132208
 export const keys = Object.keys as <T>(o: T) => Extract<keyof T, string>[];
 
@@ -271,7 +275,7 @@ export function deleteNestedProperty(obj: any, orderedProps: string[]) {
   if (prop in obj && deleteNestedProperty(obj[prop], orderedProps)) {
     delete obj[prop];
   }
-  return keys(obj).length === 0;
+  return isEmpty(obj);
 }
 
 export function titleCase(s: string) {

--- a/test/compile/model.test.ts
+++ b/test/compile/model.test.ts
@@ -107,7 +107,7 @@ describe('Model', () => {
         description: 'My awesome view'
       });
 
-      expect(model.assembleGroupEncodeEntry(true)).toEqual({});
+      expect(model.assembleGroupEncodeEntry(true)).toBeUndefined();
 
       expect(model.assembleGroupEncodeEntry(false)['description']).toEqual({value: 'My awesome view'});
     });

--- a/test/compile/model.test.ts
+++ b/test/compile/model.test.ts
@@ -99,5 +99,17 @@ describe('Model', () => {
         fill: {signal: '"red"'}
       });
     });
+
+    it('should support descriptions for non-top level models', () => {
+      const model = parseModel({
+        data: {values: []},
+        mark: 'point',
+        description: 'My awesome view'
+      });
+
+      expect(model.assembleGroupEncodeEntry(true)).toEqual({});
+
+      expect(model.assembleGroupEncodeEntry(false)['description']).toEqual({value: 'My awesome view'});
+    });
   });
 });


### PR DESCRIPTION
close #6519

Note that we do not support descriptions with signals for top-level descriptions. We also only use descriptions for views that create groups such as concatenated charts (i.e. not layered charts). 