### PR TITLE
fix: CLIs assuming incorrect base data url - Fixes #5380

### DIFF
--- a/bin/vl2pdf
+++ b/bin/vl2pdf
@@ -6,4 +6,4 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # only passes the first argument to vl2vg
-$DIR/vl2vg $1 | npx vg2pdf '/dev/stdin' ${@:2}
+$DIR/vl2vg $1 | npx vg2pdf '' ${@:2}

--- a/bin/vl2png
+++ b/bin/vl2png
@@ -6,4 +6,4 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # only passes the first argument to vl2vg
-$DIR/vl2vg $1 | npx vg2png '/dev/stdin' ${@:2}
+$DIR/vl2vg $1 | npx vg2png '' ${@:2}

--- a/bin/vl2svg
+++ b/bin/vl2svg
@@ -6,4 +6,4 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # only passes the first argument to vl2vg
-$DIR/vl2vg $1 | npx vg2svg '/dev/stdin' ${@:2}
+$DIR/vl2vg $1 | npx vg2svg '' ${@:2}


### PR DESCRIPTION
Hi. Following up on https://github.com/vega/vega-lite/issues/5380#issuecomment-632990505. I confirmed on osx 10.11 that the bug was fixed for the 3 CLIs. Thanks for the awesome project. Cheers