### PR TITLE
fix: don't pass /dev/stdin to vl scripts to fix issues with baseurl

### DIFF
--- a/bin/vl2pdf
+++ b/bin/vl2pdf
@@ -6,4 +6,4 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # only passes the first argument to vl2vg
-$DIR/vl2vg $1 | npx vg2pdf '/dev/stdin' ${@:2}
+$DIR/vl2vg $1 | npx vg2pdf '' ${@:2}

--- a/bin/vl2png
+++ b/bin/vl2png
@@ -6,4 +6,4 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # only passes the first argument to vl2vg
-$DIR/vl2vg $1 | npx vg2png '/dev/stdin' ${@:2}
+$DIR/vl2vg $1 | npx vg2png '' ${@:2}

--- a/bin/vl2svg
+++ b/bin/vl2svg
@@ -6,4 +6,4 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # only passes the first argument to vl2vg
-$DIR/vl2vg $1 | npx vg2svg '/dev/stdin' ${@:2}
+$DIR/vl2vg $1 | npx vg2svg '' ${@:2}


### PR DESCRIPTION
Fixes #5380

CLIs were assuming all data urls had a base of
/dev/ because of the passed argument and
https://github.com/vega/vega/blob/8fe8d36961c128df8300e6bc4fe6aac1e537bbe0/packages/vega-cli/src/render.js#L22
