### PR TITLE
feat: support explicit list of colors in scheme

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -3130,6 +3130,33 @@
         }
       ]
     },
+    "ColorsSchemeParams": {
+      "additionalProperties": false,
+      "properties": {
+        "colors": {
+          "description": "The colors will be interpolated to form a new scheme; use the `interpolate` property to set the interpolation type.",
+          "items": {
+            "$ref": "#/definitions/Color"
+          },
+          "type": "array"
+        },
+        "count": {
+          "description": "The number of colors to use in the scheme. This can be useful for scale types such as `\"quantize\"`, which use the length of the scale range to determine the number of discrete bins for the scale domain.",
+          "type": "number"
+        },
+        "extent": {
+          "description": "The extent of the color range to use. For example `[0.2, 1]` will rescale the color scheme such that color values in the range _[0, 0.2)_ are excluded from the scheme.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "colors"
+      ],
+      "type": "object"
+    },
     "Encoding": {
       "additionalProperties": false,
       "properties": {
@@ -13652,6 +13679,30 @@
       ],
       "type": "object"
     },
+    "NamedSchemeParams": {
+      "additionalProperties": false,
+      "properties": {
+        "count": {
+          "description": "The number of colors to use in the scheme. This can be useful for scale types such as `\"quantize\"`, which use the length of the scale range to determine the number of discrete bins for the scale domain.",
+          "type": "number"
+        },
+        "extent": {
+          "description": "The extent of the color range to use. For example `[0.2, 1]` will rescale the color scheme such that color values in the range _[0, 0.2)_ are excluded from the scheme.",
+          "items": {
+            "type": "number"
+          },
+          "type": "array"
+        },
+        "name": {
+          "description": "A color scheme name for ordinal scales (e.g., `\"category10\"` or `\"blues\"`). For the full list of supported schemes, please refer to the [Vega Scheme](https://vega.github.io/vega/docs/schemes/#reference) reference.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
     "NonArgAggregateOp": {
       "enum": [
         "average",
@@ -16094,15 +16145,8 @@
           "type": "boolean"
         },
         "scheme": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/SchemeParams"
-            }
-          ],
-          "description": "A string indicating a color [scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme) name (e.g., `\"category10\"` or `\"blues\"`) or a [scheme parameter object](https://vega.github.io/vega-lite/docs/scale.html#scheme-params).\n\nDiscrete color schemes may be used with [discrete](https://vega.github.io/vega-lite/docs/scale.html#discrete) or [discretizing](https://vega.github.io/vega-lite/docs/scale.html#discretizing) scales. Continuous color schemes are intended for use with color scales.\n\nFor the full list of supported schemes, please refer to the [Vega Scheme](https://vega.github.io/vega/docs/schemes/#reference) reference."
+          "$ref": "#/definitions/Scheme",
+          "description": "A string indicating a color [scheme](https://vega.github.io/vega-lite/docs/scale.html#scheme) name (e.g., `\"category10\"` or `\"blues\"`), an array of colors that will be interpolated to create a new scheme, or a [scheme parameter object](https://vega.github.io/vega-lite/docs/scale.html#scheme-params).\n\nDiscrete color schemes may be used with [discrete](https://vega.github.io/vega-lite/docs/scale.html#discrete) or [discretizing](https://vega.github.io/vega-lite/docs/scale.html#discretizing) scales. Continuous color schemes are intended for use with color scales.\n\nFor the full list of supported schemes, please refer to the [Vega Scheme](https://vega.github.io/vega/docs/schemes/#reference) reference."
         },
         "type": {
           "$ref": "#/definitions/ScaleType",
@@ -16373,29 +16417,31 @@
       ],
       "type": "string"
     },
-    "SchemeParams": {
-      "additionalProperties": false,
-      "properties": {
-        "count": {
-          "description": "The number of colors to use in the scheme. This can be useful for scale types such as `\"quantize\"`, which use the length of the scale range to determine the number of discrete bins for the scale domain.",
-          "type": "number"
+    "Scheme": {
+      "anyOf": [
+        {
+          "type": "string"
         },
-        "extent": {
-          "description": "The extent of the color range to use. For example `[0.2, 1]` will rescale the color scheme such that color values in the range _[0, 0.2)_ are excluded from the scheme.",
+        {
+          "$ref": "#/definitions/SchemeParams"
+        },
+        {
           "items": {
-            "type": "number"
+            "$ref": "#/definitions/Color"
           },
           "type": "array"
-        },
-        "name": {
-          "description": "A color scheme name for ordinal scales (e.g., `\"category10\"` or `\"blues\"`).\n\nFor the full list of supported schemes, please refer to the [Vega Scheme](https://vega.github.io/vega/docs/schemes/#reference) reference.",
-          "type": "string"
         }
-      },
-      "required": [
-        "name"
-      ],
-      "type": "object"
+      ]
+    },
+    "SchemeParams": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/NamedSchemeParams"
+        },
+        {
+          "$ref": "#/definitions/ColorsSchemeParams"
+        }
+      ]
     },
     "SecondaryFieldDef": {
       "additionalProperties": false,

--- a/site/docs/encoding/scale.md
+++ b/site/docs/encoding/scale.md
@@ -149,25 +149,31 @@ By default, Vega-Lite assigns different [default color schemes](#range-config) b
 
 There are multiple ways to customize the scale range for the color encoding channel:
 
-1. Set a custom `scheme`.
+#### 1. Set a custom `scheme`.
 
 {% include table.html props="scheme" source="Scale" %}
 
-For example, the following plot use the `"category20b"` scheme.
+You can customize the scheme by referring to an [existing color scheme](https://vega.github.io/vega/docs/schemes/) or providing an array of colors to be interpolated. As an example for the former, the following plot uses the `"category20b"` scheme.
 
 <div class="vl-example" data-name="stacked_area"></div>
 
 {:#scheme-params}
 
-The `scheme` property can also be a **scheme parameter object**, which contain the following properties:
+The `scheme` property can also be a **scheme parameter object**, which may contain either the `name` or `colors` property and common properties:
 
-{% include table.html props="name,extent,count" source="SchemeParams" %}
+{% include table.html props="name" source="NamedSchemeParams" %}
 
-2. Setting the `range` property to an array of valid CSS color strings.
+{% include table.html props="colors" source="ColorsSchemeParams" %}
+
+Common properties:
+
+{% include table.html props="extent,count" source="NamedSchemeParams" %}
+
+#### 2. Setting the `range` property to an array of valid CSS color strings.
 
 <div class="vl-example" data-name="point_color_custom"></div>
 
-3. Change the default color schemes using the [range config](#range-config).
+#### 3. Change the default color schemes using the [range config](#range-config).
 
 {:#continuous}
 

--- a/src/compile/scale/range.ts
+++ b/src/compile/scale/range.ts
@@ -31,8 +31,9 @@ import {
   Domain,
   hasContinuousDomain,
   hasDiscreteDomain,
+  isColorsScheme,
   isContinuousToDiscrete,
-  isExtendedScheme,
+  isNamedScheme,
   Scale,
   scaleTypeSupportProperty,
   Scheme
@@ -40,12 +41,12 @@ import {
 import {isStep, LayoutSizeMixins} from '../../spec/base';
 import * as util from '../../util';
 import {isSignalRef, VgRange} from '../../vega.schema';
+import {signalOrStringValue} from '../common';
 import {getBinSignalName} from '../data/bin';
 import {SignalRefWrapper} from '../signal';
 import {Explicit, makeExplicit, makeImplicit} from '../split';
 import {UnitModel} from '../unit';
 import {ScaleComponentIndex} from './component';
-import {signalOrStringValue} from '../common';
 
 export const RANGE_PROPERTIES: (keyof Scale)[] = ['range', 'scheme'];
 
@@ -151,10 +152,16 @@ export function parseRangeForChannel(channel: ScaleChannel, model: UnitModel): E
 }
 
 function parseScheme(scheme: Scheme | SignalRef): RangeScheme {
-  if (isExtendedScheme(scheme)) {
+  if (isNamedScheme(scheme)) {
     return {
       scheme: scheme.name,
       ...util.omit(scheme, ['name'])
+    };
+  }
+  if (isColorsScheme(scheme)) {
+    return {
+      scheme: scheme.colors,
+      ...util.omit(scheme, ['colors'])
     };
   }
   return {scheme: scheme};

--- a/test/compile/scale/range.test.ts
+++ b/test/compile/scale/range.test.ts
@@ -145,6 +145,17 @@ describe('compile/scale', () => {
         expect(parseRangeForChannel('color', model)).toEqual(makeExplicit({scheme: 'viridis'}));
       });
 
+      it('should support custom colors.', () => {
+        const model = parseUnitModelWithScaleExceptRange({
+          mark: 'point',
+          encoding: {
+            color: {field: 'x', type: 'quantitative', scale: {scheme: ['red', 'blue']}}
+          }
+        });
+
+        expect(parseRangeForChannel('color', model)).toEqual(makeExplicit({scheme: ['red', 'blue']}));
+      });
+
       it('should use the specified scheme with extent for a nominal color field.', () => {
         const model = parseUnitModelWithScaleExceptRange({
           mark: 'point',
@@ -219,6 +230,17 @@ describe('compile/scale', () => {
         });
 
         expect(parseRangeForChannel('color', model)).toEqual(makeExplicit({scheme: 'viridis', count: 3}));
+      });
+
+      it('should use the specified scheme with colors and count.', () => {
+        const model = parseUnitModelWithScaleExceptRange({
+          mark: 'point',
+          encoding: {
+            color: {field: 'x', type: 'quantitative', scale: {scheme: {colors: ['red', 'blue'], count: 3}}}
+          }
+        });
+
+        expect(parseRangeForChannel('color', model)).toEqual(makeExplicit({scheme: ['red', 'blue'], count: 3}));
       });
 
       it('should use default ramp range for quantile/quantize/threshold scales', () => {


### PR DESCRIPTION
fixes https://github.com/vega/vega-lite/issues/6576

With this pull request, Vega-Lite supports

```js
{
          mark: 'point',
          encoding: {
            color: {field: 'x', type: 'quantitative', scale: {scheme: ['red', 'blue']}}
          }
        }
```

in addition to

```js
{
          mark: 'point',
          encoding: {
            color: {field: 'x', type: 'quantitative', scale: {scheme: 'viridis'}}
          }
        }
```