### PR TITLE
fix: make `datum.label` in `labelExpr` work with custom formatter

### DIFF
--- a/src/compile/axis/assemble.ts
+++ b/src/compile/axis/assemble.ts
@@ -5,7 +5,7 @@ import {POSITION_SCALE_CHANNELS} from '../../channel';
 import {defaultTitle, FieldDefBase} from '../../channeldef';
 import {Config} from '../../config';
 import {isText} from '../../title';
-import {getFirstDefined, isEmpty} from '../../util';
+import {getFirstDefined, isEmpty, replaceAll} from '../../util';
 import {isSignalRef, VgEncodeChannel, VgValueRef} from '../../vega.schema';
 import {exprFromValueOrSignalRef} from '../common';
 import {Model} from '../model';
@@ -145,7 +145,11 @@ export function assembleAxis(
     }
 
     if (labelExpr !== undefined) {
-      setAxisEncode(axis, 'labels', 'text', {signal: labelExpr});
+      let expr = labelExpr;
+      if (axis.encode?.labels?.update && isSignalRef(axis.encode.labels.update.text)) {
+        expr = replaceAll(labelExpr, 'datum.label', axis.encode.labels.update.text.signal);
+      }
+      setAxisEncode(axis, 'labels', 'text', {signal: expr});
     }
 
     if (axis.labelAlign === null) {

--- a/src/compile/legend/assemble.ts
+++ b/src/compile/legend/assemble.ts
@@ -1,7 +1,7 @@
 import {Legend as VgLegend, LegendEncode} from 'vega';
 import {Config} from '../../config';
 import {LEGEND_SCALE_CHANNELS, SIGNAL_LEGEND_PROP_INDEX} from '../../legend';
-import {keys, stringify, vals} from '../../util';
+import {keys, replaceAll, stringify, vals} from '../../util';
 import {isSignalRef, VgEncodeChannel, VgValueRef} from '../../vega.schema';
 import {Model} from '../model';
 import {LegendComponent} from './component';
@@ -80,7 +80,11 @@ export function assembleLegend(legendCmpt: LegendComponent, config: Config) {
   }
 
   if (labelExpr !== undefined) {
-    setLegendEncode(legend, 'labels', 'text', {signal: labelExpr});
+    let expr = labelExpr;
+    if (legend.encode?.labels?.update && isSignalRef(legend.encode.labels.update.text)) {
+      expr = replaceAll(labelExpr, 'datum.label', legend.encode.labels.update.text.signal);
+    }
+    setLegendEncode(legend, 'labels', 'text', {signal: expr});
   }
 
   for (const prop in legend) {

--- a/test/compile/axis/assemble.test.ts
+++ b/test/compile/axis/assemble.test.ts
@@ -1,6 +1,7 @@
 import {assembleAxis} from '../../../src/compile/axis/assemble';
 import {AxisComponent} from '../../../src/compile/axis/component';
 import {defaultConfig} from '../../../src/config';
+import {parseUnitModelWithScale} from '../../util';
 
 describe('compile/axis/assemble', () => {
   describe('assembleAxis()', () => {
@@ -97,5 +98,30 @@ describe('compile/axis/assemble', () => {
     });
     const axis = assembleAxis(axisCmpt, 'main', {...defaultConfig, aria: false});
     expect(axis.aria).toBe(false);
+  });
+
+  it('correctly applies custom formatter to labelExpr.', () => {
+    const model = parseUnitModelWithScale({
+      data: {url: 'data/cars.json'},
+      mark: 'point',
+      encoding: {
+        y: {
+          field: 'Miles_per_Gallon',
+          type: 'quantitative',
+          axis: {
+            format: {a: 'b'},
+            formatType: 'myFormat',
+            labelExpr: 'datum.label[0]'
+          }
+        }
+      },
+      config: {customFormatTypes: true}
+    });
+    model.parseAxesAndHeaders();
+
+    const axes = model.assembleAxes();
+    expect(axes[1].encode.labels.update.text).toEqual({
+      signal: 'myFormat(datum.value, {"a":"b"})[0]'
+    });
   });
 });

--- a/test/compile/legend/assemble.test.ts
+++ b/test/compile/legend/assemble.test.ts
@@ -28,6 +28,33 @@ describe('legend/assemble', () => {
     });
   });
 
+  it('correctly applies custom formatter to labelExpr.', () => {
+    const model = parseUnitModelWithScale({
+      data: {url: 'data/cars.json'},
+      mark: 'point',
+      encoding: {
+        x: {field: 'Horsepower', type: 'quantitative'},
+        y: {field: 'Miles_per_Gallon', type: 'quantitative'},
+        color: {
+          field: 'Origin',
+          type: 'nominal',
+          legend: {
+            format: {a: 'b'},
+            formatType: 'myFormat',
+            labelExpr: 'datum.label[0]'
+          }
+        }
+      },
+      config: {customFormatTypes: true}
+    });
+    model.parseLegends();
+
+    const legends = model.assembleLegends();
+    expect(legends[0].encode.labels.update.text).toEqual({
+      signal: 'myFormat(datum.value, {"a":"b"})[0]'
+    });
+  });
+
   it('correctly applies labelExpr for timeUnit.', () => {
     const model = parseUnitModelWithScale({
       data: {url: 'data/cars.json'},


### PR DESCRIPTION
fix #6581 -- This is the same as https://github.com/vega/vega-lite/pull/6582, but will go to a hot fix patch release. 

