### PR TITLE
fix: revert to object for inlineDataset element

### DIFF
--- a/build/vega-lite-schema.json
+++ b/build/vega-lite-schema.json
@@ -10174,7 +10174,7 @@
         },
         {
           "items": {
-            "$ref": "#/definitions/Dict<unknown>"
+            "type": "object"
           },
           "type": "array"
         },
@@ -10182,7 +10182,7 @@
           "type": "string"
         },
         {
-          "$ref": "#/definitions/Dict<unknown>"
+          "type": "object"
         }
       ]
     },

--- a/src/data.ts
+++ b/src/data.ts
@@ -1,4 +1,3 @@
-import {Dict} from './util';
 /*
  * Constants and utilities for data.
  */
@@ -84,7 +83,7 @@ export type DataSource = UrlData | InlineData | NamedData;
 
 export type Data = DataSource | Generator;
 
-export type InlineDataset = number[] | string[] | boolean[] | Dict<unknown>[] | string | Dict<unknown>;
+export type InlineDataset = number[] | string[] | boolean[] | object[] | string | object;
 
 export interface DataBase {
   /**


### PR DESCRIPTION
The use of `Dict<unknown>` as an InlineDataset element would not allow the use of an interface to represent an array element. Reverting to `object`.

Note: I'm not able to run `yarn test` locally - is this because I'm using Windows?